### PR TITLE
Match expression Spanish translation 

### DIFF
--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -7,7 +7,7 @@
  <para>
   La expresión <literal>match</literal> ramifica la evaluación basada en una
   comprobación de identidad de un valor.
-  De forma similar a una declaración <literal>switch</literal>, una
+  De forma similar a una sentencia <literal>switch</literal>, una
   expresión <literal>match</literal> tiene una expresión de sujeto que se
   compara con múltiples alternativas. A diferencia de <literal>switch</literal>,
   se evaluará a un valor muy parecido al de las expresiones ternarias.
@@ -44,7 +44,7 @@ $return_value = match (subject_expression) {
 
  <para>
   La expresión <literal>match</literal> es similar a una
-  declaración <literal>switch</literal> pero tiene algunas diferencias clave:
+  sentencia <literal>switch</literal> pero tiene algunas diferencias clave:
   
   <itemizedlist>
    <listitem>
@@ -61,7 +61,7 @@ $return_value = match (subject_expression) {
    <listitem>
     <simpara>
      Los brazos de <literal>Match</literal> no pasan a casos posteriores
-     como lo hacen las declaraciones <literal>switch</literal>.
+     como lo hacen las sentencias <literal>switch</literal>.
     </simpara>
    </listitem>
    <listitem>
@@ -202,7 +202,7 @@ object(UnhandledMatchError)#1 (7) {
   </para>
 
   <example>
-   <title>Uso de expresiones match generalizadas para ramificar en rangos de enteros</title>
+   <title>Uso de expresiones match generalizadas para ramificar en rangos de integers</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -229,7 +229,7 @@ string(11) "young adult"
   </example>
 
   <example>
-   <title>Uso de expresiones match generalizadas para ramificar el contenido de cadenas.</title>
+   <title>Uso de expresiones match generalizadas para ramificar el contenido de strings.</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -5,19 +5,19 @@
  <title>match</title>
  <?phpdoc print-version-for="match"?>
  <para>
-  The <literal>match</literal> expression branches evaluation based on an
-  identity check of a value.
-  Similarly to a <literal>switch</literal> statement, a
-  <literal>match</literal> expression has a subject expression that is
-  compared against multiple alternatives. Unlike <literal>switch</literal>,
-  it will evaluate to a value much like ternary expressions.
-  Unlike <literal>switch</literal>, the comparison is an identity check
-  (<code>===</code>) rather than a weak equality check (<code>==</code>).
-  Match expressions are available as of PHP 8.0.0.
+  La expresión <literal>match</literal> ramifica la evaluación basada en una
+  comprobación de identidad de un valor.
+  De forma similar a una declaración <literal>switch</literal>, una
+  expresión <literal>match</literal> tiene una expresión de sujeto que se
+  compara con múltiples alternativas. A diferencia de <literal>switch</literal>,
+  se evaluará a un valor muy parecido al de las expresiones ternarias.
+  A diferencia de <literal>switch</literal>, la comparación es una comprobación de identidad
+  (<code>===</code>) en lugar de una comprobación de igualdad débil (<code>==</code>).
+  Las expresiones match están disponibles a partir de PHP 8.0.0.
  </para>
 
  <example>
-  <title>Structure of a <literal>match</literal> expression</title>
+  <title>Estructura de una expresión <literal>match</literal></title>
   <programlisting role="php">
 <![CDATA[
 <?php
@@ -31,64 +31,64 @@ $return_value = match (subject_expression) {
 
   <note>
    <simpara>
-    The result of a <literal>match</literal> expression does not need to be used.
+    El resultado de una expresión <literal>match</literal> no necesita ser utilizado.
    </simpara>
   </note>
   <note>
    <simpara>
-    A <literal>match</literal> expression <emphasis>must</emphasis> be
-    terminated by a semicolon <literal>;</literal>.
+    Una expresión <literal>match</literal> <emphasis>debe</emphasis> 
+    terminar con un punto y coma <literal>;</literal>.
    </simpara>
   </note>
  </example>
 
  <para>
-  The <literal>match</literal> expression is similar to a
-  <literal>switch</literal> statement but has some key differences:
+  La expresión <literal>match</literal> es similar a una
+  declaración <literal>switch</literal> pero tiene algunas diferencias clave:
   
   <itemizedlist>
    <listitem>
     <simpara>
-     A <literal>match</literal> arm compares values strictly (<code>===</code>) instead
-     of loosely as the switch statement does.
+     Un brazo de <literal>match</literal> compara los valores estrictamente (<code>===</code>) en lugar
+     de hacerlo de forma suelta como lo hace la sentencia switch.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     A <literal>match</literal> expression returns a value.
+     Una expresión <literal>match</literal> retorna un valor.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     <literal>Match</literal> arms do not fall-through to later cases the way
-     <literal>switch</literal> statements do.
+     Los brazos de <literal>Match</literal> no pasan a casos posteriores
+     como lo hacen las declaraciones <literal>switch</literal>.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     A <literal>match</literal> expression must be exhaustive.
+     Una expresión <literal>match</literal> debe ser completa.
     </simpara>
    </listitem>
   </itemizedlist>
  </para>
 
  <para>
-  As <literal>switch</literal> statements, <literal>match</literal>
-  expressions are executed match arm by match arm.
-  In the beginning, no code is executed.
-  The conditional expressions are only evaluated if all previous conditional
-  expressions failed to match the subject expression.
-  Only the return expression corresponding to the matching conditional
-  expression will be evaluated.
-  For example:
+  Como las expresiones <literal>switch</literal>, las expresiones <literal>match</literal>
+  se ejecutan de brazo a brazo.
+  Al principio, no se ejecuta ningún código.
+  Las expresiones condicionales sólo se evalúan si todas las anteriores
+  no coinciden con la expresión del sujeto.
+  Sólo se evaluará la expresión de retorno correspondiente
+  a la expresión condicional que coincida.
+  Por ejemplo:
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
 $result = match ($x) {
     foo() => ...,
-    $this->bar() => ..., // bar() isn't called if foo() === $x
-    $this->baz => beep(), // beep() isn't called unless $x === $this->baz
+    $this->bar() => ..., // bar() no se llama si foo() === $x
+    $this->baz => beep(), // beep() no se llama a menos que $x === $this->baz
     // etc.
 };
 ?>
@@ -98,9 +98,9 @@ $result = match ($x) {
  </para>
 
  <para>
-  <literal>match</literal> expression arms may contain multiple expressions
-  separated by a comma.  That is a logical OR, and is a short-hand for multiple
-  match arms with the same right-hand side.
+  Los brazos de la expresión <literal>match</literal> pueden contener varias expresiones
+  separadas por una coma.  Se trata de un OR lógico, y es una abreviatura de múltiples
+  brazos match con el mismo lado derecho.
  </para>
  <para>
   <informalexample>
@@ -108,9 +108,9 @@ $result = match ($x) {
 <![CDATA[
 <?php
 $result = match ($x) {
-    // This match arm:
+    // Este brazo match:
     $a, $b, $c => 5,
-    // Is equivalent to these three match arms:
+    // Es equivalente a estos tres:
     $a => 5,
     $b => 5,
     $c => 5,
@@ -121,9 +121,9 @@ $result = match ($x) {
   </informalexample>
  </para>
  <para>
-  A special case is the <literal>default</literal> pattern.
-  This pattern matches anything that wasn't previously matched.
-  For example:
+  Un caso especial es el patrón <literal>default</literal>.
+  Este patrón permite hacer coincidir cualquier cosa que no se haya hecho coincidir previamente.
+  Por ejemplo:
   <informalexample>
    <programlisting role="php">
 <![CDATA[
@@ -139,20 +139,20 @@ $expressionResult = match ($condition) {
   </informalexample>
   <note>
    <simpara>
-    Multiple default patterns will raise a
-    <constant>E_FATAL_ERROR</constant> error.
+    Múltiples patrones default lanzarán un
+    error <constant>E_FATAL_ERROR</constant>.
    </simpara>
   </note>
  </para>
 
  <para>
-  A <literal>match</literal> expression must be exhaustive.  If the
-  subject expression is not handled by any match arm an
-  <classname>UnhandledMatchError</classname> is thrown.
+  Una expresión <literal>match</literal> debe ser completa.  Si la
+  expresión del sujeto no es manejada por ningún brazo match
+  se lanza un <classname>UnhandledMatchError</classname>.
  </para>
 
  <example>
-  <title>Example of an unhandled match expression</title>
+  <title>Ejemplo de una expresión match no controlada</title>
   <programlisting role="php">
 <![CDATA[
 <?php
@@ -194,15 +194,15 @@ object(UnhandledMatchError)#1 (7) {
  </example>
 
  <sect2>
-  <title>Using match expressions to handle non identity checks</title>
+  <title>Usando expresiones match para manejar comprobaciones de no identidad</title>
   <para>
-   It is possible to use a <literal>match</literal> expression to handle
-   non-identity conditional cases by using <code>true</code> as the subject
-   expression.
+   Es posible utilizar un expresión <literal>match</literal> para manejar
+   casos de condicionales de no identidad usando <code>true</code> como expresión
+   del sujeto.
   </para>
 
   <example>
-   <title>Using a generalized match expressions to branch on integer ranges</title>
+   <title>Uso de expresiones match generalizadas para ramificar en rangos de enteros</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -229,7 +229,7 @@ string(11) "young adult"
   </example>
 
   <example>
-   <title>Using a generalized match expressions to branch on string content</title>
+   <title>Uso de expresiones match generalizadas para ramificar el contenido de cadenas.</title>
    <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
This PR provides the Spanish translation of [`match`](https://www.php.net/manual/es/control-structures.match.php) expression which is part of _Control Structures_. 