### PR TITLE
Update header function signature

### DIFF
--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: chuso Status: ready -->
+<!-- EN-Revision: a3a4cd9bea4344966897f9d83f92daf31e4b7b8e Maintainer: chuso Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.header">
  <refnamediv>
@@ -50,7 +50,7 @@ exit;
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>string</parameter></term>
+     <term><parameter>header</parameter></term>
      <listitem>
       <para>
        El encabezado en formato cadena.
@@ -68,7 +68,12 @@ exit;
        <informalexample>
         <programlisting role="php">
 <![CDATA[
-<?php
+         <?php
+// Este ejemplo ilustra el caso especial "HTTP/"
+// Alternativas mejores en cases de uso típicos incluyen:
+// 1. header($_SERVER["SERVER_PROTOCOL"] . " 404 Not Found");
+//    (para sobreescribir el mensaje de estado HTTP para los clientes que todavía usan HTTP/1.0)
+// 2. http_response_code(404); (para usar el mensaje defecto)
 header("HTTP/1.0 404 Not Found");
 ?>
 ]]>
@@ -127,7 +132,7 @@ header('WWW-Authenticate: NTLM', false);
      <listitem>
       <para>
        Fuerza el código de respuesta HTTP a un valor específico. Observe que
-       este parámetro solamente tiene efecto si <parameter>string</parameter>
+       este parámetro solamente tiene efecto si <parameter>header</parameter>
        no está vacío.
       </para>
      </listitem>
@@ -140,31 +145,6 @@ header('WWW-Authenticate: NTLM', false);
   &reftitle.returnvalues;
   <para>
    &return.void;
-  </para>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>5.1.2</entry>
-       <entry>
-        Esta función ahora previene que se pueda enviar más de un encabezado a la vez
-        como protección en contra de ataques de inyección de encabezados.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
   </para>
  </refsect1>
 
@@ -184,7 +164,7 @@ header('WWW-Authenticate: NTLM', false);
 <![CDATA[
 <?php
 // Vamos a mostrar un PDF
-header('Content-type: application/pdf');
+header('Content-Type: application/pdf');
 
 // Se llamará downloaded.pdf
 header('Content-Disposition: attachment; filename="downloaded.pdf"');
@@ -220,7 +200,7 @@ header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); // Fecha en el pasado
        no se usan los encabezados mencionados más arriba. Existen varias opciones
        que los usuarios pueden cambiar en sus navegadores para cambiar el comportamiento
        por defecto de la caché. Al enviar los encabezados mencionados más arriba, se
-       sobreescrirán cualquiera de las opciones que intentan guardar en caché lo que
+       sobreescritán cualquiera de las opciones que intentan guardar en caché lo que
        muestre su script.
       </para>
       <para>
@@ -268,7 +248,7 @@ header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); // Fecha en el pasado
   <note>
    <para>
     HTTP/1.1 require una <acronym>URI</acronym> absoluta como argumento para
-    <link xlink:href="&spec.http1.1;-sec14.html#sec14.30">Location:</link>
+    <link xlink:href="&spec.http1.1;#section-7.1.2">Location:</link>
     incluyendo el esquema, nombre del host y ruta absoluta, pero
     algunos clientes aceptan también URIs relativas. Se puede usar
     <varname>$_SERVER['HTTP_HOST']</varname>,
@@ -308,7 +288,8 @@ exit;
     <member><function>headers_sent</function></member>
     <member><function>setcookie</function></member>
     <member><function>http_response_code</function></member>
-    <member>
+    <member><function>header_remove</function></member>
+     <member>
      La sección<link linkend="features.http-auth">Autenticación
      HTTP</link>
     </member>

--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>header</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>replace</parameter><initializer>&true;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>response_code</parameter><initializer>0</initializer></methodparam>
- </methodsynopsis>
+  </methodsynopsis>
   <para>
    <function>header</function> es usado para enviar encabezados <acronym>HTTP</acronym>
    sin formato. Ver la especificación <link xlink:href="&url.rfc;2616">HTTP/1.1 specification</link>
@@ -68,7 +68,7 @@ exit;
        <informalexample>
         <programlisting role="php">
 <![CDATA[
-         <?php
+<?php
 // Este ejemplo ilustra el caso especial "HTTP/"
 // Alternativas mejores en cases de uso típicos incluyen:
 // 1. header($_SERVER["SERVER_PROTOCOL"] . " 404 Not Found");
@@ -289,7 +289,7 @@ exit;
     <member><function>setcookie</function></member>
     <member><function>http_response_code</function></member>
     <member><function>header_remove</function></member>
-     <member>
+    <member>
      La sección<link linkend="features.http-auth">Autenticación
      HTTP</link>
     </member>

--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -12,10 +12,10 @@
   &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>header</methodname>
-   <methodparam><type>string</type><parameter>string</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>replace</parameter><initializer>true</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>http_response_code</parameter></methodparam>
-  </methodsynopsis>
+   <methodparam><type>string</type><parameter>header</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>replace</parameter><initializer>&true;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>response_code</parameter><initializer>0</initializer></methodparam>
+ </methodsynopsis>
   <para>
    <function>header</function> es usado para enviar encabezados <acronym>HTTP</acronym>
    sin formato. Ver la especificación <link xlink:href="&url.rfc;2616">HTTP/1.1 specification</link>


### PR DESCRIPTION
* Use a better example for using header() to set status code - a3a4cd9bea4344966897f9d83f92daf31e4b7b8e
* Generate some standard methodsynopses based on stubs - 0c9c2dd669fe9395eaa73d487fbd160f9057429a
* Removed some of the PHP5 changelogs - 53bdffa6b9f8ce5ffdaf476c9d450f7cd0d1afa2
* Rename first parameter to header (bug #75875) - 158f89672a49b10183d8ba039ae21d53ad6db669
* Use entities in initializer - b8758b0605e80c4e3610137b7502a6abeea5c69b
* Add header_remove() to see also section of header() - 852eaaffc4257dc4823e2665dedb5ad88d2f3bb8
* RFC2616 was replaced by multiple RFCs (7230-7237) - 1aa48f7f540dd59ec583cc977929f0de57c682ad
* Consistency for 'Content-Type' header, as per bug/request #68653 - 11c3ae8a2616b4c6e673a82d709ec235b53b9ba6
* Update revision hash
