### PR TITLE
Replace `<literal>` nodes with `<constant>` for constants

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -865,7 +865,7 @@ El paso de datos no confiables a este parámetro es <emphasis>inseguro</emphasis
 
 <!ENTITY intl.codepoint.example 'Probar diferentes puntos de código'>
 
-<!ENTITY intl.property.parameter '<para xmlns="http://docbook.org/ns/docbook">La propiedad de Unicode a consultar (véanse las constantes <literal>IntlChar::PROPERTY_*</literal>).</para>'>
+<!ENTITY intl.property.parameter '<para xmlns="http://docbook.org/ns/docbook">La propiedad de Unicode a consultar (véanse las constantes <constant>IntlChar::PROPERTY_*</constant>).</para>'>
 
 <!ENTITY intl.property.example 'Probar diferentes propiedades'>
 

--- a/reference/event/eventbase/loop.xml
+++ b/reference/event/eventbase/loop.xml
@@ -39,7 +39,7 @@
     <listitem>
      <para>
       Flags opcionales. Puede ser una de las constantes
-      <literal>EventBase::LOOP_*</literal>.
+      <constant>EventBase::LOOP_*</constant>.
       Véase
       <link linkend="eventbase.constants">constantes EventBase</link>
       .

--- a/reference/imagick/imagickdraw/getcliprule.xml
+++ b/reference/imagick/imagickdraw/getcliprule.xml
@@ -22,7 +22,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve una constante <link linkend="imagick.constants.fillrule">FILLRULE</link> (<literal>imagick::FILLRULE_*</literal>).
+   Devuelve una constante <link linkend="imagick.constants.fillrule">FILLRULE</link> (<constant>imagick::FILLRULE_*</constant>).
   </para>
  </refsect1>
 

--- a/reference/imagick/imagickdraw/getfillrule.xml
+++ b/reference/imagick/imagickdraw/getfillrule.xml
@@ -22,7 +22,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve una constante <link linkend="imagick.constants.fillrule">FILLRULE</link> (<literal>imagick::FILLRULE_*</literal>).
+   Devuelve una constante <link linkend="imagick.constants.fillrule">FILLRULE</link> (<constant>imagick::FILLRULE_*</constant>).
   </para>
  </refsect1>
 

--- a/reference/intl/intlchar/enumchartypes.xml
+++ b/reference/intl/intlchar/enumchartypes.xml
@@ -8,7 +8,7 @@
   <refname>IntlChar::enumCharTypes</refname>
   <refpurpose>Enumerar todos los puntos de código con sus categorías generales de Unicode</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -25,7 +25,7 @@
    garantiza que el valor numérico del tipo está entre 0..31.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
@@ -38,21 +38,21 @@
       <simplelist>
        <member><type>integer</type> <literal>$start</literal> - El punto de código de inicio del rango</member>
        <member><type>integer</type> <literal>$end</literal> - El punto de código final del rango</member>
-       <member><type>integer</type> <literal>$name</literal> - El tipo de categoría (una de las constantes <literal>IntlChar::CHAR_CATEGORY_*</literal>)</member>
+       <member><type>integer</type> <literal>$name</literal> - El tipo de categoría (una de las constantes <constant>IntlChar::CHAR_CATEGORY_*</constant>)</member>
       </simplelist>
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.void;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -87,7 +87,7 @@ U+0030 hasta U+003a están en la categoría 9
    </screen>
   </example>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/intl/intlchar/getblockcode.xml
+++ b/reference/intl/intlchar/getblockcode.xml
@@ -8,7 +8,7 @@
   <refname>IntlChar::getBlockCode</refname>
   <refpurpose>Obtener el bloque de asignación de Unicode que contiene a un punto de código</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -19,7 +19,7 @@
    Devuelve el bloque de asignación de Unicode que contiene al carácter.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
@@ -31,15 +31,15 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    Devuelve el valor del bloque para <parameter>codepoint</parameter>.
-   Véanse las constantes <literal>IntlChar::BLOCK_CODE_*</literal> para los posibles valores devueltos.
+   Véanse las constantes <constant>IntlChar::BLOCK_CODE_*</constant> para los posibles valores devueltos.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -63,7 +63,7 @@ bool(true)
    </screen>
   </example>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/intl/intlchar/getpropertyenum.xml
+++ b/reference/intl/intlchar/getpropertyenum.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un valor de una consntante <literal>IntlChar::PROPERTY_</literal>,
+   Devuelve un valor de una consntante <constant>IntlChar::PROPERTY_</constant>,
    o <constant>IntlChar::PROPERTY_INVALID_CODE</constant> si el nombre dado no coincide con ninguna propiedad.
   </para>
  </refsect1>

--- a/reference/memcached/memcached/getoption.xml
+++ b/reference/memcached/memcached/getoption.xml
@@ -8,7 +8,7 @@
   <refname>Memcached::getOption</refname>
   <refpurpose>Obtener el valor de una opción de Memcached</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -22,7 +22,7 @@
    Memcached</link> para más información.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -31,14 +31,14 @@
      <term><parameter>option</parameter></term>
      <listitem>
       <para>
-       Una de las constantes <literal>Memcached::OPT_*</literal>.
+       Una de las constantes <constant>Memcached::OPT_*</constant>.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -46,7 +46,7 @@
    error.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -71,7 +71,7 @@ int(1000)
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -82,7 +82,7 @@ int(1000)
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/memcached/memcached/setoption.xml
+++ b/reference/memcached/memcached/setoption.xml
@@ -8,7 +8,7 @@
   <refname>Memcached::setOption</refname>
   <refpurpose>Establecer una opción de Memcached</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -26,22 +26,22 @@
    Las opciones enumeradas más abajo requieren valores especificados mediante constantes.
    <itemizedlist>
     <listitem><para>
-     <literal>Memcached::OPT_HASH</literal> require valores <literal>Memcached::HASH_*</literal>.
+     <constant>Memcached::OPT_HASH</constant> require valores <constant>Memcached::HASH_*</constant>.
      </para></listitem>
     <listitem><para>
-     <literal>Memcached::OPT_DISTRIBUTION</literal> requiere valores <literal>Memcached::DISTRIBUTION_*</literal>.
+     <constant>Memcached::OPT_DISTRIBUTION</constant> requiere valores <constant>Memcached::DISTRIBUTION_*</constant>.
      </para></listitem>
    </itemizedlist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -68,7 +68,7 @@ El prefijo de las claves ahora es: widgets
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -79,7 +79,7 @@ El prefijo de las claves ahora es: widgets
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -24,7 +24,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="pdo.constants.param-null">
    <term>
     <constant>PDO::PARAM_NULL</constant>
@@ -67,7 +67,7 @@
     <simpara>
      <!-- Flag to denote a string uses the national character set. -->
     </simpara>
-    <simpara> 
+    <simpara>
      Disponible desde PHP 7.2.0
     </simpara>
    </listitem>
@@ -81,7 +81,7 @@
     <simpara>
      <!-- Flag to denote a string uses the regular character set. -->
     </simpara>
-    <simpara> 
+    <simpara>
      Disponible desde PHP 7.2.0
     </simpara>
    </listitem>
@@ -297,7 +297,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="pdo.constants.fetch-key-pair">
    <term>
     <constant>PDO::FETCH_KEY_PAIR</constant>
@@ -310,7 +310,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="pdo.constants.fetch-classtype">
    <term>
     <constant>PDO::FETCH_CLASSTYPE</constant>
@@ -438,7 +438,7 @@
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -450,7 +450,7 @@
    <listitem>
     <simpara>
      Forzar a los nombres de las columnas a emplear las mayúsculas/minúsculas especificadas por
-     las constantes <literal>PDO::CASE_*</literal>.
+     las constantes <constant>PDO::CASE_*</constant>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -481,7 +481,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="pdo.constants.attr-driver-name">
    <term>
     <constant>PDO::ATTR_DRIVER_NAME</constant>
@@ -506,7 +506,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     </para>
    </listitem>
   </varlistentry>
-  
+
   <varlistentry xml:id="pdo.constants.attr-oracle-nulls">
    <term>
     <constant>PDO::ATTR_ORACLE_NULLS</constant>
@@ -524,7 +524,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>integer</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Solicitar una conexión persistente, en vez de crear una nueva conexión.
      Véase <link linkend="pdo.connections">Conexiones y su
      administración</link> para obtener más información sobre este atributo.
@@ -537,8 +537,8 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>integer</type>)
    </term>
    <listitem>
-    <simpara> 
-     
+    <simpara>
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -548,7 +548,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>integer</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Anteponer el nombre del catálogo contenedor a cada nombre de columna devuelto en el
      conjunto de resultados. El nombre del catálogo y el nombre de columna están separados por un
      carácter punto (.). El soporte de este atributo es a nivel del controlador; podría
@@ -562,7 +562,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>integer</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Anteponer el nombre de la tabla contenedora a cada nombre de columna devuelto en el
      conjunto de resultados. El nombre de la tabla y el nombre de columna están separados por un
      carácter punto (.). El soporte de este atributo es a nivel del controlador; podría
@@ -576,8 +576,8 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>integer</type>)
    </term>
    <listitem>
-    <simpara> 
-     
+    <simpara>
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -587,8 +587,8 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>integer</type>)
    </term>
    <listitem>
-    <simpara> 
-     
+    <simpara>
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -598,7 +598,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>integer</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Disponible desde PHP 5.2.0.
     </simpara>
    </listitem>
@@ -621,7 +621,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    </term>
    <listitem>
     <simpara>
-     <!--Sets the default string parameter type, this can be one of <constant>PDO::PARAM_STR_NATL</constant> 
+     <!--Sets the default string parameter type, this can be one of <constant>PDO::PARAM_STR_NATL</constant>
      and <constant>PDO::PARAM_STR_CHAR</constant>.-->
     </simpara>
     <simpara>
@@ -686,7 +686,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     (<type>integer</type>)
    </term>
    <listitem>
-    <simpara> 
+    <simpara>
      Forzar los nombres de las columnas a minúsculas.
     </simpara>
    </listitem>
@@ -709,7 +709,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -720,7 +720,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -731,7 +731,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    </term>
    <listitem>
     <simpara>
-     
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -825,7 +825,7 @@ if ($bd->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    <listitem>
     <simpara>
      Crear un objeto <classname>PDOStatement</classname> con un cursor desplazable. De deben pasar las
-     constantes <literal>PDO::FETCH_ORI_*</literal> para controlar las filas obtenidas del conjunto de resultados.
+     constantes <constant>PDO::FETCH_ORI_*</constant> para controlar las filas obtenidas del conjunto de resultados.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -36,22 +36,22 @@
      <term><parameter>attribute</parameter></term>
      <listitem>
       <para>
-       Una de las constantes <literal>PDO::ATTR_*</literal>. Las constantes que se
+       Una de las constantes <constant>PDO::ATTR_*</constant>. Las constantes que se
        aplican a las conexiones de las bases de datos son las siguientes:
-       <simplelist> 
-        <member><literal>PDO::ATTR_AUTOCOMMIT</literal></member>
-        <member><literal>PDO::ATTR_CASE</literal></member>
-        <member><literal>PDO::ATTR_CLIENT_VERSION</literal></member>
-        <member><literal>PDO::ATTR_CONNECTION_STATUS</literal></member>
-        <member><literal>PDO::ATTR_DRIVER_NAME</literal></member>
-        <member><literal>PDO::ATTR_ERRMODE</literal></member>
-        <member><literal>PDO::ATTR_ORACLE_NULLS</literal></member>
-        <member><literal>PDO::ATTR_PERSISTENT</literal></member>
-        <member><literal>PDO::ATTR_PREFETCH</literal></member>
-        <member><literal>PDO::ATTR_SERVER_INFO</literal></member>
-        <member><literal>PDO::ATTR_SERVER_VERSION</literal></member>
-        <member><literal>PDO::ATTR_TIMEOUT</literal></member>
-       </simplelist> 
+       <simplelist>
+        <member><constant>PDO::ATTR_AUTOCOMMIT</constant></member>
+        <member><constant>PDO::ATTR_CASE</constant></member>
+        <member><constant>PDO::ATTR_CLIENT_VERSION</constant></member>
+        <member><constant>PDO::ATTR_CONNECTION_STATUS</constant></member>
+        <member><constant>PDO::ATTR_DRIVER_NAME</constant></member>
+        <member><constant>PDO::ATTR_ERRMODE</constant></member>
+        <member><constant>PDO::ATTR_ORACLE_NULLS</constant></member>
+        <member><constant>PDO::ATTR_PERSISTENT</constant></member>
+        <member><constant>PDO::ATTR_PREFETCH</constant></member>
+        <member><constant>PDO::ATTR_SERVER_INFO</constant></member>
+        <member><constant>PDO::ATTR_SERVER_VERSION</constant></member>
+        <member><constant>PDO::ATTR_TIMEOUT</constant></member>
+       </simplelist>
       </para>
      </listitem>
      </varlistentry>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>statement</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>driver_options</parameter><initializer>array()</initializer></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Prepara una sentencia SQL para ser ejecutada por el método
    <function>PDOStatement::execute</function>. La sentencia SQL puede
@@ -47,7 +47,7 @@
    ejecutadas en múltiples ocasiones con diferentes parámetros optimiza el
    rendimiento de la aplicación permitiendo al driver negociar en lado del
    cliente y/o servidor el almacenamiento en caché del plan de consulta y meta información,
-   y ayuda a prevenir inyecciones SQL eliminando la necesidad de 
+   y ayuda a prevenir inyecciones SQL eliminando la necesidad de
    entrecomillar manualmente los parámetros.
   </para>
   <para>
@@ -75,8 +75,8 @@
       <para>
        Este array guarda uno o más pares clave=&gt;valor para establecer
        el valor de los atributos del objeto PDOStatement que este método
-       devuelve. Comúnmente se establece el valor <literal>PDO::ATTR_CURSOR</literal> a
-       <literal>PDO::CURSOR_SCROLL</literal> para solicitar el cursor desplazable.
+       devuelve. Comúnmente se establece el valor <constant>PDO::ATTR_CURSOR</constant> a
+       <constant>PDO::CURSOR_SCROLL</constant> para solicitar el cursor desplazable.
        Algunos drivers tienen opciones específicas que pueden ser establecidas
        en el momento de la preparación.
       </para>
@@ -85,7 +85,7 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -102,7 +102,7 @@
    </para>
   </note>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -142,7 +142,7 @@ $yellow = $sth->fetchAll();
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/pdo/pdo/setattribute.xml
+++ b/reference/pdo/pdo/setattribute.xml
@@ -16,59 +16,59 @@
    <methodparam><type>int</type><parameter>attribute</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Establece un atributo en el manejador de la base de datos. Algunos de los
    atributos genéricos disponibles están listados a continuación; algunos drivers
    pueden hacer uso de atributos adicionales específicos.
    <itemizedlist>
     <listitem><para>
-     <literal>PDO::ATTR_CASE</literal>: Fuerza a los nombres de columnas a una capitalización específica.
+     <constant>PDO::ATTR_CASE</constant>: Fuerza a los nombres de columnas a una capitalización específica.
      <itemizedlist>
       <listitem><para>
-       <literal>PDO::CASE_LOWER</literal>: Fuerza a los nombres de columnas a minúsculas.
+       <constant>PDO::CASE_LOWER</constant>: Fuerza a los nombres de columnas a minúsculas.
        </para></listitem>
       <listitem><para>
-       <literal>PDO::CASE_NATURAL</literal>: Deja los nombres de columnas como son devueltas por el driver de 
+       <constant>PDO::CASE_NATURAL</constant>: Deja los nombres de columnas como son devueltas por el driver de
        la base de datos.
        </para></listitem>
       <listitem><para>
-       <literal>PDO::CASE_UPPER</literal>: Fuerza a los nombres de columnas a mayúsculas.
+       <constant>PDO::CASE_UPPER</constant>: Fuerza a los nombres de columnas a mayúsculas.
        </para></listitem>
      </itemizedlist>
      </para></listitem>
-    <listitem><para><literal>PDO::ATTR_ERRMODE</literal>: Reporte de errores.
+    <listitem><para><constant>PDO::ATTR_ERRMODE</constant>: Reporte de errores.
      <itemizedlist>
-      <listitem><para><literal>PDO::ERRMODE_SILENT</literal>:
+      <listitem><para><constant>PDO::ERRMODE_SILENT</constant>:
        Establece los códigos de error.</para></listitem>
-      <listitem><para><literal>PDO::ERRMODE_WARNING</literal>:
+      <listitem><para><constant>PDO::ERRMODE_WARNING</constant>:
        Eleva <link linkend="errorfunc.constants.errorlevels.e-warning">E_WARNING</link>.</para></listitem>
-      <listitem><para><literal>PDO::ERRMODE_EXCEPTION</literal>:
+      <listitem><para><constant>PDO::ERRMODE_EXCEPTION</constant>:
        Lanza <link linkend="class.pdoexception">exceptions</link>.</para></listitem>
      </itemizedlist>
      </para></listitem>
-    <listitem><para><literal>PDO::ATTR_ORACLE_NULLS</literal>
+    <listitem><para><constant>PDO::ATTR_ORACLE_NULLS</constant>
      (disponible para todos los drivers, no sólo Oracle):
      Conversión de NULL y cadenas vacías.
      <itemizedlist>
-      <listitem><para><literal>PDO::NULL_NATURAL</literal>:
+      <listitem><para><constant>PDO::NULL_NATURAL</constant>:
        Sin conversión.</para></listitem>
-      <listitem><para><literal>PDO::NULL_EMPTY_STRING</literal>:
+      <listitem><para><constant>PDO::NULL_EMPTY_STRING</constant>:
        Las cadenas vacías son convertidas a &null;.</para></listitem>
-      <listitem><para><literal>PDO::NULL_TO_STRING</literal>:
+      <listitem><para><constant>PDO::NULL_TO_STRING</constant>:
        NULL se convierte a cadenas vacías.</para></listitem>
      </itemizedlist>
      </para></listitem>
-    <listitem><para><literal>PDO::ATTR_STRINGIFY_FETCHES</literal>:
+    <listitem><para><constant>PDO::ATTR_STRINGIFY_FETCHES</constant>:
      Convierte los valores numéricos a cadenas cuando se buscan.
      Requiere <type>bool</type>.
      </para></listitem>
-    <listitem><para><literal>PDO::ATTR_STATEMENT_CLASS</literal>:
+    <listitem><para><constant>PDO::ATTR_STATEMENT_CLASS</constant>:
      Establece la clase de sentencia proporcionada por el usuario derivada de PDOStatement.
      No puede ser usado con instancias PDO persistentes.
      Requiere <literal>array(string classname, array(mixed constructor_args))</literal>.
      </para></listitem>
-    <listitem><para><literal>PDO::ATTR_TIMEOUT</literal>:
+    <listitem><para><constant>PDO::ATTR_TIMEOUT</constant>:
      Especifica la duración del tiempo de espera en segundos
      Specifies the timeout duration in seconds.  Not all drivers support this option,
      and it's meaning may differ from driver to driver.  For example, sqlite will wait
@@ -76,38 +76,38 @@
      other drivers may interpret this as a connect or a read timeout interval.
      Requires <type>int</type>.
      </para></listitem>
-    <listitem><para><literal>PDO::ATTR_AUTOCOMMIT</literal>
+    <listitem><para><constant>PDO::ATTR_AUTOCOMMIT</constant>
      (available in OCI, Firebird and MySQL):
      Whether to autocommit every single statement.
      </para></listitem>
-    <listitem><para><literal>PDO::ATTR_EMULATE_PREPARES</literal>
-     Enables or disables emulation of prepared statements.  Some drivers do 
+    <listitem><para><constant>PDO::ATTR_EMULATE_PREPARES</constant>
+     Enables or disables emulation of prepared statements.  Some drivers do
      not support native prepared statements or have limited support for them.
-     Use this setting to force PDO to either always emulate prepared 
-     statements (if &true;), or to try to use native prepared statements (if 
+     Use this setting to force PDO to either always emulate prepared
+     statements (if &true;), or to try to use native prepared statements (if
      &false;).  It will always fall back to emulating the prepared statement
-     if the driver cannot successfully prepare the current query. 
+     if the driver cannot successfully prepare the current query.
      Requires <type>bool</type>.
      </para></listitem>
-    <listitem><para><literal>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</literal>
+    <listitem><para><constant>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</constant>
      (available in MySQL):
      Use buffered queries.
      </para></listitem>
-    <listitem><para><literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal>:
+    <listitem><para><constant>PDO::ATTR_DEFAULT_FETCH_MODE</constant>:
      Set default fetch mode. Description of modes is available in
      <function>PDOStatement::fetch</function> documentation.
      </para></listitem>
    </itemizedlist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo/pdostatement/bindparam.xml
+++ b/reference/pdo/pdostatement/bindparam.xml
@@ -33,9 +33,9 @@
    y algunos también como parámetros de entrada/salida, donde se envían datos y son
    actualizados al recibirlos.
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -66,7 +66,7 @@
       <para>
        El tipo de datos explícito para el parámetro, usando las <link
        linkend="pdo.constants">constantes
-       <literal>PDO::PARAM_*</literal></link>.
+       <constant>PDO::PARAM_*</constant></link>.
        Para devolver un parámetro INOUT desde un procedimiento almacenado,
        se ha de usar el operador OR a nivel de bits para establecer los bits de
        PDO::PARAM_INPUT_OUTPUT para el parámetro <parameter>data_type</parameter>.
@@ -87,21 +87,21 @@
      <term><parameter>driver_options</parameter></term>
      <listitem>
       <para>
-       
+
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example><title>Ejecutar una sentencia preparada con parámetros de sustitución con nombre</title>
@@ -121,7 +121,7 @@ $gsent->execute();
 ]]>
    </programlisting>
   </example>
-  
+
   <example><title>Ejecutar una sentencia preparada con parámetros de sustitución de signos de interrogación</title>
    <programlisting role="php">
 <![CDATA[
@@ -139,7 +139,7 @@ $gsent->execute();
 ]]>
    </programlisting>
   </example>
-  
+
   <!--
   <example><title>Pass a NULL value into a prepared statement</title>
    <programlisting role="php">
@@ -176,9 +176,9 @@ print("Después de hacer puré la fruta, el color es: $color");
 ]]>
    </programlisting>
   </example>
-  
+
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -188,7 +188,7 @@ print("Después de hacer puré la fruta, el color es: $color");
     <member><function>PDOStatement::bindValue</function></member>
    </simplelist>
   </para>
-  
+
  </refsect1>
 </refentry>
 

--- a/reference/pdo/pdostatement/bindvalue.xml
+++ b/reference/pdo/pdostatement/bindvalue.xml
@@ -22,7 +22,7 @@
    de la sentencia SQL que se utilizó para preparar la sentencia.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -53,21 +53,21 @@
       <para>
        El tipo de datos explícito para el parámetro, usando las <link
         linkend="pdo.constants">constantes
-       <literal>PDO::PARAM_*</literal></link>.
+       <constant>PDO::PARAM_*</constant></link>.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example><title>Ejecutar una sentencia preparada con parámetros de sustitución con nombre</title>
@@ -87,7 +87,7 @@ $gsent->execute();
 ]]>
    </programlisting>
   </example>
-  
+
   <example><title>Ejecutar una sentencia preparada con parámetros de sustitución de signos de interrogación</title>
    <programlisting role="php">
 <![CDATA[
@@ -105,10 +105,10 @@ $gsent->execute();
 ]]>
    </programlisting>
   </example>
-  
-  
+
+
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -118,7 +118,7 @@ $gsent->execute();
     <member><function>PDOStatement::bindParam</function></member>
    </simplelist>
   </para>
-  
+
  </refsect1>
 </refentry>
 

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -34,64 +34,64 @@
      <listitem>
       <para>
        Controla cómo se devolverá la siguiente fila al llamador. Este valor
-       debe ser una de las constantes <literal>PDO::FETCH_*</literal>,
-       estando predeterminado <literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal>
-       (el cual por defecto es <literal>PDO::FETCH_BOTH</literal>).
+       debe ser una de las constantes <constant>PDO::FETCH_*</constant>,
+       estando predeterminado <constant>PDO::ATTR_DEFAULT_FETCH_MODE</constant>
+       (el cual por defecto es <constant>PDO::FETCH_BOTH</constant>).
        <itemizedlist>
         <listitem><para>
-         <literal>PDO::FETCH_ASSOC</literal>: devuelve un array indexado por los nombres de las
+         <constant>PDO::FETCH_ASSOC</constant>: devuelve un array indexado por los nombres de las
          columnas del conjunto de resultados.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_BOTH</literal> (predeterminado): devuelve un array indexado tanto
+         <constant>PDO::FETCH_BOTH</constant> (predeterminado): devuelve un array indexado tanto
          por nombre de columna, como numéricamente con índice de base 0 tal como fue devuelto en el
          conjunto de resultados.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_BOUND</literal>: devuelve &true; y asigna los
+         <constant>PDO::FETCH_BOUND</constant>: devuelve &true; y asigna los
          valores de las columnas del conjunto de resultados a las variables de PHP a las que
          fueron vinculadas con el método <function>PDOStatement::bindColumn</function>.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_CLASS</literal>: devuelve una nueva instancia de la
+         <constant>PDO::FETCH_CLASS</constant>: devuelve una nueva instancia de la
          clase solicitada, haciendo corresponder las columnas del conjunto de resultados con los
          nombres de las propiedades de la clase, y llamando al constructor después, a menos
-         que también se proporcione <literal>PDO::FETCH_PROPS_LATE</literal>.
+         que también se proporcione <constant>PDO::FETCH_PROPS_LATE</constant>.
          Si <parameter>mode</parameter>
          incluye PDO::FETCH_CLASSTYPE (por ejemplo, <literal>PDO::FETCH_CLASS |
          PDO::FETCH_CLASSTYPE</literal>), entonces el nombre de la clase
          se determina a partir del valor de la primera columna.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_INTO</literal>: actualiza una instancia existente
+         <constant>PDO::FETCH_INTO</constant>: actualiza una instancia existente
          de la clase solicitada, haciendo coincidir el nombre de las columnas con los
          nombres de las propiedades de la clase.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_LAZY</literal>: combina
-         <literal>PDO::FETCH_BOTH</literal> y <literal>PDO::FETCH_OBJ</literal>,
+         <constant>PDO::FETCH_LAZY</constant>: combina
+         <constant>PDO::FETCH_BOTH</constant> y <constant>PDO::FETCH_OBJ</constant>,
          creando los nombres de la variables del objeto tal como se accedieron.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_NAMED</literal>: devuelve un array con la misma
-         forma que <literal>PDO::FETCH_ASSOC</literal>, excepto que si hubiera
+         <constant>PDO::FETCH_NAMED</constant>: devuelve un array con la misma
+         forma que <constant>PDO::FETCH_ASSOC</constant>, excepto que si hubiera
          múltiples columnas con el mismo nombre, el valor al que hace referencia dicha
          clave será un array con todos los valores de la fila de tuviera ese
          nombre de columna.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_NUM</literal>: devuelve un array indexado por el
+         <constant>PDO::FETCH_NUM</constant>: devuelve un array indexado por el
          número de columna tal como fue devuelto en el conjunto de resultados, comenzando por
          la columna 0.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_OBJ</literal>: devuelve un objeto anónimo con
+         <constant>PDO::FETCH_OBJ</constant>: devuelve un objeto anónimo con
          nombres de propiedades que se corresponden a los nombres de las columnas devueltas
          en el conjunto de resultados.
          </para></listitem>
         <listitem><para>
-         <literal>PDO::FETCH_PROPS_LATE</literal>: cuando se usa con
-         <literal>PDO::FETCH_CLASS</literal>, se llama al constructor de la
+         <constant>PDO::FETCH_PROPS_LATE</constant>: cuando se usa con
+         <constant>PDO::FETCH_CLASS</constant>, se llama al constructor de la
          clase antes de que las proiedades sean asignadas desde los valores de la
          columna respectiva.
          </para></listitem>
@@ -105,11 +105,11 @@
       <para>
        Para un objeto PDOStatement que represente un cursor desplazable, este
        valor determina qué columna será devuelta por el llamador. Este valor
-       debe ser una de las constantes <literal>PDO::FETCH_ORI_*</literal>,
-       siendo la predeterminada <literal>PDO::FETCH_ORI_NEXT</literal>. Para solicitar un
+       debe ser una de las constantes <constant>PDO::FETCH_ORI_*</constant>,
+       siendo la predeterminada <constant>PDO::FETCH_ORI_NEXT</constant>. Para solicitar un
        cursor desplazable para el objeto PDOStatement, se debe establecer el
-       atributo <literal>PDO::ATTR_CURSOR</literal> a
-       <literal>PDO::CURSOR_SCROLL</literal> cuando se prepare la sentencia SQL
+       atributo <constant>PDO::ATTR_CURSOR</constant> a
+       <constant>PDO::CURSOR_SCROLL</constant> cuando se prepare la sentencia SQL
        con <function>PDO::prepare</function>.
       </para>
      </listitem>
@@ -120,13 +120,13 @@
       <para>
        Para un objeto PDOStatement que represente un cursor desplazable para el cual
        el parámetro <literal>cursorOrientation</literal> está establecido a
-       <literal>PDO::FETCH_ORI_ABS</literal>, este valor especifica el número
+       <constant>PDO::FETCH_ORI_ABS</constant>, este valor especifica el número
        absoluto de la fila del conjunto de resultados que se desea obtener.
       </para>
       <para>
        Para un objeto PDOStatement que represente un cursor desplazable para el cual
        el parámetro <literal>cursorOrientation</literal> está establecido a
-       <literal>PDO::FETCH_ORI_REL</literal>, este valor especifica la
+       <constant>PDO::FETCH_ORI_REL</constant>, este valor especifica la
        fila a obtener relativa a la posición del cursor antes de que
        se llame a <function>PDOStatement::fetch</function>.
       </para>
@@ -274,9 +274,9 @@ Reading backwards:
 
    <example><title>Orden de construcción</title>
     <simpara>
-     Cuando los objetos se obtienen mediante <literal>PDO::FETCH_CLASS</literal>, las
+     Cuando los objetos se obtienen mediante <constant>PDO::FETCH_CLASS</constant>, las
      propiedades del objeto se asignan primero, y luego se invoca al constructor de la
-     clase. Si también se proporciona <literal>PDO::FETCH_PROPS_LATE</literal>, este
+     clase. Si también se proporciona <constant>PDO::FETCH_PROPS_LATE</constant>, este
      orden se invierte, es decir, primero se llama al constructor y luego se
      asignan las propiedades.
     </simpara>

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -15,26 +15,26 @@
    <modifier>public</modifier> <type>mixed</type><methodname>PDOStatement::getAttribute</methodname>
    <methodparam><type>int</type><parameter>attribute</parameter></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Obtiene un atributo de una sentencia. Actualemente, no existen atributos genéricos, sino solamente específicos del controlador:
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem><para><constant>PDO::ATTR_CURSOR_NAME</constant>
      (específico de Firebird y ODBC):
      Obtiene el nombre del cursor para <literal>UPDATE ... WHERE CURRENT OF</literal>.
      </para></listitem>
    </itemizedlist>
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    Devuelve el valor del atributo.
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -45,7 +45,7 @@
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo/pdostatement/getcolumnmeta.xml
+++ b/reference/pdo/pdostatement/getcolumnmeta.xml
@@ -15,7 +15,7 @@
    <modifier>public</modifier> <type>array</type><methodname>PDOStatement::getColumnMeta</methodname>
    <methodparam><type>int</type><parameter>column</parameter></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Devuelve los metadatos de una columna de índice basado 0 de un conjunto de resultados
    como un array asociativo.
@@ -26,7 +26,7 @@
     <function>PDOStatement::getColumnMeta</function>.
    </simpara>
   </warning>
-  
+
   <para>Los siguientes controladores admiten este método:</para>
   <itemizedlist>
    <listitem><simpara><link linkend="ref.pdo-dblib">PDO_DBLIB</link></simpara></listitem>
@@ -34,7 +34,7 @@
    <listitem><simpara><link linkend="ref.pdo-pgsql">PDO_PGSQL</link></simpara></listitem>
    <listitem><simpara><link linkend="ref.pdo-sqlite">PDO_SQLITE</link></simpara></listitem>
   </itemizedlist>
-  
+
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -51,7 +51,7 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -61,8 +61,8 @@
   <table>
    <title>Metadatos de la columna</title>
    <tgroup cols="2">
-    <colspec colname='c1'/> 
-    <colspec colname='c2'/> 
+    <colspec colname='c1'/>
+    <colspec colname='c2'/>
     <thead>
      <row>
       <entry>Nombre</entry>
@@ -108,7 +108,7 @@
       <entry><literal>pdo_type</literal></entry>
       <entry>El tipo de esta columna tal como está representado por las
        <link linkend="pdo.constants">constantes
-        <literal>PDO::PARAM_*</literal></link>.</entry>
+        <constant>PDO::PARAM_*</constant></link>.</entry>
      </row>
     </tbody>
    </tgroup>
@@ -118,7 +118,7 @@
    o si no existe dicho conjunto.
   </para>
  </refsect1>
- 
+
  <!-- Use when ERRORS exist
  <refsect1 role="errors">
   &reftitle.errors;
@@ -127,7 +127,7 @@
   </para>
  </refsect1>
  -->
- 
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -153,7 +153,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -196,7 +196,7 @@ array(6) {
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -206,7 +206,7 @@ array(6) {
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -16,26 +16,26 @@
    <methodparam><type>int</type><parameter>attribute</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Establece un atributo de una sentencia. Actualmente, no se establecen atributos genéricos, sino solamente específicos del controlador:
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem><para><constant>PDO::ATTR_CURSOR_NAME</constant>
      (específico de Firebird y ODBC):
      Establece el nombre del cursor para <literal>UPDATE ... WHERE CURRENT OF</literal>.
      </para></listitem>
    </itemizedlist>
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -46,7 +46,7 @@
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -15,26 +15,26 @@
    <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
-  
+
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>PDO::FETCH_COLUMN</parameter></methodparam>
    <methodparam><type>int</type><parameter>colno</parameter></methodparam>
   </methodsynopsis>
-  
+
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>PDO::FETCH_CLASS</parameter></methodparam>
    <methodparam><type>string</type><parameter>classname</parameter></methodparam>
    <methodparam><type>array</type><parameter>ctorargs</parameter></methodparam>
   </methodsynopsis>
-  
+
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>PDO::FETCH_INTO</parameter></methodparam>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
-  
+
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -44,7 +44,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       El modo de obtención debe ser una de las constantes <literal>PDO::FETCH_*</literal>.
+       El modo de obtención debe ser una de las constantes <constant>PDO::FETCH_*</constant>.
       </para>
      </listitem>
     </varlistentry>
@@ -83,14 +83,14 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -133,7 +133,7 @@ watermelon      pink    90
    </example>
   </para>
  </refsect1>
- 
+
  <!-- Use when adding See Also links
  <refsect1 role="seealso">
   &reftitle.seealso;
@@ -145,8 +145,8 @@ watermelon      pink    90
   </para>
  </refsect1>
  -->
- 
- 
+
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/canCompress.xml
+++ b/reference/phar/Phar/canCompress.xml
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Phar::canCompress</methodname>
    <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Este método debería usarse para comprobar si es posible una compresicón antes de
    cargar un archivo phar que contiene ficheros comprimidos.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -28,7 +28,7 @@
      <term><parameter>type</parameter></term>
      <listitem>
       <para>
-       Se puede usar tanto <literal>Phar::GZ</literal> o <literal>Phar::BZ2</literal>
+       Se puede usar tanto <constant>Phar::GZ</constant> o <constant>Phar::BZ2</constant>
        para comprobar si la compresión es posible con un algoritmo de compresión
        específico (zlib o bzip2).
       </para>
@@ -43,7 +43,7 @@
    &true; si la compresión/descompresión está disponible, &false; si no.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -63,7 +63,7 @@ if (Phar::canCompress()) {
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -81,8 +81,8 @@ if (Phar::canCompress()) {
    </simplelist>
   </para>
  </refsect1>
- 
- 
+
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/compress.xml
+++ b/reference/phar/Phar/compress.xml
@@ -7,7 +7,7 @@
   <refname>Phar::compress</refname>
   <refpurpose>Comprimir el archivo Phar entero usando la compresión Gzip o Bzip2</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>string</type><parameter>extension</parameter></methodparam>
   </methodsynopsis>
   &phar.write;
-  
+
   <para>
    Para archivos phar basados en tar y en phar, este método comprime el archivo entero usando
    la compresión gzip o bzip2. El fichero resultante puede ser procesado con el
@@ -34,12 +34,12 @@
   </para>
   <para>
    Además, este método renombra automáticamente el archivo, añadiéndole <literal>.gz</literal>,
-   <literal>.bz2</literal> o eliminado la extensión si se pasa <literal>Phar::NONE</literal> para
+   <literal>.bz2</literal> o eliminado la extensión si se pasa <constant>Phar::NONE</constant> para
    eliminar la compresión. De forma alternativa, se puede expecificar una extensión de fichero con el segundo
    parámetro.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -48,8 +48,8 @@
      <term><parameter>compression</parameter></term>
      <listitem>
       <para>
-       La compresión debe ser <literal>Phar::GZ</literal> o
-       <literal>Phar::BZ2</literal> para añadir compresión, o <literal>Phar::NONE</literal>
+       La compresión debe ser <constant>Phar::GZ</constant> o
+       <constant>Phar::BZ2</constant> para añadir compresión, o <constant>Phar::NONE</constant>
        para eliminarla.
       </para>
      </listitem>
@@ -69,14 +69,14 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    Devuelve un objeto de la clase <classname>Phar</classname>.
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -87,7 +87,7 @@
    no está habilitada.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -108,7 +108,7 @@ $p3 = $p2->compress(Phar::NONE); // excepción: /ruta/a/mi.phar ya existe
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -127,7 +127,7 @@ $p3 = $p2->compress(Phar::NONE); // excepción: /ruta/a/mi.phar ya existe
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/compressFiles.xml
+++ b/reference/phar/Phar/compressFiles.xml
@@ -7,7 +7,7 @@
   <refname>Phar::compressFiles</refname>
   <refpurpose>Comprime todos los ficheros del archivo Phar actual</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>compression</parameter></methodparam>
   </methodsynopsis>
   &phar.write;
-  
+
   <para>
    Para archivos phar basados en tar, este método lanza una
    excepción de tipo <classname>BadMethodCallException</classname>, ya que la compresión de ficheros
@@ -34,7 +34,7 @@
    para poder realizar esto.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -43,24 +43,24 @@
      <term><parameter>compression</parameter></term>
      <listitem>
       <para>
-       La compresión debe ser <literal>Phar::GZ</literal> o
-       <literal>Phar::BZ2</literal> para añadir compresión, o <literal>Phar::NONE</literal>
+       La compresión debe ser <constant>Phar::GZ</constant> o
+       <constant>Phar::BZ2</constant> para añadir compresión, o <constant>Phar::NONE</constant>
        para eliminarla.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.void;
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -72,7 +72,7 @@
    no está habilitada.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -124,7 +124,7 @@ bool(true)
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -142,7 +142,7 @@ bool(true)
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/convertToData.xml
+++ b/reference/phar/Phar/convertToData.xml
@@ -7,8 +7,8 @@
   <refname>Phar::convertToData</refname>
   <refpurpose>Convertir un archivo phar en un fichero tar o zip no ejecutable</refpurpose>
  </refnamediv>
- 
- 
+
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>compression</parameter><initializer>9021976</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>extension</parameter></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Este método se usa para convertir un archivo phar ejecutable en un
    fichero tar o zip. Para hacer del tar o zip un fichero no ejecutable, se eliminan
@@ -34,7 +34,7 @@
    de que el proceso haya finalizado.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -43,8 +43,8 @@
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       Este parámetro debería ser <literal>Phar::TAR</literal>
-       o <literal>Phar::ZIP</literal>. Si se establece a &null;, se conservará el
+       Este parámetro debería ser <constant>Phar::TAR</constant>
+       o <constant>Phar::ZIP</constant>. Si se establece a &null;, se conservará el
        formato de fichero existente.
       </para>
      </listitem>
@@ -53,9 +53,9 @@
      <term><parameter>compression</parameter></term>
      <listitem>
       <para>
-       Este parámetro debería ser <literal>Phar::NONE</literal> para no comprimir el archivo
-       completo, <literal>Phar::GZ</literal> para la compresión basada en zlib, y
-       <literal>Phar::BZ2</literal> para la compresión basada en bzip.
+       Este parámetro debería ser <constant>Phar::NONE</constant> para no comprimir el archivo
+       completo, <constant>Phar::GZ</constant> para la compresión basada en zlib, y
+       <constant>Phar::BZ2</constant> para la compresión basada en bzip.
       </para>
      </listitem>
     </varlistentry>
@@ -78,7 +78,7 @@
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -87,19 +87,19 @@
    excepción en caso de error.
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
    Este método lanza una excepción de tipo <classname>BadMethodCallException</classname> cuando no se
    puede comprimir, se ha especificado un método de compresión desconocido, el archivo
    solicitado está almacenado en buffer con <function>Phar::startBuffering</function> y
-   no se ha cerrado con <function>Phar::stopBuffering</function>, 
+   no se ha cerrado con <function>Phar::stopBuffering</function>,
    y una excepción de tipo <classname>PharException</classname> si se encontró algún problema
    durante el proceso de la creación de phar.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -132,7 +132,7 @@ try {
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -143,7 +143,7 @@ try {
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/convertToExecutable.xml
+++ b/reference/phar/Phar/convertToExecutable.xml
@@ -7,8 +7,8 @@
   <refname>Phar::convertToExecutable</refname>
   <refpurpose>Convertir un archivo phar en otro formato de archivo phar ejecutable</refpurpose>
  </refnamediv>
- 
- 
+
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -34,7 +34,7 @@
    de que el proceso haya finalizado.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -43,8 +43,8 @@
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       Este parámetro debería ser <literal>Phar::PHAR</literal>, <literal>Phar::TAR</literal>,
-       o <literal>Phar::ZIP</literal>. Si se establece a &null;, se conservará el
+       Este parámetro debería ser <constant>Phar::PHAR</constant>, <constant>Phar::TAR</constant>,
+       o <constant>Phar::ZIP</constant>. Si se establece a &null;, se conservará el
        formato de fichero existente.
       </para>
      </listitem>
@@ -53,9 +53,9 @@
      <term><parameter>compression</parameter></term>
      <listitem>
       <para>
-       Este parámetro debería ser <literal>Phar::NONE</literal> para no comprimir el archivo
-       completo, <literal>Phar::GZ</literal> para la compresión basada en zlib, y
-       <literal>Phar::BZ2</literal> para la compresión basada en bzip.
+       Este parámetro debería ser <constant>Phar::NONE</constant> para no comprimir el archivo
+       completo, <constant>Phar::GZ</constant> para la compresión basada en zlib, y
+       <constant>Phar::BZ2</constant> para la compresión basada en bzip.
       </para>
      </listitem>
     </varlistentry>
@@ -80,7 +80,7 @@
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -89,7 +89,7 @@
    excepción en caso de error.
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -102,7 +102,7 @@
    durante el proceso de la creación de phar.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -131,7 +131,7 @@ try {
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -142,7 +142,7 @@ try {
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/getSupportedCompression.xml
+++ b/reference/phar/Phar/getSupportedCompression.xml
@@ -7,7 +7,7 @@
   <refname>Phar::getSupportedCompression</refname>
   <refpurpose>Devolver un array de los algoritmos de compresión soportados</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -17,24 +17,24 @@
   <para>
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
    No tiene parámetros.
   </para>
-  
+
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un array que contiene <literal>Phar::GZ</literal> o
-   <literal>Phar::BZ2</literal>, dependiendo de la disponibilidad de
+   Devuelve un array que contiene <constant>Phar::GZ</constant> o
+   <constant>Phar::BZ2</constant>, dependiendo de la disponibilidad de
    la extensión <link linkend="book.zlib">zlib</link> o de la
    extensión <link linkend="book.bzip2">bz2</link>.
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -52,7 +52,7 @@
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/isCompressed.xml
+++ b/reference/phar/Phar/isCompressed.xml
@@ -7,7 +7,7 @@
   <refname>Phar::isCompressed</refname>
   <refpurpose>Devuelve Phar::GZ oPHAR::BZ2 si el archivo phar entero está comprimido (.tar.gz/tar.bz, etc.)</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -15,28 +15,28 @@
    <void/>
   </methodsynopsis>
   &phar.write;
-  
+
   <para>
    Devuelve Phar::GZ o PHAR::BZ2 si el archivo phar entero está comprimido
    (.tar.gz/tar.bz, etc.). Los archivos phar basados en Zip no pueden ser comprimidos como un
    fichero, y por lo tanto, este método devolverá siempre &false; si se requiere un archivo phar basado en zip.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
    No tiene parámetros.
   </para>
-  
+
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <literal>Phar::GZ</literal>, <literal>Phar::BZ2</literal> o &false;
+   <constant>Phar::GZ</constant>, <constant>Phar::BZ2</constant> o &false;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -68,7 +68,7 @@ bool(true)
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -86,7 +86,7 @@ bool(true)
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/isFileFormat.xml
+++ b/reference/phar/Phar/isFileFormat.xml
@@ -7,7 +7,7 @@
   <refname>Phar::isFileFormat</refname>
   <refpurpose>Devolver true si el archivo phar está basado en el formato de fichero tar/phar/zip dependiendo del parámetro</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -17,7 +17,7 @@
   <para>
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -26,23 +26,23 @@
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       <literal>Phar::PHAR</literal>, <literal>Phar::TAR</literal>, o
-       <literal>Phar::ZIP</literal> para comprobar el formato del archivo.
+       <constant>Phar::PHAR</constant>, <constant>Phar::TAR</constant>, o
+       <constant>Phar::ZIP</constant> para comprobar el formato del archivo.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    Devuelve &true; si el archivo phar coincide con el formato de fichero solicitado por el parámetro
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -50,7 +50,7 @@
    de fichero desconocido.
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -60,7 +60,7 @@
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/Phar/setSignatureAlgorithm.xml
+++ b/reference/phar/Phar/setSignatureAlgorithm.xml
@@ -7,7 +7,7 @@
   <refname>Phar::setSignatureAlgorithm</refname>
   <refpurpose>Establecer el algoritmo de firma para un phar y aplicarlo</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -16,12 +16,12 @@
    <methodparam choice="opt"><type>string</type><parameter>privatekey</parameter></methodparam>
   </methodsynopsis>
   &phar.write;
-  
+
   <para>
    Establece el algoritmo de firma para un phar y lo aplica. El
-   algoritmo de firma debe ser una de las constantes <literal>Phar::MD5</literal>,
-   <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
-   <literal>Phar::SHA512</literal>, o <literal>Phar::OPENSSL</literal>.
+   algoritmo de firma debe ser una de las constantes <constant>Phar::MD5</constant>,
+   <constant>Phar::SHA1</constant>, <constant>Phar::SHA256</constant>,
+   <constant>Phar::SHA512</constant>, o <constant>Phar::OPENSSL</constant>.
   </para>
   <para>
    Observe que todos los archivos phar ejecutables tienen una firma creada
@@ -31,7 +31,7 @@
    <function>Phar::setSignatureAlgorithm</function>.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -40,9 +40,9 @@
      <term><parameter>sigtype</parameter></term>
      <listitem>
       <para>
-       Una de las constantes <literal>Phar::MD5</literal>,
-       <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
-       <literal>Phar::SHA512</literal>, o <literal>Phar::OPENSSL</literal>
+       Una de las constantes <constant>Phar::MD5</constant>,
+       <constant>Phar::SHA1</constant>, <constant>Phar::SHA256</constant>,
+       <constant>Phar::SHA512</constant>, o <constant>Phar::OPENSSL</constant>
       </para>
      </listitem>
     </varlistentry>
@@ -69,16 +69,16 @@ $p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.void;
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -87,7 +87,7 @@ $p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
    si ocurrió algún problema al volcar los cambios al disco.
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -97,7 +97,7 @@ $p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/PharData/compress.xml
+++ b/reference/phar/PharData/compress.xml
@@ -7,7 +7,7 @@
   <refname>PharData::compress</refname>
   <refpurpose>Comprimir el archivo tar/zip entero usando la compresión Gzip o Bzip2</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>compression</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>extension</parameter></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Para archivos tar, este método comprime el archivo entero usando
    la compresión gzip o bzip2. El fichero resultante puede ser procesado con el
@@ -30,12 +30,12 @@
   </para>
   <para>
    Además, este método renombra automáticamente el archivo, añadiéndole <literal>.gz</literal>,
-   <literal>.bz2</literal> o eliminado la extensión si se pasa <literal>Phar::NONE</literal> para
+   <literal>.bz2</literal> o eliminado la extensión si se pasa <constant>Phar::NONE</constant> para
    eliminar la compresión. De forma alternativa, se puede expecificar una extensión de fichero con el segundo
    parámetro.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -44,8 +44,8 @@
      <term><parameter>compression</parameter></term>
      <listitem>
       <para>
-       La compresión debe ser <literal>Phar::GZ</literal> o
-       <literal>Phar::BZ2</literal> para añadir compresión, o <literal>Phar::NONE</literal>
+       La compresión debe ser <constant>Phar::GZ</constant> o
+       <constant>Phar::BZ2</constant> para añadir compresión, o <constant>Phar::NONE</constant>
        para eliminarla.
       </para>
      </listitem>
@@ -61,16 +61,16 @@
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    Devuelve un objeto de la clase <classname>PharData</classname>.
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -80,7 +80,7 @@
    no está habilitada.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -101,7 +101,7 @@ $p3 = $p2->compress(Phar::NONE); // excepción: /ruta/a/mi.tar ya existe
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -110,7 +110,7 @@ $p3 = $p2->compress(Phar::NONE); // excepción: /ruta/a/mi.tar ya existe
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/PharData/compressFiles.xml
+++ b/reference/phar/PharData/compressFiles.xml
@@ -7,14 +7,14 @@
   <refname>PharData::compressFiles</refname>
   <refpurpose>Comprime todos los ficheros del archivo tar/zip actual</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>PharData::compressFiles</methodname>
    <methodparam><type>int</type><parameter>compression</parameter></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Para archivos phar basados en tar, este método lanza una
    excepción de tipo <classname>BadMethodCallException</classname>, ya que la compresión de ficheros
@@ -30,7 +30,7 @@
    habilitada para poder descomprimir los ficheros antes de re-comprimirlos.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -39,24 +39,24 @@
      <term><parameter>compression</parameter></term>
      <listitem>
       <para>
-       La compresión debe ser <literal>Phar::GZ</literal> o
-       <literal>Phar::BZ2</literal> para añadir compresión, o <literal>Phar::NONE</literal>
+       La compresión debe ser <constant>Phar::GZ</constant> o
+       <constant>Phar::BZ2</constant> para añadir compresión, o <constant>Phar::NONE</constant>
        para eliminarla.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -68,7 +68,7 @@
    no está habilitada.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -120,7 +120,7 @@ bool(true)
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -138,7 +138,7 @@ bool(true)
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/PharData/convertToData.xml
+++ b/reference/phar/PharData/convertToData.xml
@@ -7,8 +7,8 @@
   <refname>PharData::convertToData</refname>
   <refpurpose>Convertir un archivo phar en un fichero tar o zip no ejecutable</refpurpose>
  </refnamediv>
- 
- 
+
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>compression</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>extension</parameter></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Este método se usa para convertir un archivo tar o zip no ejecutable a otro
    formato no ejecutable.
@@ -35,7 +35,7 @@
    de que el proceso haya finalizado.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -44,8 +44,8 @@
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       Este parámetro debería ser <literal>Phar::TAR</literal>
-       o <literal>Phar::ZIP</literal>. Si se establece a &null;, se conservará el
+       Este parámetro debería ser <constant>Phar::TAR</constant>
+       o <constant>Phar::ZIP</constant>. Si se establece a &null;, se conservará el
        formato de fichero existente.
       </para>
      </listitem>
@@ -54,9 +54,9 @@
      <term><parameter>compression</parameter></term>
      <listitem>
       <para>
-       Este parámetro debería ser <literal>Phar::NONE</literal> para no comprimir el archivo
-       completo, <literal>Phar::GZ</literal> para la compresión basada en zlib, y
-       <literal>Phar::BZ2</literal> para la compresión basada en bzip.
+       Este parámetro debería ser <constant>Phar::NONE</constant> para no comprimir el archivo
+       completo, <constant>Phar::GZ</constant> para la compresión basada en zlib, y
+       <constant>Phar::BZ2</constant> para la compresión basada en bzip.
       </para>
      </listitem>
     </varlistentry>
@@ -79,7 +79,7 @@
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -88,7 +88,7 @@
    excepción en caso de error.
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -100,7 +100,7 @@
    durante el proceso de la creación de phar.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -131,7 +131,7 @@ try {
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -142,7 +142,7 @@ try {
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/PharData/convertToExecutable.xml
+++ b/reference/phar/PharData/convertToExecutable.xml
@@ -7,8 +7,8 @@
   <refname>PharData::convertToExecutable</refname>
   <refpurpose>Convertir un archivo tar/zip no ejecutable en un archivo phar ejecutable</refpurpose>
  </refnamediv>
- 
- 
+
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -30,13 +30,13 @@
    En caso de éxito, el metodo crea un nuevo archivo en disco y devuelve un objeto de la clase
    <classname>PharData</classname>. El archivo antiguo no se elimina del disco, y debería hacerse manualmente después
    de que el proceso haya finalizado.
-   
+
    If successful, the method creates a new archive on disk and returns a <classname>Phar</classname>
    object.  The old archive is not removed from disk, and should be done manually after
    the process has finished.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -45,8 +45,8 @@
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       Este parámetro debería ser <literal>Phar::PHAR</literal>, <literal>Phar::TAR</literal>,
-       o <literal>Phar::ZIP</literal>. Si se establece a &null;, se conservará el
+       Este parámetro debería ser <constant>Phar::PHAR</constant>, <constant>Phar::TAR</constant>,
+       o <constant>Phar::ZIP</constant>. Si se establece a &null;, se conservará el
        formato de fichero existente.
       </para>
      </listitem>
@@ -55,9 +55,9 @@
      <term><parameter>compression</parameter></term>
      <listitem>
       <para>
-       Este parámetro debería ser <literal>Phar::NONE</literal> para no comprimir el archivo
-       completo, <literal>Phar::GZ</literal> para la compresión basada en zlib, y
-       <literal>Phar::BZ2</literal> para la compresión basada en bzip.
+       Este parámetro debería ser <constant>Phar::NONE</constant> para no comprimir el archivo
+       completo, <constant>Phar::GZ</constant> para la compresión basada en zlib, y
+       <constant>Phar::BZ2</constant> para la compresión basada en bzip.
       </para>
      </listitem>
     </varlistentry>
@@ -82,7 +82,7 @@
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -91,7 +91,7 @@
    excepción en caso de error.
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -104,7 +104,7 @@
    durante el proceso de la creación de phar.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -133,7 +133,7 @@ try {
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -144,7 +144,7 @@ try {
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -7,7 +7,7 @@
   <refname>Phar::setSignatureAlgorithm</refname>
   <refpurpose>Establecer el algoritmo de firma para un phar y aplicarlo</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -15,16 +15,16 @@
    <methodparam><type>int</type><parameter>sigtype</parameter></methodparam>
   </methodsynopsis>
   &phar.write;
-  
+
   <para>
    Establece el algoritmo de firma para un phar y lo aplica. El
-   algoritmo de firma debe ser una de las constantes <literal>Phar::MD5</literal>,
-   <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
-   <literal>Phar::SHA512</literal>, o <literal>Phar::OPENSSL</literal>.
+   algoritmo de firma debe ser una de las constantes <constant>Phar::MD5</constant>,
+   <constant>Phar::SHA1</constant>, <constant>Phar::SHA256</constant>,
+   <constant>Phar::SHA512</constant>, o <constant>Phar::OPENSSL</constant>.
    (PGP aún no está soportado y se recurre a SHA-1).
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -33,24 +33,24 @@
      <term><parameter>sigtype</parameter></term>
      <listitem>
       <para>
-       Una de las constantes <literal>Phar::MD5</literal>,
-       <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
-       <literal>Phar::SHA512</literal>, or <literal>Phar::PGP</literal>
+       Una de las constantes <constant>Phar::MD5</constant>,
+       <constant>Phar::SHA1</constant>, <constant>Phar::SHA256</constant>,
+       <constant>Phar::SHA512</constant>, or <constant>Phar::PGP</constant>
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
-  
+
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.void;
   </para>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
@@ -60,7 +60,7 @@
    si ocurrió algún problema al volcar los cambios al disco.
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
@@ -70,7 +70,7 @@
    </simplelist>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
145 occurrences were replaced from `<literal>([A-Za-z0-9_]+)::([A-Z0-9_\*]+)</literal>` to `<constant>$1::$2</constant>`.

Same as php/doc-en#2310, for the Spanish docs.