### PR TITLE
Convert curl-getinfo() constant list to table

### DIFF
--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id='function.curl-getinfo' xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
This PR converts the constant list for the second (`option`) parameter of `curl_getinfo()` to a table (as it was done in `doc-en` [here](https://github.com/php/doc-en/pull/3130)) and adds the five missing constants (`CURLINFO_CAINFO`, `CURLINFO_CAPATH`, `CURLINFO_REFERER`, `CURLINFO_RETRY_AFTER`, `CURLINFO_PROXY_ERROR`). The latter is in a separate commit so it can be easily dropped if it's not needed.