### PR TITLE
Convert MongoDB from set to book

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2330,7 +2330,7 @@ usarse en su lugar la extensión
   </para>
   <note>
    <simpara>
-    Al evaluar criterios de consulta, MongoDB compara tipos y valores según sus propias <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">reglas de comparación para tipos BSON</link>, lo cual difiere de las reglas de <link linkend="types.comparisons">comparación</link> y <link linkend="language.types.type-juggling">manejo de tipos</link> de PHP. Al encontrar un tipo BSON especial, los criterios de consulta deben utilizar la <link linkend="book.bson">clase BSON</link> respectiva (p.ej. usar <classname>MongoDB\BSON\ObjectID</classname> al encontrar un <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectID</link>).
+    Al evaluar criterios de consulta, MongoDB compara tipos y valores según sus propias <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">reglas de comparación para tipos BSON</link>, lo cual difiere de las reglas de <link linkend="types.comparisons">comparación</link> y <link linkend="language.types.type-juggling">manejo de tipos</link> de PHP. Al encontrar un tipo BSON especial, los criterios de consulta deben utilizar la <link linkend="mongodb.bson">clase BSON</link> respectiva (p.ej. usar <classname>MongoDB\BSON\ObjectID</classname> al encontrar un <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectID</link>).
    </simpara>
   </note>
  </listitem>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -3,11 +3,11 @@
 <!-- EN-Revision: 33d23851b05574b9ad0b2adcceb9d9ba713e9c6b Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 
-<book xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Arquitectura del controlador y sus entresijos</titleabbrev>
  <title>Explicación de la arquitectura del controlador y de características especiales</title>
 
- <article xml:id="mongodb.overview">
+ <section xml:id="mongodb.overview">
   <titleabbrev>Arquitectura</titleabbrev>
   <title>Vista general de la arquitectura</title>
 
@@ -39,7 +39,7 @@
    <link xlink:href="&url.mongodb.drivers;">controladores</link> mantenidos por
    MongoDB (y con suerte, también algunos controladores de la comunidad).
   </para>
-  
+
   <para>
    Justo debajo de la biblioteca tenemos los controladores de nivel más bajo: uno por plataforma.
    Estas extensiones formarán de forma efectiva el «pegamento» entre PHP y HHVM y nuestras
@@ -128,9 +128,9 @@
    solicitaremos que utilice los nuevos proyectos de antes para cualquier cosa concerniente a
    nuestros controladores de la siguiente generación.
   </para>
- </article>
+ </section>
 
- <article xml:id="mongodb.connection-handling">
+ <section xml:id="mongodb.connection-handling">
   <titleabbrev>Connections</titleabbrev>
   <title>Connection handling and persistence</title>
 
@@ -258,9 +258,9 @@ foreach ($managers as $manager) {
     <link xlink:href="&url.mongodb.libbson;">libmongoc</link> completamente.
    </para>
   </section>
- </article>
+ </section>
 
- <article xml:id="mongodb.persistence">
+ <section xml:id="mongodb.persistence">
   <titleabbrev>Persistencia de datos</titleabbrev>
   <title>Serialización y deserialización de variables de PHP en MongoDB</title>
 
@@ -916,8 +916,8 @@ function bsonUnserialize( array $map )
    </section>
   </section>
 
- </article>
-</book>
+ </section>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/book.xml
+++ b/reference/mongodb/book.xml
@@ -4,6 +4,7 @@
 <!-- Reviewed: no -->
 
 <book xml:id="set.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Controlador de MongoDB</title>
  <titleabbrev>MongoDB</titleabbrev>
 

--- a/reference/mongodb/book.xml
+++ b/reference/mongodb/book.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 1fc853737aff47054e81741af5ebba3c492ff09a Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
-<book xml:id="set.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
  <title>Controlador de MongoDB</title>
  <titleabbrev>MongoDB</titleabbrev>

--- a/reference/mongodb/book.xml
+++ b/reference/mongodb/book.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 1fc853737aff47054e81741af5ebba3c492ff09a Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
-<set xml:id="set.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<book xml:id="set.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Controlador de MongoDB</title>
  <titleabbrev>MongoDB</titleabbrev>
 
@@ -18,7 +18,7 @@
     <link linkend="class.mongodb-driver-query">consultas</link>,
     <link linkend="class.mongodb-driver-bulkwrite">escrituras</link>,
     <link linkend="class.mongodb-driver-manager">gestión de conexiones</link>
-    y <link linkend="book.bson">serialización BSON</link>.
+    y <link linkend="mongodb.bson">serialización BSON</link>.
    </simpara>
    <simpara>
     Las bibliotecas de usuario de PHP que dependan de esta extensión podrían proporcionar APIs de
@@ -35,6 +35,7 @@
  </info>
 
  &reference.mongodb.setup;
+ &reference.mongodb.constants;
  &reference.mongodb.tutorial;
  &reference.mongodb.architecture;
  &reference.mongodb.security;
@@ -43,7 +44,7 @@
  &reference.mongodb.bson;
  &reference.mongodb.monitoring;
  &reference.mongodb.exceptions;
-</set>
+</book>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/bson.xml
+++ b/reference/mongodb/bson.xml
@@ -3,10 +3,10 @@
 <!-- EN-Revision: 899b175b665b7344eee5965682605a99f8c59588 Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 
-<book xml:id="book.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="mongodb.bson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Clases de tipo BSON y funciones de serialización</title>
  <titleabbrev>MongoDB\BSON</titleabbrev>
- 
+
  <reference xml:id="ref.bson.functions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>&Functions;</title>
    &reference.mongodb.functions.entities.bson;
@@ -41,5 +41,5 @@
   &reference.mongodb.bson.int64;
   &reference.mongodb.bson.symbol;
   &reference.mongodb.bson.undefined;
- </book>
+ </part>
 

--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -3,17 +3,17 @@
 <!-- EN-Revision: 16a1bdfd1c36108534b5af08dc4b751c7ac0fdaf Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 
-<article xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
- 
+
  <section xml:id="mongodb.installation.pecl">
   <title>Instalación del Controlador de MongoDB para PHP con PECL</title>
-  
+
   <para>
    &pecl.info;
    <link xlink:href="&url.pecl.package;mongodb">&url.pecl.package;mongodb</link>
   </para>
-  
+
   <para>
    Los usuarios de Linux, Unix, y OS X pueden ejecutar el siguiente comando para instalar el
    controlador:
@@ -43,8 +43,8 @@ $ sudo pecl install mongodb
     Si el proceso de compilación no encuentra una biblioteca SSL, compruebe que
     los paquetes de desarrollo (por ej. <literal>libssl-dev</literal>) y
     <link xlink:href="&url.mongodb.wiki.pkg-config;">pkg-config</link> están
-    instalados. Si eso no resuelve el problema, considere 
-    utilizar el proceso de 
+    instalados. Si eso no resuelve el problema, considere
+    utilizar el proceso de
     <link linkend="mongodb.installation.manual">instalación manual</link>.
    </simpara>
   </note>
@@ -58,7 +58,7 @@ extension=mongodb.so
    </programlisting>
   </para>
  </section>
- 
+
  <section xml:id="mongodb.installation.homebrew">
   <title>Instalación del Controlador de MongoDB para PHP en macOS con Homebrew</title>
 
@@ -66,9 +66,9 @@ extension=mongodb.so
    <link xlink:href="https://brew.sh/2018/01/19/homebrew-1.5.0/">Homebrew 1.5.0</link>
    dejó de lado el <link xlink:href="&url.mac.homebrew;">tap Homebrew/php</link>
    y eliminó las fórmulas para las extensiones individuales de PHP. A partir de ahora,
-   se aconseja a los usuarios de macOS que instalen la 
+   se aconseja a los usuarios de macOS que instalen la
    <link xlink:href="https://formulae.brew.sh/formula/php">fórmula php</link> y
-   sigan las 
+   sigan las
    <link linkend="mongodb.installation.pecl">instrucciones de instalación estándar de PECL</link>
    utilizando el comando <link linkend="install.pecl">pecl</link> proporcionado por
    la instalación de PHP de Homebrew.
@@ -77,7 +77,7 @@ extension=mongodb.so
 
  <section xml:id="mongodb.installation.windows">
   <title>Instalación del Controlador de MongoDB para PHP en Windows</title>
-  
+
   <para>
    Hay disponibles binarios precompilados para cada versión en
    <link xlink:href="&url.pecl.package;mongodb">PECL</link> para una variedad de
@@ -85,7 +85,7 @@ extension=mongodb.so
    archivo y coloque <filename>php_mongo.dll</filename> en el directorio de extensiones
    de PHP ("ext" predeterminadamente).
   </para>
-  
+
   <para>
    Añada la siguiente línea al fichero &php.ini;:
    <programlisting role="ini">
@@ -103,10 +103,10 @@ extension=php_mongo.dll
    </para>
   </note>
  </section>
- 
+
  <section xml:id="mongodb.installation.manual">
   <title>Instalación manual del Controlador de MongoDB para PHP</title>
-  
+
   <para>
    Para los desarrolladores de controladores y gente interesada en las últimas correcciones de errores, se puede
    compilar el controlador desde el último código fuente en
@@ -124,7 +124,7 @@ $ sudo make install
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    El último paso informará sobre dónde ha sido instalado
    <filename>mongodb.so</filename>, similar a:
@@ -134,7 +134,7 @@ Installing shared extensions:     /usr/lib/php/extensions/debug-non-zts-20151012
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Asegúreser de que la opción <link linkend="ini.extension-dir">extension_dir</link>
    de &php.ini; apunta al directorio donde se instaló
@@ -147,13 +147,13 @@ $ php -i | grep extension_dir
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Si los directorios difieren, cambie
    <link linkend="ini.extension-dir">extension_dir</link> de &php.ini; o
    mueva manualmente <filename>mongodb.so</filename> al directorio correcto.
   </para>
-  
+
   <para>
    Añada la siguiente línea al fichero &php.ini;:
    <programlisting role="ini">
@@ -163,10 +163,10 @@ extension=mongodb.so
    </programlisting>
   </para>
  </section>
- 
+
  <section xml:id="mongodb.installation.hhvm">
   <title>Instalación manual de Controlador de MongoDB para HHVM</title>
-  
+
   <para>
    En el momento de escribir esto, HHVM no posee un gestor de paquetes para
    extensiones. Descargue el último controlador desde
@@ -180,7 +180,7 @@ $ git submodule sync && git submodule update --init --recursive
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Configurar los ficheros make ejecutando:
    <programlisting role="shell">
@@ -190,7 +190,7 @@ $ cmake .
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Genere los ficheros <code>configure</code> para las bibliotecas incluidas. Para que
    esto funcione, es necesario tener instalados los paquetes
@@ -202,7 +202,7 @@ $ make configlib
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Construya e instale el controlador ejecutando:
    <programlisting role="shell">
@@ -212,7 +212,7 @@ $ sudo make install
 ]]>
    </programlisting>
   </para>
-  
+
   <note>
    <para>
     Si el comando <code>hphpize</code> no está disponible, será necesario
@@ -220,7 +220,7 @@ $ sudo make install
     (p.ej. mediante <code>apt-get</code>).
    </para>
   </note>
-  
+
   <para>
    El último paso informará sobre dónde ha sido instalado
    <filename>mongodb.so</filename>, similar a:
@@ -230,7 +230,7 @@ Installing:     /usr/local/hhvm/3.9.1/lib/hhvm/extensions/20150212/mongodb.so
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Añada la siguiente línea al fichero &php.ini; (normalmente se encuentra en "/etc/hhvm"):
    <programlisting role="ini">
@@ -241,8 +241,8 @@ hhvm.dynamic_extensions[mongodb]=mongodb.so
    </programlisting>
   </para>
  </section>
- 
-</article>
+
+</section>
 
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/exceptions.xml
+++ b/reference/mongodb/exceptions.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 594b45f55e4651003dc2077f61b3ff93cead1ad1 Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 
- <book xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <titleabbrev>MongoDB\Controlador\Excepciones</titleabbrev>
   <title>Clases de excepcines</title>
 
@@ -68,5 +68,4 @@
    </itemizedlist>
   </article>
 
- </book>
- 
+ </part>

--- a/reference/mongodb/ini.xml
+++ b/reference/mongodb/ini.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: d587d7ea337c619dce2ab2bdec8f74191431b6c1 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 
-<article xml:id="mongodb.configuration" xmlns="http://docbook.org/ns/docbook">
+<section xml:id="mongodb.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
  <para>
@@ -30,14 +30,14 @@
       <entry>"0"</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Disponible desde mongodb 1.11.0.</entry>
-     </row>     
+     </row>
     </tbody>
    </tgroup>
   </table>
  </para>
- 
+
  &ini.descriptions.title;
- 
+
  <para>
   <variablelist>
    <varlistentry xml:id="ini.mongodb.debug">
@@ -112,7 +112,7 @@
     </varlistentry>
   </variablelist>
  </para>
-</article>
+</section>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mongodb/mongodb.xml
+++ b/reference/mongodb/mongodb.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 
-<book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="mongodb.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Clases del controlador de MongoDB</title>
  <titleabbrev>MongoDB\Controlador</titleabbrev>
 
@@ -30,5 +30,5 @@
   &reference.mongodb.mongodb.driver.writeconcernerror;
   &reference.mongodb.mongodb.driver.writeerror;
   &reference.mongodb.mongodb.driver.writeresult;
- </book>
+ </part>
 

--- a/reference/mongodb/monitoring.xml
+++ b/reference/mongodb/monitoring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
- <book xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Monitoring classes and subscriber functions</title>
   <titleabbrev>MongoDB\Driver\Monitoring</titleabbrev>
 
@@ -27,5 +27,5 @@
   &reference.mongodb.mongodb.driver.monitoring.commandsubscriber;
   &reference.mongodb.mongodb.driver.monitoring.sdamsubscriber;
   &reference.mongodb.mongodb.driver.monitoring.subscriber;
- </book>
+ </part>
 

--- a/reference/mongodb/tutorial.xml
+++ b/reference/mongodb/tutorial.xml
@@ -3,10 +3,10 @@
 <!-- EN-Revision: 680b85d4cc40065d48ae1f918e7579d8eb244f85 Maintainer: seros Status: ready -->
 <!-- Reviewed: yes -->
 
-<book xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Tutoriales</title>
  <titleabbrev>Tutoriales</titleabbrev>
- 
+
  <info xml:id="mongodb.tutorial.intro">
   <abstract>
    <para>
@@ -15,10 +15,10 @@
    </para>
   </abstract>
  </info>
- 
+
  &reference.mongodb.tutorial.library;
  &reference.mongodb.tutorial.apm;
-</book>
+</chapter>
 
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -3,30 +3,30 @@
 <!-- EN-Revision: dc5163157c4287bb2dbcbb33b09b0f81d3ae41fd Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
-<chapter xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Empleo de la biblioteca de PHP para MongoDB (PHPLIB)</title>
- 
+
  <para>
   Después de la configuración inicial del controlador, continuaremos explicando cómo empezar
   con el controlador de MongoDB y la correspondiente biblioteca de usuario para escribir
   nuestro primer proyecto.
  </para>
- 
+
  <section>
   <title>Instalación de la Biblioteca de PHP con Composer</title>
-  
+
   <para>
    Lo último que necesitamos instalar para empezar con la apliación
    en sí, es la biblioteca de PHP.
   </para>
-  
+
   <para>
    La bibilioteca necesita ser instalada con
    <link xlink:href="&url.mongodb.composer;">Composer</link>, un gestor de paquetes
    para PHP. Las instrucciones para instalar Composer en varias plataformas se pueden
    encontrar en su sitio web.
   </para>
-  
+
   <para>
    Instale la biblioteca ejecutando:
    <programlisting role="shell">
@@ -35,10 +35,10 @@ $ composer require "mongodb/mongodb=^1.0.0"
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Muestra algo parecido a esto:
-   
+
    <programlisting role="text">
 <![CDATA[
 ./composer.json has been created
@@ -52,17 +52,17 @@ Generating autoload files
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Composer creará varios ficheros: <code>composer.json</code>,
    <code>composer.lock</code>, y un directorio <code>vendor</code> que
    contendrá la biblioteca y cualquier otra dependencia que requiera el proyecto.
   </para>
  </section>
- 
+
  <section>
   <title>Utilizar la Biblioteca de PHP</title>
-  
+
   <para>
    Además de gestionar las dependencias, Composer también proporciona
    un autocargador (para las clases de las dependencias). Asegúrese que se
@@ -76,13 +76,13 @@ require 'vendor/autoload.php';
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Con esto hecho, ahora se puede emplear cualquier funcionalidad de la descrita en la
    <link xlink:href="&url.mongodb.library.docs;">documentación de la biblioteca</link>
    y en su <link xlink:href="&url.mongodb.library.apidocs;">API</link>.
   </para>
-  
+
   <para>
    Si ha empleado anteriormente el controlador antiguo (esto es, la extensión
    <code>mongo</code>), la API de la biblioteca debería serle familiar. Contiene una clase
@@ -98,7 +98,7 @@ require 'vendor/autoload.php';
    concordancia con una nueva <link xlink:href="&url.mongodb.crud;">specification</link>
    independiente del lenguaje.
   </para>
-  
+
   <para>
    Como ejemplo, así es como se inserta un documento en la
    colección <emphasis>beers</emphasis> de la base de datos
@@ -118,13 +118,13 @@ echo "Inserted with Object ID '{$resultado->getInsertedId()}'";
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    En lugar de inyectar el campo <code>_id</code> generado en el documento de
    entrada (tal como se hacía en el antiguo controlador), ahora se pone a disposición
    mediante el objeto de resultados devuelto por el método <code>insertOne</code>.
   </para>
-  
+
   <para>
    Por supuesto, después de la inserción también se pueden consultar los datos que se
    acaban de insertar. Para ello se utiliza el método <code>find</code>, el cual devuelve un
@@ -146,7 +146,7 @@ foreach ($resultado as $entry) {
 ]]>
    </programlisting>
   </para>
-  
+
   <para>
    Anuque pueda no ser evidente en los ejemplos, los documentos BSON y los arrays son
    deserializados como clases de tipo en la biblioteca de forma predeterminada. Estas clases aseguran
@@ -159,7 +159,7 @@ foreach ($resultado as $entry) {
    especificicación de <xref linkend="mongodb.persistence"/>.
   </para>
  </section>
-</chapter>
+</section>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
This PR converts the applicable parts of `doc-es`'s MongoDB chapter from a `<set>` to a `<book>` as is done in https://github.com/php/doc-en/pull/3627. This also needs https://github.com/php/doc-base/pull/138 to work properly.

Also, the revision hash needs to be updated once the `doc-en` changes are merged.