### PR TITLE
Update incorrect return type for fopen function

### DIFF
--- a/reference/filesystem/functions/fopen.xml
+++ b/reference/filesystem/functions/fopen.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>resource</type><methodname>fopen</methodname>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>fopen</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>mode</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>use_include_path</parameter><initializer>&false;</initializer></methodparam>


### PR DESCRIPTION
Currently the docs display a return value of resource but this should be resource|false