### PR TITLE
Update mktime documentation to php8 version

### DIFF
--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+<!-- EN-Revision: 349e3c6502e0bbeb15aef2b4a4a25f3f5e10fbfe Maintainer: seros Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mktime</refname>
@@ -116,7 +118,6 @@
    </variablelist>
   </para>
  </refsect1>                                                                                                            
-   
   
  <refsect1 role="returnvalues">
   &reftitle.returnvalues; 
@@ -229,7 +230,7 @@ echo 'Last day in Feb 2000 is: ', date('d', $ultimoDia);
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>The <classname>DateTimeImmutable</classname> class</member>
+    <member>La clase <classname>DateTimeImmutable</classname></member>
     <member><function>checkdate</function></member>
     <member><function>gmmktime</function></member>
     <member><function>date</function></member> 

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,4 +1,4 @@
-<<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,24 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+<<?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bce4e5f7d7979c5b672e9375a17860b0ced5eef3 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mktime</refname>
   <refpurpose>Obtener la marca de tiempo Unix de una fecha</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>mktime</methodname>
-   <methodparam choice="opt"><type>int</type><parameter>hour</parameter><initializer>date("H")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>minute</parameter><initializer>date("i")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>second</parameter><initializer>date("s")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>month</parameter><initializer>date("n")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>day</parameter><initializer>date("j")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>year</parameter><initializer>date("Y")</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>is_dst</parameter><initializer>-1</initializer></methodparam>
+   <type class="union"><type>int</type><type>false</type></type><methodname>mktime</methodname>
+   <methodparam><type>int</type><parameter>hour</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>minute</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>second</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>month</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>day</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>year</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Devuelve la marca de tiempo Unix correspondiente a los argumentos
@@ -27,23 +24,25 @@
    especificado.
   </para>
   <para>
-   Los argumentos pueden omitirse de derecha a izquierda; cualquier
-   argumento que se omita será establecido al valor actual según
+   Cualquier parámetro opcional omitido o a &null; se establecerá al valor actual según
    la fecha y hora locales.
   </para>
- </refsect1>
- 
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
+  <warning>
    <para>
-    Desde PHP 5.1, cuando se hace la llamada sin argumentos, <function>mktime</function>
-    lanza un aviso de tipo <constant>E_STRICT</constant>: use la 
-    función <function>time</function> en su lugar.
+    Tenga en cuenta que el orden de los argumentos es extraño:
+    <parameter>month</parameter>, <parameter>day</parameter>,
+    <parameter>year</parameter>, y no en el orden más natural de
+    <parameter>year</parameter>, <parameter>month</parameter>,
+    <parameter>day</parameter>.
    </para>
-  </note>
+  </warning>
+  <simpara>
+   Llamar a <function>mktime</function> sin argumentos no está soportado,
+   y devolverá un <classname>ArgumentCountError</classname>.
+   Puede usar <function>time</function> para obtener la marca de tiempo actual.
+  </simpara>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -114,54 +113,19 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
-     <term><parameter>is_dst</parameter></term>
-     <listitem>
-      <para>
-       Este parámetro se puede establecer a 1 si el instante está durante el horario de verano (DST), 
-       0 si no, o -1 (por omisión) si no se sabe si el instante está durante el horario
-       de verano. Si no se sabe, PHP lo intentará calcular por sí mismo.
-       Esto puede causar resultados inesperados (pero no incorrectos).
-       Algunas veces no son válidos si DST está habilitado en el sistema donde se ejecuta PHP o 
-       <parameter>is_dst</parameter> está establecido a 1. Si DST está habilitado a, p.ej. 2:00,
-       todas las horas entre las 2:00 y las 3:00 no son válidas y <function>mktime</function>
-       devuelve un valor indefinido (normalmente negativo). 
-       Algunos sistemas (p.ej. Solaris 8) habilitan DST a la medianoche por lo que la hora 0:30
-       del día, cuando DST está habilitado, es evaluada como 23:30 del día anterior.
-      </para>
-      <note>
-       <para>
-        A partir de PHP 5.1.0, este parámetro se volvió obsoleto. Como resultado, se
-        pueden usar en su lugar las nuevas características de manejo de zonas horarias.
-       </para>
-      </note>
-      <note>
-       <para>
-        Este parámetro ha sido eliminado en PHP 7.0.0.
-       </para>
-      </note>
-     </listitem>
-    </varlistentry>
    </variablelist>
   </para>
  </refsect1>                                                                                                            
- 
- 
+   
+  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues; 
   <para>
    <function>mktime</function> devuelve la marca de tiempo Unix de los argumentos
-   dados.
-   Si los argumentos no son válidos, la función devuelve &false; (antes de PHP 5.1
-   devolvía <literal>-1</literal>).
+   dados, o &false; si la marca de tiempo no cabe en un entero PHP.
   </para>
  </refsect1>
- 
- <refsect1 role="errors">
-  &reftitle.errors;
-  &date.timezone.errors.description;
- </refsect1>
- 
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -175,45 +139,25 @@
      </thead>
      <tbody>
       <row>
-       <entry>7.0.0</entry>
+       <entry>8.0.0</entry>
        <entry>
-        El parámetro <parameter>is_dst</parameter> ha sido eliminado.
+        <parameter>hour</parameter> ya no es opcional. Si necesita una
+        marca de tiempo unix, utilice <function>time</function>.
        </entry>
       </row>
       <row>
-       <entry>5.3.0</entry>
+       <entry>8.0.0</entry>
        <entry>
-        <function>mktime</function> ahora lanza un aviso de tipo <constant>E_DEPRECATED</constant> 
-        si se usa el parámetro <parameter>is_dst</parameter>.
+        <parameter>minute</parameter>, <parameter>second</parameter>, <parameter>month</parameter>,
+        <parameter>day</parameter> y <parameter>year</parameter> ahora pueden ser nulos.
        </entry>
       </row>
-      <row>
-       <entry>5.1.0</entry>
-       <entry>
-        El parámetro <parameter>is_dst</parameter> se volvió obsoleto.
-        Hacía que la funcion devolviese &false; si se pruducía un error, en vez de
-        <literal>-1</literal>.
-        Arreglada la función para que acepte el año, mes y día pasados como
-        cero.
-       </entry>
-      </row>
-      <row>
-       <entry>5.1.0</entry>
-       <entry>
-        Cuando se hace la llamada sin argumento, <function>mktime</function> lanza
-        un aviso <constant>E_STRICT</constant>. Use la
-        función <function>time</function> en su lugar.
-       </entry>
-      </row>
-      
-      &date.timezone.errors.changelog;
-      
      </tbody>
     </tgroup>
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -222,7 +166,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Establecer la zona horaria predeterminada a usar. Disponible desde PHP 5.1
+// Establece la zona horaria a utilizar.
 date_default_timezone_set('UTC');
 
 // Imprime: July 1, 2000 is on a Saturday
@@ -237,12 +181,12 @@ echo date('c', mktime(1, 2, 3, 4, 5, 2006));
   </para>
   <para>
    <example>
-    <title>Ejemplo de <function>mktime</function></title>
+    <title>Ejemplo <function>mktime</function></title>
     <para>
-     <function>mktime</function> es útil para hacer que las fechas sean
-     aritméticas y válidas, ya que calculará automáticamente el valor
-     correcto para las entradas que estén fuera de rango. Por ejemplo, cada una de las
-     líneas siguientes producirá la cadena "Jan-01-1998".
+     <function>mktime</function> es útil para hacer cálculos con fechas
+     y validaciones, ya que calculará automáticamente los valores correctos
+     para entradas fuera de rango. Por ejemplo, cada una de las siguientes líneas
+     devuelve la cadena: "Jan-01-1998".
     </para>
     <programlisting role="php">
 <![CDATA[
@@ -267,32 +211,25 @@ echo date("M-d-Y", mktime(0, 0, 0, 1, 1, 98));
     <programlisting role="php">
 <![CDATA[
 <?php
-$último_día = mktime(0, 0, 0, 3, 0, 2000);
-echo strftime("El último día en Feb 2000 es: %d", $último_día);
-$último_día = mktime(0, 0, 0, 4, -31, 2000);
-echo strftime("El último día en Feb 2000 es: %d", $último_día);
+
+$ultimoDia = mktime(0, 0, 0, 3, 0, 2000);
+echo 'Last day in Feb 2000 is: ', date('d', $ultimoDia);
+
+$ultimoDia = mktime(0, 0, 0, 4, -31, 2000);
+echo 'Last day in Feb 2000 is: ', date('d', $ultimoDia);
+
 ?>
 ]]>
     </programlisting>
    </example>
   </para>
  </refsect1>
- 
- <refsect1 role="notes">
-  &reftitle.notes;
-  <caution>
-   <para>
-    Antes de PHP 5.1.0, las marcas de tiempo negativas no estaban soportadas bajo ninguna versión
-    de Windows conocida, y tampoco en otros sistemas. Por lo tanto el rango de años
-    válidos estaba limitado desde 1970 hasta 2038.
-   </para>
-  </caution>
- </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member>The <classname>DateTimeImmutable</classname> class</member>
     <member><function>checkdate</function></member>
     <member><function>gmmktime</function></member>
     <member><function>date</function></member> 


### PR DESCRIPTION
Reviewing the mktime documentation I found differences with the English documentation since the Spanish one was outdated.

I have translated the same information that is available in the English version (https://www.php.net/manual/en/function.mktime.php)