### PR TITLE
Add "Introduction to Composer" translation

### DIFF
--- a/install/composer.xml
+++ b/install/composer.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<chapter xml:id="install.composer" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="chunk:false">
+ <title>Installation of Composer and third-party packages</title>
+
+ <sect1 xml:id="install.composer.intro">
+  <title>Introduction to Composer</title>
+  <simpara>
+   &link.composer; is a dependency manager for PHP that makes it possible
+   to define third-party code packages used by a project that can
+   then be easily installed and updated. It leverages the built-in
+   <link linkend="language.oop5.autoload">class autoloading features</link>
+   of PHP, repositories of PHP packages such as
+   <link xlink:href="&url.packagist;">Packagist</link>, and common project
+   layout and coding conventions.
+  </simpara>
+  <simpara>
+   For example, if a PHP application or website needs
+   to work with <abbrev>UUID</abbrev> values,
+   <link xlink:href="&url.packagist.package;ramsey/uuid">Ben Ramsey's
+   <literal>ramsey/uuid</literal> package</link> that implements the
+   widely known and used types of UUIDs that are defined by
+   <link xlink:href="&url.rfc;4122">RFC 4122</link> could be used.
+  </simpara>
+  <simpara>
+   Briefly, this is done by creating a <literal>composer.json</literal>
+   in the project, using Composer to install the latest version of the
+   package, and including Composer's autoload script to make it available
+   to the code. The <link xlink:href="&url.composer;doc/01-basic-usage.md">Composer
+   "Basic Usage" documentation</link> goes into this in more depth.
+  </simpara>
+  <example>
+   <title>
+    <literal>composer.json</literal> that requires a single package
+   </title>
+   <programlisting role="javascript">
+<![CDATA[
+{
+    "require": {
+        "ramsey/uuid": "^4.7"
+    }
+}
+]]>
+   </programlisting>
+  </example>
+
+ </sect1>
+</chapter>


### PR DESCRIPTION
I add a page which did not yet have a Spanish translation.
Introduction to Composer

https://www.php.net/manual/es/install.composer.intro.php