### PR TITLE
Add "Introduction to Composer" translation

### DIFF
--- a/install/composer.xml
+++ b/install/composer.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 3678a6db126048bf052180c85577daab044759aa -->
+
+<chapter xml:id="install.composer" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="chunk:false">
+ <title>Instalación de Composer y paquetes de terceros</title>
+
+ <sect1 xml:id="install.composer.intro">
+  <title>Introducción a Composer</title>
+  <simpara>
+   &link.composer; es un administrador de dependencias para PHP, lo cual hace posible
+   definir el uso de paquetes de código de terceros en un proyecto,
+   facilitando su instalación y actualización. El cual se beneficia de la característica integrada de
+   <link linkend="language.oop5.autoload">autocarga de clases</link>
+   de PHP, repositorios de paquetes de PHP como
+   <link xlink:href="&url.packagist;">Packagist</link>, y convenciones comunes
+   de diseño y codificación del proyecto.
+  </simpara>
+  <simpara>
+   Por ejemplo, si una aplicación o sitio web en PHP necesita
+   trabajar con valores <abbrev>UUID</abbrev>,
+   el <link xlink:href="&url.packagist.package;ramsey/uuid">paquete
+   <literal>ramsey/uuid</literal> de Ben Ramsey</link>
+   el cual implementa los tipos de UUID ampliamente conocidos y utilizados,
+   y definidos en <link xlink:href="&url.rfc;4122">RFC 4122</link> podrían ser utilizados.
+  </simpara>
+  <simpara>
+   Brevemente, esto se hace creando un archivo <literal>composer.json</literal>
+   en el proyecto, y usando Composer para instalar la última versión del
+   paquete, e incluyendo el script de autocarga de Composer para hacerlo disponible
+   al código. La <link xlink:href="&url.composer;doc/01-basic-usage.md">documentación
+   "Basic Usage" (Uso básico) de Composer</link> profundiza en esto.
+  </simpara>
+  <example>
+   <title>
+    <literal>composer.json</literal> el cual incluye un solo paquete.
+   </title>
+   <programlisting role="javascript">
+<![CDATA[
+{
+    "require": {
+        "ramsey/uuid": "^4.7"
+    }
+}
+]]>
+   </programlisting>
+  </example>
+
+ </sect1>
+</chapter>


### PR DESCRIPTION
I add a page which did not yet have a Spanish translation.
Introduction to Composer

https://www.php.net/manual/es/install.composer.intro.php