### PR TITLE
update EN revision number

### DIFF
--- a/appendices/configure/misc.xml
+++ b/appendices/configure/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision:  Maintainer: yago Status: ready -->
+<!-- EN-Revision: 4c676dacf58ff5d779eed96739ab4660204cbe7f Maintainer: yago Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
  <sect3 xml:id="configure.options.misc" xmlns="http://docbook.org/ns/docbook">
   <title>Otras opciones</title>
@@ -64,7 +64,7 @@
     </term>
     <listitem>
      <para>
-      Deshabilitar el paso de rutas adicionales de búsqueda de bibliotecas en tiempo de ejecución.     
+      Deshabilitar el paso de rutas adicionales de búsqueda de bibliotecas en tiempo de ejecución.
      </para>
     </listitem>
    </varlistentry>
@@ -84,7 +84,7 @@
     </term>
     <listitem>
      <para>
-      Incluir flujos de PHP experimentales. ¡No se use a menos que este 
+      Incluir flujos de PHP experimentales. ¡No se use a menos que este
       probando el código!.
      </para>
     </listitem>

--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
+<!-- EN-Revision: ca9dbbbd2dcac26d56bbbb87539297e4589bd709 Maintainer: julionc Status: ready -->
+<!-- Reviewed: no -->
 <sect1 xml:id="migration80.deprecated">
  <title>Características obsoletas</title>
 

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
+<!-- EN-Revision: b94d63fc0884d83ba43433ab33cc4810d955bf6d Maintainer: julionc Status: ready -->
+<!-- Reviewed: no -->
 <sect1 xml:id="migration80.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Cambios incompatibles hacia atrás</title>
 

--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
+<!-- EN-Revision: b94d63fc0884d83ba43433ab33cc4810d955bf6d Maintainer: julionc Status: ready -->
+<!-- Reviewed: no -->
 <sect1 xml:id="migration80.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nuevas características</title>
 

--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
+<!-- EN-Revision: b94d63fc0884d83ba43433ab33cc4810d955bf6d Maintainer: julionc Status: ready -->
+<!-- Reviewed: no -->
 <sect1 xml:id="migration80.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Otros cambios</title>
 
@@ -196,7 +197,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      Cuando mysqlnd no sea usado (que es la opción recomendada y por defecto), 
+      Cuando mysqlnd no sea usado (que es la opción recomendada y por defecto),
       la versión libmysqlclient mínima soportada es ahora 5.5.
      </para>
     </listitem>

--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: julionc Status: ready -->
+<!-- Reviewed: yes Maintainer: julionc -->
  <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook">
   <title>Constants</title>
 
@@ -20,7 +21,7 @@
   </note>
 
   <para>
-   The name of a constant follows the same rules as any label in PHP. A 
+   The name of a constant follows the same rules as any label in PHP. A
    valid constant name starts with a letter or underscore, followed
    by any number of letters, numbers, or underscores. As a regular
    expression, it would be expressed thusly:
@@ -51,7 +52,7 @@ define("2FOO",    "something");
 // This is valid, but should be avoided:
 // PHP may one day provide a magical constant
 // that will break your script
-define("__FOO__", "something"); 
+define("__FOO__", "something");
 
 ?>
 ]]>
@@ -104,15 +105,15 @@ define("__FOO__", "something");
     Unlike variables, a constant is <emphasis>not</emphasis> prepended
     with a <literal>$</literal>.
     It is also possible to use the <function>constant</function> function to
-    read a constant's value if the constant's name is obtained dynamically. 
-    Use <function>get_defined_constants</function> to get a list of 
+    read a constant's value if the constant's name is obtained dynamically.
+    Use <function>get_defined_constants</function> to get a list of
     all defined constants.
    </simpara>
 
    <note>
     <simpara>
-     Constants and (global) variables are in a different namespace. 
-     This implies that for example &true; and 
+     Constants and (global) variables are in a different namespace.
+     This implies that for example &true; and
      <varname>$TRUE</varname> are generally different.
     </simpara>
    </note>
@@ -120,12 +121,12 @@ define("__FOO__", "something");
    <simpara>
     If an undefined constant is used an <classname>Error</classname> is thrown.
     Prior to PHP 8.0.0, undefined constants would be interpreted as a bare
-    word <type>string</type>, i.e. (CONSTANT vs "CONSTANT"). 
+    word <type>string</type>, i.e. (CONSTANT vs "CONSTANT").
     This fallback is deprecated as of PHP 7.2.0, and an error of level
     <constant>E_WARNING</constant> is issued when it happens.
     Prior to PHP 7.2.0, an error of level
     <link linkend="ref.errorfunc">E_NOTICE</link> has been issued instead.
-    See also the manual entry on why 
+    See also the manual entry on why
     <link linkend="language.types.array.foo-bar">$foo[bar]</link> is
     wrong (unless <literal>bar</literal> is a constant).
     This does not apply to <link
@@ -235,7 +236,7 @@ echo ANIMALS[1]; // outputs "cat"
     </para>
    </sect2>
   </sect1>
-  
+
   <sect1 xml:id="language.constants.predefined">
    <title>Predefined constants</title>
 
@@ -255,8 +256,8 @@ echo ANIMALS[1]; // outputs "cat"
     There are nine magical constants that change depending on
     where they are used.  For example, the value of
     <constant>__LINE__</constant> depends on the line that it's
-    used on in your script. All these "magical" constants are resolved 
-    at compile time, unlike regular constants, which are resolved at runtime. 
+    used on in your script. All these "magical" constants are resolved
+    at compile time, unlike regular constants, which are resolved at runtime.
     These special constants are case-insensitive and are as follows:
    </para>
    <para>
@@ -359,7 +360,7 @@ echo ANIMALS[1]; // outputs "cat"
 
   </sect1>
  </chapter>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
+<!-- EN-Revision: e50047b76fc0be5a2345a0b7c34979e3077e8580 Maintainer: julionc Status: ready -->
+<!-- Reviewed: yes Maintainer: julionc -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>match</title>
@@ -94,7 +95,7 @@ string(18) "Eres mayor de edad"
    </note>
    <note>
     <simpara>
-     Una expresión <literal>match</literal> <emphasis>debe</emphasis> 
+     Una expresión <literal>match</literal> <emphasis>debe</emphasis>
      terminar con un punto y coma <literal>;</literal>.
     </simpara>
    </note>
@@ -104,7 +105,7 @@ string(18) "Eres mayor de edad"
  <para>
   La expresión <literal>match</literal> es similar a una
   sentencia <literal>switch</literal> pero tiene algunas diferencias clave:
-  
+
   <itemizedlist>
    <listitem>
     <simpara>

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+<!-- EN-Revision: 8c80c20688aa99cbd919f45595d4c689ff2337b9 Maintainer: julionc Status: ready -->
+<!-- Reviewed: yes Maintainer: julionc -->
 <sect1 xml:id="language.oop5.property-hooks" xmlns="http://docbook.org/ns/docbook">
  <title>Property Hooks</title>
 

--- a/reference/curl/curlhandle.xml
+++ b/reference/curl/curlhandle.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Girgias Status: ready -->
+<!-- Reviewed: no -->
 <reference xml:id="class.curlhandle" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase CurlHandle</title>

--- a/reference/curl/curlmultihandle.xml
+++ b/reference/curl/curlmultihandle.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Girgias Status: ready -->
+<!-- Reviewed: no -->
 <reference xml:id="class.curlmultihandle" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase CurlMultiHandle</title>

--- a/reference/curl/curlsharehandle.xml
+++ b/reference/curl/curlsharehandle.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Girgias Status: ready -->
+<!-- Reviewed: no -->
 <reference xml:id="class.curlsharehandle" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase CurlShareHandle</title>

--- a/reference/curl/curlstringfile.xml
+++ b/reference/curl/curlstringfile.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Girgias Status: ready -->
+<!-- Reviewed: no -->
 <reference xml:id="class.curlstringfile" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase CURLStringFile</title>

--- a/reference/curl/curlstringfile/construct.xml
+++ b/reference/curl/curlstringfile/construct.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 5017547fee4dd0873d2ced02e2bb90b696f26a24 Maintainer: Girgias Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="curlstringfile.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>CURLStringFile::__construct</refname>

--- a/reference/mongodb/monitoring.xml
+++ b/reference/mongodb/monitoring.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-
+<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: haszi Status: ready -->
+<!-- Reviewed: no -->
  <part xml:id="mongodb.monitoring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Monitoring classes and subscriber functions</title>
+  <title>Monitorización de clases y funciones de suscriptor</title>
   <titleabbrev>MongoDB\Driver\Monitoring</titleabbrev>
 
   <reference xml:id="ref.monitoring.functions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -28,4 +29,3 @@
   &reference.mongodb.mongodb.driver.monitoring.sdamsubscriber;
   &reference.mongodb.mongodb.driver.monitoring.subscriber;
  </part>
-

--- a/reference/reflection/reflectionreference.xml
+++ b/reference/reflection/reflectionreference.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Girgias Status: ready -->
+<!-- Reviewed: no -->
 
 <reference xml:id="class.reflectionreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The ReflectionReference class</title>
+ <title>La clase ReflectionReference</title>
  <titleabbrev>ReflectionReference</titleabbrev>
 
  <partintro>
@@ -12,8 +14,8 @@
   <section xml:id="reflectionreference.intro">
    &reftitle.intro;
    <para>
-    The <classname>ReflectionReference</classname> class provides information about
-    a reference.
+    La clase <classname>ReflectionReference</classname> proporciona
+    información sobre una referencia.
    </para>
   </section>
 <!-- }}} -->
@@ -32,7 +34,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <!--
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
@@ -52,7 +54,6 @@
  &reference.reflection.entities.reflectionreference;
 
 </reference>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/security/sessions.xml
+++ b/security/sessions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision:  Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 8782bc734072865ade29b8951bc94d98a53750ef Maintainer: edwincartagenah Status: ready -->
 <!-- Reviewed: yes -->
 
  <chapter xml:id="security.sessions" xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
This pull request includes updates to various XML documentation files, primarily focusing on updating the `EN-Revision` metadata and maintainer information. These changes ensure that the documentation reflects the latest revisions and maintains accurate records of the maintainers responsible for each section.

Metadata updates:

* [`appendices/configure/misc.xml`](diffhunk://#diff-d166447a28f23deba31d0168ff22130bc9f0c3ef8d0b5d955ed2027cc40314c5L3-R3): Updated `EN-Revision` metadata to `4c676dacf58ff5d779eed96739ab4660204cbe7f`.
* [`appendices/migration80/deprecated.xml`](diffhunk://#diff-53f277056ff60303fccb8d49d0da5e877315693d0901ca3c69856d271a8d9e3aL3-R4): Added `EN-Revision` metadata `ca9dbbbd2dcac26d56bbbb87539297e4589bd709` and maintainer information.
* [`appendices/migration80/incompatible.xml`](diffhunk://#diff-dc046224091f8e12cac61d0f1373afa026a8425c1dac1032440080786e77f047L3-R4): Added `EN-Revision` metadata `b94d63fc0884d83ba43433ab33cc4810d955bf6d` and maintainer information.
* [`appendices/migration80/new-features.xml`](diffhunk://#diff-b11fd6ee9964982101272e78cea8a7b8cd3e6ed8d1b706d519683608b0e8a0a8L3-R4): Added `EN-Revision` metadata `b94d63fc0884d83ba43433ab33cc4810d955bf6d` and maintainer information.
* [`appendices/migration80/other-changes.xml`](diffhunk://#diff-a438df641281cef81b9ca8ba0f8fd4b578def42bb4964a59170d8cedd8cfe129L3-R4): Added `EN-Revision` metadata `b94d63fc0884d83ba43433ab33cc4810d955bf6d` and maintainer information.

Additional updates include similar metadata revisions across multiple files in the `language`, `reference`, and `security` directories, ensuring consistency and up-to-date documentation.