### PR TITLE
add file untranslate page in appendice folder

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,0 +1,1554 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: a1ab750f296de54d79fe3749d5c9164b0593d803 Maintainer: Phildaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Descripción de las directivas internas del &php.ini;</title>
+  <para>
+   Esta lista incluye las directivas internas del &php.ini; que puede
+   definir para personalizar su configuración de PHP. Las directivas
+   gestionadas por las extensiones se enumeran y detallan en las páginas de
+   documentación respectivas de las extensiones; la información sobre las
+   directivas en las sesiones, por ejemplo, se puede encontrar en la
+   página de documentación de las <link linkend="session.configuration">sesiones</link>.
+  </para>
+  <note>
+   <para>
+    Los valores predeterminados enumerados aquí se utilizarán cuando &php.ini;
+    no se carga; los valores de los archivos &php.ini; en entornos de producción
+    y desarrollo pueden variar.
+   </para>
+  </note>
+
+  <section xml:id="ini.sect.language-options">
+   <title>Opciones del lenguaje</title>
+   <para>
+    <table>
+     <title>Opciones de configuración</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Default;</entry>
+        <entry>&Changeable;</entry>
+        <entry>&Changelog;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><link linkend="ini.short-open-tag">short_open_tag</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.precision">precision</link></entry>
+        <entry>"14"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.serialize-precision">serialize_precision</link></entry>
+        <entry>"-1"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry>
+         Antes de PHP 7.1.0, el valor predeterminado era 17.
+        </entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.disable-functions">disable_functions</link></entry>
+        <entry>""</entry>
+        <entry><constant>INI_SYSTEM</constant> solo</entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
+        <entry>""</entry>
+        <entry>&php.ini; solo</entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
+        <entry>""</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.expose-php">expose_php</link></entry>
+        <entry>"1"</entry>
+        <entry>&php.ini; solo</entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.hard-timeout">hard_timeout</link></entry>
+        <entry>"2"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry>Disponible a partir de 7.1.0.</entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.zend.exception-ignore-args">zend.exception_ignore_args</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry>Disponible a partir de 7.4.0</entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.zend.multibyte">zend.multibyte</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.zend.script-encoding">zend.script_encoding</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.zend.detect-unicode">zend.detect-unicode</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.zend.signal-check">zend.signal_check</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.zend.assertions">zend.assertions</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_ALL</constant> con restricciones</entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.zend.exception-string-param-max-len">zend.exception_string_param_max_len</link></entry>
+        <entry>"15"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry>Disponible a partir de PHP 8.0.0.</entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+   </para>
+
+   &ini.descriptions.title;
+
+   <para>
+    <variablelist>
+     <varlistentry xml:id="ini.short-open-tag">
+      <term>
+       <parameter>short_open_tag</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Define si las etiquetas cortas de apertura de PHP (<userinput>&lt;? ?&gt;</userinput>) están permitidas o no. Si desea usar PHP con XML, debe desactivar esta opción de configuración para poder usar <userinput>&lt;?xml ?&gt;</userinput>. De lo contrario, puede escribirlo usando PHP, por ejemplo: <userinput>&lt;?php echo '&lt;?xml version="1.0"&gt;'; ?&gt;</userinput>. Si esta opción está desactivada, debe usar la versión larga de las etiquetas de apertura de PHP (<userinput>&lt;?php ?&gt;</userinput>).
+       </para>
+       <note>
+        <para>
+         Esta directiva no afecta el uso de <userinput>&lt;?=</userinput>, que siempre está disponible.
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.precision">
+      <term>
+       <parameter>precision</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        El número de decimales significativos que se mostrarán en los números de coma flotante. <literal>-1</literal> significa que se utilizará el mejor algoritmo para redondear este número.
+       </simpara>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.serialize-precision">
+      <term>
+       <parameter>serialize_precision</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        El número de dígitos significativos conservados al serializar números de coma flotante. <literal>-1</literal> significa que se utilizará el mejor algoritmo para redondear este número.
+       </simpara>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.expose-php">
+      <term>
+       <parameter>expose_php</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Expone a todos los clientes el hecho de que PHP está instalado en el servidor. Esto incluye la versión de PHP en los encabezados HTTP de la respuesta (X-Powered-By: PHP/5.3.7).
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.disable-functions">
+      <term>
+       <parameter>disable_functions</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Esta directiva le permite deshabilitar ciertas funciones. Toma una lista de nombres de funciones separados por comas.
+       </para>
+       <para>
+        Solo las <link linkend="functions.internal">funciones internas</link> pueden deshabilitarse usando esta directiva. Las <link linkend="functions.user-defined">funciones definidas por el usuario</link> no se ven afectadas.
+       </para>
+       <para>
+        Esta directiva debe definirse en el &php.ini;. Por ejemplo, no puede definirse en el archivo &httpd.conf;.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.disable-classes">
+      <term>
+       <parameter>disable_classes</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <simpara>
+        Esta directiva le permite deshabilitar ciertas clases. Toma una lista de nombres de clases separados por comas.
+       </simpara>
+       <simpara>
+        Esta directiva debe definirse en el &php.ini;. Por ejemplo, no puede definirse en el archivo &httpd.conf;.
+       </simpara>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.zend.assertions">
+      <term>
+       <parameter>zend.assertions</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        Cuando se establece en <literal>1</literal>, se generará el código de aserción (en modo de desarrollo). Cuando se establece en <literal>0</literal>, se generará el código de aserción, pero se ignorará (no se ejecutará) durante la ejecución. Cuando se establece en <literal>-1</literal>, el código de aserción no se generará, haciendo que las aserciones sean completamente neutrales (en modo de producción).
+       </simpara>
+       <note>
+        <para>
+         Si un proceso se inicia en modo de producción, <link linkend="ini.zend.assertions">zend.assertions</link> no puede cambiarse en tiempo de ejecución, ya que el código para las aserciones no se ha generado.
+        </para>
+        <para>
+         Si un proceso se inicia en modo de desarrollo, <link linkend="ini.zend.assertions">zend.assertions</link> no puede establecerse en <literal>-1</literal> en tiempo de ejecución.
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.zend.exception-string-param-max-len">
+      <term>
+       <parameter>zend.exception_string_param_max_len</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        La longitud máxima de los argumentos de función de cadenas en los trazas de pila convertidos en cadenas. Debe estar en el rango entre <literal>"0"</literal> y <literal>"1000000"</literal>.
+       </simpara>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.hard-timeout">
+      <term>
+       <parameter>hard_timeout</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+        Cuando se alcanza el tiempo de espera establecido en <link linkend="ini.max-execution-time">max_execution_time</link>, el tiempo de ejecución de PHP destruirá los recursos de manera elegante. Si algo se bloquea cuando esto ocurre, se activará el tiempo de espera forzado durante el número de segundos establecido. Cuando se alcanza el tiempo de espera forzado, PHP saldrá de manera no elegante. Cuando se establece en 0, el tiempo de espera forzado nunca se activará.
+       </para>
+       <para>
+        Cuando PHP finaliza con un tiempo de espera forzado, se verá algo así: <screen>
+<![CDATA[
+Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unknown on line 0
+]]>
+        </screen>
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.zend.exception-ignore-args">
+      <term>
+       <parameter>zend.exception_ignore_args</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Excluye los argumentos en los trazas de pila generados desde las excepciones.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.zend.multibyte">
+      <term>
+       <parameter>zend.multibyte</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Activa el análisis léxico de archivos PHP en codificaciones multibyte. Activar zend.multibyte es necesario para usar ciertas codificaciones de caracteres como SJIS, BIG5, etc., que contienen caracteres especiales en codificación multibyte. Las codificaciones compatibles con ISO-8859-1 como UTF-8, EUC, etc., no requieren esta opción.
+       </para>
+       <para>
+        Activar zend.multibyte requiere la extensión mbstring.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.zend.script-encoding">
+      <term>
+       <parameter>zend.script_encoding</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Este valor se usará a menos que una directiva <link linkend="control-structures.declare.encoding">declare(encoding=...)</link> aparezca en la parte superior del script. Cuando se usa una codificación incompatible con ISO-8859-1, se deben usar las opciones zend.multibyte y zend.script_encoding.
+       </para>
+       <para>
+        Las cadenas de caracteres se convertirán desde zend.script_encoding a mbstring.internal_encoding, como si se hubiera llamado a la función <function>mb_convert_encoding</function>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.zend.detect-unicode">
+      <term>
+       <parameter>zend.detect_unicode</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Verifica el <literal>BOM (Byte Order Mark)</literal> y mira si el archivo contiene caracteres multibyte válidos. Esta detección se realiza antes de que se ejecute la función <function>__halt_compiler</function>. Disponible solo en modo multibyte de Zend.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.zend.signal-check">
+      <term>
+       <parameter>zend.signal_check</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Verifica si se está utilizando un manejador de señales de reemplazo al detenerse.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.exit-on-timeout">
+      <term>
+       <parameter>exit_on_timeout</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Esta es una directiva solo para Apache1 mod_php que fuerza a los hilos de Apache a salir si ocurre un tiempo de espera de expiración de PHP. Tal expiración produce internamente una llamada a longjmp() en Apache1 que puede dejar algunas extensiones en un estado no consistente. Al terminar el proceso, todos los bloqueos y la memoria se limpiarán.
+       </para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+   </para>
+  </section>
+
+  <section xml:id="ini.sect.resource-limits">
+   <title>Límite de recursos</title>
+   <para>
+    <table>
+     <title>Opciones de configuración</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Default;</entry>
+        <entry>&Changeable;</entry>
+        <entry>&Changelog;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><link linkend="ini.memory-limit">memory_limit</link></entry>
+        <entry>"128M"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+   </para>
+
+   &ini.descriptions.title;
+
+   <para>
+    <variablelist>
+     <varlistentry xml:id="ini.memory-limit">
+      <term>
+       <parameter>memory_limit</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+        Esta opción determina la memoria límite, en bytes, que un script está permitido asignar. Esto evita que un script mal codificado use toda la memoria. Tenga en cuenta que para no tener ningún límite, debe establecer esta directiva en <literal>-1</literal>.
+       </para>
+
+       &ini.shorthandbytes;
+
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </para>
+   <para>
+    Véase también: <link linkend="ini.max-execution-time">max_execution_time</link>.
+   </para>
+  </section>
+
+  <section xml:id="ini.sect.performance">
+   <title>Ajuste de rendimiento</title>
+   <para>
+    <table>
+     <title>Ajuste de rendimiento</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Default;</entry>
+        <entry>&Changeable;</entry>
+        <entry>&Changelog;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><link linkend="ini.realpath-cache-size">realpath_cache_size</link></entry>
+        <entry>"4M"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry>Antes de PHP 7.0.16 y 7.1.2, el valor predeterminado era <literal>"16K"</literal></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.realpath-cache-ttl">realpath_cache_ttl</link></entry>
+        <entry>"120"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+    <note>
+     <para>
+      Usar <link linkend="ini.open-basedir">open_basedir</link> <emphasis>desactivará</emphasis> la caché realpath.
+     </para>
+    </note>
+   </para>
+   &ini.descriptions.title;
+   <para>
+    <variablelist>
+     <varlistentry xml:id="ini.realpath-cache-size">
+      <term>
+       <parameter>realpath_cache_size</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+        Determina el tamaño de la caché de realpath que usará PHP. Este valor debería aumentarse en sistemas donde PHP abre varios archivos, para reflejar la cantidad de operaciones realizadas en los archivos.
+       </para>
+       <para>
+        El tamaño representa el número total de bytes en la cadena almacenada del camino, más el tamaño de los datos asociados con la entrada de la caché. Esto significa que para almacenar caminos largos en la caché, el tamaño de la caché debe ser lo suficientemente grande. Este valor no controla directamente el número de caminos distintos que pueden almacenarse en caché.
+       </para>
+       <para>
+        El tamaño necesario para los datos de la entrada de la caché depende del sistema.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="ini.realpath-cache-ttl">
+      <term>
+       <parameter>realpath_cache_ttl</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+        Tiempo (en segundos) durante el cual persiste la información de la caché de realpath para un archivo o directorio dado. Para sistemas con archivos que cambian poco, considere aumentar este valor.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </para>
+  </section>
+
+  <section xml:id="ini.sect.data-handling">
+   <title>Manejo de datos</title>
+   <para>
+    <table>
+     <title>Opciones de configuración</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Default;</entry>
+        <entry>&Changeable;</entry>
+        <entry>&Changelog;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><link linkend="ini.arg-separator.output">arg_separator.output</link></entry>
+        <entry>"&amp;"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.arg-separator.input">arg_separator.input</link></entry>
+        <entry>"&amp;"</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.variables-order">variables_order</link></entry>
+        <entry>"EGPCS"</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.request-order">request_order</link></entry>
+        <entry>""</entry>
+        <entry><constant>INI_SYSTEM</constant>|<constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.auto-globals-jit">auto_globals_jit</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.post-max-size">post_max_size</link></entry>
+        <entry>"8M"</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.auto-prepend-file">auto_prepend_file</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.auto-append-file">auto_append_file</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.default-mimetype">default_mimetype</link></entry>
+        <entry>"text/html"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.default-charset">default_charset</link></entry>
+        <entry>"UTF-8"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.input-encoding">input_encoding</link></entry>
+        <entry>""</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.output-encoding">output_encoding</link></entry>
+        <entry>""</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.internal-encoding">internal_encoding</link></entry>
+        <entry>""</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+   </para>
+
+   &ini.descriptions.title;
+
+   <para>
+    <variablelist>
+     <varlistentry xml:id="ini.arg-separator.output">
+      <term>
+       <parameter>arg_separator.output</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        El separador utilizado cuando PHP genera las URL para separar los argumentos.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.arg-separator.input">
+      <term>
+       <parameter>arg_separator.input</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Lista de separadores utilizados por PHP para analizar las URL entrantes y deducir los valores.
+       </para>
+       <note>
+        <para>
+         ¡Cada carácter de esta directiva se considera un separador!
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.variables-order">
+      <term>
+       <parameter>variables_order</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Define el orden de análisis de las variables EGPCS (<literal>E</literal>nvironment, <literal>G</literal>et, <literal>P</literal>ost, <literal>C</literal>ookie y <literal>S</literal>erver). Por ejemplo, si variables_order se establece en <literal>"SP"</literal>, entonces PHP creará &link.superglobals; <varname>$_SERVER</varname> y <varname>$_POST</varname>, pero no creará <varname>$_ENV</varname>, <varname>$_GET</varname> y <varname>$_COOKIE</varname>. Establecer este orden en "" significa que ninguna &link.superglobals; se definirá.
+       </para>
+       <warning>
+        <para>
+         En las SAPIs CGI y FastCGI, <varname>$_SERVER</varname> también se llena con valores del entorno; <literal>S</literal> siempre es equivalente a <literal>ES</literal> en lo que respecta a la posición de <literal>E</literal> en cualquier otro lugar en esta directiva.
+        </para>
+       </warning>
+       <note>
+        <para>
+         El contenido y el orden de <varname>$_REQUEST</varname> también se ven afectados por esta directiva.
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.request-order">
+      <term>
+       <parameter>request_order</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Esta directiva describe el orden en el que PHP coloca las variables GET, POST y Cookie en la matriz _REQUEST. La colocación se realiza de izquierda a derecha, con los valores más recientes sobrescribiendo los valores más antiguos.
+       </para>
+       <para>
+        Si esta directiva no está definida, se utiliza <link linkend="ini.variables-order">variables_order</link> para el contenido de <varname>$_REQUEST</varname>.
+       </para>
+       <para>
+        Tenga en cuenta que los archivos <filename>php.ini</filename> de la distribución predeterminada no contienen <literal>'C'</literal> para las cookies, por razones de seguridad.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.auto-globals-jit">
+      <term>
+       <parameter>auto_globals_jit</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Cuando esta directiva está activada, las variables SERVER, REQUEST y ENV se crean cuando se usan: solo si es necesario. Si estas variables no se usan en un script, el script verá un aumento en el rendimiento.
+       </para>
+       <warning>
+        <para>
+         El uso de las variables SERVER, REQUEST y ENV se verifica durante la compilación. Por lo tanto, usarlas con, por ejemplo, <link linkend="language.variables.variable">variables dinámicas</link> no provocará su inicialización.
+        </para>
+       </warning>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.register-argc-argv">
+      <term>
+       <parameter>register_argc_argv</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <simpara>
+        Le dice a PHP si debe declarar o no las variables argv y argc (que contendrán la información GET).
+       </simpara>
+       <simpara>
+        Véase también las <link linkend="features.commandline">líneas de comando</link>.
+       </simpara>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.enable-post-data-reading">
+      <term>
+       <parameter>enable_post_data_reading</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <simpara>
+        Si se desactiva esta opción, las variables <varname>$_POST</varname> y <varname>$_FILES</varname> no se <emphasis>poblarán</emphasis>. La única forma de leer los datos transmitidos será usando el manejador de flujo <link linkend="wrappers.php">php://input</link>. Esto puede ser interesante para las solicitudes a través de un proxy o para analizar los datos transmitidos directamente en la memoria.
+       </simpara>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.post-max-size">
+      <term>
+       <parameter>post_max_size</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        Define el tamaño máximo de los datos recibidos por el método POST. Esta opción también afecta a los archivos cargados. Para cargar archivos grandes, este valor debe ser mayor que el valor de <link linkend="ini.upload-max-filesize">upload_max_filesize</link>.
+       </simpara>
+       <simpara>
+        De manera general, <link linkend="ini.memory-limit">memory_limit</link> debe ser mayor que <parameter>post_max_size</parameter>.
+       </simpara>
+
+       &ini.shorthandbytes;
+
+       <simpara>
+        Si el tamaño de los datos recibidos por el método POST es mayor que <parameter>post_max_size</parameter>, las <link linkend="language.variables.superglobals">superglobales</link> <varname>$_POST</varname> y <varname>$_FILES</varname> estarán vacías. Esto se puede monitorear de diferentes formas, por ejemplo, pasando una variable <varname>$_GET</varname> al script que procesa los datos, es decir, <literal>&lt;form action="edit.php?processed=1"&gt;</literal>, y luego verificar si <varname>$_GET['processed']</varname> está definido.
+       </simpara>
+       <para>
+        <note>
+         <para>
+          PHP permite palabras clave para los bytes, incluyendo K (kilo), M (mega) y G (giga). PHP realiza la conversión automáticamente si usa estas palabras clave. Tenga cuidado de no exceder el límite de un entero con signo de 32 bits (si usa las versiones de 32 bits), en cuyo caso su script fallará.
+         </para>
+        </note>
+       </para>
+       <para>
+        <table>
+         <title>Historial para <literal>post_max_size</literal></title>
+         <tgroup cols="2">
+          <thead>
+           <row>
+            <entry>&Version;</entry>
+            <entry>&Description;</entry>
+           </row>
+          </thead>
+          <tbody>
+           <row>
+            <entry>5.3.4</entry>
+            <entry>
+             <parameter>post_max_size</parameter> = 0 no desactivará el límite cuando el tipo de contenido es application/x-www-form-urlencoded o no está registrado con PHP.
+            </entry>
+           </row>
+           <row>
+            <entry>5.3.2 , 5.2.12</entry>
+            <entry>
+             Permite un tamaño de envío ilimitado estableciendo <parameter>post_max_size</parameter> en 0.
+            </entry>
+           </row>
+          </tbody>
+         </tgroup>
+        </table>
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.auto-prepend-file">
+      <term>
+       <parameter>auto_prepend_file</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Especifica el nombre de un archivo que se recorrerá automáticamente antes del archivo principal. Este archivo se incluye como si se hubiera incluido con la función <function>require</function>, por lo que se usa <link linkend="ini.include-path">include_path</link>.
+       </para>
+       <para>
+        El valor especial <literal>none</literal> desactiva la adición automática.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.auto-append-file">
+      <term>
+       <parameter>auto_append_file</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Especifica el nombre del archivo que se recorrerá automáticamente después del archivo principal. Este archivo se incluye como si se hubiera incluido con la función <function>require</function>, por lo que se usa <link linkend="ini.include-path">include_path</link>.
+       </para>
+       <para>
+        El valor especial <literal>none</literal> desactiva la adición automática.
+        <note>
+         <simpara>
+          Si el script termina con la función <function>exit</function>, no se realizará la adición automática.
+         </simpara>
+        </note>
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.default-mimetype">
+      <term>
+       <parameter>default_mimetype</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Por defecto, PHP enviará el tipo de medio usando el encabezado Content-Type. Para desactivar esto, deje este valor vacío.
+       </para>
+       <para>
+        El tipo de medio predeterminado en PHP es text/html.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.default-charset">
+      <term>
+       <parameter>default_charset</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        "UTF-8" es el valor predeterminado y se usa como el conjunto de caracteres predeterminado para las funciones y módulos. PHP siempre enviará un conjunto de caracteres predeterminado para <function>htmlentities</function>, <function>html_entity_decode</function> y <function>htmlspecialchars</function> si se omite el parámetro <parameter>encoding</parameter>. El valor de <parameter>default_charset</parameter> también se usará para establecer el conjunto de caracteres predeterminado para las funciones <link linkend="book.iconv">iconv</link> si las opciones de configuración <link linkend="ini.iconv.input-encoding"><parameter>iconv.input_encoding</parameter></link>, <link linkend="ini.iconv.output-encoding"><parameter>iconv.output_encoding</parameter></link> y <link linkend="ini.iconv.internal-encoding"><parameter>iconv.internal_encoding</parameter></link> no están definidas, y para las funciones <link linkend="book.mbstring">mbstring</link> si las opciones de configuración <link linkend="ini.mbstring.http-input"><parameter>mbstring.http_input</parameter></link>, <link linkend="ini.mbstring.http-output"><parameter>mbstring.http_output</parameter></link> y <link linkend="ini.mbstring.internal-encoding"><parameter>mbstring.internal_encoding</parameter></link> no están definidas.
+       </para>
+       <para>
+        Todas las versiones de PHP usarán este valor como el conjunto de caracteres predeterminado en el encabezado Content-Type predeterminado enviado por PHP si el encabezado no se sobrescribe a través de una llamada a la función <function>header</function>.
+       </para>
+       <para>
+        No se recomienda establecer un <parameter>default_charset</parameter> en un valor vacío.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.input-encoding">
+      <term>
+       <parameter>input_encoding</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Este parámetro se usa para los módulos multibyte como mbstring e iconv. Vacío por defecto.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.output-encoding">
+      <term>
+       <parameter>output_encoding</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Este parámetro se usa para los módulos multibyte como mbstring e iconv. Vacío por defecto.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.internal-encoding">
+      <term>
+       <parameter>internal_encoding</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Este parámetro se usa para los módulos multibyte como mbstring e iconv. Vacío por defecto. Si está vacío, se usa <link linkend="ini.default-charset">default_charset</link>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+   </para>
+  </section>
+
+  <section xml:id="ini.sect.path-directory">
+   <title>Rutas y directorios</title>
+   <para>
+    <table>
+     <title>Opciones de configuración</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Default;</entry>
+        <entry>&Changeable;</entry>
+        <entry>&Changelog;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><link linkend="ini.include-path">include_path</link></entry>
+        <entry>".;/ruta/a/php/pear"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.open-basedir">open_basedir</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.doc-root">doc_root</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.user-dir">user_dir</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link></entry>
+        <entry>"300"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.user-ini.filename">user_ini.filename</link></entry>
+        <entry>".user.ini"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.extension-dir">extension_dir</link></entry>
+        <entry>"/ruta/a/php"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.extension">extension</link></entry>
+        <entry>NULL</entry>
+        <entry>&php.ini; solo</entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.zend-extension">zend_extension</link></entry>
+        <entry>NULL</entry>
+        <entry>&php.ini; solo</entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.cgi.check-shebang-line">cgi.check_shebang_line</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.cgi.discard-path">cgi.discard_path</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.cgi.fix-pathinfo">cgi.fix_pathinfo</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.cgi.force-redirect">cgi.force_redirect</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.cgi.nph">cgi.nph</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.cgi.redirect-status-env">cgi.redirect_status_env</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.cgi.rfc2616-headers">cgi.rfc2616_headers</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.fastcgi.impersonate">fastcgi.impersonate</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.fastcgi.logging">fastcgi.logging</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+   </para>
+
+   &ini.descriptions.title;
+
+   <para>
+    <variablelist>
+     <varlistentry xml:id="ini.include-path">
+      <term>
+       <parameter>include_path</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Especifica una lista de directorios donde las funciones <function>require</function>, <function>include</function>, <function>fopen</function>, <function>file</function>, <function>readfile</function> y <function>file_get_contents</function> buscarán los archivos. El formato es idéntico a la variable de entorno del sistema <envar>PATH</envar>: una lista de directorios separados por dos puntos (<literal>:</literal>) en Unix o por un punto y coma (<literal>;</literal>) en Windows.
+       </para>
+       <para>
+        PHP considera cada entrada del camino de inclusión por separado al buscar archivos para incluir. Verificará el primer camino y, si no encuentra el archivo, verificará el siguiente camino, hasta encontrar el archivo para incluir o devolver una alerta de tipo <constant>E_WARNING</constant> o de tipo <constant>E_ERROR</constant> usando la función <function>set_include_path</function>.
+       </para>
+       <para>
+        <example>
+         <title>include_path en Unix</title>
+         <programlisting role="php.ini">
+<![CDATA[
+include_path=".:/php/includes"
+]]>
+         </programlisting>
+        </example>
+       </para>
+       <para>
+        <example>
+         <title>include_path en Windows</title>
+         <programlisting role="php.ini">
+<![CDATA[
+include_path=".;c:\php\includes"
+]]>
+         </programlisting>
+        </example>
+       </para>
+       <para>
+        El uso de un punto (<literal>.</literal>) en el camino de inclusión le permite hacer inclusiones relativas al directorio actual. Sin embargo, es más eficiente incluir explícitamente un archivo con <literal>include './file'</literal> que pedirle a PHP que verifique el directorio actual en cada inclusión.
+       </para>
+       <note>
+        <para>
+         Las variables <literal>ENV</literal> también están disponibles en los archivos .ini. Por lo tanto, es posible hacer referencia al directorio home usando la sintaxis <literal>${LOGIN}</literal> y <literal>${USER}</literal>.
+        </para>
+        <para>
+         Las variables de entorno pueden variar según las APIs del servidor, así como según los entornos.
+        </para>
+       </note>
+       <para>
+        <example>
+         <title>include_path en Unix usando la variable de entorno ${USER}</title>
+         <programlisting role="php.ini">
+<![CDATA[
+include_path = ".:${USER}/pear/php"
+]]>
+         </programlisting>
+        </example>
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.open-basedir">
+      <term>
+       <parameter>open_basedir</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Limita los archivos que pueden ser accedidos por PHP a una estructura de directorios específica, incluyendo el archivo mismo.
+       </para>
+       <para>
+        Cuando un script intenta acceder a un archivo con, por ejemplo, la función <function>include</function> o la función <function>fopen</function>, la ruta al archivo se analiza. Cuando el archivo se encuentra fuera de la estructura de directorios especificada, PHP se negará a acceder a él. Todos los enlaces simbólicos se resuelven, por lo que no es posible eludir esta restricción con un enlace simbólico. Si el archivo no existe, entonces el enlace simbólico no se puede resolver y el nombre del archivo se compara con <option>open_basedir</option>.
+       </para>
+       <para>
+        La opción <option>open_basedir</option> puede afectar más que las funciones del sistema de archivos; por ejemplo, si MySQL está configurado para usar el controlador mysqlnd, <literal>LOAD DATA INFILE</literal> se verá afectado por la opción <option>open_basedir</option>. La mayoría de las extensiones de PHP usan la opción <literal>open_basedir</literal> de esta manera.
+       </para>
+       <para>
+        El valor especial <systemitem class="filesystem">.</systemitem> indica que se usará el directorio actual del script como directorio base. Sin embargo, esto es ligeramente peligroso en el sentido de que el directorio actual puede cambiarse fácilmente con la función <function>chdir</function>.
+       </para>
+       <para>
+        En el archivo <filename>httpd.conf</filename>, <option>open_basedir</option> puede desactivarse (por ejemplo, para algunos hosts virtuales) de la <link linkend="configuration.changes.apache">misma manera</link> que cualquier directiva de configuración con "<literal>php_admin_value open_basedir none</literal>".
+       </para>
+       <para>
+        En Windows, separe los directorios con un punto y coma. En todos los demás sistemas, separe los directorios con dos puntos. Al usar Apache como módulo, los caminos de <option>open_basedir</option> desde los directorios padres ahora se heredan automáticamente.
+       </para>
+       <para>
+        La restricción especificada con <option>open_basedir</option> es un nombre de directorio, no un prefijo.
+       </para>
+       <para>
+        De manera predeterminada, todos los archivos pueden abrirse.
+       </para>
+       <note>
+        <simpara>
+         <option>open_basedir</option> puede afinarse en el momento de la ejecución. Esto significa que si <option>open_basedir</option> se establece en <literal>/www/</literal> en el archivo &php.ini;, un script puede afinar la configuración en <literal>/www/tmp/</literal> en el momento de la ejecución usando la función <function>ini_set</function>. Al recorrer varios directorios, puede usar la constante <constant>PATH_SEPARATOR</constant> según el sistema operativo.
+        </simpara>
+        <simpara>
+         A partir de PHP 8.3.0, <option>open_basedir</option> ya no acepta rutas que contengan el directorio padre (<literal>..</literal>) cuando se establece en tiempo de ejecución.
+        </simpara>
+       </note>
+       <note>
+        <para>
+         Usar open_basedir establecerá <link linkend="ini.realpath-cache-size">realpath_cache_size</link> a <literal>0</literal> y, por lo tanto, <emphasis>desactivará</emphasis> la caché realpath.
+        </para>
+       </note>
+       <caution>
+        <para>
+         <literal>open_basedir</literal> es solo una medida de protección adicional y no es de ninguna manera exhaustiva, y no debe dependerse de ella cuando se necesita seguridad.
+        </para>
+       </caution>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.doc-root">
+      <term>
+       <parameter>doc_root</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        El directorio raíz de PHP en el servidor. Solo se usa si no está vacío. Si PHP no se compiló con FORCE_REDIRECT, debe definir el doc_root si usa PHP como CGI bajo cualquier servidor web (distinto de IIS). Alternativamente, puede usar la configuración <link linkend="ini.cgi.force-redirect">cgi.force_redirect</link>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.user-ini.cache-ttl">
+      <term>
+       <parameter>user_ini.cache_ttl</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.user-ini.filename">
+      <term>
+       <parameter>user_ini.filename</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.user-dir">
+      <term>
+       <parameter>user_dir</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        El nombre base del directorio usado en un directorio de usuario para los archivos PHP, por ejemplo, <filename class="directory">public_html</filename>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.extension-dir">
+      <term>
+       <parameter>extension_dir</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Especifica el directorio donde PHP debe buscar extensiones externas para cargar. Se recomienda especificar una ruta absoluta. Véase también <link linkend="ini.enable-dl">enable_dl</link> y <function>dl</function>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.extension">
+      <term>
+       <parameter>extension</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Qué extensiones deben cargarse dinámicamente al iniciar PHP.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.zend-extension">
+      <term>
+       <parameter>zend_extension</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Nombre de la extensión Zend cargable dinámicamente (por ejemplo, XDebug) que se cargará al iniciar PHP.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.cgi.check-shebang-line">
+      <term>
+       <parameter>cgi.check_shebang_line</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Controla si PHP CGI verifica la línea que comienza con <literal>#!</literal> (shebang) en la parte superior del script ejecutado. Esta línea es necesaria si el script está destinado a ejecutarse de forma independiente y a través de un PHP CGI. PHP en modo CGI no lee esta línea y omite su contenido si esta directiva está activa.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.cgi.discard-path">
+      <term>
+       <parameter>cgi.discard_path</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Si está activado, el binario PHP CGI puede colocarse fuera del árbol web de manera segura y las personas no podrán eludir la seguridad .htaccess.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.cgi.fix-pathinfo">
+      <term>
+       <parameter>cgi.fix_pathinfo</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Proporciona un <emphasis>real</emphasis> <literal>PATH_INFO</literal>/<literal>PATH_TRANSLATED</literal> para CGI. El comportamiento anterior de PHP era establecer <literal>PATH_TRANSLATED</literal> en <literal>SCRIPT_FILENAME</literal> y no llenar <literal>PATH_INFO</literal>. Para obtener más información sobre <literal>PATH_INFO</literal>, consulte las especificaciones CGI. Si se establece en <literal>1</literal>, PHP CGI corregirá este camino según las especificaciones. Si se establece en <literal>0</literal>, PHP aplicará el comportamiento anterior. De manera predeterminada, esta directiva está activada. Debe modificar sus scripts para usar <literal>SCRIPT_FILENAME</literal> en lugar de <literal>PATH_TRANSLATED</literal>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.cgi.force-redirect">
+      <term>
+       <parameter>cgi.force_redirect</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        cgi.force_redirect es necesario por razones de seguridad al usar PHP en modo CGI bajo la mayoría de los servidores web. Si no lo establece, PHP lo activará automáticamente de manera predeterminada. Puede desactivarlo <emphasis>bajo su propio riesgo</emphasis>.
+       </para>
+       <note>
+        <para>
+         Usuarios de Windows: Al usar IIS, esta opción <emphasis>debe</emphasis> desactivarse; lo mismo ocurre con OmniHTTPD y Xitami.
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.cgi.nph">
+      <term>
+       <parameter>cgi.nph</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Si cgi.nph está activado, forzará a CGI a enviar siempre el estado: 200 con cada solicitud.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.cgi.redirect-status-env">
+      <term>
+       <parameter>cgi.redirect_status_env</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        Si cgi.force_redirect está activado y no está ejecutando un servidor web Apache o Netscape (iPlanet), <emphasis>debería</emphasis> definir un nombre de variable de entorno que PHP usará para verificar si todo está correcto para continuar la ejecución.
+       </para>
+       <note>
+        <para>
+         Definir esta variable <emphasis>puede</emphasis> tener consecuencias de seguridad. <emphasis>Saber lo que hace antes de hacerlo</emphasis>.
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.cgi.rfc2616-headers">
+      <term>
+       <parameter>cgi.rfc2616_headers</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Le dice a PHP qué tipo de encabezado usar al enviar el código de respuesta HTTP. Si está desactivado, PHP enviará un encabezado "Status:" (<link xlink:href="&url.rfc;3875">RFC 3875</link>) que es compatible con Apache y otros servidores web. Cuando está activado, PHP enviará un encabezado que cumple con la especificación <link xlink:href="&url.rfc;2616">RFC 2616</link>.
+       </para>
+       <para>
+        Si esta opción está activada y está ejecutando PHP en un entorno CGI (por ejemplo, PHP-FPM), no debe usar los encabezados de respuesta HTTP "status" RFC 2616, sino usar el equivalente RFC 3875, es decir, en lugar del encabezado ("HTTP/1.0 404 Not found"), use ("Status: 404 Not Found").
+       </para>
+       <para>
+        Deje este parámetro desactivado a menos que sepa exactamente lo que está haciendo.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.fastcgi.impersonate">
+      <term>
+       <parameter>fastcgi.impersonate</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        FastCGI en IIS (en sistemas operativos basados en WINNT) admite la capacidad de determinar la marca de seguridad del cliente que llama. Esto permite que IIS establezca el contexto de seguridad en el que se ejecutará la solicitud. mod_fastcgi en Apache no admite actualmente esta funcionalidad (03/17/2002). Active si se ejecuta en IIS. De manera predeterminada, está desactivado.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.fastcgi.logging">
+      <term>
+       <parameter>fastcgi.logging</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Activa el registro SAPI con FastCGI. Activado de manera predeterminada.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </para>
+  </section>
+
+  <section xml:id="ini.sect.file-uploads">
+   <title>Carga de archivos</title>
+   <para>
+    <table>
+     <title>Opciones de configuración</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Default;</entry>
+        <entry>&Changeable;</entry>
+        <entry>&Changelog;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><link linkend="ini.file-uploads">file_uploads</link></entry>
+        <entry>"1"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.upload-tmp-dir">upload_tmp_dir</link></entry>
+        <entry>NULL</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.max-input-nesting-level">max_input_nesting_level</link></entry>
+        <entry>64</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.max-input-vars">max_input_vars</link></entry>
+        <entry>1000</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.upload-max-filesize">upload_max_filesize</link></entry>
+        <entry>"2M"</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+       <row>
+        <entry><link linkend="ini.max-file-uploads">max_file_uploads</link></entry>
+        <entry>20</entry>
+        <entry><constant>INI_PERDIR</constant></entry>
+        <entry></entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+   </para>
+
+   &ini.descriptions.title;
+
+   <para>
+    <variablelist>
+     <varlistentry xml:id="ini.file-uploads">
+      <term>
+       <parameter>file_uploads</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Permite o no la <link linkend="features.file-upload">carga de archivos</link> por HTTP. Véase también las directivas <link linkend="ini.upload-max-filesize">upload_max_filesize</link>, <link linkend="ini.upload-tmp-dir">upload_tmp_dir</link> y <link linkend="ini.post-max-size">post_max_size</link>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.upload-tmp-dir">
+      <term>
+       <parameter>upload_tmp_dir</parameter>
+       <type>string</type>
+      </term>
+      <listitem>
+       <para>
+        El directorio temporal usado para almacenar archivos durante la carga. El usuario bajo el cual se ejecuta PHP debe tener permisos de escritura en este directorio. Si no se especifica, PHP usará el directorio temporal predeterminado del sistema.
+       </para>
+       <para>
+        Si el directorio especificado aquí no es accesible en escritura, PHP recurrirá al directorio temporal predeterminado del sistema. Si <link linkend="ini.open-basedir">open_basedir</link> está activado, entonces el directorio temporal predeterminado del sistema debe estar permitido para que la carga de archivos funcione.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.upload-max-filesize">
+      <term>
+       <parameter>upload_max_filesize</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+        El tamaño máximo en bytes de un archivo subido.
+       </para>
+       <para>
+        <link linkend="ini.post-max-size">post_max_size</link> debe ser mayor que este valor.
+       </para>
+
+       &ini.shorthandbytes;
+
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="ini.max-file-uploads">
+      <term>
+       <parameter>max_file_uploads</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+        El número máximo de archivos que pueden enviarse simultáneamente. Los campos de carga que se dejan vacíos al enviar no se cuentan en el cálculo de este límite.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </para>
+  </section>
+
+  <section xml:id="ini.sect.sql-general">
+   <title>SQL general</title>
+   <para>
+    <table>
+     <title>Opciones de configuración</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Default;</entry>
+        <entry>&Changeable;</entry>
+        <entry>&Changelog;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><link linkend="ini.sql.safe-mode">sql.safe_mode</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry>Eliminado a partir de PHP 7.2.0</entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+   </para>
+
+   &ini.descriptions.title;
+
+   <para>
+    <variablelist>
+     <varlistentry xml:id="ini.sql.safe-mode">
+      <term>
+       <parameter>sql.safe_mode</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Si está activado, las funciones de conexión a la base de datos que especifican valores predeterminados usarán estos valores en lugar de los argumentos proporcionados. Para los valores predeterminados, consulte la documentación de las funciones de conexión para la base de datos correspondiente.
+       </para>
+       <warning>
+        <simpara>
+         ¡Esta funcionalidad ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.2.0!
+        </simpara>
+       </warning>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </para>
+  </section>
+
+  <section xml:id="ini.sect.windows">
+   <title>Específico de Windows</title>
+   <para>
+    <table>
+     <title>Opciones de configuración específicas de Windows</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+        <entry>&Name;</entry>
+        <entry>&Default;</entry>
+        <entry>&Changeable;</entry>
+        <entry>&Changelog;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><link linkend="ini.windows-show-crt-warning">windows.show_crt_warning</link></entry>
+        <entry>"0"</entry>
+        <entry><constant>INI_ALL</constant></entry>
+        <entry></entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+   </para>
+
+   &ini.descriptions.title;
+
+   <para>
+    <variablelist>
+     <varlistentry xml:id="ini.windows-show-crt-warning">
+      <term>
+       <parameter>windows.show_crt_warning</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Esta directiva muestra las advertencias de CRT de Windows cuando está activada.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </para>
+  </section>
+
+ </section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -1,0 +1,841 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: Phildaiguille Status: ready -->
+<!-- Reviewed: no -->
+<section xml:id="ini.list" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Lista de directivas del &php.ini;</title>
+ <para>
+  Esta lista incluye las directivas del &php.ini; que pueden ser utilizadas
+  para configurar PHP.
+ </para>
+ <para>
+  La columna "&Changeable;" muestra los modos que determinan cuándo y dónde se puede definir una directiva. Ver la sección sobre los
+  <link linkend="configuration.changes.modes">valores del modo modificable</link>
+  para sus definiciones.
+ </para>
+ <para>
+  <table>
+   <title>Opciones de configuración</title>
+   <tgroup cols="4">
+    <thead>
+     <row>
+      <entry>&Name;</entry>
+      <entry>&Default;</entry>
+      <entry>&Changeable;</entry>
+      <entry>&Changelog;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry><link linkend="ini.allow-url-fopen">allow_url_fopen</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.allow-url-include">allow_url_include</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>Obsoleto a partir de PHP 7.4.0.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.arg-separator.input">arg_separator.input</link></entry>
+      <entry>"&amp;"</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.arg-separator.output">arg_separator.output</link></entry>
+      <entry>"&amp;"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.assert.active">assert.active</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.assert.quiet-eval">assert.quiet_eval</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Eliminado a partir de PHP 8.0.0.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.assert.warning">assert.warning</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.auto-append-file">auto_append_file</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.auto-globals-jit">auto_globals_jit</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.auto-prepend-file">auto_prepend_file</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bc.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.browscap">browscap</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.cgi.check-shebang-line">cgi.check_shebang_line</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.cgi.discard-path">cgi.discard_path</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.cgi.fix-pathinfo">cgi.fix_pathinfo</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.cgi.force-redirect">cgi.force_redirect</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.cgi.nph">cgi.nph</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.cgi.redirect-status-env">cgi.redirect_status_env</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.cgi.rfc2616-headers">cgi.rfc2616_headers</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.child-terminate">child_terminate</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('readline.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('features.commandline.ini.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('com.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('curl.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('datetime.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dba.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.default-charset">default_charset</link></entry>
+      <entry>"UTF-8"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Por defecto "UTF-8".</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.input-encoding">input_encoding</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.output-encoding">output_encoding</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.internal-encoding">internal_encoding</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.default-mimetype">default_mimetype</link></entry>
+      <entry>"text/html"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.default-socket-timeout">default_socket_timeout</link></entry>
+      <entry>"60"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
+      <entry>""</entry>
+      <entry>&php.ini; solo</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.disable-functions">disable_functions</link></entry>
+      <entry>""</entry>
+      <entry>&php.ini; solo</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.display-errors">display_errors</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.display-startup-errors">display_startup_errors</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>
+       Anterior a PHP 8.0.0, el valor predeterminado era <literal>"0"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.docref-ext">docref_ext</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.docref-root">docref_root</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.doc-root">doc_root</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.enable-dl">enable_dl</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>&removed.php.future;</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>
+      <entry>On</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.engine">engine</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.error-append-string">error_append_string</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.error-log">error_log</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.error-log-mode">error_log_mode</link></entry>
+      <entry>0o644</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Disponible a partir de PHP 8.2.0</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.error-prepend-string">error_prepend_string</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.error-reporting">error_reporting</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exif.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('expect.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.expose-php">expose_php</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry>&php.ini; solo</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.extension">extension</link></entry>
+      <entry>&null;</entry>
+      <entry>&php.ini; solo</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.extension-dir">extension_dir</link></entry>
+      <entry>"/path/to/php"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.fastcgi.impersonate">fastcgi.impersonate</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.fastcgi.logging">fastcgi.logging</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.file-uploads">file_uploads</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('filter.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.from">from</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('image.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('geoip.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry>hard_timeout</entry>
+      <entry>"2"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>Disponible a partir de 7.1.0.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.syntax-highlighting">highlight.comment</link></entry>
+      <entry>"#FF8000"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.syntax-highlighting">highlight.default</link></entry>
+      <entry>"#0000BB"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.syntax-highlighting">highlight.html</link></entry>
+      <entry>"#000000"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.syntax-highlighting">highlight.keyword</link></entry>
+      <entry>"#007700"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.syntax-highlighting">highlight.string</link></entry>
+      <entry>"#DD0000"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.html-errors">html_errors</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibase.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibm-db2.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iconv.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.ignore-repeated-errors">ignore_repeated_errors</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ignore-repeated-source">ignore_repeated_source</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.ignore-user-abort">ignore_user_abort</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.implicit-flush">implicit_flush</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.include-path">include_path</link></entry>
+      <entry>".:/path/to/php/pear"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('intl.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.last-modified">last_modified</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ldap.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.log-errors">log_errors</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.log-errors-max-len">log_errors_max_len</link></entry>
+      <entry>"1024"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.mail.add-x-header">mail.add_x_header</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry>mail.force_extra_parameters</entry>
+      <entry>&null;</entry>
+      <entry>&php.ini; solo</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.mail.log">mail.log</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.max-execution-time">max_execution_time</link></entry>
+      <entry>"30"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.max-input-nesting-level">max_input_nesting_level</link></entry>
+      <entry>"64"</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.max-input-vars">max_input_vars</link></entry>
+      <entry>1000</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.max-input-time">max_input_time</link></entry>
+      <entry>"-1"</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mbstring.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mcrypt.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('memcache.ini.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.memory-limit">memory_limit</link></entry>
+      <entry>"128M"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysql.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.config.options.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('oci8.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('odbc.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('opcache.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.open-basedir">open_basedir</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.output-buffering">output_buffering</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.output-handler">output_handler</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pcre.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-odbc.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pgsql.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('phar.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.post-max-size">post_max_size</link></entry>
+      <entry>"8M"</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.precision">precision</link></entry>
+      <entry>"14"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.realpath-cache-size">realpath_cache_size</link></entry>
+      <entry>"16K"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.realpath-cache-ttl">realpath_cache_ttl</link></entry>
+      <entry>"120"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry>report_zend_debug</entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.request-order">request_order</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('runkit7.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.sendmail-from">sendmail_from</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.sendmail-path">sendmail_path</link></entry>
+      <entry>"/usr/sbin/sendmail -t -i"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.serialize-precision">serialize_precision</link></entry>
+      <entry>"-1"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>
+       Anterior a PHP 7.1.0, el valor predeterminado era 17.
+      </entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('session.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.short-open-tag">short_open_tag</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.smtp">SMTP</link></entry>
+      <entry>"localhost"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.smtp-port">smtp_port</link></entry>
+      <entry>"25"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('soap.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.sql.safe-mode">sql.safe_mode</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>Eliminado a partir de PHP 7.2.0</entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sqlite3.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.syslog.facility">syslog.facility</link></entry>
+      <entry>"LOG_USER"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>Disponible a partir de PHP 7.3.0.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.syslog.filter">syslog.filter</link></entry>
+      <entry>"no-ctrl"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Disponible a partir de PHP 7.3.0.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.syslog.ident">syslog.ident</link></entry>
+      <entry>"php"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>Disponible a partir de PHP 7.3.0.</entry>
+     </row>
+     <row>
+      <entry>sys_temp_dir</entry>
+      <entry>""</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sem.configuration.list')/*)"><xi:fallback/></xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('tidy.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.track-errors">track_errors</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Obsoleto a partir de PHP 7.2.0, eliminado a partir de PHP 8.0.0.</entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry>uploadprogress.file.filename_template</entry>
+      <entry>"/tmp/upt_%s.txt"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.upload-max-filesize">upload_max_filesize</link></entry>
+      <entry>"2M"</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.max-file-uploads">max_file_uploads</link></entry>
+      <entry>20</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.upload-tmp-dir">upload_tmp_dir</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.url-rewriter.hosts">url_rewriter.hosts</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Disponible a partir de PHP 7.1.0.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.url-rewriter.tags">url_rewriter.tags</link></entry>
+      <entry>"form="</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Anterior a PHP 7.1.0, el valor predeterminado era "a=href,area=href,frame=src,form=,fieldset=".</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.user-agent">user_agent</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.user-dir">user_dir</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link></entry>
+      <entry>"300"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.user-ini.filename">user_ini.filename</link></entry>
+      <entry>".user.ini"</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('uopz.configuration.list')/*)"><xi:fallback/></xi:include>
+     <row>
+      <entry><link linkend="ini.variables-order">variables_order</link></entry>
+      <entry>"EGPCS"</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.windows-show-crt-warning">windows.show_crt_warning</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.xbithack">xbithack</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.xmlrpc-errors">xmlrpc_errors</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.xmlrpc-error-number">xmlrpc_error_number</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry>yaz.keepalive</entry>
+      <entry>"120"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry>yaz.log_mask</entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Disponible a partir de yaz 1.0.3.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.zend.assertions">zend.assertions</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.zend.detect-unicode">zend.detect_unicode</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.zend.enable-gc">zend.enable_gc</link></entry>
+      <entry><literal>"1"</literal></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+     <entry><link linkend="ini.zend.max-allowed-stack-size">zend.max_allowed_stack_size</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>Disponible a partir de PHP 8.3.0</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.fiber.stack-size">fiber.stack_size</link></entry>
+      <entry></entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Disponible a partir de PHP 8.1.0</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.zend.multibyte">zend.multibyte</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.zend.script-encoding">zend.script_encoding</link></entry>
+      <entry>&null;</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.zend.signal-check">zend.signal_check</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.zend-extension">zend_extension</link></entry>
+      <entry>&null;</entry>
+      <entry>&php.ini; solo</entry>
+      <entry></entry>
+     </row>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('zlib.configuration.list')/*)"><xi:fallback/></xi:include>
+    </tbody>
+   </tgroup>
+  </table>
+ </para>
+</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration82.xml
+++ b/appendices/migration82.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9c422d0dd7aaa5864487d9526696dbff01a2052c Maintainer: Phildaiguille Status: ready -->
+<!-- Reviewed: no -->
+<appendix xml:id="migration82" xmlns="http://docbook.org/ns/docbook">
+ <title>Migración de PHP 8.1.x a PHP 8.2.x</title>
+
+  <para>
+   Esta nueva versión menor aporta un cierto número de
+   <link linkend="migration82.new-features">nuevas funcionalidades</link> y
+   <link linkend="migration82.incompatible">algunas incompatibilidades</link>
+   que deberían ser probadas antes de cambiar de versión de PHP en entornos de producción.
+  </para>
+
+  <para>
+   &manual.migration.seealso;
+   <link linkend="migration71">7.1.x</link>,
+   <link linkend="migration72">7.2.x</link>,
+   <link linkend="migration73">7.3.x</link>,
+   <link linkend="migration74">7.4.x</link>,
+   <link linkend="migration80">8.0.x</link>,
+   <link linkend="migration81">8.1.x</link>.
+  </para>
+
+ &appendices.migration82.new-features;
+ &appendices.migration82.new-functions;
+ &appendices.migration82.constants;
+ &appendices.migration82.incompatible;
+ &appendices.migration82.deprecated;
+ &appendices.migration82.other-changes;
+ &appendices.migration82.windows-support;
+
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration83.xml
+++ b/appendices/migration83.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9c422d0dd7aaa5864487d9526696dbff01a2052c Maintainer: Phildaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<appendix xml:id="migration83" xmlns="http://docbook.org/ns/docbook">
+ <title>Migración de PHP 8.2.x a PHP 8.3.x</title>
+
+ <para>
+  Esta nueva versión menor aporta un cierto número de
+  <link linkend="migration83.new-features">nuevas funcionalidades</link> y
+  <link linkend="migration82.incompatible">algunas incompatibilidades</link>
+  que deberían ser probadas antes de cambiar de versión de PHP en entornos de producción.
+ </para>
+
+ <para>
+  &manual.migration.seealso;
+  <link linkend="migration71">7.1.x</link>,
+  <link linkend="migration72">7.2.x</link>,
+  <link linkend="migration73">7.3.x</link>,
+  <link linkend="migration74">7.4.x</link>,
+  <link linkend="migration80">8.0.x</link>,
+  <link linkend="migration81">8.1.x</link>,
+  <link linkend="migration82">8.2.x</link>.
+ </para>
+
+ &appendices.migration83.new-features;
+ &appendices.migration83.new-classes;
+ &appendices.migration83.new-functions;
+ &appendices.migration83.constants;
+ &appendices.migration83.incompatible;
+ &appendices.migration83.deprecated;
+ &appendices.migration83.other-changes;
+ &appendices.migration83.windows-support;
+
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84.xml
+++ b/appendices/migration84.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d64e811eac61a5c7c744312d8bc6e2244de81488 Maintainer: Phildaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<appendix xml:id="migration84" xmlns="http://docbook.org/ns/docbook">
+ <title>Migración de PHP 8.3.x a PHP 8.4.x</title>
+
+ <para>
+  Esta nueva versión menor aporta un cierto número de
+  <link linkend="migration84.new-features">nuevas funcionalidades</link> y
+  <link linkend="migration84.incompatible">algunas incompatibilidades</link>
+  que deberían ser probadas antes de cambiar de versión de PHP en
+  entornos de producción.
+ </para>
+
+ <para>
+  &manual.migration.seealso;
+  <link linkend="migration71">7.1.x</link>,
+  <link linkend="migration72">7.2.x</link>,
+  <link linkend="migration73">7.3.x</link>,
+  <link linkend="migration74">7.4.x</link>,
+  <link linkend="migration80">8.0.x</link>,
+  <link linkend="migration81">8.1.x</link>,
+  <link linkend="migration82">8.2.x</link>,
+  <link linkend="migration83">8.3.x</link>.
+ </para>
+
+ &appendices.migration84.new-features;
+ &appendices.migration84.new-classes;
+ &appendices.migration84.new-functions;
+ &appendices.migration84.constants;
+ &appendices.migration84.incompatible;
+ &appendices.migration84.deprecated;
+ &appendices.migration84.removed-extensions;
+ &appendices.migration84.other-changes;
+ &appendices.migration84.windows-support;
+
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -1,0 +1,673 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b2fa00ca2e052f87785a7f8b296466edc4e55767 Maintainer: Phildaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<sect2 xml:id="reserved.constants.core" xmlns="http://docbook.org/ns/docbook">
+ <title>Constantes predefinidas</title>
+ <simpara>
+  Estas constantes están definidas por el núcleo de PHP. Esto incluye PHP,
+  el motor Zend y los módulos SAPI.
+ </simpara>
+ <variablelist>
+  <varlistentry xml:id="constant.php-version">
+   <term>
+    <constant>PHP_VERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La versión actual de PHP como una cadena en la notación "mayor.menor.lanzamiento[extra]".
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-major-version">
+   <term>
+    <constant>PHP_MAJOR_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La versión mayor actual de PHP como una cadena (por ejemplo, int(5) desde la versión "5.2.7-extra").
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-minor-version">
+   <term>
+    <constant>PHP_MINOR_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La versión menor actual de PHP como una cadena (por ejemplo, int(2) desde la versión "5.2.7-extra").
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-release-version">
+   <term>
+    <constant>PHP_RELEASE_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La versión de lanzamiento actual de PHP como una cadena (por ejemplo, int(7) desde la versión "5.2.7-extra").
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-version-id">
+   <term>
+    <constant>PHP_VERSION_ID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La versión actual de PHP como un entero, útil para la comparación de versiones (por ejemplo, int(50207) desde la versión "5.2.7-extra").
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-extra-version">
+   <term>
+    <constant>PHP_EXTRA_VERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La versión "extra" actual de PHP como una cadena (por ejemplo, '-extra' desde la versión "5.2.7-extra"). Ocasionalmente utilizada por los empaquetadores de distribuciones para indicar una versión de paquete.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.zend-thread-safe">
+   <term>
+    <constant>ZEND_THREAD_SAFE</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Indica si la versión actual de PHP se compiló con soporte para subprocesos.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.zend-debug-build">
+   <term>
+    <constant>ZEND_DEBUG_BUILD</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Indica si la versión actual de PHP es una compilación de depuración.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-zts">
+   <term>
+    <constant>PHP_ZTS</constant>
+    (<type>bool</type>)
+    &Alias; <constant>ZEND_THREAD_SAFE</constant>
+   </term>
+   <listitem>
+    <simpara>
+     Indica si la versión actual de PHP se compiló con soporte para subprocesos.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-debug">
+   <term>
+    <constant>PHP_DEBUG</constant>
+    (<type>bool</type>)
+    &Alias; <constant>ZEND_DEBUG_BUILD</constant>
+   </term>
+   <listitem>
+    <simpara>
+     Indica si la versión actual de PHP es una compilación de depuración.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.debug-backtrace-provide-object">
+   <term>
+    <constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Reemplaza el índice "object".
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.debug-backtrace-ignore-args">
+   <term>
+    <constant>DEBUG_BACKTRACE_IGNORE_ARGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No incluye información de argumentos para las funciones en la traza de la pila.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-maxpathlen">
+   <term>
+    <constant>PHP_MAXPATHLEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La longitud máxima de los nombres de archivo (incluyendo el camino) soportada por este binario de PHP.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-os">
+   <term>
+    <constant>PHP_OS</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El sistema operativo para el que se compiló PHP.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-os-family">
+   <term>
+    <constant>PHP_OS_FAMILY</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La familia del sistema operativo para el que se compiló PHP. Uno de <literal>'Windows'</literal>, <literal>'BSD'</literal>, <literal>'Darwin'</literal>, <literal>'Solaris'</literal>, <literal>'Linux'</literal> o <literal>'Unknown'</literal>. Disponible desde PHP 7.2.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-sapi">
+   <term>
+    <constant>PHP_SAPI</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La API del servidor para este binario de PHP. Véase también <function>php_sapi_name</function>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-eol">
+   <term>
+    <constant>PHP_EOL</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El carácter de nueva línea correcto para esta plataforma.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-int-max">
+   <term>
+    <constant>PHP_INT_MAX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El entero más grande soportado por este binario de PHP. Habitualmente, int(2147483647) en sistemas de 32 bits y int(9223372036854775807) en sistemas de 64 bits.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-int-min">
+   <term>
+    <constant>PHP_INT_MIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El entero más pequeño soportado en esta versión de PHP. Habitualmente, int(-2147483648) en sistemas de 32 bits y int(-9223372036854775808) en sistemas de 64 bits. Habitualmente, PHP_INT_MIN === ~PHP_INT_MAX.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-int-size">
+   <term>
+    <constant>PHP_INT_SIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El tamaño de un entero, en bytes, en esta versión de PHP.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-float-dig">
+   <term>
+    <constant>PHP_FLOAT_DIG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Número de dígitos decimales de precisión en un número de punto flotante y devueltos sin pérdida de precisión. Disponible desde PHP 7.2.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-float-epsilon">
+   <term>
+    <constant>PHP_FLOAT_EPSILON</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El número de punto flotante positivo más pequeño x, de modo que x + 1.0 != 1.0. Disponible desde PHP 7.2.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-float-min">
+   <term>
+    <constant>PHP_FLOAT_MIN</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El número de punto flotante positivo más pequeño. Si necesita la representación negativa más pequeña de un número de punto flotante, use <literal>- PHP_FLOAT_MAX</literal>. Disponible desde PHP 7.2.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-float-max">
+   <term>
+    <constant>PHP_FLOAT_MAX</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El número de punto flotante positivo más grande. Disponible desde PHP 7.2.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.default-include-path">
+   <term>
+    <constant>DEFAULT_INCLUDE_PATH</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pear-install-dir">
+   <term>
+    <constant>PEAR_INSTALL_DIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pear-extension-dir">
+   <term>
+    <constant>PEAR_EXTENSION_DIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-extension-dir">
+   <term>
+    <constant>PHP_EXTENSION_DIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El directorio predeterminado donde buscar extensiones cargables dinámicamente (a menos que se sobrescriba con <link linkend="ini.extension-dir">extension_dir</link>). Por defecto <constant>PHP_PREFIX</constant> (o <code>PHP_PREFIX . "\\ext"</code> en Windows).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-prefix">
+   <term>
+    <constant>PHP_PREFIX</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El valor de <option role="configure">--prefix</option> que se definió durante la configuración. En Windows, es el valor de <option role="configure">--with-prefix</option> que se definió durante la configuración.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-bindir">
+   <term>
+    <constant>PHP_BINDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El valor de <option role="configure">--bindir</option> que se definió durante la configuración. En Windows, es el valor de <option role="configure">--with-prefix</option> que se definió durante la configuración.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-sbindir">
+   <term>
+    <constant>PHP_SBINDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El valor definido por <option role="configure">--sbindir</option> durante la configuración. En Windows, es el valor definido por <option role="configure">--with-prefix</option> durante la configuración. Disponible desde PHP 8.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-binary">
+   <term>
+    <constant>PHP_BINARY</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Especifica el camino hacia el binario de PHP durante la ejecución del script.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-man-dir">
+   <term>
+    <constant>PHP_MANDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Especifica el camino de instalación de las páginas man.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-libdir">
+   <term>
+    <constant>PHP_LIBDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-datadir">
+   <term>
+    <constant>PHP_DATADIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-sysconfdir">
+   <term>
+    <constant>PHP_SYSCONFDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-localstatedir">
+   <term>
+    <constant>PHP_LOCALSTATEDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-config-file-path">
+   <term>
+    <constant>PHP_CONFIG_FILE_PATH</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-config-file-scan-dir">
+   <term>
+    <constant>PHP_CONFIG_FILE_SCAN_DIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-shlib-suffix">
+   <term>
+    <constant>PHP_SHLIB_SUFFIX</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El sufijo de la plataforma de compilación para bibliotecas compartidas, como "so" (en sistemas Unix) o "dll" (en Windows).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-fd-setsize">
+   <term>
+    <constant>PHP_FD_SETSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Número máximo de descriptores de archivo para seleccionar funciones de sistema. Disponible desde PHP 7.1.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>E_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_PARSE</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_NOTICE</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_CORE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_CORE_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_COMPILE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_COMPILE_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_USER_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_USER_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_USER_NOTICE</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_RECOVERABLE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_DEPRECATED</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_USER_DEPRECATED</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_STRICT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <link linkend="errorfunc.constants">Constantes de informe de errores</link>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>__COMPILER_HALT_OFFSET__</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.true">
+   <term>
+    &true;
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Ver <link linkend="language.types.boolean">Booleanos</link>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.false">
+   <term>
+    &false;
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Ver <link linkend="language.types.boolean">Booleanos</link>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.null">
+   <term>
+    &null;
+    (<type>null</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Ver <link linkend="language.types.null">Null</link>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-event-ctrl-c">
+   <term>
+    <constant>PHP_WINDOWS_EVENT_CTRL_C</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Evento de Windows <keycombo action='simul'>
+      <keycap>CTRL</keycap>
+      <keycap>C</keycap>
+     </keycombo>. Disponible desde PHP 7.4.0 (solo Windows).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-event-ctrl-break">
+   <term>
+    <constant>PHP_WINDOWS_EVENT_CTRL_BREAK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Evento de Windows <keycombo action='simul'>
+      <keycap>CTRL</keycap>
+      <keycap>BREAK</keycap>
+     </keycombo>. Disponible desde PHP 7.4.0 (solo Windows).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-cli-process-title">
+   <term>
+    <constant>PHP_CLI_PROCESS_TITLE</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Indica si el establecimiento y la recuperación del título del proceso están disponibles. Disponible solo en la API CLI.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stderr">
+   <term>
+    <constant>STDERR</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Un flujo ya abierto hacia <literal>stderr</literal>. Disponible solo en la API CLI.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stdin">
+   <term>
+    <constant>STDIN</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Un flujo ya abierto hacia <literal>stdin</literal>. Disponible solo en la API CLI.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stdout">
+   <term>
+    <constant>STDOUT</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Un flujo ya abierto hacia <literal>stdout</literal>. Disponible solo en la API CLI.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ <para>
+  Véase también las
+  <link linkend="language.constants.magic">constantes mágicas</link>.
+ </para>
+</sect2>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+-->


### PR DESCRIPTION
This pull request includes updates to the migration documentation for PHP versions and a minor change to the types documentation.

### Migration Documentation Updates:

* [`appendices/migration82.xml`](diffhunk://#diff-25cbed81f350a394524f855447f3a44d83a3231b1dd3e0b71dae2e08c0b51828R1-R52): Added documentation for migrating from PHP 8.1.x to PHP 8.2.x, including new features, functions, constants, incompatibilities, deprecated features, and other changes.
* [`appendices/migration83.xml`](diffhunk://#diff-d753a1c92bdbd35aeb4afecee385d1692026ec4a56a9e2ea9fa1f85b09298bacR1-R54): Added documentation for migrating from PHP 8.2.x to PHP 8.3.x, covering new features, classes, functions, constants, incompatibilities, deprecated features, and other changes.
* [`appendices/migration84.xml`](diffhunk://#diff-7de1c4d29577ef312f7ca26d7f04520103d2e50f2ad4022fa7a4ec5353698c49R1-R57): Added documentation for migrating from PHP 8.3.x to PHP 8.4.x, detailing new features, classes, functions, constants, incompatibilities, deprecated features, removed extensions, and other changes.

### Types Documentation Update:

* [`language/types.xml`](diffhunk://#diff-8bdf4ea928ba22992d537eaf657a47cc6f69b1e07b06444b75e1b97a7732c795L113-R113): Replaced the `&language.types.value;` entity with `&language.types.singleton;` to reflect updated terminology.