### PR TITLE
add translate page zip

### DIFF
--- a/appendices/migration82/new-functions.xml
+++ b/appendices/migration82/new-functions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 919a02eb2746bd49d16418dee3d75bae46ebe38e Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 919a02eb2746bd49d16418dee3d75bae46ebe38e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration82.new-functions">
  <title>Nuevas funciones</title>

--- a/reference/zip/functions/zip-close.xml
+++ b/reference/zip/functions/zip-close.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-close" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_close</refname>
+  <refpurpose>Cierra un archivo Zip</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+   &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type>void</type><methodname>zip_close</methodname>
+   <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_close</function> cierra el archivo ZIP dado.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip</parameter></term>
+     <listitem>
+      <para>
+       Un archivo ZIP previamente abierto con la función <function>zip_open</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos, ver <methodname>ZipArchive::close</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_open</function></member>
+    <member><function>zip_read</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-entry-close.xml
+++ b/reference/zip/functions/zip-entry-close.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-entry-close" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_entry_close</refname>
+  <refpurpose>Cierra un directorio de archivo</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type>bool</type><methodname>zip_entry_close</methodname>
+   <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_entry_close</function> cierra un directorio de archivo dado.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip_entry</parameter></term>
+     <listitem>
+      <para>
+       Un directorio de archivo previamente abierto con la función
+       <function>zip_entry_open</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_entry_open</function></member>
+    <member><function>zip_entry_read</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-entry-compressedsize.xml
+++ b/reference/zip/functions/zip-entry-compressedsize.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-entry-compressedsize" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_entry_compressedsize</refname>
+  <refpurpose>Lee el tamaño comprimido de un directorio de archivo</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_compressedsize</methodname>
+   <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_entry_compressedsize</function> devuelve el tamaño comprimido
+   de un directorio de archivo dado.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip_entry</parameter></term>
+     <listitem>
+      <para>
+       Un directorio de archivo devuelto por la función
+       <function>zip_read</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   El tamaño comprimido, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos, ver <methodname>ZipArchive::statIndex</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_open</function></member>
+    <member><function>zip_read</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-entry-compressionmethod.xml
+++ b/reference/zip/functions/zip-entry-compressionmethod.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-entry-compressionmethod" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_entry_compressionmethod</refname>
+  <refpurpose>Lee el método de compresión usado en un directorio de archivo</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_compressionmethod</methodname>
+   <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_entry_compressionmethod</function> devuelve el método de compresión
+   usado en el directorio de archivo especificado por <parameter>zip_entry</parameter>.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip_entry</parameter></term>
+     <listitem>
+      <para>
+       Un directorio de archivo devuelto por la función <function>zip_read</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   El método de compresión, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos, ver <methodname>ZipArchive::statIndex</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_open</function></member>
+    <member><function>zip_read</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-entry-filesize.xml
+++ b/reference/zip/functions/zip-entry-filesize.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-entry-filesize" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_entry_filesize</refname>
+  <refpurpose>Lee el tamaño descomprimido de un directorio de archivo</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_filesize</methodname>
+   <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_entry_filesize</function> devuelve el tamaño descomprimido
+   de un directorio de archivo dado.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip_entry</parameter></term>
+     <listitem>
+      <para>
+       Un directorio de archivo devuelto por la función
+       <function>zip_read</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   El tamaño descomprimido del directorio de archivo, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos, ver <methodname>ZipArchive::statIndex</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_open</function></member>
+    <member><function>zip_read</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-entry-name.xml
+++ b/reference/zip/functions/zip-entry-name.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-entry-name" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_entry_name</refname>
+  <refpurpose>Lee el nombre de un directorio de archivo</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_name</methodname>
+   <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_entry_name</function> devuelve el nombre de un
+   directorio de archivo dado.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip_entry</parameter></term>
+     <listitem>
+      <para>
+       Un directorio de archivo devuelto por la función <function>zip_read</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   El nombre del directorio de archivo, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos, ver <methodname>ZipArchive::statIndex</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_open</function></member>
+    <member><function>zip_read</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-entry-open.xml
+++ b/reference/zip/functions/zip-entry-open.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-entry-open" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_entry_open</refname>
+  <refpurpose>Abre un directorio de archivo para lectura</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type>bool</type><methodname>zip_entry_open</methodname>
+   <methodparam><type>resource</type><parameter>zip_dp</parameter></methodparam>
+   <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>mode</parameter><initializer>"rb"</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_entry_open</function> abre un directorio en un archivo ZIP
+   para lectura.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip_dp</parameter></term>
+     <listitem>
+      <para>
+       Un recurso válido devuelto por la función
+       <function>zip_open</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>zip_entry</parameter></term>
+     <listitem>
+      <para>
+       Un directorio de archivo devuelto por la función
+       <function>zip_read</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>mode</parameter></term>
+     <listitem>
+      <para>
+       Todos los métodos especificados en la documentación
+       de la función <function>fopen</function>.
+      </para>
+      <note>
+       <para>
+        Actualmente, <parameter>mode</parameter> es ignorado y siempre vale
+        <literal>"rb"</literal>. Esto se debe a que el soporte ZIP
+        de PHP es solo de lectura.
+       </para>
+      </note>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+  <note>
+   <para>
+    A diferencia de <function>fopen</function> y otras funciones
+    de archivos, el valor devuelto por <function>zip_entry_open</function>
+    solo indica el resultado de la operación y no es necesario
+    para la lectura o el cierre del archivo del directorio de archivo.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_entry_close</function></member>
+    <member><function>zip_entry_read</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-entry-read" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_entry_read</refname>
+  <refpurpose>Lee el contenido de un archivo en un directorio</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_read</methodname>
+   <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>1024</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_entry_read</function> lee en un directorio de archivo abierto.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip_entry</parameter></term>
+     <listitem>
+      <para>
+       Un directorio de archivo devuelto por la función
+       <function>zip_read</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>len</parameter></term>
+     <listitem>
+      <para>
+       El número de bytes a devolver.
+      </para>
+      <note>
+       <para>
+        Esto debe ser el tamaño descomprimido que desea leer.
+       </para>
+      </note>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Devuelve los datos leídos, una cadena vacía si se está al
+   final del archivo, o &false; si ocurre un error.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos, ver <methodname>ZipArchive::getFromIndex</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_entry_open</function></member>
+    <member><function>zip_entry_close</function></member>
+    <member><function>zip_entry_filesize</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-open.xml
+++ b/reference/zip/functions/zip-open.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-open" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_open</refname>
+  <refpurpose>Abre un archivo ZIP</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type class="union"><type>resource</type><type>int</type><type>false</type></type><methodname>zip_open</methodname>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_open</function> abre un nuevo archivo ZIP para lectura.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>filename</parameter></term>
+     <listitem>
+      <para>
+       El nombre del archivo ZIP a abrir.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Devuelve un recurso a utilizar
+   más tarde con las funciones <function>zip_read</function> y
+   <function>zip_close</function>, o bien devuelve &false; o
+   el número de error si el parámetro <parameter>filename</parameter>
+   no existe o en caso de otro error.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos, ver <methodname>ZipArchive::open</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_read</function></member>
+    <member><function>zip_close</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/functions/zip-read.xml
+++ b/reference/zip/functions/zip-read.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.zip-read" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>zip_read</refname>
+  <refpurpose>Lee la siguiente entrada en un archivo ZIP</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>zip_read</methodname>
+   <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>zip_read</function> lee la siguiente entrada en un archivo
+   ZIP.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>zip</parameter></term>
+     <listitem>
+      <para>
+       Un archivo ZIP previamente abierto con la función
+       <function>zip_open</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Devuelve un recurso de entrada de archivo,
+   para usar más tarde con otras funciones de la biblioteca,
+   &false; si no hay más entradas para leer en el archivo ZIP o el número
+   de error si ocurre un error.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Esta función está obsoleta en favor de la API orientada a objetos, ver <methodname>ZipArchive::statIndex</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>zip_open</function></member>
+    <member><function>zip_close</function></member>
+    <member><function>zip_entry_open</function></member>
+    <member><function>zip_entry_read</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/ziparchive/clearerror.xml
+++ b/reference/zip/ziparchive/clearerror.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="ziparchive.clearerror" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ZipArchive::clearError</refname>
+  <refpurpose>Borra el mensaje de error, los mensajes del sistema y/o zip</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ZipArchive">
+   <modifier>public</modifier> <type>void</type><methodname>ZipArchive::clearError</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Borra el mensaje de error, los mensajes del sistema y/o zip.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ZipArchive::getStatusString</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bb6e8c9fb1f4cc4c83a67a2c3e031ac3c8c28ccc Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="ziparchive.getarchiveflag" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ZipArchive::getArchiveFlag</refname>
+  <refpurpose>Devuelve el valor de una bandera global del archivo</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ZipArchive">
+   <modifier>public</modifier> <type>int</type><methodname>ZipArchive::getArchiveFlag</methodname>
+   <methodparam><type>int</type><parameter>flag</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Devuelve el valor de una bandera global del archivo.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>flag</parameter></term>
+     <listitem>
+      <para>
+       La bandera global a recuperar, entre las constantes <literal>AFL_*</literal>:
+       <itemizedlist>
+        <listitem>
+         <para>
+          <constant>ZipArchive::AFL_RDONLY</constant>
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <constant>ZipArchive::AFL_IS_TORRENTZIP</constant>
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
+         </para>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       Si <parameter>flags</parameter> se define como <constant>ZipArchive::FL_UNCHANGED</constant>,
+       la bandera original no se modifica y se devuelve.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Devuelve 1 si la bandera está definida para el archivo, 0 si no lo está, y -1 si ocurre un error.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Prueba si el archivo está en formato torrentzip</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$zip = new ZipArchive;
+$res = $zip->open('test.zip');
+
+if ($res === TRUE) {
+    var_dump($zip->getArchiveFlag(ZipArchive::AFL_IS_TORRENTZIP));
+} else {
+    echo 'Fallo, código: ' . $res;
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ZipArchive::setArchiveFlag</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/ziparchive/getstreamindex.xml
+++ b/reference/zip/ziparchive/getstreamindex.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="ziparchive.getstreamindex" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ZipArchive::getStreamIndex</refname>
+  <refpurpose>Recupera un manejador de archivo para la entrada definida por su índice (solo lectura)</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ZipArchive">
+   <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>ZipArchive::getStreamIndex</methodname>
+   <methodparam><type>int</type><parameter>index</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Recupera un manejador de archivo para la entrada definida por su índice. Actualmente,
+   esta función solo soporta operaciones de lectura.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>index</parameter></term>
+     <listitem>
+      <para>
+       Índice de la entrada a utilizar.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       Si <parameter>flags</parameter> se define como <constant>ZipArchive::FL_UNCHANGED</constant>, el flujo original
+       es devuelto.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Devuelve un puntero de archivo (recurso) en caso de éxito, &return.falseforfailure;.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+    <example>
+     <title>Obtener el contenido de la entrada con <function>fread</function> y almacenarlo</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$contents = '';
+$z = new ZipArchive();
+if ($z->open('test.zip')) {
+    $fp = $z->getStreamIndex(1, ZipArchive::FL_UNCHANGED);
+    if(!$fp) die($z->getStatusString());
+
+    echo stream_get_contents($fp);
+
+    fclose($fp);
+}
+?>
+]]>
+     </programlisting>
+    </example>
+   </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ZipArchive::getStreamName</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/ziparchive/getstreamname.xml
+++ b/reference/zip/ziparchive/getstreamname.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="ziparchive.getstreamname" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ZipArchive::getStreamName</refname>
+  <refpurpose>Recupera un manejador de archivo para la entrada definida por su nombre (solo lectura)</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ZipArchive">
+   <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>ZipArchive::getStreamName</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Recupera un manejador de archivo para la entrada definida por su nombre. Actualmente,
+   esta función solo soporta operaciones de lectura.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>name</parameter></term>
+     <listitem>
+      <para>
+       El nombre de la entrada a utilizar.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       Si <parameter>flags</parameter> se define como <constant>ZipArchive::FL_UNCHANGED</constant>, el flujo original
+       es devuelto.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Devuelve un puntero de archivo (recurso) en caso de éxito, &return.falseforfailure;.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+    <example>
+     <title>Obtener el contenido de la entrada con <function>fread</function> y almacenarlo</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$contents = '';
+$z = new ZipArchive();
+if ($z->open('test.zip')) {
+    $fp = $z->getStreamName('test', ZipArchive::FL_UNCHANGED);
+    if(!$fp) die($z->getStatusString());
+
+    echo stream_get_contents($fp);
+
+    fclose($fp);
+}
+?>
+]]>
+     </programlisting>
+    </example>
+   </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ZipArchive::getStreamIndex</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/ziparchive/iscompressionmethoddupported.xml
+++ b/reference/zip/ziparchive/iscompressionmethoddupported.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="ziparchive.iscompressionmethodsupported" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ZipArchive::isCompressionMethodSupported</refname>
+  <refpurpose>Verifica si un método de compresión es soportado por libzip</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ZipArchive">
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>ZipArchive::isCompressionMethodSupported</methodname>
+   <methodparam><type>int</type><parameter>method</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>true</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Verifica si un método de compresión es soportado por libzip.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>method</parameter></term>
+     <listitem>
+      <para>
+       El método de compresión, una de las constantes
+       <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>enc</parameter></term>
+     <listitem>
+      <para>
+       Si es &true;, verifica la compresión; si es &false;, verifica la
+       descompresión.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Esta función está disponible solo si la compilación
+    se realizó con ≥ 1.7.0.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ZipArchive::setCompressionIndex</methodname></member>
+    <member><methodname>ZipArchive::setCompressionName</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/ziparchive/isencryptionmethoddupported.xml
+++ b/reference/zip/ziparchive/isencryptionmethoddupported.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="ziparchive.isencryptionmethodsupported" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ZipArchive::isEncryptionMethodSupported</refname>
+  <refpurpose>Verifica si un método de cifrado es soportado por libzip</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ZipArchive">
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>ZipArchive::isEncryptionMethodSupported</methodname>
+   <methodparam><type>int</type><parameter>method</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>true</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Verifica si un método de cifrado es soportado por libzip.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>method</parameter></term>
+     <listitem>
+      <para>
+       El método de cifrado, una de las constantes
+       <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>enc</parameter></term>
+     <listitem>
+      <para>
+       Si es <literal>true</literal>, verifica el cifrado; si es <literal>false</literal>, verifica el
+       descifrado.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Esta función está disponible solo si la extensión ha sido compilada con
+    libzip ≥ 1.7.0.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ZipArchive::setEncryptionIndex</methodname></member>
+    <member><methodname>ZipArchive::setEncryptionName</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zip/ziparchive/setarchiveflag.xml
+++ b/reference/zip/ziparchive/setarchiveflag.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="ziparchive.setarchiveflag" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ZipArchive::setArchiveFlag</refname>
+  <refpurpose>Define una bandera global de un archivo ZIP</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ZipArchive">
+   <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setArchiveFlag</methodname>
+   <methodparam><type>int</type><parameter>flag</parameter></methodparam>
+   <methodparam><type>int</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Define una bandera global de un archivo ZIP.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>flag</parameter></term>
+     <listitem>
+      <para>
+       La bandera global a cambiar, entre las constantes <literal>AFL_*</literal>.
+       <itemizedlist>
+        <listitem>
+         <para>
+          <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
+         </para>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       El nuevo valor de la bandera.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+    <example>
+     <title>Crear un archivo torrentzip</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$zip = new ZipArchive;
+$res = $zip->open('test.zip', ZipArchive::CREATE);
+if ($res === TRUE) {
+    $zip->setArchiveFlag(ZipArchive::AFL_WANT_TORRENTZIP, 1);
+    $zip->addFromString('test.txt', 'file content goes here');
+    $zip->close();
+    echo 'ok';
+} else {
+    echo 'failed';
+}
+?>
+]]>
+     </programlisting>
+    </example>
+   </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ZipArchive::getArchiveFlag</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
This pull request includes the addition of multiple XML documentation files for various zip functions. Each function's documentation includes details such as purpose, parameters, return values, changelog, and related functions. The most important changes include the addition of documentation for `zip_close`, `zip_entry_close`, `zip_entry_compressedsize`, `zip_entry_compressionmethod`, `zip_entry_filesize`, `zip_entry_name`, `zip_entry_open`, and `zip_entry_read`.

New XML documentation files:

* [`reference/zip/functions/zip-close.xml`](diffhunk://#diff-0f83179f559f77e57c2f6368e2e5e7ae62953f9b7aa6286d6a4048fb8b4893baR1-R101): Added documentation for the `zip_close` function, which closes a given ZIP file.
* [`reference/zip/functions/zip-entry-close.xml`](diffhunk://#diff-3ddcf4002f63b86021223d452153834561a1cc6f7b1d39a00e41ee1f39ea87b4R1-R102): Added documentation for the `zip_entry_close` function, which closes a given directory entry in a ZIP file.
* [`reference/zip/functions/zip-entry-compressedsize.xml`](diffhunk://#diff-9ca9e3365ddb166b8f15745857b02c7224621ab7bda4640ee02812a516ec7490R1-R103): Added documentation for the `zip_entry_compressedsize` function, which reads the compressed size of a given directory entry in a ZIP file.
* [`reference/zip/functions/zip-entry-compressionmethod.xml`](diffhunk://#diff-6b393541fc81ee367272fad76d95da75cdb20b01f721da10e045c6c98f9186e3R1-R102): Added documentation for the `zip_entry_compressionmethod` function, which reads the compression method used in a given directory entry in a ZIP file.
* [`reference/zip/functions/zip-entry-filesize.xml`](diffhunk://#diff-d7c9122c4ca7a43a38ca1fa44570d5f9b1ec7a1d472868efea1ea0b100455200R1-R103): Added documentation for the `zip_entry_filesize` function, which reads the uncompressed size of a given directory entry in a ZIP file.
* [`reference/zip/functions/zip-entry-name.xml`](diffhunk://#diff-30a3c03833d0020ffd2590519281e76bc919470150589e8a71a2d65928a3bc50R1-R102): Added documentation for the `zip_entry_name` function, which reads the name of a given directory entry in a ZIP file.
* [`reference/zip/functions/zip-entry-open.xml`](diffhunk://#diff-204927fb660692602ee0ccab228aace2b89ec56e29f58165eae5a259aa7661f0R1-R138): Added documentation for the `zip_entry_open` function, which opens a given directory entry in a ZIP file for reading.
* [`reference/zip/functions/zip-entry-read.xml`](diffhunk://#diff-5f5b9f58ab5d8b553e14493336b505add8e17c472e6dcaa42db498e31112f7d7R1-R118): Added documentation for the `zip_entry_read` function, which reads the content of a file in a given directory entry in a ZIP file.