### PR TITLE
translate page wincache + wkhmtltox

### DIFF
--- a/reference/wincache/functions/wincache-fcache-fileinfo.xml
+++ b/reference/wincache/functions/wincache-fcache-fileinfo.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-fcache-fileinfo" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_fcache_fileinfo</refname>
+  <refpurpose>
+   Extrae información sobre los archivos almacenados en la caché de archivos
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>wincache_fcache_fileinfo</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>summaryonly</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Extrae información sobre el contenido de la caché de archivos y su utilización.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>summaryonly</parameter></term>
+     <listitem>
+      <para>
+       Controla si el array devuelto debe contener información sobre las entradas individuales del caché además del resumen del caché de archivos.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Array de metadatos sobre la caché de archivos &return.falseforfailure;
+  </para>
+  <para>
+   El array devuelto por esta función contiene los siguientes elementos:
+   <itemizedlist spacing="compact">
+    <listitem>
+     <simpara>
+      <literal>total_cache_uptime</literal> - Tiempo total de actividad en segundos de la caché de archivos
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_file_count</literal> - Número total de archivos actualmente en la caché de archivos
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_hit_count</literal> - Número de veces que los archivos han sido servidos desde la caché de archivos
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_miss_count</literal> - Número de veces que los archivos no se encontraron en la caché de archivos
+     </simpara>
+    </listitem>
+    <listitem>
+     <para>
+      <literal>file_entries</literal> - Array que contiene información sobre todos los archivos almacenados en caché:
+      <itemizedlist spacing="compact">
+       <listitem>
+        <simpara>
+         <literal>file_name</literal> - Nombre y ruta absoluta del archivo en caché
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>add_time</literal> - Tiempo en segundos desde que el archivo fue añadido a la caché de archivos
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>use_time</literal> - Tiempo en segundos desde que el archivo fue consultado en la caché de archivos
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>last_check</literal> - Tiempo en segundos desde la última verificación de modificaciones
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>hit_count</literal> - Número de veces que el archivo ha sido servido desde la caché
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>file_size</literal> - Tamaño en bytes del archivo almacenado en caché
+        </simpara>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un ejemplo de <function>wincache_fcache_fileinfo</function></title>
+    <programlisting role="php">
+<![CDATA[
+<pre>
+<?php
+print_r(wincache_fcache_fileinfo());
+?>
+</pre>
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [total_cache_uptime] => 3234
+    [total_file_count] => 5
+    [total_hit_count] => 0
+    [total_miss_count] => 1
+    [file_entries] => Array
+        (
+            [1] => Array
+                (
+                    [file_name] => c:\inetpub\wwwroot\checkcache.php
+                    [add_time] => 1
+                    [use_time] => 0
+                    [last_check] => 1
+                    [hit_count] => 1
+                    [file_size] => 2435
+                )
+            [2] => Array (...iterates for each cached file)
+        )
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_fcache_meminfo</function></member>
+    <member><function>wincache_ocache_fileinfo</function></member>
+    <member><function>wincache_ocache_meminfo</function></member>
+    <member><function>wincache_rplist_fileinfo</function></member>
+    <member><function>wincache_rplist_meminfo</function></member>
+    <member><function>wincache_refresh_if_changed</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+    <member><function>wincache_scache_info</function></member>
+    <member><function>wincache_scache_meminfo</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/functions/wincache-ocache-fileinfo.xml
+++ b/reference/wincache/functions/wincache-ocache-fileinfo.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-ocache-fileinfo" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_ocache_fileinfo</refname>
+  <refpurpose>
+   Extrae información sobre los archivos almacenados en el caché opcode
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>wincache_ocache_fileinfo</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>summaryonly</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Extrae información sobre el contenido del caché opcode y su utilización.
+  </para>
+  &warn.removed.function-7-0-0;
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>summaryonly</parameter></term>
+     <listitem>
+      <para>
+       Controla si el array devuelto debe contener información sobre las entradas individuales del caché además del resumen del caché opcode.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Array de metadatos sobre el caché opcode &return.falseforfailure;
+  </para>
+  <para>
+   El array devuelto por esta función contiene los siguientes elementos:
+   <itemizedlist spacing="compact">
+    <listitem>
+     <simpara>
+      <literal>total_cache_uptime</literal> - Tiempo total de actividad en segundos del caché opcode
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_file_count</literal> - Número total de archivos actualmente en el caché opcode
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_hit_count</literal> - Número total de veces que el opcode compilado ha sido servido desde el caché
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_miss_count</literal> - Número de veces que el opcode compilado no se encontró en el caché
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>is_local_cache</literal> - true si los metadatos del caché son para una instancia de caché local, false si los metadatos son para el caché global.
+     </simpara>
+    </listitem>
+    <listitem>
+     <para>
+      <literal>file_entries</literal> - Array que contiene información sobre todos los archivos almacenados en caché:
+      <itemizedlist spacing="compact">
+       <listitem>
+        <simpara>
+         <literal>file_name</literal> - Nombre de archivo absoluto del archivo en caché
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>add_time</literal> - Tiempo en segundos desde que el archivo fue añadido al caché opcode
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>use_time</literal> - Tiempo en segundos desde que el archivo fue consultado en el caché opcode
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>last_check</literal> - Tiempo en segundos desde que el archivo fue verificado para cambios
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>hit_count</literal> - Número de veces que el archivo ha sido servido desde el caché
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>function_count</literal> - Número de funciones en el caché
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>class_count</literal> - Número de clases en el caché
+        </simpara>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un ejemplo de <function>wincache_ocache_fileinfo</function></title>
+    <programlisting role="php">
+<![CDATA[
+<pre>
+<?php
+print_r(wincache_ocache_fileinfo());
+?>
+</pre>
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [total_cache_uptime] => 17357
+    [total_file_count] => 121
+    [total_hit_count] => 36562
+    [total_miss_count] => 201
+    [file_entries] => Array
+        (
+            [1] => Array
+                (
+                    [file_name] => c:\inetpub\wwwroot\checkcache.php
+                    [add_time] => 17356
+                    [use_time] => 7
+                    [last_check] => 10
+                    [hit_count] => 454
+                    [function_count] => 0
+                    [class_count] => 1
+                )
+            [2] => Array (...iterates for each cached file)
+        )
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_fcache_fileinfo</function></member>
+    <member><function>wincache_fcache_meminfo</function></member>
+    <member><function>wincache_ocache_meminfo</function></member>
+    <member><function>wincache_rplist_fileinfo</function></member>
+    <member><function>wincache_rplist_meminfo</function></member>
+    <member><function>wincache_refresh_if_changed</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+    <member><function>wincache_scache_info</function></member>
+    <member><function>wincache_scache_meminfo</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/functions/wincache-ocache-meminfo.xml
+++ b/reference/wincache/functions/wincache-ocache-meminfo.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 709e2ce20a09ae33eb76cb54a6fec0eb36adabb3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-ocache-meminfo" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_ocache_meminfo</refname>
+  <refpurpose>
+   Extrae información sobre la utilización del caché opcode
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>wincache_ocache_meminfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Extrae información sobre la utilización de la memoria por el caché opcode.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Tabla de metadatos sobre la utilización de la memoria caché opcode &return.falseforfailure;
+  </para>
+  <para>
+   La tabla devuelta por esta función contiene los siguientes elementos:
+   <itemizedlist spacing="compact">
+    <listitem>
+     <simpara>
+      <literal>memory_total</literal> - Cantidad de memoria en bytes, asignada para el caché opcode
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>memory_free</literal> - Cantidad de memoria libre en bytes, disponible para el caché opcode
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>num_used_blks</literal> - Número de bloques de memoria utilizados por el caché opcode
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>num_free_blks</literal> - Número de bloques de memoria libres disponibles para el caché opcode
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>memory_overhead</literal> - Cantidad de memoria en bytes utilizada para la estructura interna del caché opcode
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+  &warn.removed.function-7-0-0;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un ejemplo de <function>wincache_ocache_meminfo</function></title>
+    <programlisting role="php">
+<![CDATA[
+<pre>
+<?php
+print_r(wincache_ocache_meminfo());
+?>
+</pre>
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [memory_total] => 134217728
+    [memory_free] => 112106972
+    [num_used_blks] => 15469
+    [num_free_blks] => 4
+    [memory_overhead] => 247600
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_fcache_fileinfo</function></member>
+    <member><function>wincache_fcache_meminfo</function></member>
+    <member><function>wincache_ocache_fileinfo</function></member>
+    <member><function>wincache_rplist_fileinfo</function></member>
+    <member><function>wincache_rplist_meminfo</function></member>
+    <member><function>wincache_refresh_if_changed</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+    <member><function>wincache_scache_info</function></member>
+    <member><function>wincache_scache_meminfo</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/functions/wincache-refresh-if-changed.xml
+++ b/reference/wincache/functions/wincache-refresh-if-changed.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 07e42841b078fc8dfb4a2d053b707b5233c4cfeb Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-refresh-if-changed" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_refresh_if_changed</refname>
+  <refpurpose>
+   Actualiza las entradas del caché para los archivos almacenados en caché
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>wincache_refresh_if_changed</methodname>
+   <methodparam choice="opt"><type>array</type><parameter>files</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Actualiza las entradas del caché para los archivos cuyos nombres se han pasado en los
+   argumentos de entrada. Si no se especifica ningún argumento, entonces se actualizan todas las entradas del caché.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>files</parameter></term>
+     <listitem>
+      <para>
+       Array de nombres de archivos para los archivos que necesitan ser actualizados.
+       Se puede usar una ruta de archivo absoluta o relativa.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   WinCache realiza verificaciones regulares en los archivos almacenados en caché para
+   asegurarse de que, si un archivo ha cambiado, la entrada correspondiente en la memoria caché
+   se actualice. Por defecto, esta verificación se realiza cada 30 segundos.
+   Si, por ejemplo, un script PHP actualiza otro script PHP donde se almacenan las configuraciones
+   de la aplicación, entonces puede ocurrir que, después de que los cambios de configuración se hayan guardado,
+   la aplicación siga utilizando los parámetros antiguos durante algún tiempo hasta que el caché se actualice.
+   En este caso, es preferible actualizar el caché justo después de que el archivo haya sido modificado.
+   El ejemplo siguiente muestra cómo hacerlo.
+   <example>
+    <title>Un ejemplo de <function>wincache_refresh_if_changed</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$filename = 'C:\inetpub\wwwroot\config.php';
+$handle = fopen($filename, 'w+');
+if ($handle === FALSE) die('Failed to open file '.$filename.' for writing');
+fwrite($handle, '<?php $setting=something; ?>');
+fclose($handle);
+wincache_refresh_if_changed(array($filename));
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_fcache_fileinfo</function></member>
+    <member><function>wincache_fcache_meminfo</function></member>
+    <member><function>wincache_ocache_fileinfo</function></member>
+    <member><function>wincache_ocache_meminfo</function></member>
+    <member><function>wincache_rplist_fileinfo</function></member>
+    <member><function>wincache_rplist_meminfo</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/functions/wincache-rplist-fileinfo.xml
+++ b/reference/wincache/functions/wincache-rplist-fileinfo.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 709e2ce20a09ae33eb76cb54a6fec0eb36adabb3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-rplist-fileinfo" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_rplist_fileinfo</refname>
+  <refpurpose>Recupera información de la caché sobre una ruta de archivo resuelta</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>wincache_rplist_fileinfo</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>summaryonly</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Recupera información sobre las asignaciones almacenadas en caché entre rutas de archivos relativas y sus correspondencias en rutas de archivos absolutas
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>summaryonly</parameter></term>
+     <listitem>
+      <para>
+
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un array de metadatos con información sobre la caché de una ruta de archivo resuelta &return.falseforfailure;
+  </para>
+  <para>
+   El array devuelto por esta función contiene los siguientes elementos:
+   <itemizedlist spacing="compact">
+    <listitem>
+     <simpara>
+      <literal>total_file_count</literal> - número total de rutas de archivos almacenadas en la caché
+     </simpara>
+    </listitem>
+    <listitem>
+     <para>
+      <literal>rplist_entries</literal> - un array que contiene la información sobre las rutas de archivo presentes en la caché:
+      <itemizedlist spacing="compact">
+       <listitem>
+        <simpara>
+         <literal>resolve_path</literal> - ruta hacia el archivo
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>subkey_data</literal> - ruta absoluta correspondiente
+        </simpara>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Ejemplo con <function>wincache_rplist_fileinfo</function></title>
+    <programlisting role="php">
+<![CDATA[
+<pre>
+<?php
+print_r(wincache_rplist_fileinfo());
+?>
+</pre>
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [total_file_count] => 5
+    [rplist_entries] => Array
+        (
+            [1] => Array
+                (
+                    [resolve_path] => checkcache.php
+                    [subkey_data] => c:\inetpub\wwwroot|c:\inetpub\wwwroot\checkcache.php
+                )
+
+            [2] => Array (...iterates for each cached file)
+        )
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_fcache_meminfo</function></member>
+    <member><function>wincache_fcache_fileinfo</function></member>
+    <member><function>wincache_ocache_fileinfo</function></member>
+    <member><function>wincache_ocache_meminfo</function></member>
+    <member><function>wincache_rplist_meminfo</function></member>
+    <member><function>wincache_refresh_if_changed</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+    <member><function>wincache_scache_info</function></member>
+    <member><function>wincache_scache_meminfo</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/functions/wincache-rplist-meminfo.xml
+++ b/reference/wincache/functions/wincache-rplist-meminfo.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 709e2ce20a09ae33eb76cb54a6fec0eb36adabb3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-rplist-meminfo" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_rplist_meminfo</refname>
+  <refpurpose>Recupera información sobre el uso de la memoria por la caché de ruta de archivo resuelta</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>wincache_rplist_meminfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Recupera información sobre el uso de la memoria por la caché de ruta de archivo resuelta.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un array de metadatos que describe el uso de la memoria
+   por la caché de ruta de archivo resuelta. &return.falseforfailure;
+  </para>
+  <para>
+   El array devuelto por esta función contiene los siguientes elementos:
+   <itemizedlist spacing="compact">
+    <listitem>
+     <simpara>
+      <literal>memory_total</literal> - cantidad de memoria, en bytes, asignada
+      a la caché de rutas de archivos resueltas
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>memory_free</literal> - cantidad de memoria libre, en bytes, disponible para la
+      caché de rutas de archivos resueltas
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>num_used_blks</literal> - número de bloques de memoria usados por la caché de rutas
+      de archivos resueltas
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>num_free_blks</literal> - número de bloques de memoria libres para la caché
+      de rutas de archivos resueltas
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>memory_overhead</literal> - cantidad de memoria, en bytes, usada para la
+      estructura interna de la caché de rutas de archivos resueltas
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Ejemplo con <function>wincache_rplist_meminfo</function></title>
+    <programlisting role="php">
+<![CDATA[
+<pre>
+<?php
+print_r(wincache_rplist_meminfo());
+?>
+</pre>
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [memory_total] => 9437184
+    [memory_free] => 9416744
+    [num_used_blks] => 23
+    [num_free_blks] => 1
+    [memory_overhead] => 416
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_fcache_fileinfo</function></member>
+    <member><function>wincache_fcache_meminfo</function></member>
+    <member><function>wincache_ocache_fileinfo</function></member>
+    <member><function>wincache_ocache_meminfo</function></member>
+    <member><function>wincache_rplist_fileinfo</function></member>
+    <member><function>wincache_refresh_if_changed</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+    <member><function>wincache_scache_info</function></member>
+    <member><function>wincache_scache_meminfo</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/functions/wincache-scache-info.xml
+++ b/reference/wincache/functions/wincache-scache-info.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-scache-info" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_scache_info</refname>
+  <refpurpose>Recupera información sobre archivos almacenados en el caché de sesión.</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>wincache_scache_info</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>summaryonly</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Recupera información sobre el contenido del caché de sesión y su utilización.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>summaryonly</parameter></term>
+     <listitem>
+      <para>
+       Controla si el array devuelto debe contener información sobre entradas
+       individuales del caché además del resumen del caché.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+  <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un array de metadatos sobre el caché para esta sesión
+   &return.falseforfailure;
+  </para>
+    <para>
+     El array devuelto por esta función contiene los siguientes elementos:
+   <itemizedlist spacing="compact">
+    <listitem>
+     <simpara>
+      <literal>total_cache_uptime</literal> - duración total (en segundos) de activación del caché
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_item_count</literal> - número total de elementos contenidos actualmente en el caché
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>is_local_cache</literal> - &true; si los metadatos del caché son para una instancia
+      de caché local, &false; si son para un caché global
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_hit_count</literal> - número total de veces que los datos han sido servidos
+      desde el caché
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>total_miss_count</literal> - número total de veces que los datos no se encontraron en
+      el caché
+     </simpara>
+    </listitem>
+    <listitem>
+     <para>
+      <literal>scache_entries</literal> - un array que contiene información sobre los elementos almacenados en caché:
+      <itemizedlist spacing="compact">
+       <listitem>
+        <simpara>
+         <literal>key_name</literal> - nombre de la clave usada para almacenar los datos
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>value_type</literal> - tipo del valor almacenado
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>use_time</literal> - tiempo, en segundos, desde el último acceso del archivo desde el caché opcode
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>last_check</literal> - tiempo, en segundos, desde la última vez que el archivo fue verificado
+         para detectar cambios
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>ttl_seconds</literal> - tiempo restante antes de la eliminación de los datos del caché, 0 significa que nunca serán eliminados
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>age_seconds</literal> - tiempo transcurrido desde el momento en que se agregaron los datos en la caché
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>hitcount</literal> - número de veces que los datos han sido servidos desde el caché
+        </simpara>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Ejemplo con <function>wincache_scache_info</function></title>
+    <programlisting role="php">
+<![CDATA[
+<pre>
+<?php
+print_r(wincache_scache_info());
+?>
+</pre>
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [total_cache_uptime] => 17357
+    [total_file_count] => 121
+    [total_hit_count] => 36562
+    [total_miss_count] => 201
+    [scache_entries] => Array
+        (
+            [1] => Array
+                (
+                    [file_name] => c:\inetpub\wwwroot\checkcache.php
+                    [add_time] => 17356
+                    [use_time] => 7
+                    [last_check] => 10
+                    [hit_count] => 454
+                    [function_count] => 0
+                    [class_count] => 1
+                )
+            [2] => Array (...iterates for each cached file)
+        )
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_fcache_fileinfo</function></member>
+    <member><function>wincache_fcache_meminfo</function></member>
+    <member><function>wincache_ocache_meminfo</function></member>
+    <member><function>wincache_rplist_fileinfo</function></member>
+    <member><function>wincache_rplist_meminfo</function></member>
+    <member><function>wincache_refresh_if_changed</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+    <member><function>wincache_scache_meminfo</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/functions/wincache-ucache-add.xml
+++ b/reference/wincache/functions/wincache-ucache-add.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 07e42841b078fc8dfb4a2d053b707b5233c4cfeb Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-ucache-add" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_ucache_add</refname>
+  <refpurpose>
+   Añade una nueva variable al caché de usuario solo si la variable todavía no existe en el cache
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>wincache_ucache_add</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <methodsynopsis>
+   <type>bool</type><methodname>wincache_ucache_add</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Añade una variable al caché de usuario, solo si no existe ya en el caché. La variable permanecerá en el caché mientras no se alcance el tiempo de expiración o hasta que no se elimine con la función
+   <function>wincache_ucache_delete</function> o la función <function>wincache_ucache_clear</function>.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       Almacena la variable usando el nombre <parameter>key</parameter>. Si una variable
+       correspondiente a la misma clave ya está presente en el caché, la función
+       fallará y devolverá &false;. El parámetro <parameter>key</parameter> es sensible a mayúsculas y minúsculas. Para sobrescribir este valor, si <parameter>key</parameter> está presente,
+       use la función <function>wincache_ucache_set</function> en su lugar.
+       <parameter>key</parameter> también puede ser un array de pares nombre => valor donde
+       los nombres serán usados como claves. Este formato puede ser usado para añadir
+       múltiples valores en el caché en una sola operación.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       El valor de la variable a almacenar. El parámetro <parameter>Value</parameter>
+       soporta todos los tipos de datos, excepto recursos, como punteros de archivos.
+       Este parámetro será ignorado si el primer argumento es un array. Generalmente, se debe
+       pasar el valor &null; al parámetro <parameter>value</parameter> cuando se usa un array para el parámetro <parameter>key</parameter>. Si el parámetro <parameter>value</parameter>
+       es un objeto, o un array que contiene objetos, entonces los objetos serán serializados. Consulte la función <link linkend="object.sleep">__sleep()</link>
+       para más detalles sobre la serialización de objetos.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>values</parameter></term>
+     <listitem>
+      <para>
+       Array asociativo de claves y valores.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>ttl</parameter></term>
+     <listitem>
+      <para>
+       Duración de vida de la variable en el caché, en segundos. Después del tiempo especificado
+       por el parámetro <parameter>ttl</parameter>, la variable almacenada será eliminada del caché. Este parámetro toma, como
+       valor por defecto, cero (<literal>0</literal>), lo que significa que la variable
+       permanecerá en el caché hasta que no sea explícitamente eliminada usando la función <function>wincache_ucache_delete</function>
+       o la función <function>wincache_ucache_clear</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Si el parámetro <parameter>key</parameter> es una &string;, la función devuelve
+   &true; en caso de éxito, &false; si ocurre un error.
+  </simpara>
+  <para>
+   Si el parámetro <parameter>key</parameter> es un array, la función devuelve:
+   <itemizedlist spacing="compact">
+    <listitem>
+     <simpara>
+      Si todas las parejas nombre => valor del array pueden ser definidas, la función devolverá
+      un array vacío;
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Si ninguna de las parejas nombre => valor del array puede ser definida, la función devolverá
+      &false; ;
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Si algunas pueden ser definidas, y otras no, la función devolverá un array de parejas
+      nombre => valor que no han podido ser definidas en el caché de usuario.
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Ejemplo con <function>wincache_ucache_add</function> y el parámetro <parameter>key</parameter> en forma de &string;</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$bar = 'BAR';
+var_dump(wincache_ucache_add('foo', $bar));
+var_dump(wincache_ucache_add('foo', $bar));
+var_dump(wincache_ucache_get('foo'));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(true)
+bool(false)
+string(3) "BAR"
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Ejemplo con <function>wincache_ucache_add</function> y el parámetro <parameter>key</parameter> en forma de &array;</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$colors_array = array('green' => '5', 'Blue' => '6', 'yellow' => '7', 'cyan' => '8');
+var_dump(wincache_ucache_add($colors_array));
+var_dump(wincache_ucache_add($colors_array));
+var_dump(wincache_ucache_get('Blue'));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(0) { }
+array(4) {
+  ["green"]=> int(-1)
+  ["Blue"]=> int(-1)
+  ["yellow"]=> int(-1)
+  ["cyan"]=> int(-1)
+}
+string(1) "6"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_ucache_set</function></member>
+    <member><function>wincache_ucache_get</function></member>
+    <member><function>wincache_ucache_delete</function></member>
+    <member><function>wincache_ucache_clear</function></member>
+    <member><function>wincache_ucache_exists</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+    <member><link linkend="object.sleep">__sleep()</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/functions/wincache-ucache-set.xml
+++ b/reference/wincache/functions/wincache-ucache-set.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 07e42841b078fc8dfb4a2d053b707b5233c4cfeb Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.wincache-ucache-set" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>wincache_ucache_set</refname>
+  <refpurpose>Añade una variable a la caché de usuario y sobrescribe la variable si ya existe en la caché</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>wincache_ucache_set</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <methodsynopsis>
+   <type>bool</type><methodname>wincache_ucache_set</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Añade una variable a la caché de usuario. Sobrescribe una variable si ya existe
+   en la caché. La variable así creada o actualizada permanecerá en la caché de usuario
+   mientras no se alcance el tiempo de expiración o hasta que no se elimine con la función
+   <function>wincache_ucache_delete</function> o la función <function>wincache_ucache_clear</function>.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       Almacena la variable usando la clave <parameter>key</parameter>.
+       Si una variable usando la misma clave <parameter>key</parameter> ya está presente,
+       la función sobrescribirá el valor anterior con el nuevo. El parámetro <parameter>key</parameter>
+       es sensible a mayúsculas y minúsculas. <parameter>key</parameter> también puede ser un
+       array de pares nombre => valor donde los nombres serán usados como claves. Esto puede ser útil
+       para añadir múltiples valores en la caché en una sola operación, evitando así las condiciones de carrera.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       Valor de la variable a almacenar. El parámetro <parameter>Value</parameter>
+       soporta todos los tipos de datos, excepto recursos, como punteros de archivos. Este parámetro
+       es ignorado si el primer argumento es un array. Es convención pasar &null; como
+       <parameter>value</parameter> cuando se usa un array en el parámetro <parameter>key</parameter>.
+       Si el parámetro <parameter>value</parameter> es un objeto, o un array que contiene objetos,
+       entonces todos los objetos serán serializados. Consulte la función <link linkend="object.sleep">__sleep()</link>
+       para más detalles sobre la serialización de objetos.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>values</parameter></term>
+     <listitem>
+      <para>
+       Array asociativo de claves y valores.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>ttl</parameter></term>
+     <listitem>
+      <para>
+       Tiempo de vida de la variable en la caché, en segundos. Después del tiempo especificado
+       por el parámetro <parameter>ttl</parameter>, la variable almacenada será eliminada de la caché de usuario.
+       Este parámetro toma por defecto el valor cero (<literal>0</literal>), lo que significa que la variable
+       permanecerá en la caché hasta que no sea explícitamente eliminada llamando a la función
+       <function>wincache_ucache_delete</function> o la función <function>wincache_ucache_clear</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Si <parameter>key</parameter> es un &string;, la función devolverá &true; en caso de éxito,
+   &false; si ocurre un error.
+  </simpara>
+  <para>
+   Si <parameter>key</parameter> es un array, la función devolverá:
+   <itemizedlist spacing="compact">
+    <listitem>
+     <simpara>
+      Si todas las parejas nombre => valor del array han podido ser definidas,
+      la función devolverá un array vacío.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Si ninguna de las parejas nombre => valor del array ha podido ser definida,
+      la función devolverá &false;.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      Si algunas parejas han sido definidas, y otras no, la función
+      devolverá un array de parejas nombre => valor que no han podido ser definidas
+      en la caché de usuario.
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Ejemplo con <function>wincache_ucache_set</function> y
+     el parámetro <parameter>key</parameter> en forma de &string;</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$bar = 'BAR';
+var_dump(wincache_ucache_set('foo', $bar));
+var_dump(wincache_ucache_get('foo'));
+$bar1 = 'BAR1';
+var_dump(wincache_ucache_set('foo', $bar1));
+var_dump(wincache_ucache_get('foo'));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(true)
+string(3) "BAR"
+bool(true)
+string(3) "BAR1"
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Ejemplo con <function>wincache_ucache_set</function> y
+     el parámetro <parameter>key</parameter> en forma de &array;</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$colors_array = array('green' => '5', 'Blue' => '6', 'yellow' => '7', 'cyan' => '8');
+var_dump(wincache_ucache_set($colors_array));
+var_dump(wincache_ucache_set($colors_array));
+var_dump(wincache_ucache_get('Blue'));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(0) {}
+array(0) {}
+string(1) "6"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>wincache_ucache_add</function></member>
+    <member><function>wincache_ucache_get</function></member>
+    <member><function>wincache_ucache_delete</function></member>
+    <member><function>wincache_ucache_clear</function></member>
+    <member><function>wincache_ucache_exists</function></member>
+    <member><function>wincache_ucache_meminfo</function></member>
+    <member><function>wincache_ucache_info</function></member>
+    <member><link linkend="object.sleep">__sleep()</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/setup.xml
+++ b/reference/wincache/setup.xml
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 48ce43fe79fa0c9f31f187ea8ec995b4cb13037e Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<chapter xml:id="wincache.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
+
+ <section xml:id="wincache.requirements">
+  &reftitle.required;
+  <para>
+   La extensión actualmente solo es compatible con las siguientes configuraciones:
+  </para>
+  <simpara>Sistema Operativo Windows:</simpara>
+  <itemizedlist spacing="compact">
+   <listitem>
+    <simpara>Windows XP SP3 con IIS 5.1 y la <link xlink:href="&url.iis.fastcgi.downloads;">Extensión FastCGI</link></simpara>
+   </listitem>
+   <listitem>
+    <simpara>Windows Server 2003 con IIS 6.0 y la <link xlink:href="&url.iis.fastcgi.downloads;">Extensión FastCGI</link></simpara>
+   </listitem>
+   <listitem>
+    <simpara>Windows Vista SP1 con IIS 7.0 y el módulo FastCGI</simpara>
+   </listitem>
+   <listitem>
+    <simpara>Windows Server 2008 con IIS 7.0 y el módulo FastCGI</simpara>
+   </listitem>
+   <listitem>
+    <simpara>Windows 7 con IIS 7.5 y el módulo FastCGI</simpara>
+   </listitem>
+   <listitem>
+    <simpara>Windows Server 2008 R2 con IIS 7.5 y el módulo FastCGI</simpara>
+   </listitem>
+  </itemizedlist>
+  <simpara>PHP:</simpara>
+  <itemizedlist spacing="compact">
+   <listitem>
+    <simpara>PHP 5.2.X, compilación no segura para subprocesos</simpara>
+   </listitem>
+   <listitem>
+    <simpara>PHP 5.3 X86, compilación VC9 no segura para subprocesos</simpara>
+   </listitem>
+  </itemizedlist>
+  <note>
+   <simpara>
+    La extensión WinCache solo puede ser utilizada cuando IIS está configurado para ejecutar PHP a través de FastCGI.
+   </simpara>
+  </note>
+ </section>
+ <section xml:id="wincache.installation">
+  &reftitle.install;
+  <para>
+   &pecl.moved;
+  </para>
+  <para>
+   &pecl.info;
+   <link xlink:href="&url.pecl.package;wincache">&url.pecl.package;wincache</link>.
+  </para>
+  <para>
+   Hay dos paquetes para esta extensión: un paquete es para las versiones PHP 5.2.X,
+   y el otro paquete es para PHP 5.3.X. Elija el paquete adecuado para la versión de PHP
+   que esté utilizando.
+  </para>
+  <para>
+   Para instalar y activar la extensión, siga estos pasos:
+  </para>
+  <procedure>
+   <step>
+    <simpara>
+     Descomprima el paquete en una ubicación temporal.
+    </simpara>
+   </step>
+   <step>
+    <simpara>
+     Copie el archivo <filename>php_wincache.dll</filename> en la carpeta de extensiones PHP.
+     Generalmente, esta carpeta se llama "ext" y está ubicada en el mismo directorio que todos
+     los archivos binarios de PHP. Por ejemplo: <filename>C:\Program Files\PHP\ext</filename>.
+    </simpara>
+   </step>
+   <step>
+    <simpara>
+     Con un editor de texto, abra el archivo php.ini, que generalmente se encuentra en el mismo
+     directorio que todos los archivos binarios de PHP. Por ejemplo:
+     <filename>C:\Program Files\PHP\php.ini</filename>.
+    </simpara>
+   </step>
+   <step>
+    <simpara>
+     Agregue la siguiente línea al final del archivo php.ini:
+     <literal>extension = php_wincache.dll</literal>.
+    </simpara>
+   </step>
+   <step>
+    <simpara>
+     Guarde y cierre el archivo <filename>php.ini</filename>.
+    </simpara>
+   </step>
+   <step>
+    <simpara>
+     Reinicie el grupo de aplicaciones IIS para que PHP recoja los cambios de configuración. Para verificar que la extensión se ha activado, cree un archivo llamado
+     <filename>phpinfo.php</filename> que contenga una llamada a la función
+     <link linkend="function.phpinfo">phpinfo</link>.
+    </simpara>
+   </step>
+   <step>
+    <simpara>
+     Guarde el archivo <filename>phpinfo.php</filename> en el directorio raíz de un
+     sitio web IIS que utilice PHP, luego abra un navegador y realice una solicitud a
+     http://localhost/phpinfo.php. Busque una sección llamada <literal>wincache</literal>
+     en la página devuelta. Si la extensión está activada, la salida de
+     <link linkend="function.phpinfo">phpinfo</link> listará los parámetros de configuración
+     proporcionados por WinCache.
+    </simpara>
+   </step>
+  </procedure>
+  <note>
+   <simpara>
+    No olvide eliminar el archivo <filename>phpinfo.php</filename> del directorio raíz después de haber verificado que la extensión se ha activado.
+   </simpara>
+  </note>
+ </section>
+ &reference.wincache.ini;
+
+ <section xml:id="wincache.stats">
+  <title>Script de estadísticas WinCache</title>
+  <para>
+   El paquete de instalación para WinCache incluye un script PHP,
+   <filename>wincache.php</filename>, que puede ser utilizado para obtener información y estadísticas sobre la caché.
+  </para>
+  <para>
+   Si la extensión WinCache se instaló a través del instalador de Microsoft Web Platform,
+   entonces este script se encuentra en
+   <filename>%SystemDrive%\Program Files\IIS\Windows Cache for PHP\</filename>.
+   En una versión de 64 bits del sistema operativo Windows Server, el script se encuentra en
+   <filename>%SystemDrive%\Program Files (x86)\IIS\Windows Cache for PHP</filename>.
+   Si la extensión se instaló manualmente, entonces el archivo <filename>wincache.php</filename>
+   estará ubicado en el mismo directorio desde el cual se extrajo el contenido del paquete de instalación.
+  </para>
+  <para>
+   Para usar <filename>wincache.php</filename>, cópielo en el directorio raíz de un sitio web o
+   en cualquier subdirectorio. Para proteger el script, ábralo en cualquier editor y
+   reemplace los valores de las constantes <emphasis>USERNAME</emphasis> y <emphasis>PASSWORD</emphasis>. Si alguna otra autenticación IIS está habilitada en el servidor, entonces siga las instrucciones
+   en los comentarios:
+   <example>
+    <title>Configuración de la autenticación para <filename>wincache.php</filename></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+/**
+ * ======================== CONFIGURACIÓN DE AJUSTES ==============================
+ * Si no desea usar la autenticación para esta página, establezca USE_AUTHENTICATION en 0.
+ * Si usa autenticación, reemplace la contraseña predeterminada.
+ */
+define('USE_AUTHENTICATION', 1);
+define('USERNAME', 'wincache');
+define('PASSWORD', 'wincache');
+
+/**
+ * La autenticación PHP básica solo funcionará cuando IIS esté configurado para admitir
+ * 'Autenticación anónima' y nada más. Si IIS está configurado para admitir/usar
+ * cualquier otro tipo de autenticación como Básica/Negociar/Digest, etc., esto no funcionará.
+ * En ese caso, use la matriz a continuación para definir los nombres de los usuarios en su
+ * dominio/red/grupo de trabajo a los que desea otorgar acceso.
+ */
+$user_allowed = array('DOMAIN\user1', 'DOMAIN\user2', 'DOMAIN\user3');
+
+/**
+ * Si la matriz contiene la cadena 'all', entonces todos los usuarios autenticados por IIS
+ * tendrán acceso a la página. Descomente la línea a continuación y comente la línea anterior
+ * para otorgar acceso a todos los usuarios que sean autenticados por IIS.
+ */
+/* $user_allowed = array('all'); */
+
+/** ===================== FIN DE CONFIGURACIÓN DE AJUSTES ========================== */
+?>
+]]>
+    </programlisting>
+   </example>
+   <note>
+    <simpara>
+     Siempre proteja el script <filename>wincache.php</filename> utilizando el mecanismo de autenticación integrado o el mecanismo de autenticación del servidor. Dejar este script sin protección puede comprometer la seguridad de su aplicación web
+     y del servidor.
+    </simpara>
+   </note>
+  </para>
+ </section>
+ <section xml:id="wincache.sessionhandler">
+  <title>Manejador de sesiones WinCache</title>
+  <para>
+   El manejador de sesiones WinCache (disponible desde WinCache 1.1.0) puede ser utilizado
+   para configurar PHP para almacenar los datos de sesión en la memoria compartida del caché de sesión.
+   El uso de la memoria compartida en lugar de la sesión predeterminada ayuda a mejorar el rendimiento
+   de las aplicaciones PHP que almacenan grandes cantidades de datos en objetos de sesión.
+   El caché de sesión Wincache utiliza archivos basados en memoria compartida, lo que
+   asegura que los datos de sesión no se perderán durante el reciclaje de la cola de aplicaciones IIS.
+  </para>
+  <para>
+   Para configurar PHP para usar el manejador de sesiones WinCache, establezca el parámetro
+   <link linkend="ini.session.save-handler">session.save_handler</link> del archivo
+   <filename>php.ini</filename> a <emphasis>wincache</emphasis>.
+   De forma predeterminada, la ubicación donde se almacenan los archivos temporales en Windows se usa
+   para almacenar los datos de sesión. Para cambiar esta ubicación, use la directiva
+   <link linkend="ini.session.save-path">session.save_path</link>.
+   <example>
+    <title>Activar el manejador de sesiones WinCache</title>
+    <programlisting role="php.ini">
+<![CDATA[
+session.save_handler = wincache
+session.save_path = C:\inetpub\temp\session\
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </section>
+ <section xml:id="wincache.reroutes">
+ <title>Redirecciones de funciones WinCache</title>
+ <para>
+  <emphasis>NOTA:</emphasis>
+  <link linkend="ini.wincache.rerouteini">wincache.rerouteini</link>
+  fue eliminado con WinCache 1.3.7.0. Esto ha sido reemplazado por el redireccionamiento automático de funciones. Ver:
+  <link linkend="ini.wincache.reroute_enabled">wincache.reroute_enabled</link>
+  </para>
+  <para>
+   Las funcionalidades de redireccionamiento de funciones de WinCache (disponibles
+   desde WinCache 1.2.0, eliminadas desde WinCache 1.3.7.0) pueden ser utilizadas para reemplazar funciones PHP nativas por sus equivalentes optimizados para casos particulares. La extensión
+   Wincache incluye implementaciones de funciones PHP optimizadas para Windows,
+   especialmente en casos de acceso a red o sistema de archivos.
+   Las siguientes funciones están involucradas:
+  </para>
+  <itemizedlist spacing="compact">
+   <listitem>
+    <simpara>
+     <link linkend="function.file-exists">file_exists</link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="function.file-get-contents">file_get_contents</link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="function.readfile">readfile</link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="function.is-readable">is_readable</link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="function.is-writable">is_writable</link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="function.is-dir">is_dir</link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="function.realpath">realpath</link>
+    </simpara>
+   </listitem>
+      <listitem>
+    <simpara>
+     <link linkend="function.filesize">filesize</link>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+  <para>
+   Para configurar el redireccionamiento de funciones con Wincache, use el archivo
+   <filename>reroute.ini</filename> incluido en el paquete. Cópielo en el directorio
+   donde se encuentra <filename>php.ini</filename>. Luego, agregue wincache.rerouteini en
+   <filename>php.ini</filename> y especifique la ruta absoluta o relativa a
+   <filename>reroute.ini</filename>.
+   <example>
+    <title>Activación de las funcionalidades de redireccionamiento de funciones de WinCache</title>
+    <programlisting role="php.ini">
+<![CDATA[
+wincache.rerouteini = C:\PHP\reroute.ini
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <note>
+   <simpara>
+    Si está habilitado, se recomienda aumentar el tamaño del caché de archivos. Esto se puede hacer
+    usando el parámetro <link linkend="ini.wincache.fcachesize">wincache.fcachesize</link>.
+   </simpara>
+  </note>
+  <para>
+   El archivo <filename>reroute.ini</filename> contiene la correspondencia entre la función PHP nativa y
+   el equivalente de Wincache. Cada línea en el archivo define una correspondencia. Aquí está la sintaxis:
+  </para>
+  <simpara>
+   <literal>&lt;Nombre de la función PHP&gt;:[&lt;número de parámetros de la función&gt;]=&lt;nombre de la función wincache&gt;</literal>
+  </simpara>
+  <para>
+   A continuación se muestra un ejemplo de archivo. En este ejemplo, las llamadas a las funciones PHP
+   <function>file_get_contents</function> serán reemplazadas por <function>wincache_file_get_contents</function>
+   solo si el número de parámetros pasados a la función es menor o igual a dos. Es útil especificar el número de parámetros cuando la función de reemplazo no está diseñada para usar todos ellos.
+   <example>
+    <title>Reroute.ini</title>
+    <programlisting role="php.ini">
+ <![CDATA[
+[FunctionRerouteList]
+file_exists=wincache_file_exists
+file_get_contents:2=wincache_file_get_contents
+readfile:2=wincache_readfile
+is_readable=wincache_is_readable
+is_writable=wincache_is_writable
+is_writeable=wincache_is_writable
+is_file=wincache_is_file
+is_dir=wincache_is_dir
+realpath=wincache_realpath
+filesize=wincache_filesize
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </section>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wincache/win32build.xml
+++ b/reference/wincache/win32build.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8b6d169424ff189bb563ef4c3f35f8adff3f42c5 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<appendix xml:id="wincache.win32build" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Compilación en Windows</title>
+  <section xml:id="wincache.win32build.prereq">
+   <title>Prerrequisitos</title>
+   <para>
+    Para compilar la extensión WinCache, se necesitará:
+   </para>
+   <orderedlist spacing="compact">
+    <listitem>
+     <simpara>el código fuente de PHP</simpara>
+    </listitem>
+    <listitem>
+     <simpara>un entorno de compilación PHP</simpara>
+    </listitem>
+    <listitem>
+     <simpara>el código fuente de WinCache</simpara>
+    </listitem>
+   </orderedlist>
+   <para>
+    Para completar los dos primeros pasos, siga la guía paso a paso
+    <link xlink:href="&url.php.win.build;">Compilar PHP en Windows</link>.
+   </para>
+   <para>
+    Para obtener el código fuente de WinCache, siga las instrucciones descritas
+    en <link linkend="install.pecl.downloads">Descargar extensiones PECL</link>.
+   </para>
+  </section>
+  <section xml:id="wincache.win32build.building">
+   <title>Compilar y construir</title>
+   <para>
+    Los siguientes pasos describen cómo compilar y construir WinCache en Windows:
+   </para>
+   <procedure>
+    <step>
+     <simpara>Abra una ventana de comandos utilizada para compilar PHP</simpara>
+    </step>
+    <step>
+     <simpara>Vaya al directorio raíz donde se encuentran las fuentes de PHP</simpara>
+    </step>
+    <step>
+     <para>
+      Ejecute el comando:
+      <programlisting role="cmd">
+<![CDATA[
+cscript.exe win32\build\buildconf.js
+]]>
+      </programlisting>
+     </para>
+    </step>
+    <step>
+     <para>
+      Ejecute el comando:
+      <programlisting role="cmd">
+<![CDATA[
+configure.bat --help
+]]>
+      </programlisting>
+      La salida contendrá una nueva opción <literal>--enable-wincache</literal>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Ejecute el comando:
+      <programlisting role="cmd">
+<![CDATA[
+configure.js [todas las opciones usadas para compilar PHP] --enable-wincache
+]]>
+      </programlisting>
+      <literal>--enable-wincache</literal> es la única opción adicional requerida
+      para asegurarse de que la extensión WinCache se compile correctamente.
+      Esta opción permite construir WinCache y enlazarlo estáticamente con la
+      DLL de PHP. Para construir la extensión como una DLL externa, use la
+      opción <literal>--enable-wincache=shared</literal>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Ejecute el comando:
+      <programlisting role="cmd">
+<![CDATA[
+nmake
+]]>
+      </programlisting>
+     </para>
+    </step>
+   </procedure>
+  </section>
+  <section xml:id="wincache.win32build.verify">
+   <title>Verificar la compilación</title>
+   <para>
+    Los siguientes pasos describen cómo verificar que WinCache se ha compilado correctamente:
+   </para>
+   <procedure>
+    <step>
+     <simpara>
+      Vaya al directorio donde se construyen los archivos PHP.
+     </simpara>
+    </step>
+    <step>
+     <para>
+      Ejecute el comando:
+      <programlisting role="cmd">
+<![CDATA[
+php.exe -n -d extension=php_wincache.dll -re wincache
+]]>
+      </programlisting>
+      Si WinCache se ha compilado correctamente, la salida de este comando listará
+      las directivas INI y las funciones soportadas por WinCache.
+     </para>
+    </step>
+   </procedure>
+  </section>
+</appendix>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wkhtmltox/wkhtmltox/bits/load.xml
+++ b/reference/wkhtmltox/wkhtmltox/bits/load.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+
+<row>
+  <entry>load.username</entry>
+  <entry>nombre de usuario a utilizar al conectarse a un sitio web</entry>
+  <entry>bart</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.password</entry>
+  <entry>contraseña a utilizar al conectarse a un sitio web</entry>
+  <entry>elbarto</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.jsdelay</entry>
+  <entry>el tiempo en milisegundos a esperar después de cargar una página antes de capturarla</entry>
+  <entry>1200</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.zoomFactor</entry>
+  <entry>cuánto zoom debe aplicarse al contenido</entry>
+  <entry>2.2</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.customHeaders</entry>
+  <entry>encabezados personalizados a enviar al solicitar la página web principal</entry>
+  <entry></entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.repertCustomHeaders</entry>
+  <entry>establecer en true para enviar con todas las solicitudes</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.cookies</entry>
+  <entry>cookie a enviar al solicitar la página web principal</entry>
+  <entry></entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.post</entry>
+  <entry>string a enviar al realizar una solicitud post a la página web principal</entry>
+  <entry></entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.blockLocalFileAccess</entry>
+  <entry>impide que los archivos locales y los archivos de tubería accedan a otros archivos locales</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.stopSlowScript</entry>
+  <entry>detiene los scripts lentos de javascript</entry>
+  <entry>booleano</entry>
+  <entry></entry>
+</row>
+<row>
+  <entry>load.debugJavascript</entry>
+  <entry>permite que javascript lance advertencias</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.loadErrorHandling</entry>
+  <entry>define la estrategia de manejo de errores</entry>
+  <entry>
+   <table>
+    <title></title>
+    <tgroup cols="2">
+     <tbody>
+      <row>
+       <entry>abort</entry>
+       <entry>aborta el proceso de conversión</entry>
+      </row>
+      <row>
+       <entry>skip</entry>
+       <entry>no añade el objeto a la salida final</entry>
+      </row>
+      <row>
+       <entry>ignore</entry>
+       <entry>intenta añadir el objeto a la salida final</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>load.proxy</entry>
+  <entry></entry>
+  <entry></entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>

--- a/reference/wkhtmltox/wkhtmltox/bits/web.xml
+++ b/reference/wkhtmltox/wkhtmltox/bits/web.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3f75f75dcf86e42bc79d5753836fee49ea6a97be Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+
+<row>
+  <entry>web.background</entry>
+  <entry>incluye una imagen de fondo en la salida</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>web.loadImages</entry>
+  <entry>incluye imágenes en la salida</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>web.enableJavascript</entry>
+  <entry>activa o desactiva javascript</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>web.enableIntelligentShrinking</entry>
+  <entry>activa el intento de poner más contenido en la página, se aplica solo a la salida PDF</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>web.minimumFontSize</entry>
+  <entry>el tamaño de fuente mínimo permitido</entry>
+  <entry>9</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>web.printMediaType</entry>
+  <entry>muestra el contenido usando el tipo de medio de impresión en lugar del tipo de medio de pantalla</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>web.defaultEncoding</entry>
+  <entry>el contenido a usar cuando no se especifica ninguna codificación</entry>
+  <entry>utf-8</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>web.userStyleSheet</entry>
+  <entry>URL o ruta hacia una hoja de estilo de usuario especificada</entry>
+  <entry>/ruta/hacia/estilo.css</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>
+<row>
+  <entry>web.enablePlugins</entry>
+  <entry>activa o desactiva los plugins NS</entry>
+  <entry>booleano</entry>
+  <entry>&gt;= 0.1.0</entry>
+</row>

--- a/reference/wkhtmltox/wkhtmltox/image/converter/construct.xml
+++ b/reference/wkhtmltox/wkhtmltox/image/converter/construct.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="wkhtmltox-image-converter.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>wkhtmltox\Image\Converter::__construct</refname>
+  <refpurpose>Crea un nuevo convertidor de imágenes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>wkhtmltox\Image\Converter::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>buffer</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>settings</parameter></methodparam>
+  </constructorsynopsis>
+  <para>
+   Crea un convertidor de imágenes, utilizando opcionalmente un buffer de entrada
+   así como una configuración
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>buffer</parameter></term>
+    <listitem>
+     <para>
+      HTML
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>settings</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title></title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Nombre</entry>
+          <entry>Descripción</entry>
+          <entry>Valor</entry>
+          <entry>Registro de cambios</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>in</entry>
+          <entry>URL o ruta del archivo de entrada, si se usa la salida "-"</entry>
+          <entry>/ruta/hacia/marcado.html</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>out</entry>
+          <entry>Ruta del archivo de salida, si es "-" se usa stdout; por omisión, se usa un buffer interno</entry>
+          <entry>/ruta/hacia/salida.png</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>fmt</entry>
+          <entry>Formato de salida a usar</entry>
+          <entry>
+           <table>
+            <title></title>
+            <tgroup cols="2">
+             <tbody>
+              <row>
+               <entry>""</entry>
+               <entry>predeterminado</entry>
+              </row>
+              <row>
+               <entry>jpg</entry>
+               <entry>salida como JPEG</entry>
+              </row>
+              <row>
+               <entry>png</entry>
+               <entry>salida como PNG</entry>
+              </row>
+              <row>
+               <entry>bmp</entry>
+               <entry>salida como mapa de bits</entry>
+              </row>
+              <row>
+               <entry>svg</entry>
+               <entry>salida como SVG</entry>
+              </row>
+             </tbody>
+            </tgroup>
+           </table>
+          </entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>transparent</entry>
+          <entry>En la salida PNG o SVG, hace el fondo transparente</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>screenWidth</entry>
+          <entry>El ancho de pantalla a usar para el renderizado en píxeles</entry>
+          <entry>800</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>smartWidth</entry>
+          <entry>Cuando es &true;, el ancho de la pantalla se extiende al ancho del contenido</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>quality</entry>
+          <entry>Factor de compresión a usar cuando la salida es una imagen JPEG</entry>
+          <entry>94</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>crop.left</entry>
+          <entry>Izquierda/coordenada X de la ventana a capturar, en píxeles</entry>
+          <entry>200</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>crop.top</entry>
+          <entry>Arriba/coordenada Y de la ventana a capturar, en píxeles</entry>
+          <entry>200</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>crop.width</entry>
+          <entry>Ancho de la ventana a capturar, en píxeles</entry>
+          <entry>200</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>crop.height</entry>
+          <entry>Altura de la ventana a capturar, en píxeles</entry>
+          <entry>200</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+           <entry>load.cookieJar</entry>
+           <entry>Ruta del archivo utilizado para cargar y almacenar las cookies.</entry>
+           <entry>/tmp/cookies.txt</entry>
+           <entry>&gt;= 0.1.0</entry>
+         </row>
+         &reference.wkhtmltox.wkhtmltox.bits.load;
+         &reference.wkhtmltox.wkhtmltox.bits.web;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <!-- Return values commented out, as constructors generally don't return a
+      value. Uncomment this if you do need a return values section (for
+      example, because there's also a procedural version of the method).
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+ -->
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wkhtmltox/wkhtmltox/pdf/converter/construct.xml
+++ b/reference/wkhtmltox/wkhtmltox/pdf/converter/construct.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="wkhtmltox-pdf-converter.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>wkhtmltox\PDF\Converter::__construct</refname>
+  <refpurpose>Crea un nuevo conversor de PDF</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>wkhtmltox\PDF\Converter::__construct</methodname>
+   <methodparam choice="opt"><type>array</type><parameter>settings</parameter></methodparam>
+  </constructorsynopsis>
+  <para>
+   Crea un nuevo conversor de PDF, utilizando opcionalmente una configuración.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>settings</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title></title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Nombre</entry>
+          <entry>Descripción</entry>
+          <entry>Valores</entry>
+          <entry>Registro de cambios</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>size.pageSize</entry>
+          <entry>Tamaño del papel del documento final</entry>
+          <entry>A4</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>size.width</entry>
+          <entry>Ancho del documento final</entry>
+          <entry>210mm</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>size.height</entry>
+          <entry>Altura del documento final</entry>
+          <entry>297mm</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>orientation</entry>
+          <entry>Orientación del documento final</entry>
+          <entry>
+           <table>
+            <title></title>
+            <tgroup cols="1">
+             <tbody>
+              <row>
+               <entry>Landscape</entry>
+              </row>
+              <row>
+               <entry>Portrait</entry>
+              </row>
+             </tbody>
+            </tgroup>
+           </table>
+          </entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>colorMode</entry>
+          <entry>Modo de color del documento final</entry>
+          <entry>
+           <table>
+            <title></title>
+            <tgroup cols="1">
+             <tbody>
+              <row>
+               <entry>Color</entry>
+              </row>
+              <row>
+               <entry>Greyscale</entry>
+              </row>
+             </tbody>
+            </tgroup>
+           </table>
+          </entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>resolution</entry>
+          <entry>Resolución del documento final</entry>
+          <entry>La mayoría de las veces, no tiene ningún efecto</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>dpi</entry>
+          <entry>DPI a usar al imprimir</entry>
+          <entry>80</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>pageOffset</entry>
+          <entry>Entero a añadir a los números de página generados para el encabezado,
+           el pie de página y el índice</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>copies</entry>
+          <entry></entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>collate</entry>
+          <entry>Si se deben intercalar las copias</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>outline</entry>
+          <entry>Genera un índice PDF</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>outlineDepth</entry>
+          <entry>Profundidad máxima del índice</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>dumpOutline</entry>
+          <entry>Ruta del archivo para extraer el índice XML</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>out</entry>
+          <entry>Ruta para el archivo final, si es "-" se usa stdout</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>documentTitle</entry>
+          <entry>Título del documento final</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>useCompression</entry>
+          <entry>Activa o desactiva la compresión sin pérdida</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>margin.top</entry>
+          <entry>Tamaño del margen superior</entry>
+          <entry>2cm</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>margin.bottom</entry>
+          <entry>Tamaño del margen inferior</entry>
+          <entry>2cm</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>margin.left</entry>
+          <entry>Tamaño del margen izquierdo</entry>
+          <entry>2cm</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>margin.right</entry>
+          <entry>Tamaño del margen derecho</entry>
+          <entry>2cm</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>imageDPI</entry>
+          <entry>DPI máximo para las imágenes en el documento final</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>imageQuality</entry>
+          <entry>El factor de compresión jpeg para las imágenes en el documento final</entry>
+          <entry>94</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+           <entry>load.cookieJar</entry>
+           <entry>Ruta hacia el archivo utilizado para cargar y almacenar las cookies</entry>
+           <entry>/tmp/cookies.txt</entry>
+           <entry>&gt;= 0.1.0</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <!-- Return values commented out, as constructors generally don't return a
+      value. Uncomment this if you do need a return values section (for
+      example, because there's also a procedural version of the method).
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+ -->
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/wkhtmltox/wkhtmltox/pdf/object/construct.xml
+++ b/reference/wkhtmltox/wkhtmltox/pdf/object/construct.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 6d9dd2c79f2acfda54aedb5d53e9ce96aa759544 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="wkhtmltox-pdf-object.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>wkhtmltox\PDF\Object::__construct</refname>
+  <refpurpose>Crea un nuevo objeto PDF</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>wkhtmltox\PDF\Object::__construct</methodname>
+   <methodparam><type>string</type><parameter>buffer</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>settings</parameter></methodparam>
+  </constructorsynopsis>
+  <para>
+   Crea un nuevo objeto PDF desde el buffer proporcionado,
+   y las configuraciones opcionales.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>buffer</parameter></term>
+    <listitem>
+     <para>
+      HTML
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>settings</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title></title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Nombre</entry>
+          <entry>Descripción</entry>
+          <entry>Valor</entry>
+          <entry>Registro de cambios</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>page</entry>
+          <entry>URL o ruta del archivo HTML a
+           convertir</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>useExternalLinks</entry>
+          <entry>Establecer en &true; para convertir los enlaces externos
+            enlaces PDF en la salida</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>useLocalLinks</entry>
+          <entry>Establecer en &true; para convertir los enlaces internos
+           en los datos de entrada en enlaces PDF en la salida</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>produceForms</entry>
+          <entry>Establecer en &true; para convertir los formularios
+           HTML en formularios PDF</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>replacements</entry>
+          <entry>no documentado</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>includeInOutline</entry>
+          <entry>Establecer en &true; para incluir las secciones
+           de este objeto en el contorno y la tabla de contenidos</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>pagesCount</entry>
+          <entry>Establecer en &true; para incluir en la tabla de contenidos el número
+           de páginas de este objeto</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>tocXsl</entry>
+          <entry>Establecer en hoja de estilo para convertir este objeto en un objeto de tabla de contenidos</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>toc.useDottedLines</entry>
+          <entry>Establecer en &true; para usar líneas de puntos
+           en la tabla de contenidos</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>toc.captionText</entry>
+          <entry>El pie de ilustración para la tabla de contenidos</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>toc.forwardLinks</entry>
+          <entry>Establecer en &true; para crear enlaces
+           desde la tabla de contenidos hacia el contenido</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>toc.backLinks</entry>
+          <entry>Establecer en &true; para crear enlaces
+           desde el contenido hacia la tabla de contenidos</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>toc.indentation</entry>
+          <entry>La indentación para la tabla de contenidos</entry>
+          <entry>2em</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>toc.fontScale</entry>
+          <entry>El factor para reducir la fuente de caracteres
+           en todos los niveles de la tabla de contenidos</entry>
+          <entry>0.8</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>header.fontSize</entry>
+          <entry>El tamaño de la fuente de caracteres a usar en el encabezado</entry>
+          <entry>13</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>header.fontName</entry>
+          <entry>El nombre de la fuente de caracteres a usar en el encabezado</entry>
+          <entry>times</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>header.left</entry>
+          <entry>El texto para el lado izquierdo del encabezado</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>header.center</entry>
+          <entry>El texto para el centro del encabezado</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>header.right</entry>
+          <entry>El texto para el lado derecho del encabezado</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>header.line</entry>
+          <entry>Activa o desactiva la regla horizontal bajo el encabezado</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>header.spacing</entry>
+          <entry>El espacio entre el encabezado y el contenido</entry>
+          <entry>1.8</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>header.htmlUrl</entry>
+          <entry>URL o la ruta hacia el archivo HTML a usar
+           en el encabezado</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>footer.fontSize</entry>
+          <entry>El tamaño de la fuente de caracteres a usar en el pie de página</entry>
+          <entry>13</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>footer.fontName</entry>
+          <entry>El nombre de la fuente de caracteres a usar en el pie de página</entry>
+          <entry>times</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>footer.left</entry>
+          <entry>El texto para el lado izquierdo del pie de página</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>footer.center</entry>
+          <entry>El texto para el centro del pie de página</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>footer.right</entry>
+          <entry>El texto para el lado derecho del pie de página</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>footer.line</entry>
+          <entry>Activa o desactiva la regla horizontal bajo el pie de página</entry>
+          <entry>booleano</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>footer.spacing</entry>
+          <entry>El espacio entre el pie de página y el contenido</entry>
+          <entry>1.8</entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         <row>
+          <entry>footer.htmlUrl</entry>
+          <entry>URL o la ruta del archivo HTML a usar en el
+           pie de página</entry>
+          <entry></entry>
+          <entry>&gt;= 0.1.0</entry>
+         </row>
+         &reference.wkhtmltox.wkhtmltox.bits.load;
+         &reference.wkhtmltox.wkhtmltox.bits.web;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <!-- Return values commented out, as constructors generally don't return a
+      value. Uncomment this if you do need a return values section (for
+      example, because there's also a procedural version of the method).
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+ -->
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
This pull request includes several new documentation files for the WinCache functions. These files provide detailed information about the functions, their parameters, return values, and examples of usage. The most important changes include the addition of documentation for functions related to file cache, opcode cache, and cache refresh.

Documentation additions:

* [`reference/wincache/functions/wincache-fcache-fileinfo.xml`](diffhunk://#diff-9c1075ce74597e558ec4266a9cf80ac194026d5afbd170b1eb4a45fa78b74a03R1-R189): Added documentation for the `wincache_fcache_fileinfo` function, which extracts information about files stored in the file cache.
* [`reference/wincache/functions/wincache-ocache-fileinfo.xml`](diffhunk://#diff-571506167009bd311df4f981df7e28b40922b0bab07f81fa50b21e45b9b3a205R1-R201): Added documentation for the `wincache_ocache_fileinfo` function, which extracts information about files stored in the opcode cache.
* [`reference/wincache/functions/wincache-ocache-meminfo.xml`](diffhunk://#diff-cc9fe50d5e6b5716bfaa78293429406ec4fcad86f34f9398bebbd64e5392e61bR1-R138): Added documentation for the `wincache_ocache_meminfo` function, which extracts information about memory usage by the opcode cache.
* [`reference/wincache/functions/wincache-refresh-if-changed.xml`](diffhunk://#diff-85dcf36e19793799191fa9195aab87f13336fac2a7ff5f4525befc01bc172546R1-R113): Added documentation for the `wincache_refresh_if_changed` function, which updates cache entries for files stored in the cache.
* [`reference/wincache/functions/wincache-rplist-fileinfo.xml`](diffhunk://#diff-f3b30332121ab87bac348645da7d2ddc6c491082f2d0ab5cb0197cfdb4fd8fd5R1-R149): Added documentation for the `wincache_rplist_fileinfo` function, which retrieves information from the cache about resolved file paths.