### PR TITLE
translate page uodbc

### DIFF
--- a/reference/uodbc/functions/odbc-connection-string-is-quoted.xml
+++ b/reference/uodbc/functions/odbc-connection-string-is-quoted.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d8085016354e4c76913e9fcd3614bd82e9780202 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.odbc-connection-string-is-quoted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>odbc_connection_string_is_quoted</refname>
+  <refpurpose>Determina si un string de conexión ODBC está entre comillas</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>odbc_connection_string_is_quoted</methodname>
+   <methodparam><type>string</type><parameter>str</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Determina si un string está correctamente entre comillas para un string de
+    conexión ODBC. La puesta entre comillas de strings de conexión ODBC se realiza
+    utilizando llaves, y las llaves de cierre en un string deben ser escapadas
+    repitiéndolas dos veces, similar a la puesta entre comillas SQL.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>str</parameter></term>
+    <listitem>
+     <para>
+      El string a verificar para la puesta entre comillas.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &true; si el string está correctamente entre comillas, &false; en caso contrario.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>odbc_connection_string_quote</function></member>
+    <member><function>odbc_connection_string_should_quote</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uodbc/functions/odbc-connection-string-is-quoted.xml
+++ b/reference/uodbc/functions/odbc-connection-string-is-quoted.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: d8085016354e4c76913e9fcd3614bd82e9780202 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.odbc-connection-string-is-quoted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>odbc_connection_string_is_quoted</refname>

--- a/reference/uodbc/functions/odbc-connection-string-quote.xml
+++ b/reference/uodbc/functions/odbc-connection-string-quote.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: d8085016354e4c76913e9fcd3614bd82e9780202 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.odbc-connection-string-quote" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>odbc_connection_string_quote</refname>

--- a/reference/uodbc/functions/odbc-connection-string-quote.xml
+++ b/reference/uodbc/functions/odbc-connection-string-quote.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d8085016354e4c76913e9fcd3614bd82e9780202 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.odbc-connection-string-quote" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>odbc_connection_string_quote</refname>
+  <refpurpose>Pone entre comillas un valor de string de conexión ODBC</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>odbc_connection_string_quote</methodname>
+   <methodparam><type>string</type><parameter>str</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Pone entre comillas un valor de string de conexión, según las reglas ODBC.
+   Es decir, será rodeado de comillas, y cualquier llave de cierre
+   será escapada. Esto debe hacerse para todos los valores de string de conexión
+   que provengan de la entrada del usuario. No hacerlo puede causar
+   problemas al analizar la cadena de conexión, o valores inyectados
+   en la cadena de conexión.
+  </para>
+  <para>
+   Observe que esta función no verifica si el string ya
+   está puesto entre comillas, ni si el string necesita ser puesto entre comillas. Para ello, llamar
+   <function>odbc_connection_string_is_quoted</function> y
+   <function>odbc_connection_string_should_quote</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>str</parameter></term>
+    <listitem>
+     <para>
+      El string a poner entre comillas.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un string, rodeado de comillas, y correctamente escapado.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples"><!-- {{{ -->
+  &reftitle.examples;
+  <example xml:id="odbc-connection-string-quote.example.basic"><!-- {{{ -->
+   <title><function>odbc_connection_string_quote</function> ejemplo</title>
+   <para>
+    Este ejemplo pone entre comillas un string, luego lo coloca en una cadena de conexión.
+    Observe que el string está puesto entre comillas, y el carácter de cierre de comillas
+    en medio del string ha sido escapado.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$value = odbc_connection_string_quote("foo}bar");
+$connection_string = "DSN=PHP;UserValue=$value";
+echo $connection_string;
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+DSN=PHP;UserValue={foo}}bar}
+]]>
+   </screen>
+  </example><!-- }}} -->
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>odbc_connection_string_is_quoted</function></member>
+    <member><function>odbc_connection_string_should_quote</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uodbc/functions/odbc-connection-string-should-quote.xml
+++ b/reference/uodbc/functions/odbc-connection-string-should-quote.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d8085016354e4c76913e9fcd3614bd82e9780202 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="function.odbc-connection-string-should-quote" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>odbc_connection_string_should_quote</refname>
+  <refpurpose>Determina si un valor de string de conexión ODBC debe ser puesto entre comillas</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>odbc_connection_string_should_quote</methodname>
+   <methodparam><type>string</type><parameter>str</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Determina si un string debe ser puesto entre comillas para una conexión ODBC.
+    Es decir, si contiene caracteres especiales.
+  </para>
+  <para>
+   Observe que esta función no verifica si el string ya
+   está puesto entre comillas; un string ya puesto entre comillas
+   contendrá caracteres que harán que esta función devuelva true. Debería llamar
+   <function>odbc_connection_string_is_quoted</function> para verificar.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>str</parameter></term>
+    <listitem>
+     <para>
+      El string a verificar.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &true; si el string debe ser puesto entre comillas, de lo contrario &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>odbc_connection_string_quote</function></member>
+    <member><function>odbc_connection_string_is_quoted</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uodbc/functions/odbc-connection-string-should-quote.xml
+++ b/reference/uodbc/functions/odbc-connection-string-should-quote.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: d8085016354e4c76913e9fcd3614bd82e9780202 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.odbc-connection-string-should-quote" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>odbc_connection_string_should_quote</refname>


### PR DESCRIPTION
This pull request introduces new documentation for three ODBC functions in the `reference/uodbc/functions` directory. The changes provide detailed descriptions, parameters, return values, and examples for each function.

Documentation for ODBC functions:

* [`reference/uodbc/functions/odbc-connection-string-is-quoted.xml`](diffhunk://#diff-20cfa4a8d0355ba9b74678f9bafac1ddda2bb6145d4d6f06fe08d876b58b6492R1-R75): Added documentation for the `odbc_connection_string_is_quoted` function, which determines if an ODBC connection string is correctly quoted.
* [`reference/uodbc/functions/odbc-connection-string-quote.xml`](diffhunk://#diff-7be38a87bcf329426e79b916bee4a10d852961302b369ba3659ae48d0d7c25b7R1-R110): Added documentation for the `odbc_connection_string_quote` function, which quotes an ODBC connection string according to ODBC rules.
* [`reference/uodbc/functions/odbc-connection-string-should-quote.xml`](diffhunk://#diff-9193bef7197eeb12db7bafbb5d979078490f808d7d5b66e9a2d66af52d4edee9R1-R79): Added documentation for the `odbc_connection_string_should_quote` function, which determines if an ODBC connection string should be quoted.