### PR TITLE
parse_ini_*(): Add warning that the functions are unsafe with untrusted inputs

### DIFF
--- a/reference/filesystem/functions/parse-ini-file.xml
+++ b/reference/filesystem/functions/parse-ini-file.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5346daf2bb2fab250fa03f0f6639a408d0b2240 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: bb54309eff8a7d75ead0fdf48cc6dae99dd00367 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.parse-ini-file" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>parse_ini_file</refname>
@@ -18,14 +18,20 @@
   <para>
    <function>parse_ini_file</function> carga el archivo
    <parameter>filename</parameter> y devuelve las
-   configuraciones que contiene en forma de un array
-   asociativo.
+   configuraciones que contiene como un array asociativo.
   </para>
   <para>
-   La estructura de los archivos de configuración leídos es similar
-   a la de &php.ini;.
+   La estructura de los archivos de configuración leídos es similar a la de &php.ini;.
   </para>
- </refsect1>
+   <warning>
+   <simpara>
+    Esta función no debe ser utilizada con entradas no confiables, a menos que
+    <parameter>scanner_mode</parameter> sea <constant>INI_SCANNER_RAW</constant>,
+    ya que la salida analizada podría contener los valores de constantes sensibles,
+    como constantes que contienen una contraseña de base de datos.
+   </simpara>
+  </warning>
+</refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/filesystem/functions/parse-ini-string.xml
+++ b/reference/filesystem/functions/parse-ini-string.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: bb54309eff8a7d75ead0fdf48cc6dae99dd00367 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.parse-ini-string" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>parse_ini_string</refname>
@@ -23,6 +23,14 @@
   <para>
    La estructura de la cadena debe ser la misma que la del archivo &php.ini;.
   </para>
+   <warning>
+   <simpara>
+    Esta función no debe ser utilizada con entradas no confiables, a menos que
+    <parameter>scanner_mode</parameter> sea <constant>INI_SCANNER_RAW</constant>,
+    ya que la salida analizada podría contener los valores de constantes sensibles,
+    como constantes que contienen una contraseña de base de datos.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Update

- `reference/filesystem/functions/parse-ini-*`

to [EN-bb54309](https://github.com/php/doc-en/commit/bb54309eff8a7d75ead0fdf48cc6dae99dd00367)