### PR TITLE
Enable runnable (WASM) examples for datetime

### DIFF
--- a/reference/datetime/book.xml
+++ b/reference/datetime/book.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 71692b6f4cace8dca72a18ccd80d4cd7305e5d4e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 
-<book xml:id="book.datetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<book xml:id="book.datetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <?phpdoc extension-membership="core"?>
  <title>Fecha y Hora</title>
  <titleabbrev>Fecha/Hora</titleabbrev>

--- a/reference/datetime/dateinterval/construct.xml
+++ b/reference/datetime/dateinterval/construct.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 71692b6f4cace8dca72a18ccd80d4cd7305e5d4e Maintainer: Marqitos Status: ready -->
-<!-- Reviewed: no Maintainer: seros -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="dateinterval.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::__construct</refname>
@@ -171,7 +171,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Contruyendo y usando objetos <classname>DateInterval</classname></title>
+    <title>Construyendo y usando objetos <classname>DateInterval</classname></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -203,11 +203,8 @@ echo $interval->format("%d");
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $interval = new DateInterval('P1W2D');
 var_dump($interval);
-
-?>
 ]]>
     </programlisting>
     &example.outputs.82;

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 34f483426930c25870b4c5455157e7a759e0053c Maintainer: Marqitos Status: ready -->
-<!-- Reviewed: no Maintainer: seros -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::createFromDateString</refname>
@@ -108,7 +108,7 @@
   <para>
    <example>
     <title>Analizando intervalos de fechas válidos</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Each set of intervals is equal.
@@ -132,7 +132,6 @@ $i = DateInterval::createFromDateString('1 day + 12 hours');
 
 $i = new DateInterval('PT3600S');
 $i = DateInterval::createFromDateString('3600 seconds');
-?>
 ]]>
     </programlisting>
    </example>
@@ -148,11 +147,10 @@ echo $i->format('%d %h %i'), "\n";
 
 $i = DateInterval::createFromDateString('1 year - 10 days');
 echo $i->format('%y %d'), "\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
-    <screen role="shell">
+    <screen>
 <![CDATA[
 449 2 70
 1 -10

--- a/reference/datetime/dateinterval/format.xml
+++ b/reference/datetime/dateinterval/format.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: Marqitos Status: ready -->
-<!-- Reviewed: no Maintainer: seros -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="dateinterval.format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::format</refname>
@@ -29,7 +29,7 @@
       <para>
        <table>
         <title>
-         Los siguietes caracteres están reconocidos en el
+         Los siguientes caracteres están reconocidos en el
          parámetro de cadena <parameter>format</parameter>.
          Cada carácter de formato debe ser prefijado con un signo de porcentaje
          (<literal>%</literal>).
@@ -191,11 +191,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $interval = new DateInterval('P2Y4DT6H8M');
 echo $interval->format('%d days');
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -212,11 +209,8 @@ echo $interval->format('%d days');
     <programlisting role="php">
      <![CDATA[
 <?php
-
 $interval = new DateInterval('P32D');
 echo $interval->format('%d days');
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -236,7 +230,6 @@ echo $interval->format('%d days');
     <programlisting role="php">
      <![CDATA[
 <?php
-
 $january = new DateTime('2010-01-01');
 $february = new DateTime('2010-02-01');
 $interval = $february->diff($january);
@@ -247,8 +240,6 @@ echo $interval->format('%a total days')."\n";
 // Mientras que %d sólo imprimirá el múmero total de días no cubiertos por el
 // mes.
 echo $interval->format('%m month, %d days');
-
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/dateperiod.xml
+++ b/reference/datetime/dateperiod.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 576c7c43febb2eec5718d8320f92606423413983 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DavidA -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <reference xml:id="class.dateperiod" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase DatePeriod</title>
@@ -164,7 +163,8 @@
       <para>
        <informalexample>
         <programlisting role="php">
-<![CDATA[<?php
+<![CDATA[
+<?php
 $start = new DateTime('2018-12-31 00:00:00');
 $end   = new DateTime('2021-12-31 00:00:00');
 $interval = new DateInterval('P1M');
@@ -186,15 +186,17 @@ echo $period->recurrences, "\n";
 
 $period = new DatePeriod($start, $interval, $end, DatePeriod::EXCLUDE_START_DATE);
 echo $period->recurrences, "\n";
-?>]]>
+]]>
          </programlisting>
          &example.outputs;
          <screen role="php">
+<![CDATA[
 5
 6
 7
 1
 0
+]]>
          </screen>
         </informalexample>
        </para>

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d81260767f008218ffd338b365cfa3d10eb3d15 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="dateperiod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::__construct</refname>
@@ -211,12 +211,12 @@ $period = new DatePeriod($iso);
 foreach ($period as $date) {
     echo $date->format('Y-m-d')."\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in script on line 11
 2012-07-01
 2012-07-08
 2012-07-15
@@ -245,7 +245,6 @@ $period = new DatePeriod($start, $interval, $end,
 foreach ($period as $date) {
     echo $date->format('Y-m-d')."\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -275,7 +274,6 @@ $period = new DatePeriod($begin, $interval, $end, DatePeriod::EXCLUDE_START_DATE
 foreach ($period as $dt) {
     echo $dt->format('l Y-m-d'), "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/dateperiod/createfromiso8601string.xml
+++ b/reference/datetime/dateperiod/createfromiso8601string.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0070ddc45d60b6eda095053847dba544aa4339bf Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="dateperiod.createfromiso8601string" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::createFromISO8601String</refname>
@@ -123,7 +123,6 @@
 <![CDATA[
 <?php
 $iso = 'R4/2023-07-01T00:00:00Z/P7D';
-
 $period = DatePeriod::createFromISO8601String($iso);
 
 // Al iterar sobre el objeto DatePeriod, todas las
@@ -131,7 +130,6 @@ $period = DatePeriod::createFromISO8601String($iso);
 foreach ($period as $date) {
     echo $date->format('Y-m-d'), "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/dateperiod/getdateinterval.xml
+++ b/reference/datetime/dateperiod/getdateinterval.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: Gildas Dubois-->
-
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="dateperiod.getdateinterval" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::getDateInterval</refname>
@@ -43,10 +41,9 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$period = new DatePeriod('R7/2016-05-16T00:00:00Z/P1D');
+$period = DatePeriod::createFromIso8601String('R7/2016-05-16T00:00:00Z/P1D');
 $interval = $period->getDateInterval();
 echo $interval->format('%d day');
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/reference/datetime/dateperiod/getenddate.xml
+++ b/reference/datetime/dateperiod/getenddate.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: Gildas Dubois-->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="dateperiod.getenddate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::getEndDate</refname>
@@ -59,7 +58,6 @@ $period = new DatePeriod(
 );
 $start = $period->getEndDate();
 echo $start->format(DateTime::ISO8601);
-?>
 ]]>
    </programlisting>
    &examples.outputs;
@@ -80,7 +78,6 @@ $period = new DatePeriod(
     7
 );
 var_dump($period->getEndDate());
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/reference/datetime/dateperiod/getrecurrences.xml
+++ b/reference/datetime/dateperiod/getrecurrences.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="dateperiod.getrecurrences" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::getRecurrences</refname>
@@ -28,7 +28,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   El número de recurrencias se define pasando explícitamente el valor de <literal>$recurrences</literal> al constructor de la clase <classname>DatePeriod</classname>, de lo contrario se define como &null;.
+   El número de recurrencias se define pasando explícitamente las
+   <literal>$recurrences</literal> al constructor de la clase
+   <classname>DatePeriod</classname>, de lo contrario se define como &null;.
   </para>
  </refsect1>
 
@@ -38,7 +40,8 @@
    <example>
     <title>Valores diferentes para <methodname>DatePeriod::getRecurrences</methodname></title>
     <programlisting role="php">
-<![CDATA[<?php
+<![CDATA[
+<?php
 $start = new DateTime('2018-12-31 00:00:00');
 $end   = new DateTime('2021-12-31 00:00:00');
 $interval = new DateInterval('P1M');
@@ -59,16 +62,18 @@ var_dump($period->getRecurrences());
 
 $period = new DatePeriod($start, $interval, $end, DatePeriod::EXCLUDE_START_DATE);
 var_dump($period->getRecurrences());
-?>]]>
+]]>
    </programlisting>
    &example.outputs;
    <screen role="php">
+<![CDATA[
 5
 5
 5
 
 NULL
 NULL
+]]>
     </screen>
    </example>
   </para>

--- a/reference/datetime/dateperiod/getstartdate.xml
+++ b/reference/datetime/dateperiod/getstartdate.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DAnnebicque -->
-
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="dateperiod.getstartdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::getStartDate</refname>
@@ -50,10 +48,9 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$period = new DatePeriod('R7/2016-05-16T00:00:00Z/P1D');
+$period = DatePeriod::createFromIso8601String('R7/2016-05-16T00:00:00Z/P1D');
 $start = $period->getStartDate();
 echo $start->format(DateTime::ISO8601);
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/reference/datetime/datetime/createfromimmutable.xml
+++ b/reference/datetime/datetime/createfromimmutable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.createfromimmutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -72,13 +72,11 @@
   <para>
    <example>
     <title>Creando un objeto de fecha y hora mutable</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $date = new DateTimeImmutable("2014-06-20 11:45 Europe/London");
-
 $mutable = DateTime::createFromImmutable( $date );
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/datetime/createfrominterface.xml
+++ b/reference/datetime/datetime/createfrominterface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.createfrominterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,16 +47,14 @@
   <para>
    <example>
     <title>Creando un objeto fecha y hora mutable</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $date = new DateTimeImmutable("2014-06-20 11:45 Europe/London");
-
 $mutable = DateTime::createFromInterface($date);
 
 $date = new DateTime("2014-06-20 11:45 Europe/London");
 $also_mutable = DateTime::createFromInterface($date);
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c8ba91f7e546462dc66c2a11a7eab6f55c93915b Maintainer: Marqitos Status: ready -->
-<!-- Reviewed: no Maintainer: seros -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="datetime.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::modify</refname>
@@ -94,9 +94,14 @@
 $date = new DateTime('2006-12-12');
 $date->modify('+1 day');
 echo $date->format('Y-m-d');
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2006-12-13
+]]>
+   </screen>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
@@ -104,10 +109,9 @@ echo $date->format('Y-m-d');
 $date = date_create('2006-12-12');
 date_modify($date, '+1 day');
 echo date_format($date, 'Y-m-d');
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 2006-12-13
@@ -126,7 +130,6 @@ echo $date->format('Y-m-d') . "\n";
 
 $date->modify('+1 month');
 echo $date->format('Y-m-d') . "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -152,7 +155,6 @@ echo $date->format('Y-m-d H:i') . "\n";
 
 $date->modify('17:30');
 echo $date->format('Y-m-d H:i') . "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/reference/datetime/datetime/settimezone.xml
+++ b/reference/datetime/datetime/settimezone.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: Marqitos Status: ready -->
-<!-- Reviewed: no Maintainer: seros -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="datetime.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::setTimezone</refname>
@@ -72,9 +72,15 @@ echo $date->format('Y-m-d H:i:sP') . "\n";
 
 $date->setTimezone(new DateTimeZone('Pacific/Chatham'));
 echo $date->format('Y-m-d H:i:sP') . "\n";
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2000-01-01 00:00:00+12:00
+2000-01-01 01:45:00+13:45
+]]>
+   </screen>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
@@ -84,10 +90,9 @@ echo date_format($date, 'Y-m-d H:i:sP') . "\n";
 
 date_timezone_set($date, timezone_open('Pacific/Chatham'));
 echo date_format($date, 'Y-m-d H:i:sP') . "\n";
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 2000-01-01 00:00:00+12:00

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8b4c3d8dc5e190fbd5d84eede38a4da13537043d Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -131,9 +131,14 @@ try {
 }
 
 echo $date->format('Y-m-d');
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2000-01-01
+]]>
+   </screen>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
@@ -148,10 +153,9 @@ if (!$date) {
 }
 
 echo date_format($date, 'Y-m-d');
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 2000-01-01
@@ -163,8 +167,9 @@ echo date_format($date, 'Y-m-d');
    <programlisting role="php">
 <![CDATA[
 <?php
-// Especificando una fecha/hora en la zona horaria de su ordenador.
+date_default_timezone_set('America/Jamaica');
 
+// Especificando una fecha/hora en la zona horaria por omisión
 $date = new DateTimeImmutable('2000-01-01');
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
@@ -172,8 +177,7 @@ echo $date->format('Y-m-d H:i:sP') . "\n";
 $date = new DateTimeImmutable('2000-01-01', new DateTimeZone('Pacific/Nauru'));
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
-// Fecha/hora actual en la zona horaria de su ordenador.
- Current date/time in your computer's time zone.
+// Fecha/hora actual en la zona horaria por omisión de PHP.
 $date = new DateTimeImmutable();
 echo $date->format('Y-m-d H:i:sP') . "\n";
 
@@ -188,7 +192,6 @@ echo $date->format('Y-m-d H:i:sP') . "\n";
 // Completado de los valores inexistentes.
 $date = new DateTimeImmutable('2000-02-30');
 echo $date->format('Y-m-d H:i:sP') . "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -202,6 +205,12 @@ echo $date->format('Y-m-d H:i:sP') . "\n";
 2000-03-01 00:00:00-05:00
 ]]>
    </screen>
+   <note>
+    <para>
+     Las fechas desbordadas se pueden detectar comprobando las advertencias mediante
+     <function>DateTimeImmutable::getLastErrors</function>.
+    </para>
+   </note>
   </example>
 
   <example>
@@ -214,14 +223,13 @@ $timeZone = new \DateTimeZone('Asia/Tokyo');
 $time = new \DateTimeImmutable();
 $time = $time->setTimezone($timeZone);
 
-echo $time->format('Y/m/d H:i:s'), "\n";
-?>
+echo $time->format('Y/m/d H:i:s e'), "\n";
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-2022/08/12 23:49:23
+2022/08/12 23:49:23 Asia/Tokyo
 ]]>
    </screen>
   </example>
@@ -234,7 +242,6 @@ echo $time->format('Y/m/d H:i:s'), "\n";
 $time = new \DateTimeImmutable("-1 year");
 
 echo $time->format('Y/m/d H:i:s'), "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;

--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dcf89d157a7e3f7fe6e74593af09b650c3cf7fbc Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.createfromformat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -521,7 +521,6 @@
 <?php
 $date = DateTimeImmutable::createFromFormat('j-M-Y', '15-Feb-2009');
 echo $date->format('Y-m-d');
-?>
 ]]>
    </programlisting>
   </example>
@@ -532,9 +531,17 @@ echo $date->format('Y-m-d');
    <programlisting role="php">
 <![CDATA[
 <?php
-$date = DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, '2004-02-12T15:19:21+00:00');
-$date = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, '2013-10-14T09:00:00.000+02:00');
-?>
+$date = DateTimeImmutable::createFromFormat(
+    DateTimeInterface::ISO8601,
+    '2004-02-12T15:19:21+00:00'
+);
+echo $date->format('c e') . "\n";
+
+$date = DateTimeImmutable::createFromFormat(
+    DateTimeInterface::RFC3339_EXTENDED,
+    '2013-10-14T09:00:00.000+02:00'
+);
+echo $date->format('c e') . "\n";
 ]]>
    </programlisting>
    <para>
@@ -574,7 +581,6 @@ echo "Formato: $format; " . $date->format('Y-m-d H:i:s') . "\n";
 $format = 'i';
 $date = DateTimeImmutable::createFromFormat($format, '15');
 echo "Formato: $format; " . $date->format('Y-m-d H:i:s') . "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -596,7 +602,6 @@ Formato: i; 2022-06-02 00:15:00
 <![CDATA[
 <?php
 echo DateTimeImmutable::createFromFormat('H\h i\m s\s','23h 15m 03s')->format('H:i:s');
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -613,7 +618,6 @@ echo DateTimeImmutable::createFromFormat('H\h i\m s\s','23h 15m 03s')->format('H
 <![CDATA[
 <?php
 echo DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2021-17-35 16:60:97')->format(DateTimeImmutable::RFC2822);
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -663,7 +667,6 @@ Sat, 04 Jun 2022 17:01:37 +0000
 <?php
 $d = DateTime::createFromFormat(DateTimeInterface::RFC1123, 'Mon, 3 Aug 2020 25:00:00 +0000');
 echo $d->format(DateTime::RFC1123), "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -708,7 +711,6 @@ $d = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2021-17-35 16:60:97');
 echo $d->format(DateTimeImmutable::RFC2822), "\n\n";
 
 var_dump(DateTimeImmutable::GetLastErrors());
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -740,7 +742,6 @@ array(4) {
 <![CDATA[
 <?php
 print_r(date_parse_from_format('Gis', '60101'));
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;

--- a/reference/datetime/datetimeimmutable/createfrominterface.xml
+++ b/reference/datetime/datetimeimmutable/createfrominterface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.createfrominterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,16 +47,14 @@
   <para>
    <example>
     <title>Creando un objeto fecha y hora inmutable</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $date = new DateTime("2014-06-20 11:45 Europe/London");
-
 $immutable = DateTimeImmutable::createFromInterface($date);
 
 $date = new DateTimeImmutable("2014-06-20 11:45 Europe/London");
 $also_immutable = DateTimeImmutable::createFromInterface($date);
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/datetimeimmutable/createfrommutable.xml
+++ b/reference/datetime/datetimeimmutable/createfrommutable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.createfrommutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -72,13 +72,11 @@
   <para>
    <example>
     <title>Creando un objeto de fecha y hora inmutable</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $date = new DateTime("2014-06-20 11:45 Europe/London");
-
 $immutable = DateTimeImmutable::createFromMutable( $date );
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/datetimeimmutable/getlasterrors.xml
+++ b/reference/datetime/datetimeimmutable/getlasterrors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 453f103a69eb2db96a4a162f526fd22dd54843dc Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.getlasterrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -73,34 +73,62 @@ try {
     print_r(DateTimeImmutable::getLastErrors());
 
     // La forma correcta de hacer esto con programación orientada a objetos es
-    // echo $e->getMessage();
+    echo $e->getMessage();
 }
 ?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 Array
 (
-   [warning_count] => 1
-   [warnings] => Array
-       (
-           [6] => Double timezone specification
-       )
+    [warning_count] => 1
+    [warnings] => Array
+        (
+            [6] => Double timezone specification
+        )
 
-   [error_count] => 1
-   [errors] => Array
-       (
-           [0] => The timezone could not be found in the database
-       )
-
+    [error_count] => 1
+    [errors] => Array
+        (
+            [0] => The timezone could not be found in the database
+        )
 )
+Failed to parse time string (asdfasdf) at position 0 (a): The timezone could not be found in the database
 ]]>
    </screen>
    <para>
     Los índices 6, y 0 en la salida de ejemplo se refieren al índice de caracteres en la cadena donde ocurrió el error.
    </para>
+  </example>
+  <example>
+   <title>Detectando fechas desbordadas</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTimeImmutable::createFromFormat('!Y-m-d', '2020-02-30');
+print_r(DateTimeImmutable::getLastErrors());
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Array
+(
+    [warning_count] => 1
+    [warnings] => Array
+        (
+            [10] => The parsed date was invalid
+        )
+
+    [error_count] => 0
+    [errors] => Array
+        (
+        )
+)
+]]>
+   </screen>
   </example>
  </refsect1>
 

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42d5fb01e01e9ab1fdb47612833dd13d9003df6a Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -86,10 +86,9 @@
 $date = new DateTimeImmutable('2006-12-12');
 $newDate = $date->modify('+1 day');
 echo $newDate->format('Y-m-d');
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 2006-12-13
@@ -108,7 +107,6 @@ echo $newDate1->format('Y-m-d') . "\n";
 
 $newDate2 = $newDate1->modify('+1 month');
 echo $newDate2->format('Y-m-d') . "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/reference/datetime/datetimeimmutable/setdate.xml
+++ b/reference/datetime/datetimeimmutable/setdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42d5fb01e01e9ab1fdb47612833dd13d9003df6a Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.setdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -72,10 +72,9 @@
 $date = new DateTimeImmutable();
 $newDate = $date->setDate(2001, 2, 3);
 echo $newDate->format('Y-m-d');
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 2001-02-03
@@ -97,7 +96,6 @@ echo $newDate->format('Y-m-d') . "\n";
 
 $newDate = $date->setDate(2001, 14, 3);
 echo $newDate->format('Y-m-d') . "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2cfd69623a8af79d46deaad5ebeb4d9e73b15d6d Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.setisodate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -75,9 +75,15 @@ echo $newDate->format('Y-m-d') . "\n";
 
 $newDate = $date->setISODate(2008, 2, 7);
 echo $newDate->format('Y-m-d') . "\n";
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2008-01-07
+2008-01-13
+]]>
+   </screen>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
@@ -90,10 +96,9 @@ echo date_format($date, 'Y-m-d') . "\n";
 
 date_isodate_set($date, 2008, 2, 7);
 echo date_format($date, 'Y-m-d') . "\n";
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 2008-01-07
@@ -117,7 +122,6 @@ echo $newDate->format('Y-m-d') . "\n";
 
 $newDate = $date->setISODate(2008, 53, 7);
 echo $newDate->format('Y-m-d') . "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -138,10 +142,9 @@ echo $newDate->format('Y-m-d') . "\n";
 $date = new DateTimeImmutable();
 $newDate = $date->setISODate(2008, 14);
 echo $newDate->format('n');
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 3

--- a/reference/datetime/datetimeimmutable/settime.xml
+++ b/reference/datetime/datetimeimmutable/settime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42d5fb01e01e9ab1fdb47612833dd13d9003df6a Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -113,7 +113,7 @@ echo $newDate->format('Y-m-d H:i:s') . "\n";
 ?>
 ]]>
    </programlisting>
-   &examples.outputs.similar;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
 2001-01-01 14:55:00

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42d5fb01e01e9ab1fdb47612833dd13d9003df6a Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -57,10 +57,9 @@ echo $date->format('U = Y-m-d H:i:s') . "\n";
 
 $newDate = $date->setTimestamp(1171502725);
 echo $newDate->format('U = Y-m-d H:i:s') . "\n";
-?>
 ]]>
    </programlisting>
-   &examples.outputs.similar;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
 1272508903 = 2010-04-28 22:41:43

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42d5fb01e01e9ab1fdb47612833dd13d9003df6a Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -60,7 +60,7 @@ echo $newDate->format('Y-m-d H:i:sP') . "\n";
 ?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 2000-01-01 00:00:00+12:00

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42d5fb01e01e9ab1fdb47612833dd13d9003df6a Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.sub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -94,7 +94,7 @@ echo $newDate->format('Y-m-d') . "\n";
 ?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 2000-01-10

--- a/reference/datetime/datetimeinterface/diff.xml
+++ b/reference/datetime/datetimeinterface/diff.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 52222422c00aba192c5f7fed3c4efdaa870e799e Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.diff" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -103,9 +103,14 @@ $origin = new DateTimeImmutable('2009-10-11');
 $target = new DateTimeImmutable('2009-10-13');
 $interval = $origin->diff($target);
 echo $interval->format('%R%a days');
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
++2 days
+]]>
+   </screen>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
@@ -114,10 +119,9 @@ $origin = date_create('2009-10-11');
 $target = date_create('2009-10-13');
 $interval = date_diff($origin, $target);
 echo $interval->format('%R%a days');
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 +2 days
@@ -135,7 +139,6 @@ $originalTime = new DateTimeImmutable("2021-10-30 09:00:00 Europe/London");
 $targetTime = new DateTimeImmutable("2021-10-31 08:30:00 Europe/London");
 $interval = $originalTime->diff($targetTime);
 echo $interval->format("%H:%I:%S (Días completos: %a)"), "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -161,7 +164,6 @@ $originalTime = new DateTimeImmutable("2023-01-01 UTC");
 $targetTime = new DateTimeImmutable("2023-12-31 UTC");
 $interval = $originalTime->diff($targetTime);
 echo "Días completos: ", $interval->format("%a"), "\n";
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -189,7 +191,6 @@ $date2 = new DateTime("tomorrow");
 var_dump($date1 == $date2);
 var_dump($date1 < $date2);
 var_dump($date1 > $date2);
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d78942045456715efcc7d54e56096d4187dda3c Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -419,6 +419,12 @@ echo $date->format('Y-m-d H:i:s');
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+2000-01-01 00:00:00
+]]>
+    </screen>
     <para>&style.procedural;</para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/datetime/datetimeinterface/getoffset.xml
+++ b/reference/datetime/datetimeinterface/getoffset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e057f1f552548a68030830e96ae1bdf313b1794e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetime.getoffset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeInterface::getOffset</refname>
@@ -63,9 +63,15 @@ $summer = new DateTimeImmutable('2008-06-21', new DateTimeZone('America/New_York
 
 echo $winter->getOffset() . "\n";
 echo $summer->getOffset() . "\n";
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+-18000
+-14400
+]]>
+   </screen>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
@@ -75,10 +81,9 @@ $summer = date_create('2008-06-21', timezone_open('America/New_York'));
 
 echo date_offset_get($winter) . "\n";
 echo date_offset_get($summer) . "\n";
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 -18000

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8859c8b96cd9e80652813f7bcf561432a5e9f934 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetime.gettimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeInterface::getTimestamp</refname>
@@ -98,19 +98,23 @@
 <?php
 $date = new DateTimeImmutable();
 echo $date->getTimestamp();
-?>
 ]]>
    </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+1272509157
+]]>
+   </screen>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
 $date = date_create();
 echo date_timestamp_get($date);
-?>
 ]]>
    </programlisting>
-   &examples.outputs.similar;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
 1272509157
@@ -133,10 +137,9 @@ $milli = (int) $date->format('Uv'); // Timestamp en milisegundos
 $micro = (int) $date->format('Uu'); // Timestamp en microsegundos
 
 echo $milli, "\n", $micro, "\n";
-?>
 ]]>
    </programlisting>
-   &examples.outputs.similar;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
 1674057635586

--- a/reference/datetime/datetimeinterface/gettimezone.xml
+++ b/reference/datetime/datetimeinterface/gettimezone.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetime.gettimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeInterface::getTimezone</refname>
@@ -60,23 +59,27 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$date = new DateTimeImmutable(null, new DateTimeZone('Europe/London'));
+$date = new DateTimeImmutable("now", new DateTimeZone('Europe/London'));
 $tz = $date->getTimezone();
 echo $tz->getName();
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Europe/London
+]]>
+   </screen>
    <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php
-$date = date_create(null, timezone_open('Europe/London'));
+$date = date_create("now", timezone_open('Europe/London'));
 $tz = date_timezone_get($date);
 echo timezone_name_get($tz);
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 Europe/London

--- a/reference/datetime/datetimeinterface/serialize.xml
+++ b/reference/datetime/datetimeinterface/serialize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 053ae3f6f54cba66a12f85d2eebe32863c6f221e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetime.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::__serialize</refname>
@@ -50,10 +50,9 @@
 <?php
 $date = new DateTime('2025-03-27');
 var_dump(serialize($date));
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 string(114) "O:8:"DateTime":3:{s:4:"date";s:26:"2025-03-27 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}"

--- a/reference/datetime/datetimeinterface/unserialize.xml
+++ b/reference/datetime/datetimeinterface/unserialize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 053ae3f6f54cba66a12f85d2eebe32863c6f221e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetime.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::__unserialize</refname>
@@ -58,10 +58,9 @@
 <?php
 $serializedDate = 'O:8:"DateTime":3:{s:4:"date";s:26:"2025-03-27 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}';
 var_dump(unserialize($serializedDate));
-?>
 ]]>
    </programlisting>
-   &examples.outputs;
+   &example.outputs;
    <screen>
 <![CDATA[
 object(DateTime)#1 (3) {

--- a/reference/datetime/datetimezone/construct.xml
+++ b/reference/datetime/datetimezone/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d9ac376dbee6e45ef775059456caf0ec348ada6a Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetimezone.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeZone::__construct</refname>
@@ -113,17 +113,18 @@ foreach ($timezones as $tz) {
     $tzo = new DateTimeZone($tz);
 
     $local = $d->setTimezone($tzo);
-    echo $local->format(DateTimeInterface::RFC2822 . ' — e'), "\n";
+    echo $local->format(DateTimeInterface::RFC2822 . ' — e') . "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
+<![CDATA[
 Thu, 02 Jun 2022 16:44:48 +0100 — Europe/London
 Thu, 02 Jun 2022 20:29:48 +0445 — +04:45
 Thu, 02 Jun 2022 09:44:48 -0600 — -06:00
 Thu, 02 Jun 2022 17:44:48 +0200 — CEST
+]]>
     </screen>
    </example>
   </para>
@@ -140,16 +141,17 @@ $timezones = array('Europe/London', 'Mars/Phobos', 'Jupiter/Europa');
 foreach ($timezones as $tz) {
     try {
         $mars = new DateTimeZone($tz);
+        echo $mars->getName() . "\n";
     } catch(Exception $e) {
-        echo $e->getMessage() . '<br />';
+        echo $e->getMessage() . "\n";
     }
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+Europe/London
 DateTimeZone::__construct() [datetimezone.--construct]: Unknown or bad timezone (Mars/Phobos)
 DateTimeZone::__construct() [datetimezone.--construct]: Unknown or bad timezone (Jupiter/Europa)
 ]]>

--- a/reference/datetime/datetimezone/getlocation.xml
+++ b/reference/datetime/datetimezone/getlocation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c90415586ef8e226765667808874b6fd9c33ef09 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimezone.getlocation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -54,7 +54,6 @@
 $tz = new DateTimeZone("Asia/Jakarta");
 print_r($tz->getLocation());
 print_r(timezone_location_get($tz));
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/datetimezone/getoffset.xml
+++ b/reference/datetime/datetimezone/getoffset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e057f1f552548a68030830e96ae1bdf313b1794e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetimezone.getoffset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeZone::getOffset</refname>
@@ -79,9 +79,14 @@ $timeOffset = $dateTimeZoneJapan->getOffset($dateTimeTaipei);
 
 // Debería mostrar int(32400) (para las fechas posteriores al Sat Sep 8 01:00:00 1951 JST).
 var_dump($timeOffset);
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+int(32400)
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/datetimezone/gettransitions.xml
+++ b/reference/datetime/datetimezone/gettransitions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetimezone.gettransitions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeZone::getTransitions</refname>
@@ -129,29 +129,29 @@ Array
 (
     [0] => Array
         (
-            [ts]  => -9223372036854775808
-             [time] =>  -292277022657-01-27T08:29:52+0000
-             [offset] => 3600
-            [isdst]  => 1
-            [abbr] => BST
-         )
+            [ts] => -2147483648
+            [time] => 1901-12-13T20:45:52+00:00
+            [offset] => -75
+            [isdst] =>
+            [abbr] => LMT
+        )
 
     [1] => Array
         (
-            [ts]  => -1691964000
-            [time] => 1916-05-21T02:00:00+0000
-            [offset]  => 3600
-            [isdst] => 1
-             [abbr] => BST
+            [ts] => 442304971
+            [time] => 1847-12-01T00:01:15+00:00
+            [offset] => 0
+            [isdst] =>
+            [abbr] => GMT
         )
 
     [2] => Array
         (
-            [ts]  => -1680472800
-            [time] => 1916-10-01T02:00:00+0000
-            [offset]  => 0
-            [isdst] =>
-             [abbr] => GMT
+            [ts] => -1691964000
+            [time] => 1916-05-21T02:00:00+00:00
+            [offset] => 3600
+            [isdst] => 1
+            [abbr] => BST
         )
 
 )
@@ -178,8 +178,8 @@ Array
 (
     [0] => Array
         (
-            [ts] => 1654184161
-            [time] => 2022-06-02T15:36:01+0000
+            [ts] => 1759058251
+            [time] => 2025-09-28T11:17:31+00:00
             [offset] => 3600
             [isdst] => 1
             [abbr] => BST
@@ -187,8 +187,8 @@ Array
 
     [1] => Array
         (
-            [ts] => 1667091600
-            [time] => 2022-10-30T01:00:00+0000
+            [ts] => 1761440400
+            [time] => 2025-10-26T01:00:00+00:00
             [offset] => 0
             [isdst] =>
             [abbr] => GMT
@@ -196,8 +196,8 @@ Array
 
     [2] => Array
         (
-            [ts] => 1679792400
-            [time] => 2023-03-26T01:00:00+0000
+            [ts] => 1774746000
+            [time] => 2026-03-29T01:00:00+00:00
             [offset] => 3600
             [isdst] => 1
             [abbr] => BST

--- a/reference/datetime/datetimezone/listabbreviations.xml
+++ b/reference/datetime/datetimezone/listabbreviations.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetimezone.listabbreviations" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeZone::listAbbreviations</refname>
@@ -60,7 +60,6 @@
 <?php
 $timezone_abbreviations = DateTimeZone::listAbbreviations();
 print_r($timezone_abbreviations["acst"]);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -70,30 +69,44 @@ Array
 (
     [0] => Array
         (
-            [dst] => 1
-            [offset] => -14400
-            [timezone_id] => America/Porto_Acre
+            [dst] =>
+            [offset] => 34200
+            [timezone_id] => Australia/Adelaide
         )
 
     [1] => Array
         (
-            [dst] => 1
-            [offset] => -14400
-            [timezone_id] => America/Eirunepe
+            [dst] =>
+            [offset] => 34200
+            [timezone_id] => Australia/Broken_Hill
         )
 
     [2] => Array
         (
-            [dst] => 1
-            [offset] => -14400
-            [timezone_id] => America/Rio_Branco
+            [dst] =>
+            [offset] => 34200
+            [timezone_id] => Australia/Darwin
         )
 
     [3] => Array
         (
-            [dst] => 1
-            [offset] => -14400
-            [timezone_id] => Brazil/Acre
+            [dst] =>
+            [offset] => 34200
+            [timezone_id] => Australia/North
+        )
+
+    [4] => Array
+        (
+            [dst] =>
+            [offset] => 34200
+            [timezone_id] => Australia/South
+        )
+
+    [5] => Array
+        (
+            [dst] =>
+            [offset] => 34200
+            [timezone_id] => Australia/Yancowinna
         )
 
 )

--- a/reference/datetime/examples.xml
+++ b/reference/datetime/examples.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DAnnebicque -->
-
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <chapter xml:id="datetime.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
 
  <section xml:id="datetime.examples-arithmetic">
   <title>Aritmética con DateTime</title>
   <para>
-   Los ejemplos siguientes muestran algunos problemas de la aritmética de DateTime
-   en lo que respecta a las transiciones DST y los meses con diferente número
-   de días.
+   Los ejemplos siguientes muestran algunos problemas de la aritmética de DateTime en lo que respecta
+   a las transiciones DST y los meses con diferente número de días.
   </para>
   <para>
    <example>
@@ -28,7 +25,6 @@ $dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New
 echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->add(new DateInterval("PT3H"));
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -55,7 +51,6 @@ $dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New
 echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+24 hours");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -89,7 +84,6 @@ $dt = new DateTimeImmutable("2016-01-31 00:00:00", new DateTimeZone("America/New
 echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+1 month");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -121,7 +115,6 @@ $dt = new DateTimeImmutable("2016-01-31 00:00:00", new DateTimeZone("America/New
 echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("last day of next month");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 64dc79d6c9710dddf196aa28e3c5f63b562e7aef Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <chapter xml:id="datetime.formats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Formatos soportados de tiempo y fechas</title>
 
@@ -81,7 +81,6 @@
 <?php
 $res = date_parse("2015-09-31");
 var_dump($res["warnings"]);
-?>
 ]]>
      </programlisting>
      &example.outputs;

--- a/reference/datetime/functions/checkdate.xml
+++ b/reference/datetime/functions/checkdate.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="function.checkdate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>checkdate</refname>
@@ -72,7 +73,6 @@
 <?php
 var_dump(checkdate(12, 31, 2000));
 var_dump(checkdate(2, 29, 2001));
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/functions/date-default-timezone-get.xml
+++ b/reference/datetime/functions/date-default-timezone-get.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4bf21e8867650755d5dea13e01049d2825486ea2 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: PhilDaiguille -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.date-default-timezone-get" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_default_timezone_get</refname>
@@ -63,14 +63,12 @@
 date_default_timezone_set('Europe/London');
 
 if (date_default_timezone_get()) {
-    echo 'date_default_timezone_set : ' . date_default_timezone_get() . '<br />';
+    echo 'date_default_timezone_set: ' . date_default_timezone_get() . "\n";
 }
 
 if (ini_get('date.timezone')) {
     echo 'date.timezone : ' . ini_get('date.timezone');
 }
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -90,7 +88,6 @@ date.timezone : Europe/London
 <?php
 date_default_timezone_set('America/Los_Angeles');
 echo date_default_timezone_get() . ' => ' . date('e') . ' => ' . date('T');
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/functions/date-default-timezone-set.xml
+++ b/reference/datetime/functions/date-default-timezone-set.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0a10abc50524fcbb21807b5e6ebffb3b86d45907 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: PhilDaiguille -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.date-default-timezone-set" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_default_timezone_set</refname>
@@ -66,13 +66,13 @@
 date_default_timezone_set('America/Los_Angeles');
 
 $script_tz = date_default_timezone_get();
+$ini_tz = ini_get('date.timezone');
 
-if (strcmp($script_tz, ini_get('date.timezone'))){
+if (strcmp($script_tz, $ini_tz)){
     echo 'La zona horaria del script difiere de la zona horaria definida en el archivo ini.';
 } else {
     echo 'La zona horaria del script es equivalente a la definida en el archivo ini.';
 }
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/date-parse-from-format.xml
+++ b/reference/datetime/functions/date-parse-from-format.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d13f5e4b45f699eb855a5e84736aeda2ebd142a Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 
 <refentry xml:id="function.date-parse-from-format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -145,7 +145,6 @@
 <?php
 $date = "6.1.2009 13:00+01:00";
 print_r(date_parse_from_format("j.n.Y H:iP", $date));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -159,7 +158,7 @@ Array
     [hour] => 13
     [minute] => 0
     [second] => 0
-    [fraction] =>
+    [fraction] => 0
     [warning_count] => 0
     [warnings] => Array
         (
@@ -195,7 +194,6 @@ echo "Warnings count: ", $parsed['warning_count'], "\n";
 foreach ($parsed['warnings'] as $position => $message) {
     echo "\tOn position {$position}: {$message}\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -224,7 +222,6 @@ echo "Errors count: ", $parsed['error_count'], "\n";
 foreach ($parsed['errors'] as $position => $message) {
     echo "\tOn position {$position}: {$message}\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -232,7 +229,7 @@ foreach ($parsed['errors'] as $position => $message) {
 <![CDATA[
 Errors count: 3
 	On position 15: A two digit hour could not be found
-	On position 19: Data missing
+	On position 19: Not enough data available to satisfy format
 ]]>
     </screen>
    </example>

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 50dcf55ce543220dd8375df2fdb4f7db702b9c9f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.date-parse" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_parse</refname>
@@ -138,7 +138,6 @@
 <![CDATA[
 <?php
 var_dump(date_parse("2006-12-12 10:00:00.5"));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -188,7 +187,6 @@ array(12) {
 <![CDATA[
 <?php
 var_dump(date_parse("June 2nd, 2022, 10:28:17 BST"));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -239,7 +237,6 @@ array(16) {
 <![CDATA[
 <?php
 var_dump(date_parse("June 2nd, 2022, 10:28:17 Europe/London"));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -294,7 +291,6 @@ array(14) {
 <![CDATA[
 <?php
 var_dump(date_parse("June 2nd, 2022"));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -342,7 +338,6 @@ array(12) {
 <![CDATA[
 <?php
 var_dump(date_parse("2006-12-12 10:00:00.5 +1 week +1 hour"));
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -408,7 +403,6 @@ array(13) {
 <![CDATA[
 <?php
 var_dump(date_parse("Thursday, June 2nd"));
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 03b6583a4ade7a2b68b57fe958d2d9022b15a873 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.date-sun-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_sun_info</refname>
@@ -181,7 +181,6 @@ $sun_info = date_sun_info(strtotime("2006-12-12"), 31.7667, 35.2333);
 foreach ($sun_info as $key => $val) {
   echo "$key: " . date("H:i:s", $val) . "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -220,7 +219,6 @@ foreach ($si as $key => $value) {
         ": {$key}",
         "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -249,7 +247,6 @@ never: sunset
 <?php
 $si = date_sun_info(strtotime("2022-06-26"), 69.68, 18.94);
 print_r($si);
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -282,7 +279,6 @@ $diff = $si['sunset'] - $si['sunrise'];
 echo "Duración del día: ",
     floor($diff / 3600), "h ",
     floor(($diff % 3600) / 60), "s\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.date-sunrise" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
 
  <refnamediv>
@@ -12,8 +12,8 @@
  <refsynopsisdiv>
   <warning>
    <para>
-    Esta función está <emphasis>DEPRECADA</emphasis> a partir de PHP 8.1.0.
-    Depender de esta función se desaconseja fuertemente. Se recomienda
+    Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 8.1.0.
+    Depender de esta función está altamente desaconsejado. Se recomienda
     el uso de <function>date_sun_info</function> en su lugar.
    </para>
   </warning>
@@ -221,14 +221,14 @@ offset: +1 GMT
 */
 
 echo date("D M d Y"). ', hora de salida del sol: ' .date_sunrise(time(), SUNFUNCS_RET_STRING, 38.4, -9, 90, 1);
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
-Mon Dec 20 2004, hora de salida del sol: 08:54
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in script on line 10
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in script on line 10
+Mon Dec 20 2004, sunrise time : 08:54
 ]]>
     </screen>
    </example>
@@ -239,12 +239,13 @@ Mon Dec 20 2004, hora de salida del sol: 08:54
 <?php
 $solstice = strtotime('2017-12-21');
 var_dump(date_sunrise($solstice, SUNFUNCS_RET_STRING, 69.245833, -53.537222));
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in script on line 3
+Deprecated: Function date_sunrise() is deprecated since 8.1, use date_sun_info() instead in script on line 3
 bool(false)
 ]]>
     </screen>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.date-sunset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>date_sunset</refname>
@@ -13,9 +13,9 @@
  <refsynopsisdiv>
   <warning>
    <para>
-    Esta función está <emphasis>DEPRECADA</emphasis> a partir de PHP 8.1.0.
-    Depender de esta función se desaconseja fuertemente. Se recomienda el uso
-    de <function>date_sun_info</function> en su lugar.
+    Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 8.1.0.
+    Depender de esta función está altamente desaconsejo. Use
+    <function>date_sun_info</function> en su lugar.
    </para>
   </warning>
  </refsynopsisdiv>
@@ -223,14 +223,14 @@ offset:1 GMT
 */
 
 echo date("D M d Y"). ', hora de puesta del sol : ' .date_sunset(time(), SUNFUNCS_RET_STRING, 38.4, -9, 90, 1);
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
-Mon Dec 20 2004, hora de puesta del sol : 18:13
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in script on line 10
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in script on line 10
+Mon Dec 20 2004, sunset time : 18:13
 ]]>
     </screen>
    </example>
@@ -241,12 +241,13 @@ Mon Dec 20 2004, hora de puesta del sol : 18:13
 <?php
 $solstice = strtotime('2017-12-21');
 var_dump(date_sunset($solstice, SUNFUNCS_RET_STRING, 69.245833, -53.537222));
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+Deprecated: Constant SUNFUNCS_RET_STRING is deprecated in script on line 3
+Deprecated: Function date_sunset() is deprecated since 8.1, use date_sun_info() instead in script on line 3
 bool(false)
 ]]>
     </screen>

--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d94400847cec608f93830aa85e0761b97d7cb9bf Maintainer: Marqitos Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="function.date" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>date</refname>
@@ -108,21 +108,20 @@ date_default_timezone_set('UTC');
 
 
 // Imprime algo como: Monday
-echo date("l");
+echo date("l") . "\n";
 
 // Imprime algo como: Monday 8th of August 2005 03:12:46 PM
-echo date('l jS \of F Y h:i:s A');
+echo date('l jS \of F Y h:i:s A') . "\n";
 
-// Prints: July 1, 2000 is on a Saturday
-echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000));
+// Imprime: July 1, 2000 is on a Saturday
+echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000)) . "\n";
 
 /* Usar las constantes en el parámetro de formato */
 // Imprime algo como: Wed, 25 Sep 2013 15:28:57 -0700
-echo date(DATE_RFC2822);
+echo date(DATE_RFC2822) . "\n";
 
 // Imprime algo como: 2000-07-01T00:00:00+00:00
 echo date(DATE_ATOM, mktime(0, 0, 0, 7, 1, 2000));
-?>
 ]]>
     </programlisting>
    </example>
@@ -139,34 +138,9 @@ echo date(DATE_ATOM, mktime(0, 0, 0, 7, 1, 2000));
 <?php
 // Imprime algo como: Wednesday the 15th
 echo date('l \t\h\e jS');
-?>
 ]]>
     </programlisting>
    </example>
-  </para>
-  <para>
-   Es posible usar <function>date</function> y
-   <function>mktime</function> juntos para buscar fechas en el futuro
-   o en el pasado.
-   <example>
-    <title>Ejemplo de <function>date</function> y <function>mktime</function></title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-$tomorrow  = mktime(0, 0, 0, date("m")  , date("d")+1, date("Y"));
-$lastmonth = mktime(0, 0, 0, date("m")-1, date("d"),   date("Y"));
-$nextyear  = mktime(0, 0, 0, date("m"),   date("d"),   date("Y")+1);
-?>
-]]>
-    </programlisting>
-   </example>
-   <note>
-    <para>
-     Esto puede ser más fiable que añadir o sustraer simplemente el número
-     de segundos de un día o mes a una marca de tiempo debido al horario de
-     verano.
-    </para>
-   </note>
   </para>
   <para>
    Algunos ejemplos de formatear <function>date</function>. Observe que
@@ -180,20 +154,20 @@ $nextyear  = mktime(0, 0, 0, date("m"),   date("d"),   date("Y")+1);
     <programlisting role="php">
 <![CDATA[
 <?php
-// Se asume que hoy es March 10th, 2001, 5:16:18 pm, y que estamos en la
+// Asumiendo que hoy es 10 de marzo de 2001, 5:16:18 pm, y que estamos en la
 // zona horaria Mountain Standard Time (MST)
+date_default_timezone_set("America/Phoenix");
 
-$today = date("F j, Y, g:i a");                 // March 10, 2001, 5:16 pm
-$today = date("m.d.y");                         // 03.10.01
-$today = date("j, n, Y");                       // 10, 3, 2001
-$today = date("Ymd");                           // 20010310
-$today = date('h-i-s, j-m-y, it is w Day');     // 05-16-18, 10-03-01, 1631 1618 6 Satpm01
-$today = date('\i\t \i\s \t\h\e jS \d\a\y.');   // it is the 10th day.
-$today = date("D M j G:i:s T Y");               // Sat Mar 10 17:16:18 MST 2001
-$today = date('H:m:s \m \i\s\ \m\o\n\t\h');     // 17:03:18 m is month
-$today = date("H:i:s");                         // 17:16:18
-$today = date("Y-m-d H:i:s");                   // 2001-03-10 17:16:18 (the MySQL DATETIME format)
-?>
+echo date("F j, Y, g:i a") . "\n";                 // March 10, 2001, 5:16 pm
+echo date("m.d.y") . "\n";                         // 03.10.01
+echo date("j, n, Y") . "\n";                       // 10, 3, 2001
+echo date("Ymd") . "\n";                           // 20010310
+echo date('h-i-s, j-m-y, it is w Day') . "\n";     // 05-16-18, 10-03-01, 1631 1618 6 Satpm01
+echo date('\i\t \i\s \t\h\e jS \d\a\y.') . "\n";   // it is the 10th day.
+echo date("D M j G:i:s T Y") . "\n";               // Sat Mar 10 17:16:18 MST 2001
+echo date('H:m:s \m \i\s\ \m\o\n\t\h') . "\n";     // 17:03:18 m is month
+echo date("H:i:s") . "\n";                         // 17:16:18
+echo date("Y-m-d H:i:s") . "\n";                   // 2001-03-10 17:16:18 (the MySQL DATETIME format)
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/getdate.xml
+++ b/reference/datetime/functions/getdate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 34188f8256bdc6f0e6e1965c2be94247997165b6 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.getdate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>getdate</refname>
@@ -148,7 +148,6 @@
 <?php
 $today = getdate();
 print_r($today);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -156,17 +155,17 @@ print_r($today);
 <![CDATA[
 Array
 (
-     [seconds] => 40
-     [minutes] => 58
-     [hours]   => 21
-     [mday]    => 17
-     [wday]    => 2
-     [mon]     => 6
-     [year]    => 2003
-     [yday]    => 167
-     [weekday] => Tuesday
-     [month]   => June
-     [0]       => 1055901520
+    [seconds] => 40
+    [minutes] => 58
+    [hours] => 21
+    [mday] => 17
+    [wday] => 2
+    [mon] => 6
+    [year] => 2003
+    [yday] => 167
+    [weekday] => Tuesday
+    [month] => June
+    [0] => 1055901520
 )
 ]]>
     </screen>

--- a/reference/datetime/functions/gettimeofday.xml
+++ b/reference/datetime/functions/gettimeofday.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DAnnebicque -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.gettimeofday" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gettimeofday</refname>
@@ -82,7 +81,6 @@
 print_r(gettimeofday());
 
 echo gettimeofday(true);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -95,7 +93,6 @@ Array
    [minuteswest] => 0
    [dsttime] => 1
 )
-
 1073504408.23910
 ]]>
     </screen>

--- a/reference/datetime/functions/gmdate.xml
+++ b/reference/datetime/functions/gmdate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.gmdate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmdate</refname>
@@ -78,20 +78,22 @@
   <para>
    <example>
     <title>Ejemplo con <function>gmdate</function></title>
-    <para>
-     Cuando esta función se ejecuta en Finlandia (GMT0200), la primera
-     línea a continuación mostrará <literal>"Jan 01 1998 00:00:00"</literal>,
-     mientras que la segunda mostrará
-     <literal>"Dec 31 1997 22:00:00"</literal>.
-    </para>
     <programlisting role="php">
 <![CDATA[
 <?php
-echo date("M d Y H:i:s", mktime(0, 0, 0, 1, 1, 1998));
-echo gmdate("M d Y H:i:s", mktime(0, 0, 0, 1, 1, 1998));
-?>
+date_default_timezone_set("Europe/Helsinki");
+
+echo date("M d Y H:i:s e", mktime(0, 0, 0, 1, 1, 1998)) . "\n";
+echo gmdate("M d Y H:i:s e", mktime(0, 0, 0, 1, 1, 1998));
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Jan 01 1998 00:00:00 Europe/Helsinki
+Dec 31 1997 22:00:00 UTC
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/functions/gmmktime.xml
+++ b/reference/datetime/functions/gmmktime.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 57e27d2a7615da2ee6de57ed27eb40b473d487cb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: PhilDaiguille -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.gmmktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmmktime</refname>
@@ -160,11 +160,17 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Muestra: July 1, 2000 is on a Saturday
+date_default_timezone_set("Indian/Maldives");
+
 echo "July 1, 2000 is on a " . date("l", gmmktime(0, 0, 0, 7, 1, 2000));
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+July 1, 2000 is on a Saturday
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/functions/gmstrftime.xml
+++ b/reference/datetime/functions/gmstrftime.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.gmstrftime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmstrftime</refname>
@@ -25,19 +25,16 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>timestamp</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>gmstrftime</function> se comporta exactamente como
-   <function>strftime</function> con la excepción de que la hora utilizada
-   es la de Greenwich (<literal>Greenwich Mean Time</literal>, GMT).
-   Por ejemplo, en la zona <literal>Eastern Standard Time</literal>
-   (este de USA) es GMT -0500, la primera línea del ejemplo a continuación
-   muestra <literal>"Dec 31 1998 20:00:00"</literal>, mientras que
-   la segunda muestra <literal>"Jan 01 1999 01:00:00"</literal>.
+   Se comporta igual que <function>strftime</function> excepto que la
+   hora devuelta es la hora del meridiano de Greenwich (GMT). Por ejemplo, cuando se ejecuta
+   en la hora estándar del este (GMT -0500), la primera línea a continuación imprime
+   "Dec 31 1998 20:00:00", mientras que la segunda imprime
+   "Jan 01 1999 01:00:00".
   </para>
   <warning>
    <para>
-    Esta función depende de la información local del sistema
-    operativo, que puede ser inconsistente o no estar disponible.
-    Se recomienda utilizar el método
+    Esta función depende de la información local del sistema operativo, que puede
+    ser inconsistente o no estar disponible. Se recomienda utilizar el método
     <methodname>IntlDateFormatter::format</methodname>.
    </para>
   </warning>
@@ -51,8 +48,7 @@
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       Ver la descripción de la función
-       <function>strftime</function>.
+       Ver la descripción de la función <function>strftime</function>.
       </para>
      </listitem>
     </varlistentry>
@@ -109,7 +105,6 @@
 setlocale(LC_TIME, 'en_US');
 echo strftime("%b %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98)) . "\n";
 echo gmstrftime("%b %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98)) . "\n";
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/idate.xml
+++ b/reference/datetime/functions/idate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: PhilDaiguille -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.idate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>idate</refname>
@@ -201,15 +201,24 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$timestamp = strtotime('1st January 2004'); //1072915200
+$timestamp = strtotime('1st January 2004'); // 1072915200
 
 // esto muestra el año en dos dígitos
 // sin embargo, dado que este dígito comenzará con "0",
 // solo "4" será mostrado
+echo idate('y', $timestamp) . "\n";
+
+$timestamp = strtotime('1st January 2024'); // 1704067200
 echo idate('y', $timestamp);
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+4
+24
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/functions/localtime.xml
+++ b/reference/datetime/functions/localtime.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a4ba07f273fd7d34520a8d02052a746076094e32 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DAnnebicque -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.localtime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>localtime</refname>
@@ -149,7 +148,6 @@ $localtime = localtime();
 $localtime_assoc = localtime(time(), true);
 print_r($localtime);
 print_r($localtime_assoc);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;

--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.microtime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>microtime</refname>
@@ -71,30 +71,28 @@
 $time_start = microtime(true);
 
 // Espera durante un momento
-usleep(100);
+usleep(10_000);
 
 $time_end = microtime(true);
 $time = $time_end - $time_start;
 
-echo "No hacer nada durante $time segundos\n";
-?>
+print "No hacer nada durante $time segundos\n";
 ]]>
     </programlisting>
    </example>
    <example>
     <title>Ejemplo con <function>microtime</function> y <literal>REQUEST_TIME_FLOAT</literal></title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Duración de espera aleatoria
-usleep(mt_rand(100, 10000));
+usleep(random_int(10_000, 1_000_000));
 
 // REQUEST_TIME_FLOAT está disponible en el array superglobal $_SERVER.
 // Contiene el timestamp del inicio de la petición, con precisión de microsegundo.
 $time = microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"];
 
 echo "No hacer nada durante $time segundos\n";
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 349e3c6502e0bbeb15aef2b4a4a25f3f5e10fbfe Maintainer: seros Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -171,13 +171,19 @@
 date_default_timezone_set('UTC');
 
 // Imprime: July 1, 2000 is on a Saturday
-echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000));
+echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000)) . "\n";
 
 // Imprime algo como: 2006-04-05T01:02:03+00:00
-echo date('c', mktime(1, 2, 3, 4, 5, 2006));
-?>
+echo date('c', mktime(1, 2, 3, 4, 5, 2006)) . "\n";
 ]]>
     </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+July 1, 2000 is on a Saturday
+2006-04-05T01:02:03+00:00
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -192,14 +198,59 @@ echo date('c', mktime(1, 2, 3, 4, 5, 2006));
     <programlisting role="php">
 <![CDATA[
 <?php
-echo date("M-d-Y", mktime(0, 0, 0, 12, 32, 1997));
-echo date("M-d-Y", mktime(0, 0, 0, 13, 1, 1997));
-echo date("M-d-Y", mktime(0, 0, 0, 1, 1, 1998));
-echo date("M-d-Y", mktime(0, 0, 0, 1, 1, 98));
-?>
+date_default_timezone_set('America/New_York');
+
+echo date("c", mktime(0, 0, 0, 12, 32, 1997)) . "\n";
+echo date("c", mktime(0, 0, 0, 13, 1, 1997)) . "\n";
+echo date("c", mktime(0, 0, 0, 1, 1, 1998)) . "\n";
+echo date("c", mktime(0, 0, 0, 1, 1, 98)) . "\n";
 ]]>
     </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+1998-01-01T00:00:00-05:00
+1998-01-01T00:00:00-05:00
+1998-01-01T00:00:00-05:00
+1998-01-01T00:00:00-05:00
+]]>
+    </screen>
    </example>
+  </para>
+  <para>
+   <example>
+    <title>Usando mktime para buscar fechas relativas</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+date_default_timezone_set('Asia/Tokyo');
+
+$tomorrow  = mktime(0, 0, 0, date("m")  , date("d")+1, date("Y"));
+print date('c', $tomorrow) . "\n";
+
+$lastmonth = mktime(0, 0, 0, date("m")-1, date("d"),   date("Y"));
+print date('c', $lastmonth) . "\n";
+
+$nextyear  = mktime(0, 0, 0, date("m"),   date("d"),   date("Y")+1) . "\n";
+print date('c', $nextyear) . "\n";
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+2025-09-30T00:00:00+09:00
+2025-08-29T00:00:00+09:00
+2026-09-29T00:00:00+09:00
+]]>
+    </screen>
+   </example>
+   <note>
+    <para>
+     Esto puede ser más fiable que simplemente sumar o restar el número
+     de segundos de un día o mes a una marca de tiempo debido al horario
+     de verano.
+    </para>
+   </note>
   </para>
   <para>
    <example>
@@ -213,15 +264,20 @@ echo date("M-d-Y", mktime(0, 0, 0, 1, 1, 98));
 <![CDATA[
 <?php
 
-$ultimoDia = mktime(0, 0, 0, 3, 0, 2000);
-echo 'Last day in Feb 2000 is: ', date('d', $ultimoDia);
+$lastday = mktime(0, 0, 0, 3, 0, 2000);
+echo 'Last day in Feb 2000 is: ', date('d', $lastday) . "\n";
 
-$ultimoDia = mktime(0, 0, 0, 4, -31, 2000);
-echo 'Last day in Feb 2000 is: ', date('d', $ultimoDia);
-
-?>
+$lastday = mktime(0, 0, 0, 4, -31, 2000);
+echo 'Last day in Feb 2000 is: ', date('d', $lastday) . "\n";
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Last day in Feb 2000 is: 29
+Last day in Feb 2000 is: 29
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/datetime/functions/strftime.xml
+++ b/reference/datetime/functions/strftime.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.strftime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>strftime</refname>
@@ -32,17 +32,18 @@
   </para>
   <warning>
    <para>
-    Todos los caracteres modificadores no siempre son soportados por
-    todas las bibliotecas C. En este caso, no serán soportados por PHP tampoco. Además, todas las plataformas no soportan
-    los timestamps negativos, y sus fechas podrían estar limitadas por el
-    inicio de la época Unix. Esto significa que
+    Es posible que no todos los especificadores de conversión sean compatibles con su biblioteca C, en cuyo
+    caso no serán compatibles con <function>strftime</function> de PHP.
+    Además, no todas las plataformas admiten marcas de tiempo negativas, por lo que su
+    rango de fechas puede estar limitado a fechas no anteriores a la época Unix. Esto significa que
     <literal>%e</literal>, <literal>%T</literal>, <literal>%R</literal> y <literal>%D</literal>
     (y puede que otros) y las fechas anteriores al
     <literal>1 de Enero de 1970</literal> no funcionarán bajo Windows,
-    en algunas distribuciones de Linux, y en algunos sistemas operativos.
-    Para Windows, una lista completa de las opciones de conversión está disponible
-    en el <link xlink:href="&url.strftime.win32;">sitio de <acronym>MSDN</acronym></link>.
-    Utilice en su lugar el método <methodname>IntlDateFormatter::format</methodname>.
+    en algunas distribuciones de Linux, y algunos otros sistemas operativos. Para Windows, una
+    lista completa de las opciones de conversión está disponible en el
+    <link xlink:href="&url.strftime.win32;">sitio de <acronym>MSDN</acronym></link>.
+    Utilice en su lugar el método
+    <methodname>IntlDateFormatter::format</methodname>.
    </para>
   </warning>
  </refsect1>
@@ -431,7 +432,7 @@
    instaladas en su sistema.
    <example>
     <title>Ejemplo con <function>strftime</function></title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 setlocale(LC_TIME, "C");
@@ -442,7 +443,6 @@ setlocale(LC_TIME, "fr_FR");
 echo strftime(" in French %A and");
 setlocale(LC_TIME, "de_DE");
 echo strftime(" in German %A.\n");
-?>
 ]]>
     </programlisting>
    </example>
@@ -494,8 +494,6 @@ echo "1/2/2005 - %V,%G,%Y = " . strftime("%V,%G,%Y",strtotime("1/2/2005")) . "\n
 
 // Muestra: 1/3/2005 - %V,%G,%Y = 1,2005,2005
 echo "1/3/2005 - %V,%G,%Y = " . strftime("%V,%G,%Y",strtotime("1/3/2005")) . "\n";
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -517,7 +515,6 @@ if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
 }
 
 echo strftime($format);
-?>
 ]]>
     </programlisting>
    </example>
@@ -608,7 +605,6 @@ foreach ($strftimeValues as $format => $value) {
 foreach (array_diff_key($strftimeFormats, $strftimeValues) as $format => $description) {
     echo "Formato desconocido: '{$format}'   ", str_pad(' ', $maxValueLength), ($description ? " ( {$description} )" : ''), "\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;

--- a/reference/datetime/functions/strptime.xml
+++ b/reference/datetime/functions/strptime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.strptime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <refnamediv>
@@ -166,7 +166,6 @@ $strf = strftime($format);
 echo "$strf\n";
 
 print_r(strptime($strf, $format));
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.strtotime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>strtotime</refname>
@@ -117,7 +117,6 @@ echo strtotime("+1 week"), "\n";
 echo strtotime("+1 week 2 days 4 hours 2 seconds"), "\n";
 echo strtotime("next Thursday"), "\n";
 echo strtotime("last Monday"), "\n";
-?>
 ]]>
     </programlisting>
    </example>
@@ -135,7 +134,6 @@ if (($timestamp = strtotime($str)) === false) {
 } else {
    echo "$str == " . date('l dS \o\f F Y h:i:s A', $timestamp);
 }
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/time.xml
+++ b/reference/datetime/functions/time.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-
 <refentry xml:id="function.time" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>time</refname>
@@ -50,7 +49,6 @@
 <![CDATA[
 <?php
 echo 'Hoy : '. time();
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;

--- a/reference/datetime/functions/timezone-name-from-abbr.xml
+++ b/reference/datetime/functions/timezone-name-from-abbr.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c951013ca04161992efed8b86fb40f55669958e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
-
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.timezone-name-from-abbr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>timezone_name_from_abbr</refname>
@@ -77,7 +76,6 @@
 <?php
 echo timezone_name_from_abbr("CET") . "\n";
 echo timezone_name_from_abbr("", 3600, 0) . "\n";
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;

--- a/reference/datetime/functions/timezone-version-get.xml
+++ b/reference/datetime/functions/timezone-version-get.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b7ac6fa547cef108d56729fa322677eec4882285 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.timezone-version-get" xmlns="http://docbook.org/ns/docbook"  xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>timezone_version_get</refname>
@@ -58,7 +57,6 @@
 <![CDATA[
 <?php
 echo timezone_version_get();
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;


### PR DESCRIPTION
Update `reference\datetime\**` to [EN 3a8c3e7](https://github.com/php/doc-en/commit/3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3)