### PR TITLE
Various updates, up to EN 876557a

### DIFF
--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a63b9c754188b610fe1916404831aa9f1b41efbf Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 170b6cda37f29c39b9e08375344c5eb9523b2de3 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <appendix xml:id="reserved" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Palabras reservadas en PHP</title>
  <para>
@@ -501,7 +501,7 @@
      <listitem>
       <simpara>
        <link linkend="language.oop5.paamayim-nekudotayim">Clase
-        padre</link>.
+       padre</link>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -524,78 +524,86 @@
      <tbody>
       <row>
        <entry>
+        parent
+       </entry>
+       <entry>
+        self
+       </entry>
+       <entry>
         int
        </entry>
        <entry>
         float
        </entry>
+      </row>
+      <row>
        <entry>
         bool
        </entry>
        <entry>
         string
        </entry>
-      </row>
-      <row>
        <entry>
         true
        </entry>
        <entry>
         false
        </entry>
+      </row>
+      <row>
        <entry>
         null
        </entry>
        <entry>
         void (disponible a partir de PHP 7.1)
        </entry>
-       </row>
-       <row>
-        <entry>
-         iterable (disponible a partir de PHP 7.1)
-        </entry>
-        <entry>
-         object (disponible a partir de PHP 7.2)
-        </entry>
-        <entry>
-         mixed (disponible a partir de PHP 8.0)
-        </entry>
-        <entry>
-         never (disponible a partir de PHP 8.1)
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
-   </para>
-   <para>
-    La lista de palabras siguientes presenta una particularidad. Aunque pueden ser
-    utilizadas en los nombres de clase, de interfaz, y de trait, conviene evitar
-    utilizarlas sabiendo que pueden ser utilizadas en las futuras versiones de PHP.
-   </para>
-   <para>
-    <table>
-     <title>Palabras reservadas suaves</title>
-     <tgroup cols="4">
-      <tbody>
-       <row>
-        <entry>
-         enum
-        </entry>
-        <entry>
-         resource
-        </entry>
-        <entry>
-         numeric
-        </entry>
-        <entry>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
-   </para>
-  </sect1>
+       <entry>
+        iterable (disponible a partir de PHP 7.1)
+       </entry>
+       <entry>
+        object (disponible a partir de PHP 7.2)
+       </entry>
+      </row>
+      <row>
+       <entry>
+        mixed (disponible a partir de PHP 8.0)
+       </entry>
+       <entry>
+        never (disponible a partir de PHP 8.1)
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   La lista de palabras siguientes presenta una particularidad. Aunque pueden ser
+   utilizadas en los nombres de clase, de interfaz, y de trait, conviene evitar
+   utilizarlas sabiendo que pueden ser utilizadas en las futuras versiones de PHP.
+  </para>
+  <para>
+   <table>
+    <title>Palabras reservadas suaves</title>
+    <tgroup cols="4">
+     <tbody>
+      <row>
+       <entry>
+        enum
+       </entry>
+       <entry>
+        resource
+       </entry>
+       <entry>
+        numeric
+       </entry>
+       <entry>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+ </sect1>
 </appendix>
 
 <!-- Keep this comment at the end of the file

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1fd637525fd3bbaec04f6fff80eeb33fce880b10 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
-
+<!-- EN-Revision: 876557ae38f6ca5035618f7cea48ca627118b437 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <chapter xml:id="tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Una introducción a PHP</title>
 
@@ -14,61 +13,21 @@
    más información.
   </para>
   <para>
-   Las páginas web que utilizan PHP se tratan como páginas HTML estándar, y se pueden crear, editar y borrar
-   de la misma manera que se hace normalmente con páginas HTML
-   clásicas.
+   Las páginas web que utilizan PHP se tratan como páginas HTML clásicas,
+   y se pueden crear, editar y borrar de la misma manera que normalmente se crean
+   las páginas HTML clásicas.
   </para>
-
-  <section xml:id="tutorial.requirements">
-   <title>Lo necesario</title>
-   <para>
-    En este tutorial, se presume que se dispone de un servidor
-    web con soporte PHP activado, y que los ficheros terminados
-    por la extensión <filename class="extension">.php</filename> son tratados por
-    PHP. En la mayoría de los servidores, esta es la configuración por
-    omisión, pero no dude en consultar a su administrador
-    del sistema en caso de duda. Si su servidor web soporta PHP,
-    no hay nada que hacer. Simplemente, cree una carpeta,
-    luego cree un fichero de texto, con la extensión <filename class="extension">.php</filename> :
-    el servidor lo ejecutará automáticamente con PHP. No hay
-    compilación ni instalación complicada. Tenga en cuenta que
-    los ficheros son comparables a ficheros HTML, en los que
-    se utilizarán etiquetas mágicas, que harán muchas
-    cosas por usted.
-   </para>
-   <para>
-    Supongamos que desea ahorrar tiempo en línea y trabajar
-    localmente. En este caso, debe instalar un servidor web como
-    <link xlink:href="&url.apache;">Apache</link>, y por supuesto
-    <link xlink:href="&url.php.downloads;">PHP</link>.  También se deseará
-    instalar una base de datos como
-    <link xlink:href="&url.mysql.docs;">MySQL</link>.
-   </para>
-   <para>
-    Se puede instalar estos programas individualmente o de una manera simplificada.
-    Nuestro manual contiene las <link linkend="install">instrucciones de instalación de PHP</link>
-    (suponiendo que ya tenga un servidor web instalado). Si encuentra problemas en la instalación de PHP, se sugiere
-    hacer sus preguntas en nuestra
-    <link xlink:href="&url.php.mailing-lists;">lista de difusión</link> reservada para este uso.
-    Si elige una versión simplificada, puede utilizar
-    <link xlink:href="&url.installkits;">instaladores</link>
-    que se encargan de toda la instalación en unos pocos
-    clics. Es fácil configurar un servidor web con soporte
-    de PHP en cualquier sistema operativo, incluyendo
-    Mac OS, Linux y Windows. En Linux, también se pueden encontrar
-    comandos como <link xlink:href="&url.rpmfind;">rpmfind</link> y
-    <link xlink:href="&url.rpmfind.pbone;">PBone</link>
-    muy prácticos para buscar los paquetes precompilados.
-    También se puede visitar <link xlink:href="&url.apt-get;">apt-get</link>,
-    para paquetes Debian.
-   </para>
-  </section>
 
   <section xml:id="tutorial.firstpage">
    <title>Su primera página PHP</title>
+   <simpara>
+    Este tutorial presupone que PHP ya está instalado.
+    Las instrucciones de instalación se pueden encontrar en la
+    <link xlink:href="&url.php.downloads;">página de descargas</link>.
+   </simpara>
    <para>
-    Cree un fichero llamado <filename>hola.php</filename> en su
-    carpeta web raíz (<varname>DOCUMENT_ROOT</varname>) con el siguiente contenido :
+    Cree un fichero llamado <filename>hola.php</filename>
+    con el siguiente contenido :
    </para>
    <para>
     <example>
@@ -77,22 +36,31 @@
 <![CDATA[
 <?php
 
-echo "Hello World!";
+echo "¡Hola Mundo!";
 
 ?>
 ]]>
      </programlisting>
      <simpara>
+      Usando su terminal, navegue hasta el directorio que contiene este fichero y
+      inicie un servidor de desarrollo con el siguiente comando:
+     </simpara>
+     <programlisting role="shell">
+<![CDATA[
+php -S localhost:8000
+]]>
+     </programlisting>
+     <simpara>
       Utilice su navegador para acceder al fichero utilizando la URL de su servidor web, terminando
-      por la referencia al fichero <literal>/hola.php</literal>. Cuando se desarrolla localmente, esta
-      URL será algo como <literal>http://localhost/hola.php</literal>
-      o <literal>http://127.0.0.1/hola.php</literal>, pero esto depende de la configuración
-      del servidor web. Si todo está correctamente configurado, este fichero será analizado por PHP y
-      se verá el mensaje "Hello World" en su navegador.
+      por la referencia al fichero <literal>/hola.php</literal>.
+      De acuerdo con el comando ejecutado anteriormente, la URL será
+      <literal>http://localhost:8000/hello.php</literal>.
+      Si todo está correctamente configurado, este fichero será analizado por PHP
+      y se verá el mensaje "¡Hola Mundo!" en su navegador.
      </simpara>
      <simpara>
       PHP puede ser integrado en una página web HTML normal. Esto significa que, en su documento HTML,
-      se pueden escribir instrucciones PHP, como se demuestra en el siguiente ejemplo :
+      se pueden escribir instrucciones PHP, como se demuestra en el siguiente ejemplo:
      </simpara>
      <programlisting role="php">
 <![CDATA[
@@ -136,19 +104,7 @@ echo "Hello World!";
     pasarlos a PHP. Considere esto como una página HTML normal que contiene una serie
     de etiquetas especiales que le permitirán realizar muchas cosas interesantes.
    </para>
-   <para>
-    Si ha probado este ejemplo y no ha mostrado nada especial,
-    o incluso un cuadro de diálogo ha surgido para proponerle descargarlo,
-    o incluso, ha visto el código tal como lo hemos escrito en el
-    fichero, entonces su servidor web probablemente no soporta PHP o está mal configurado.
-    Pida a su administrador que lo active para usted, utilizando
-    el capítulo <link linkend="install">Instalación</link>. Si está desarrollando localmente,
-    lea también el capítulo de instalación para asegurarse de que todo está configurado correctamente.
-    Asegúrese de que está intentando acceder al fichero a través de http y que el servidor web le proporciona la
-    salida. Si llama a su fichero desde su gestor de ficheros, no será analizado
-    por PHP. Si el problema persiste a pesar de esto, no dude en utilizar una
-    <link xlink:href="&url.php.support;">de las opciones de soporte</link> de PHP.
-   </para>
+
    <para>
     El punto importante de este ejemplo era mostrar el formato de las
     etiquetas especiales PHP. Hemos utilizado aquí
@@ -214,7 +170,11 @@ echo "Hello World!";
      <title>Recuperación de la información del sistema desde PHP</title>
      <programlisting role="php">
 <![CDATA[
-<?php phpinfo(); ?>
+<?php
+
+phpinfo();
+
+?>
 ]]>
      </programlisting>
     </example>
@@ -252,7 +212,9 @@ echo "Hello World!";
     <programlisting role="php">
 <![CDATA[
 <?php
+
 echo $_SERVER['HTTP_USER_AGENT'];
+
 ?>
 ]]>
     </programlisting>
@@ -294,9 +256,11 @@ Mozilla/5.0 (Linux) Firefox/112.0
      <programlisting role="php">
 <![CDATA[
 <?php
+
 if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
     echo 'Está utilizando Firefox.';
 }
+
 ?>
 ]]>
      </programlisting>

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,86 +1,217 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eac9eff7b66d8c2b168c25c72de0422126daf8cb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: 147b80d1974b969caad1db188a48f4bcd90f5eb8 Maintainer: Marqitos Status: ready -->
+<!-- Reviewed: no -->
 <sect1 xml:id="language.types.callable">
- <title>Funciones de retrollamada / Tipos Callable</title>
+ <title>Callables</title>
 
- <para>
-  Las funciones de retrollamada pueden ser identificadas a través del tipo <type>callable</type>.
- </para>
+ <simpara>
+  Un callable es una referencia a una función o método que se pasa a
+  otra función como argumento.
+  Se representa con la declaración de tipo <type>callable</type>.
+ </simpara>
+ <informalexample>
+  <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+function foo(callable $callback) {
+    $callback();
+}
+?>
+]]>
+  </programlisting>
+ </informalexample>
 
- <para>
-  Algunas funciones, como <function>call_user_func</function> o
-  <function>usort</function>, aceptan como argumento funciones de retrollamada
-  definidas por el usuario. Las funciones de retrollamada pueden ser funciones
-  simples, pero también métodos de &object;s, incluyendo métodos
-  estáticos de clase.
- </para>
+ <simpara>
+  Algunas funciones aceptan funciones de retrollamada como parámetro, por ejemplo
+  <function>array_map</function>, <function>usort</function>, o
+  <function>preg_replace_callback</function>.
+ </simpara>
 
  <sect2 xml:id="language.types.callable.passing">
-  <title>Paso de una función de retrollamada</title>
+  <title>Creación de callables</title>
 
-  <para>
-   Una función PHP es pasada por su nombre, como un &string; o como
-   un <link linkend="functions.first_class_callable_syntax">callable de primera clase</link>..
-   Se puede usar cualquier función interna o definida por el usuario, excepto las construcciones del lenguaje
-   como: <function>array</function>, <function>echo</function>,
-   <function>empty</function>, <function>eval</function>,
-   <function>exit</function>, <function>isset</function>,
-   <function>list</function>, <function>print</function>, o
-   <function>unset</function>.
-  </para>
+  <simpara>
+   Un callable es un tipo que representa algo que se puede invocar.
+   Los callables se pueden pasar como argumentos a funciones o métodos que
+   esperan un parámetro de retrollamada o se pueden invocar directamente.
+   El tipo <type>callable</type> no se puede usar como declaración de tipo para propiedades
+   de clase. En su lugar, use una declaración de tipo <classname>Closure</classname>.
+  </simpara>
 
-  <para>
-   Un método de un &object; instanciado es pasado como un &array; que contiene
-   un &object; en el índice 0, y el nombre del método en el índice 1.
-   Acceder a los métodos protegidos y privados dentro de una clase
-   está permitido.
-  </para>
+  <simpara>
+   Los callables se pueden crear de varias maneras diferentes:
+  </simpara>
 
-  <para>
-   Los métodos estáticos de clase también pueden ser pasados sin instanciar
-   un &object; de esa clase, ya sea pasando el nombre de la clase en lugar de un
-   &object; en el índice 0, o pasando
-   <literal>'NombreDeLaClase::NombreDelMetodo'</literal>.
-  </para>
+  <itemizedlist>
+   <listitem>
+    <simpara>Un objeto <classname>Closure</classname></simpara>
+   </listitem>
+   <listitem>
+    <simpara>Un &string; conteniendo el nombre de una función o método</simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     Un &array; conteniendo un nombre de clase o un <type>object</type>
+     en el índice 0 y el nombre del método en el índice 1
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     Un &object; implementando el método mágico
+     <link linkend="object.invoke">__invoke()</link>
+    </simpara>
+   </listitem>
+  </itemizedlist>
 
-  <para>
-   Además de las funciones definidas normalmente por el usuario,
-   las <link linkend="functions.anonymous">funciones anónimas</link> y
-   las <link linkend="functions.arrow">funciones flecha</link>
-   también pueden ser utilizadas como argumento de tipo callback.
-  </para>
+  <simpara>
+   Un objeto <classname>Closure</classname> puede ser creado usando la sintaxis de
+   <link linkend="functions.anonymous">funciones anónimas</link>, sintaxis de
+   <link linkend="functions.arrow">funciones de flecha</link>,
+   <link linkend="functions.first_class_callable_syntax">sintaxis callable de primera
+   clase</link>, o el método <methodname>Closure::fromCallable</methodname>.
+  </simpara>
 
   <note>
-   <para>
-    A partir de PHP 8.1.0, las funciones anónimas también pueden ser creadas utilizando la
-    <link linkend="functions.first_class_callable_syntax">sintaxis callable de primera clase</link>.
-   </para>
+   <simpara>
+    La <link linkend="functions.first_class_callable_syntax">sintaxis callable de primera
+   clase</link> solo está disponible a partir de PHP 8.1.0.
+   </simpara>
   </note>
 
-  <para>
-   Generalmente, cualquier objeto que implemente <link linkend="object.invoke">__invoke()</link>
-   también puede ser pasado al argumento callback.
-  </para>
+  <example>
+   <title>
+    Ejemplo de callback usando una <classname>Closure</classname>
+   </title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+// Usando sintaxis de función anónima
+$double1 = function ($a) {
+    return $a * 2;
+};
 
-  <para>
-   <example>
-    <title>
-     Ejemplos de funciones de retrollamada
-    </title>
-    <programlisting role="php">
+// Usando sintaxis de callable de primera clase
+function double_function($a) {
+    return $a * 2;
+}
+$double2 = double_function(...);
+
+// Usando sintaxis de función de flecha
+$double3 = fn($a) => $a * 2;
+
+// Usando Closure::fromCallable
+$double4 = Closure::fromCallable('double_function');
+
+// Utilizar clousure como función de devolución de retrollamada
+// para duplicar el tamaño de cada elemento en nuestro rango
+$new_numbers = array_map($double1, range(1, 5));
+print implode(' ', $new_numbers) . PHP_EOL;
+
+$new_numbers = array_map($double2, range(1, 5));
+print implode(' ', $new_numbers) . PHP_EOL;
+
+$new_numbers = array_map($double3, range(1, 5));
+print implode(' ', $new_numbers) . PHP_EOL;
+
+$new_numbers = array_map($double4, range(1, 5));
+print implode(' ', $new_numbers);
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.81;
+   <screen>
+<![CDATA[
+2 4 6 8 10
+2 4 6 8 10
+2 4 6 8 10
+2 4 6 8 10
+]]>
+   </screen>
+  </example>
+
+  <simpara>
+   Un callable también puede ser un string que contenga el nombre de una función o
+   método estático.
+   Cualquier función interna o definida por el usuario puede ser usada, excepto las construcciones del lenguaje
+   como: <function>array</function>, <function>echo</function>,
+   <function>empty</function>, <function>eval</function>,
+   <function>isset</function>,
+   <function>list</function>, <function>print</function>, o
+   <function>unset</function>.
+  </simpara>
+
+  <simpara>
+   Un método de clase estático puede ser usado sin instanciar un
+   <type>object</type> de esa clase, ya sea creando un array con
+   el nombre de la clase en el índice 0 y el nombre del método en el índice 1, o usando
+   la sintaxis especial con el operador de resolución de ámbito
+   <literal>::</literal>, como en <literal>'ClassName::methodName'</literal>.
+  </simpara>
+
+  <simpara>
+   Un método de un <type>object</type> instanciado puede ser un callable
+   cuando se pasa como un array con el <type>object</type> en el índice 0
+   y el nombre del método en el índice 1.
+  </simpara>
+
+  <simpara>
+   La principal diferencia entre un objeto <classname>Closure</classname> y el
+   tipo <type>callable</type> es que un objeto <classname>Closure</classname> es
+   independiente del ámbito y siempre se puede invocar, mientras que un tipo
+   callable puede depender del ámbito y puede que no se pueda invocar directamente.
+   <classname>Closure</classname> es la forma preferida de crear callables.
+  </simpara>
+
+  <note>
+   <simpara>
+    Mientras que los objetos <classname>Closure</classname> están vinculados al ámbito
+    donde se crean, los callables que hacen referencia a métodos de clase como strings
+    o arrays se resuelven en el ámbito donde se llaman.
+    Para crear un callable a partir de un método privado o protegido, que luego se pueda
+    invocar desde fuera del ámbito de la clase, use
+    <methodname>Closure::fromCallable</methodname> o la
+    <link linkend="functions.first_class_callable_syntax">sintaxis callable de primera
+    clase</link>.
+   </simpara>
+  </note>
+
+  <simpara>
+   PHP permite la creación de callables que pueden ser usados como argumento de retrollamada
+   pero que no pueden ser llamados directamente.
+   Estos son callables dependientes del contexto que hacen referencia a un método de clase en la
+   jerarquía de herencia de una clase, por ejemplo
+   <literal>'parent::method'</literal> o <literal>["static", "method"]</literal>.
+  </simpara>
+
+  <note>
+   <simpara>
+    A partir de PHP 8.2.0, los callables dependientes del contexto
+    están obsoletos. Elimine la dependencia del contexto reemplazando
+    <literal>'parent::method'</literal> con
+    <literal>parent::class . '::method'</literal> o use la
+    <link linkend="functions.first_class_callable_syntax">sintaxis callable de primera
+    clase</link>.
+   </simpara>
+  </note>
+
+  <example>
+   <title>
+    Invocando varios tipos de callables con <function>call_user_func</function>
+   </title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
 // Un ejemplo de función de retrollamada
 function my_callback_function() {
-    echo 'hello world!', PHP_EOL;
+    echo '¡hola mundo!', PHP_EOL;
 }
 
 // Un ejemplo de método de retrollamada
 class MyClass {
     static function myCallbackMethod() {
-        echo 'Hello World!', PHP_EOL;
+        echo '¡Hola Mundo!', PHP_EOL;
     }
 }
 
@@ -88,33 +219,37 @@ class MyClass {
 call_user_func('my_callback_function');
 
 // Tipo 2: Llamada a un método estático de clase
-call_user_func(array('MyClass', 'myCallbackMethod'));
+call_user_func(['MyClass', 'myCallbackMethod']);
 
 // Tipo 3: Llamada a un método de objeto
 $obj = new MyClass();
-call_user_func(array($obj, 'myCallbackMethod'));
+call_user_func([$obj, 'myCallbackMethod']);
 
 // Tipo 4: Llamada a un método estático de clase
 call_user_func('MyClass::myCallbackMethod');
 
-// Tipo 5: Llamada a un método estático de clase relativo
+// Type 5: Llamada a un método estático de clase usando la palabla clave ::class
+call_user_func([MyClass::class, 'myCallbackMethod']);
+
+// Tipo 6: Llamada a un método estático de clase relativo
 class A {
     public static function who() {
-        echo "A", PHP_EOL;
+        echo 'A', PHP_EOL;
     }
 }
 
 class B extends A {
     public static function who() {
-        echo "B", PHP_EOL;
+        echo 'B', PHP_EOL;
     }
 }
 
-call_user_func(array('B', 'parent::who')); // A, obsoleto a partir de PHP 8.2.0
-// Tipo 6: Los objetos que implementan __invoke pueden ser utilizados como callables
+call_user_func(['B', 'parent::who']); // obsoleto a partir de PHP 8.2.0
+
+// Tipo 7: Los objetos que implementan __invoke pueden ser utilizados como callables
 class C {
     public function __invoke($name) {
-        echo 'Hello ', $name, PHP_EOL;
+        echo 'Hola ', $name;
     }
 }
 
@@ -122,41 +257,22 @@ $c = new C();
 call_user_func($c, 'PHP!');
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>
-     Ejemplo de una función de retrollamada utilizando una <classname>Closure</classname>
-    </title>
-   <programlisting role="php">
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
-<?php
-// Nuestra closure
-$double = function($a) {
-    return $a * 2;
-};
+¡hola mundo!
+¡Hola Mundo!
+¡Hola Mundo!
+¡Hola Mundo!
+¡Hola Mundo!
 
-// Este es nuestro rango de números
-$numbers = range(1, 5);
-
-// Uso de la closure como función de retrollamada.
-// Aquí, para duplicar el tamaño de cada elemento de nuestro rango
-$new_numbers = array_map($double, $numbers);
-
-print implode(' ', $new_numbers);
-?>
+Deprecated: Callables of the form ["B", "parent::who"] are deprecated in script on line 41
+A
+Hola PHP!
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-2 4 6 8 10
-]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
 
   &note.func-callback-exceptions;
  </sect2>

--- a/reference/stream/streamwrapper/stream-cast.xml
+++ b/reference/stream/streamwrapper/stream-cast.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 821af5a8ba67e317b646a1c6b74b3229eb85c2fd Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d01c0533924b3519bd31d5f909846ae8f36429ff Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 
 <refentry xml:id="streamwrapper.stream-cast" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>streamWrapper::stream_cast</refname>
-  <refpurpose>Lee el recurso subyacente de flujo</refpurpose>
+  <refpurpose>Recuperar el recurso subyacente</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">


### PR DESCRIPTION
Various updates, up to [EN 876557a](https://github.com/php/doc-en/commit/876557ae38f6ca5035618f7cea48ca627118b437)

- [Simplifiying the "A simple tutorial" page](https://github.com/php/doc-en/commit/876557ae38f6ca5035618f7cea48ca627118b437)
- [List of other reserved words: add "parent" and "self"](https://github.com/php/doc-en/commit/170b6cda37f29c39b9e08375344c5eb9523b2de3)
- [stream-cast.xml Fix typo](https://github.com/php/doc-en/commit/d01c0533924b3519bd31d5f909846ae8f36429ff)
- [Rewrite the callback and callable page](https://github.com/php/doc-en/commit/147b80d1974b969caad1db188a48f4bcd90f5eb8)
