### PR TITLE
mb-strpos.xml Use parameter names instead of types, fix typos and XML syntax

### DIFF
--- a/reference/mbstring/functions/mb-stripos.xml
+++ b/reference/mbstring/functions/mb-stripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-stripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -59,10 +59,7 @@
     <varlistentry>
      <term><parameter>encoding</parameter></term>
      <listitem>
-      <para>
-       Nombre del codificado a utilizar.
-       Si este parámetro es omitido, se utiliza el codificado interno.
-      </para>
+      &mbstring.encoding.parameter;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/mbstring/functions/mb-stristr.xml
+++ b/reference/mbstring/functions/mb-stristr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f63aa0afcde35bf8450e32128295d6e08cd6b120 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-stristr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_stristr</refname>
@@ -64,10 +64,7 @@
     <varlistentry>
      <term><parameter>encoding</parameter></term>
      <listitem>
-      <para>
-       Nombre del juego de caracteres a utilizar.
-       Si este parámetro se omite, se utiliza el juego de caracteres interno.
-      </para>
+      &mbstring.encoding.parameter;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/mbstring/functions/mb-strpos.xml
+++ b/reference/mbstring/functions/mb-strpos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-strpos" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -18,8 +18,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Localiza la posición de la primera ocurrencia de un carácter en
-   la cadena proporcionada.
+   Localiza la posición de la primera ocurrencia de <parameter>needle</parameter> en el string <parameter>haystack</parameter>.
   </para>
   <para>
    Realiza una búsqueda de tipo
@@ -38,7 +37,8 @@
      <term><parameter>haystack</parameter></term>
      <listitem>
       <para>
-       La cadena a analizar.
+       El string a partir del cual se obtiene la posición de la primera aparición
+       de <parameter>needle</parameter>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-strrchr.xml
+++ b/reference/mbstring/functions/mb-strrchr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f63aa0afcde35bf8450e32128295d6e08cd6b120 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-strrchr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_strrchr</refname>
@@ -60,10 +60,7 @@
     <varlistentry>
      <term><parameter>encoding</parameter></term>
      <listitem>
-      <para>
-       Nombre del codificación a utilizar. Si este parámetro es omitido,
-       se utilizará la codificación interna.
-      </para>
+      &mbstring.encoding.parameter;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/mbstring/functions/mb-strrichr.xml
+++ b/reference/mbstring/functions/mb-strrichr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f63aa0afcde35bf8450e32128295d6e08cd6b120 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-strrichr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_strrichr</refname>
@@ -62,10 +62,7 @@
     <varlistentry>
      <term><parameter>encoding</parameter></term>
      <listitem>
-      <para>
-       Nombre del conjunto de caracteres a utilizar. Si este parámetro se omite, se utilizará
-       el conjunto de caracteres interno.
-      </para>
+      &mbstring.encoding.parameter;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/mbstring/functions/mb-strripos.xml
+++ b/reference/mbstring/functions/mb-strripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-strripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -35,7 +35,7 @@
      <listitem>
       <para>
        La cadena desde la cual se recupera la posición de la última ocurrencia de
-       <parameter>needle</parameter>
+       <parameter>needle</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -43,7 +43,7 @@
      <term><parameter>needle</parameter></term>
      <listitem>
       <para>
-       La cadena a buscar en <parameter>haystack</parameter>
+       La cadena a buscar en <parameter>haystack</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -51,18 +51,16 @@
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       La posición en <parameter>haystack</parameter>
-       desde la cual se debe comenzar a buscar
+       Se puede especificar para comenzar la búsqueda en un número arbitrario de caracteres dentro
+       de <parameter>haystack</parameter>. Los valores negativos detendrán la búsqueda en un punto arbitrario
+       antes del final de <parameter>haystack</parameter>.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>encoding</parameter></term>
      <listitem>
-      <para>
-       Nombre del codificación a utilizar. Si este parámetro es omitido,
-       se utiliza la codificación interna.
-      </para>
+      &mbstring.encoding.parameter;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/mbstring/functions/mb-strrpos.xml
+++ b/reference/mbstring/functions/mb-strrpos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-strrpos" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,7 +34,8 @@
      <term><parameter>haystack</parameter></term>
      <listitem>
       <para>
-       La cadena a analizar.
+       El <type>string</type> donde se comprobará, para la última aparición
+       de <parameter>needle</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -42,7 +43,7 @@
      <term><parameter>needle</parameter></term>
      <listitem>
       <para>
-       La cadena a buscar en la cadena <parameter>haystack</parameter>.
+       El <type>string</type> a buscar en <parameter>haystack</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -50,9 +51,9 @@
      <term><parameter>offset</parameter></term>
      <listitem>
       <simpara>
-       Debe ser especificado para comenzar la búsqueda un número arbitrario
-       de caracteres en una cadena. Los valores negativos detienen
-       la búsqueda en un punto arbitrario antes del final de la cadena.
+       Se puede especificar para comenzar la búsqueda en un número arbitrario de caracteres dentro
+       de <parameter>haystack</parameter>. Los valores negativos detendrán la búsqueda en un punto arbitrario
+       antes del final de <parameter>haystack</parameter>.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-strstr.xml
+++ b/reference/mbstring/functions/mb-strstr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f63aa0afcde35bf8450e32128295d6e08cd6b120 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-strstr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_strstr</refname>
@@ -62,9 +62,7 @@
     <varlistentry>
      <term><parameter>encoding</parameter></term>
      <listitem>
-      <para>
-       Nombre de la codificación a utilizar. Si este parámetro es omitido, se utiliza la codificación interna.
-      </para>
+      &mbstring.encoding.parameter;
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/strings/functions/strripos.xml
+++ b/reference/strings/functions/strripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.strripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -78,9 +78,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve la posición de la última ocurrencia de <parameter>needle</parameter>
-   en relación con el inicio del string <parameter>haystack</parameter>
-   (independientemente de la dirección de búsqueda o del offset).
+   Devuelve la posición donde existe <parameter>needle</parameter> en relación con el comienzo del
+   string <parameter>haystack</parameter> (independientemente de la dirección de búsqueda
+   o <parameter>offset</parameter>).
    <note>
     <simpara>
      Las posiciones de los &string; comienzan en 0, y no en 1.
@@ -145,17 +145,19 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 $haystack = 'ababcd';
 $needle   = 'aB';
 
 $pos      = strripos($haystack, $needle);
 
 if ($pos === false) {
-    echo "Lo sentimos, no se pudo encontrar ($needle) en ($haystack)";
+    echo "Lo sentimos, no se pudo encontrar `$needle` en `$haystack`";
 } else {
     echo "¡Felicidades!\n";
-    echo "Hemos encontrado el último ($needle) en ($haystack) en la posición ($pos)";
+    echo "Hemos encontrado el último `$needle` en `$haystack` en la posición `$pos`";
 }
+
 ?>
 ]]>
     </programlisting>
@@ -163,7 +165,7 @@ if ($pos === false) {
     <screen>
 <![CDATA[
 ¡Felicidades!
-Hemos encontrado el último (aB) en (ababcd) en la posición (2)
+Hemos encontrado el último `aB` en `ababcd` en la posición `2`
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Update

- `reference/mbstring/functions/mb-*`
- `reference/strings/functions/*`

to [EN 95d0554](https://github.com/php/doc-en/commit/95d05546430b9e5db225dd42a0d285b870f0da42)

