### PR TITLE
Various updates, up to EN b68b5e4

### DIFF
--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 147b80d1974b969caad1db188a48f4bcd90f5eb8 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 312c0c7b39d0722c419f6784cbda24823220dfb3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.callable">
  <title>Callables</title>
@@ -82,7 +82,7 @@ function foo(callable $callback) {
    <title>
     Ejemplo de callback usando una <classname>Closure</classname>
    </title>
-  <programlisting role="php">
+   <programlisting role="php">
 <![CDATA[
 <?php
 // Usando sintaxis de función anónima
@@ -278,7 +278,6 @@ Hola PHP!
  </sect2>
 
 </sect1>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/array/functions/array-first.xml
+++ b/reference/array/functions/array-first.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 85c47f89f35f927d7c7ad23235c830dc4b514ddd Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: b68b5e427e7454a59437dd6f7ff27b4f9228fe6d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.array-first" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <type>mixed</type><methodname>array_first</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Obtiene el primer valor del <parameter>array</parameter> dado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>array</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un array.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,18 +35,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el primer valor de <parameter>array</parameter> si el array no está vacío;
    &null; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example xml:id="array_first.example.basic">
-    <title>Uso básico de <function>array_first</function></title>
-    <programlisting role="php">
+  <example xml:id="array_first.example.basic">
+   <title>Uso básico de <function>array_first</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $array = [1 => 'a', 0 => 'b', 3 => 'c', 2 => 'd'];
@@ -56,15 +55,14 @@ $firstValue = array_first($array);
 var_dump($firstValue);
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 string(1) "a"
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/array/functions/array-last.xml
+++ b/reference/array/functions/array-last.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 85c47f89f35f927d7c7ad23235c830dc4b514ddd Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: b68b5e427e7454a59437dd6f7ff27b4f9228fe6d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.array-last" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <type>mixed</type><methodname>array_last</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Obtiene el último valor del <parameter>array</parameter> dado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>array</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un array.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,18 +35,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el último valor de <parameter>array</parameter> si el array no está vacío;
    &null; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example xml:id="array_last.example.basic">
-    <title>Uso básico de <function>array_last</function></title>
-    <programlisting role="php">
+  <example xml:id="array_last.example.basic">
+   <title>Uso básico de <function>array_last</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $array = [1 => 'a', 0 => 'b', 3 => 'c', 2 => 'd'];
@@ -56,15 +55,14 @@ $lastValue = array_last($array);
 var_dump($lastValue);
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 string(1) "d"
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 0cf48a5a4869bd8b42f84e7032076756cde6a474 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="dateperiod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -24,14 +24,17 @@
    <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
   </constructorsynopsis>
   <warning>
+   <simpara>
+    La siguiente variante del constructor ha quedado obsoleta:
+   </simpara>
    <constructorsynopsis role="DatePeriod">
     <modifier>public</modifier> <methodname>DatePeriod::__construct</methodname>
     <methodparam><type>string</type><parameter>isostr</parameter></methodparam>
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    Esta variante del constructor ha sido declarada obsoleta, utilice
-    <methodname>DatePeriod::createFromISO8601String</methodname> en su lugar.
+    En su lugar, debería utilizarse el constructor virtual (factory method) estático
+    <methodname>DatePeriod::createFromISO8601String</methodname>.
    </simpara>
   </warning>
   <para>

--- a/reference/intl/locale/canonicalize.xml
+++ b/reference/intl/locale/canonicalize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a22321e312e13fb1e2785169a0e83df84c0c3d0 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="locale.canonicalize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,12 +14,17 @@
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Locale::canonicalize</methodname>
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>
+   Convierte el string de configuración regional pasada al formato ICU.
+  </simpara>
+  <simpara>
+   Esto no necesariamente indica ni devuelve una configuración regional válida. Es solo una versión
+   de la entrada que se ha estandarizado según las reglas de ICU.
+  </simpara>
+  <simpara>
+   El comportamiento de esta función depende de la versión de ICU que PHP esté utilizando
+   (<constant>INTL_ICU_VERSION</constant>).
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +33,9 @@
    <varlistentry>
     <term><parameter>locale</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      String de configuración regional original.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,6 +49,25 @@
   &intl.locale-len.return;
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <function>locale_canonicalize</function></title>
+   <programlisting role="php">
+    <![CDATA[
+echo Locale::canonicalize('en-US.utf8') . "\n";
+echo Locale::canonicalize('totally-not-valid') . "\n";
+    ]]>
+   </programlisting>
+  </example>
+  &example.outputs.similar;
+  <screen>
+   <![CDATA[
+en_US
+totally_NOT_VALID
+   ]]>
+  </screen>
+ </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/wkhtmltox/wkhtmltox/pdf/converter/construct.xml
+++ b/reference/wkhtmltox/wkhtmltox/pdf/converter/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c80bf6d45f226ee03eeb45d0ac7cbb61a2ae0604 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="wkhtmltox-pdf-converter.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
Various updates, up to [EN b68b5e4](https://github.com/php/doc-en/commit/b68b5e427e7454a59437dd6f7ff27b4f9228fe6d)

- [Markup nits for new array_first and array_last function docs](https://github.com/php/doc-en/commit/b68b5e427e7454a59437dd6f7ff27b4f9228fe6d)
- [Fix indentation](https://github.com/php/doc-en/commit/312c0c7b39d0722c419f6784cbda24823220dfb3)
- [Rephrase warning to prevent weird rendering issue](https://github.com/php/doc-en/commit/0cf48a5a4869bd8b42f84e7032076756cde6a474)
- [Document locale_canonicalize](https://github.com/php/doc-en/commit/8a22321e312e13fb1e2785169a0e83df84c0c3d0)


- `reference/wkhtmltox/wkhtmltox/pdf/converter/construct.xml` (Only update [EN-Revision to c80bf6d](https://github.com/php/doc-en/commit/c80bf6d45f226ee03eeb45d0ac7cbb61a2ae0604))
