### PR TITLE
Improve the documentation of mysqli_stmt_result_metadata()

### DIFF
--- a/reference/mysqli/mysqli_stmt/result-metadata.xml
+++ b/reference/mysqli/mysqli_stmt/result-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8abf6408d9259abbd5c5bfb5077ce841db7f5735 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="mysqli-stmt.result-metadata" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_stmt::result_metadata</refname>
@@ -26,10 +26,17 @@
    devuelve el objeto de resultado que será utilizado para leer las metadatos,
    como el número de campos y las informaciones de columnas.
   </para>
+  <simpara>
+   Esta función devuelve un objeto <classname>mysqli_result</classname> vacío
+   que permite acceder a la información de metadatos de la sentencia preparada
+   sin necesidad de recuperar las filas de datos. No es necesario usar esta
+   función si se utiliza <function>mysqli_stmt_get_result</function> para
+   recuperar el conjunto de resultados completo de una sentencia preparada como un objeto de resultado.
+  </simpara>
   <note>
    <para>
-    Este resultado puede ser pasado como argumento a todas las funciones
-    que demanden un campo, para leer las metadatos:
+    Este conjunto de resultados solo se puede pasar como argumento a las funciones
+    basadas en campos para procesar metadatos del conjunto de resultados, tales como:
     <itemizedlist>
      <listitem><para><function>mysqli_num_fields</function></para></listitem>
      <listitem><para><function>mysqli_fetch_field</function></para></listitem>
@@ -42,16 +49,13 @@
     </itemizedlist>
    </para>
   </note>
-  <para>
-   Es recomendado liberar el recurso de resultado cuando se haya terminado de usarlo,
-   pasándolo a la función <function>mysqli_free_result</function>.
-  </para>
   <note>
-   <para>
-    El juego de resultado devuelto por <function>mysqli_stmt_result_metadata</function>
-    contiene solo metadatos. No contiene ninguna línea de resultado.
-    Estas líneas se obtienen utilizando la función <function>mysqli_stmt_fetch</function>.
-   </para>
+   <simpara>
+    El conjunto de resultados devuelto por <function>mysqli_stmt_result_metadata</function>
+    contiene únicamente metadatos. No contiene ninguna fila de resultado.
+    Las filas se obtienen llamando a <function>mysqli_stmt_get_result</function>
+    en el manejador de la sentencia o con <function>mysqli_stmt_fetch</function>.
+   </simpara>
   </note>
  </refsect1>
 
@@ -66,9 +70,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un objeto de resultados, o &false; si ocurre un error.
-  </para>
+   Si la sentencia no produce un conjunto de resultados, también se devuelve &false;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -100,12 +105,6 @@ $result = $stmt->result_metadata();
 $field = $result->fetch_field();
 
 printf("Nombre del campo : %s\n", $field->name);
-
-/* Liberación del resultado */
-$result->close();
-
-/* Cierre de la conexión */
-$mysqli->close();
 ?>
 ]]>
    </programlisting>
@@ -132,12 +131,6 @@ $result = mysqli_stmt_result_metadata($stmt);
 $field = mysqli_fetch_field($result);
 
 printf("Nombre del campo : %s\n", $field->name);
-
-/* Liberación del resultado */
-mysqli_free_result($result);
-
-/* Cierre de la conexión */
-mysqli_close($link);
 ?>
 ]]>
    </programlisting>
@@ -150,6 +143,7 @@ mysqli_close($link);
    <simplelist>
     <member><function>mysqli_prepare</function></member>
     <member><function>mysqli_free_result</function></member>
+    <member><function>mysqli_stmt_get_result</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Update `reference/mysqli/mysqli_stmt/result-metadata.xml`

- [Improve the documentation of mysqli_stmt_result_metadata()](https://github.com/php/doc-en/commit/8abf6408d9259abbd5c5bfb5077ce841db7f5735)