### PR TITLE
Mark $http_response_header as deprecated

### DIFF
--- a/language/predefined/variables/httpresponseheader.xml
+++ b/language/predefined/variables/httpresponseheader.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f1cd5121f7c9f8347ca69c8f657fdb24c0f9729 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: PhilDaiguille -->
+<!-- EN-Revision: fcf847c112e36140d1fdf30cc6fc83cb1c4eb297 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 
 <refentry role="variable" xml:id="reserved.variables.httpresponseheader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>$http_response_header</refname>
   <refpurpose>Cabeceras de respuesta HTTP</refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.feature-8-5-0;
+  <simpara>
+   Utilice <function>http_get_last_response_headers</function> en su lugar.
+  </simpara>
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;


### PR DESCRIPTION
[Mark $http_response_header as deprecated](https://github.com/php/doc-en/commit/fcf847c112e36140d1fdf30cc6fc83cb1c4eb297)