### PR TITLE
Add changelog entry for deprecation of backtick operator in PHP 8.5.0

### DIFF
--- a/language/operators/execution.xml
+++ b/language/operators/execution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: eb8957c4fd67d7bd458140e1bc0588834ab49b3e Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.operators.execution">
  <title>Operador de ejecución</title>
  <titleabbrev>Ejecución</titleabbrev>
@@ -39,6 +39,28 @@ echo "<pre>$output</pre>";
    de comillas dobles.
   </para>
  </note>
+
+ <sect2 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       El operador de comillas invertidas como alias para <function>shell_exec</function> ha quedado obsoleto.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </sect2>
 
  <sect2 role="seealso">
   &reftitle.seealso;


### PR DESCRIPTION
[Add changelog entry for deprecation of backtick operator in PHP 8.5.0](https://github.com/php/doc-en/commit/eb8957c4fd67d7bd458140e1bc0588834ab49b3e)