### PR TITLE
PHPC-2643: Document using PIE to install ext-mongodb

### DIFF
--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -1,8 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec7d2da818c8122d35b7e40a455efa1dce4b031d Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6536bde9ac873428828d7c62cc8d0d04b1a24267 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <section xml:id="mongodb.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
+
+ <section xml:id="mongodb.installation.pie">
+  <title>Instalar la extensión de MongoDB PHP con PIE</title>
+
+   &pecl.moving.to.pie;
+
+   <para>
+    Para instalar la extensión MongoDB usando PIE, ejecute el siguiente comando:
+    <programlisting role="shell">
+     <![CDATA[
+pie install mongodb/mongodb-extension
+]]>
+    </programlisting>
+   </para>
+
+ </section>
 
  <section xml:id="mongodb.installation.pecl">
   <title>Instalar la extensión de MongoDB PHP con PECL</title>

--- a/reference/mongodb/setup.xml
+++ b/reference/mongodb/setup.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6536bde9ac873428828d7c62cc8d0d04b1a24267 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <chapter xml:id="mongodb.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
  <section xml:id="mongodb.requirements">
   &reftitle.required;
   <para>
-   Desde la versión 1.16.0, la extensión requiere PHP 7.2 o superior. Las
+   Desde la versión 1.21.0, la extensión requiere PHP 8.1 o superior. Las
    versiones anteriores de la extensión permiten la compatibilidad con las antiguas versiones de PHP.
   </para>
   <para>


### PR DESCRIPTION
[PHPC-2643: Document using PIE to install ext-mongodb](https://github.com/php/doc-en/commit/6536bde9ac873428828d7c62cc8d0d04b1a24267)

- Update note about required PHP version
- PHPC-2643: Document using PIE to install ext-mongodb