### PR TITLE
Array type: Add a top of page link to the array functions docs

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 094816bd170e26abf0e057dae1cfb498dd6aad88 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3061900171d4ae84d532571bfd6eda823726dad4 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.array">
  <title>Arrays</title>
+
+ <para>
+  Para obtener una lista de todas las funciones de arrays, vea el capítulo <link linkend="ref.array">funciones de arrays</link> en la documentación.
+ </para>
 
  <para>
   Un <type>array</type> en PHP es en realidad un mapa ordenado. Un mapa es un tipo que


### PR DESCRIPTION
[Array type: Add a top of page link to the array functions docs](https://github.com/php/doc-en/commit/3061900171d4ae84d532571bfd6eda823726dad4) - [(EN/#4654)](https://github.com/php/doc-en/pull/4654)