### PR TITLE
Update array-key-exists.xml with deprecation notice

### DIFF
--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 73048c75fbe328342b74f0ffb0a0c85c477f5cde Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DavidA. -->
+<!-- EN-Revision: faa17c20aa7cdada1806b5b60d2c1b3bbcfff0d9 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.array-key-exists" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_key_exists</refname>
@@ -74,6 +73,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Usar <type>null</type> en el parámetro <parameter>key</parameter> está obsoleto, use un string vacío en su lugar.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
[Update array-key-exists.xml with deprecation notice](https://github.com/php/doc-en/commit/faa17c20aa7cdada1806b5b60d2c1b3bbcfff0d9) ([EN-#5063](https://github.com/php/doc-en/pull/5063))

Added deprecation notice for using null as key.