### PR TITLE
Add 96 missing entities to language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1031,123 +1031,123 @@ $font = 'SomeFont';
     </varlistentry>
 ">
 
-<!ENTITY gd.return.identifier 'Returns an image object on success, &false; on errors.'>
+<!ENTITY gd.return.identifier 'Devuelve un objeto de imagen en caso de éxito, &false; en caso de error.'>
 
-<!ENTITY gd.return.trueonerror '<caution xmlns="http://docbook.org/ns/docbook"><simpara>However, if libgd fails to output the image, this function returns &true;.</simpara></caution>'>
+<!ENTITY gd.return.trueonerror '<caution xmlns="http://docbook.org/ns/docbook"><simpara>Sin embargo, si libgd no logra producir la imagen, esta función devuelve &true;.</simpara></caution>'>
 
-<!ENTITY gd.identifier.color "A color identifier created with <function xmlns='http://docbook.org/ns/docbook'>imagecolorallocate</function>.">
+<!ENTITY gd.identifier.color "Un identificador de color creado con <function xmlns='http://docbook.org/ns/docbook'>imagecolorallocate</function>.">
 
-<!ENTITY gd.value.red 'Value of red component.'>
+<!ENTITY gd.value.red 'Valor del componente rojo.'>
 
-<!ENTITY gd.value.green 'Value of green component.'>
+<!ENTITY gd.value.green 'Valor del componente verde.'>
 
-<!ENTITY gd.value.blue 'Value of blue component.'>
+<!ENTITY gd.value.blue 'Valor del componente azul.'>
 
-<!ENTITY gd.source.height 'Source height.'>
+<!ENTITY gd.source.height 'Altura de la fuente.'>
 
-<!ENTITY gd.source.width 'Source width.'>
+<!ENTITY gd.source.width 'Ancho de la fuente.'>
 
-<!ENTITY gd.image.path 'The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or &null;, the raw image stream will be output directly.'>
+<!ENTITY gd.image.path 'La ruta o un recurso de flujo abierto (que se cierra automáticamente después de que esta función retorne) donde guardar el archivo. Si no se define o es &null;, el flujo de imagen sin procesar se enviará directamente.'>
 
-<!ENTITY gd.image.new 'Create a new image from file or URL'>
+<!ENTITY gd.image.new 'Crear una nueva imagen a partir de un archivo o una URL'>
 
-<!ENTITY gd.image.source 'Source image resource.'>
+<!ENTITY gd.image.source 'Recurso de imagen de origen.'>
 
-<!ENTITY gd.image.destination 'Destination image resource.'>
+<!ENTITY gd.image.destination 'Recurso de imagen de destino.'>
 
-<!ENTITY gd.image.output 'Output image to browser or file'>
+<!ENTITY gd.image.output 'Enviar la imagen al navegador o a un archivo'>
 
-<!ENTITY gd.image.colors 'If you created the image from a file, only colors used in the image are resolved. Colors present only in the palette are not resolved.'>
+<!ENTITY gd.image.colors 'Si la imagen fue creada a partir de un archivo, solo se resuelven los colores utilizados en la imagen. Los colores presentes únicamente en la paleta no se resuelven.'>
 
-<!ENTITY gd.font.size 'The font size in points.'>
+<!ENTITY gd.font.size 'El tamaño de la fuente en puntos.'>
 
 <!ENTITY gd.constants.types '<simpara xmlns="http://docbook.org/ns/docbook">
-    Used as a return value by <function>imagetypes</function>
+    Utilizado como valor de retorno por <function>imagetypes</function>
 </simpara>'>
 
 <!ENTITY gd.constants.color '<simpara xmlns="http://docbook.org/ns/docbook">
-    Special color option which can be used instead of a color allocated with
-    <function>imagecolorallocate</function> or
+    Opción de color especial que puede utilizarse en lugar de un color asignado con
+    <function>imagecolorallocate</function> o
     <function>imagecolorallocatealpha</function>.
 </simpara>'>
 
 <!ENTITY gd.constants.affine '<simpara xmlns="http://docbook.org/ns/docbook">
-    An affine transformation type constant used by the <function>imageaffinematrixget</function> function.
+    Constante de tipo de transformación afín utilizada por la función <function>imageaffinematrixget</function>.
 </simpara>'>
 
 <!ENTITY gd.constants.arc '<simpara xmlns="http://docbook.org/ns/docbook">
-    A style constant used by the <function>imagefilledarc</function> function.
+    Constante de estilo utilizada por la función <function>imagefilledarc</function>.
 </simpara>'>
 
 <!ENTITY gd.constants.gd2 '<simpara xmlns="http://docbook.org/ns/docbook">
-    A type constant used by the <function>imagegd2</function> function.
+    Constante de tipo utilizada por la función <function>imagegd2</function>.
 </simpara>'>
 
 <!ENTITY gd.constants.effect '<simpara xmlns="http://docbook.org/ns/docbook">
-    Alpha blending effect used by the <function>imagelayereffect</function> function.
+    Efecto de mezcla alfa utilizado por la función <function>imagelayereffect</function>.
 </simpara>'>
 
 <!ENTITY gd.constants.filter '<simpara xmlns="http://docbook.org/ns/docbook">
-    Special GD filter used by the <function>imagefilter</function> function.
+    Filtro GD especial utilizado por la función <function>imagefilter</function>.
 </simpara>'>
 
 <!ENTITY gd.constants.type '<simpara xmlns="http://docbook.org/ns/docbook">
-    Image type constant used by the <function>image_type_to_mime_type</function>
-    and <function>image_type_to_extension</function> functions.
+    Constante de tipo de imagen utilizada por las funciones <function>image_type_to_mime_type</function>
+    y <function>image_type_to_extension</function>.
 </simpara>'>
 
 <!ENTITY gd.constants.png-filter '<simpara xmlns="http://docbook.org/ns/docbook">
-    A special PNG filter, used by the <function>imagepng</function> function.
+    Filtro PNG especial, utilizado por la función <function>imagepng</function>.
 </simpara>'>
 
 <!ENTITY gd.constants.flip '<simpara xmlns="http://docbook.org/ns/docbook">
-    Used together with <function>imageflip</function>, available as of PHP 5.5.0.
+    Utilizado junto con <function>imageflip</function>, disponible a partir de PHP 5.5.0.
 </simpara>'>
 
 <!ENTITY gd.constants.interpolation '<simpara xmlns="http://docbook.org/ns/docbook">
-    Used together with <function>imagesetinterpolation</function>, available as of PHP 5.5.0.
+    Utilizado junto con <function>imagesetinterpolation</function>, disponible a partir de PHP 5.5.0.
 </simpara>'>
 
 <!ENTITY gd.changlog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
-    <entry>7.0.0</entry><entry>T1Lib support was removed from PHP, thus this function was removed.</entry>
+    <entry>7.0.0</entry><entry>El soporte de T1Lib fue eliminado de PHP, por lo tanto esta función fue eliminada.</entry>
 </row>'>
 
-<!ENTITY gd.deprecated.gd-formats '<warning xmlns="http://docbook.org/ns/docbook"><simpara>The GD
-and GD2 image formats are proprietary image formats of libgd. They have to be regarded
-<emphasis>obsolete</emphasis>, and should only be used for development and testing
-purposes.</simpara></warning>'>
+<!ENTITY gd.deprecated.gd-formats '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Los formatos
+de imagen GD y GD2 son formatos propietarios de libgd. Deben considerarse
+<emphasis>obsoletos</emphasis>, y solo deben utilizarse con fines de desarrollo y
+pruebas.</simpara></warning>'>
 
 <!ENTITY gd.changelog.image-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>image</parameter> expects a <classname>GdImage</classname>
-  instance now; previously, a valid <literal>gd</literal> <type>resource</type> was expected.
+  <parameter>image</parameter> ahora espera una instancia de <classname>GdImage</classname>;
+  anteriormente, se esperaba un <type>resource</type> <literal>gd</literal> válido.
  </entry>
 </row>'>
 
 <!-- CSV -->
 <!ENTITY warning.csv.escape-parameter '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"><simpara>
- When <parameter>escape</parameter> is set to anything other than an empty string
- (<literal>""</literal>) it can result in CSV that is not compliant with
- <link xlink:href="&url.rfc;4180">RFC 4180</link> or unable to survive a roundtrip
- through the PHP CSV functions. The default for <parameter>escape</parameter> is
- <literal>"\\"</literal> so it is recommended to set it to the empty string explicitly.
- The default value will change in a future version of PHP, no earlier than PHP 9.0.
+ Cuando <parameter>escape</parameter> se define con un valor diferente a una cadena vacía
+ (<literal>""</literal>), puede resultar en un CSV que no sea compatible con
+ <link xlink:href="&url.rfc;4180">RFC 4180</link> o que no pueda sobrevivir a un ciclo de ida y vuelta
+ a través de las funciones CSV de PHP. El valor predeterminado de <parameter>escape</parameter> es
+ <literal>"\\"</literal>, por lo que se recomienda definirlo explícitamente como cadena vacía.
+ El valor predeterminado cambiará en una futura versión de PHP, no antes de PHP 9.0.
 </simpara></warning>'>
 
 <!-- DBM notes -->
 
 <!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>dbm_identifier</parameter></term><listitem><para>The DBM link identifier,
-returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
+<parameter>dbm_identifier</parameter></term><listitem><para>El identificador de enlace DBM,
+devuelto por <function>dbmopen</function>.</para></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
 <!ENTITY json.implementation.superset '
  <note xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <para>
-   PHP implements a superset of JSON as specified in the original
-   <link xlink:href="&url.rfc;7159">RFC 7159</link>.
+   PHP implementa un superconjunto de JSON tal como se especifica en el
+   <link xlink:href="&url.rfc;7159">RFC 7159</link> original.
   </para>
  </note>
 '>
@@ -1155,76 +1155,76 @@ returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
 <!-- cURL notes -->
 
 <!ENTITY curl.ch.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>handle</parameter>
-</term><listitem><para>A cURL handle returned by
+</term><listitem><para>Un gestor cURL devuelto por
 <function>curl_init</function>.</para></listitem></varlistentry>'>
 
 <!ENTITY curl.mh.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>multi_handle</parameter>
-</term><listitem><para>A cURL multi handle returned by
+</term><listitem><para>Un gestor múltiple cURL devuelto por
 <function>curl_multi_init</function>.</para></listitem></varlistentry>'>
 
 <!ENTITY curl.sh.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>share_handle</parameter>
-</term><listitem><para>A cURL share handle returned by
+</term><listitem><para>Un gestor compartido cURL devuelto por
 <function>curl_share_init</function>.</para></listitem></varlistentry>'>
 
 <!ENTITY curl.changelog.handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>handle</parameter> expects a <classname>CurlHandle</classname>
-  instance now; previously, a <type>resource</type> was expected.
+  <parameter>handle</parameter> ahora espera una instancia de <classname>CurlHandle</classname>;
+  anteriormente, se esperaba un <type>resource</type>.
  </entry>
 </row>'>
 
 <!ENTITY curl.changelog.multi-handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>multi_handle</parameter> expects a <classname>CurlMultiHandle</classname>
-  instance now; previously, a <type>resource</type> was expected.
+  <parameter>multi_handle</parameter> ahora espera una instancia de <classname>CurlMultiHandle</classname>;
+  anteriormente, se esperaba un <type>resource</type>.
  </entry>
 </row>'>
 
 <!ENTITY curl.changelog.share-handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>share_handle</parameter> expects a <classname>CurlShareHandle</classname>
-  instance now; previously, a <type>resource</type> was expected.
+  <parameter>share_handle</parameter> ahora espera una instancia de <classname>CurlShareHandle</classname>;
+  anteriormente, se esperaba un <type>resource</type>.
  </entry>
 </row>'>
 
 <!-- dba notes -->
-<!ENTITY dba.parameter.dba 'A <classname xmlns="http://docbook.org/ns/docbook">Dba\Connection</classname> instance, returned by <function xmlns="http://docbook.org/ns/docbook">dba_open</function> or <function xmlns="http://docbook.org/ns/docbook">dba_popen</function>.'>
+<!ENTITY dba.parameter.dba 'Una instancia de <classname xmlns="http://docbook.org/ns/docbook">Dba\Connection</classname>, devuelta por <function xmlns="http://docbook.org/ns/docbook">dba_open</function> o <function xmlns="http://docbook.org/ns/docbook">dba_popen</function>.'>
 <!ENTITY dba.changelog.dba-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  The <parameter>dba</parameter> parameter expects a <classname>Dba\Connection</classname>
-  instance now; previously, a valid <literal>dba</literal> &resource; was expected.
+  El parámetro <parameter>dba</parameter> ahora espera una instancia de <classname>Dba\Connection</classname>;
+  anteriormente, se esperaba un &resource; <literal>dba</literal> válido.
  </entry>
 </row>'>
 
 <!-- dbase notes -->
 
 <!ENTITY dbase.type-conversion '<para xmlns="http://docbook.org/ns/docbook">
-   Each field is converted to the appropriate PHP type, except:
+   Cada campo se convierte al tipo PHP apropiado, excepto:
    <itemizedlist>
     <listitem>
      <simpara>
-      Dates are left as strings.
+      Las fechas se mantienen como cadenas.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      DateTime values are converted to strings.
+      Los valores DateTime se convierten en cadenas.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      Integers outside the range
-      <constant>PHP_INT_MIN</constant>..<constant>PHP_INT_MAX</constant> are
-      returned as strings.
+      Los enteros fuera del rango
+      <constant>PHP_INT_MIN</constant>..<constant>PHP_INT_MAX</constant> se
+      devuelven como cadenas.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      Before dbase 7.0.0, booleans (<literal>L</literal>) were converted to <literal>1</literal> or
+      Antes de dbase 7.0.0, los booleanos (<literal>L</literal>) se convertían en <literal>1</literal> o
       <literal>0</literal>.
      </simpara>
     </listitem>
@@ -1237,7 +1237,7 @@ returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
      <term><parameter>broker</parameter></term>
      <listitem>
       <para>
-       An Enchant broker returned by <function>enchant_broker_init</function>.
+       Un broker Enchant devuelto por <function>enchant_broker_init</function>.
       </para>
      </listitem>
     </varlistentry>'>
@@ -1246,8 +1246,8 @@ returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
      <term><parameter>dictionary</parameter></term>
      <listitem>
       <para>
-       An Enchant dictionary returned by <function>enchant_broker_request_dict</function>
-       or <function>enchant_broker_request_pwl_dict</function>.
+       Un diccionario Enchant devuelto por <function>enchant_broker_request_dict</function>
+       o <function>enchant_broker_request_pwl_dict</function>.
       </para>
      </listitem>
     </varlistentry>'>
@@ -1255,16 +1255,16 @@ returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
 <!ENTITY enchant.changelog.broker-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>broker</parameter> expects an <classname>EnchantBroker</classname> instance now;
-  previoulsy, a &resource; was expected.
+  <parameter>broker</parameter> ahora espera una instancia de <classname>EnchantBroker</classname>;
+  anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
 
 <!ENTITY enchant.changelog.dictionary-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>dictionary</parameter> expects an <classname>EnchantDictionary</classname> instance now;
-  previoulsy, a &resource; was expected.
+  <parameter>dictionary</parameter> ahora espera una instancia de <classname>EnchantDictionary</classname>;
+  anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
 
@@ -1273,216 +1273,216 @@ returned by <function>dbmopen</function>.</para></listitem></varlistentry>'>
 <!ENTITY imap.changelog.imap-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  The <parameter>imap</parameter> parameter expects an <classname>IMAP\Connection</classname>
-  instance now; previously, a valid <literal>imap</literal> &resource; was expected.
+  El parámetro <parameter>imap</parameter> ahora espera una instancia de <classname>IMAP\Connection</classname>;
+  anteriormente, se esperaba un &resource; <literal>imap</literal> válido.
  </entry>
 </row>'>
 
 <!ENTITY imap.imap-parameter.imap '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><para>An <classname>IMAP\Connection</classname> instance.</para></listitem></varlistentry>'>
+<parameter>imap</parameter></term><listitem><para>Una instancia de <classname>IMAP\Connection</classname>.</para></listitem></varlistentry>'>
 
 <!-- Deprecated -->
 <!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><para>An IMAP stream returned by
+<parameter>imap</parameter></term><listitem><para>Un flujo IMAP devuelto por
 <function>imap_open</function>.</para></listitem></varlistentry>'>
 
-<!ENTITY imap.pattern '<para xmlns="http://docbook.org/ns/docbook">Specifies where in the mailbox hierarchy
-to start searching.</para><para xmlns="http://docbook.org/ns/docbook">There are two special characters you can
-pass as part of the <parameter>pattern</parameter>:
-&apos;<literal>*</literal>&apos; and &apos;<literal>&#37;</literal>&apos;.
-&apos;<literal>*</literal>&apos; means to return all mailboxes. If you pass
-<parameter>pattern</parameter> as &apos;<literal>*</literal>&apos;, you will
-get a list of the entire mailbox hierarchy.
+<!ENTITY imap.pattern '<para xmlns="http://docbook.org/ns/docbook">Especifica en qué parte de la jerarquía del buzón
+comenzar la búsqueda.</para><para xmlns="http://docbook.org/ns/docbook">Hay dos caracteres especiales que se pueden
+pasar como parte del <parameter>pattern</parameter>:
+&apos;<literal>*</literal>&apos; y &apos;<literal>&#37;</literal>&apos;.
+&apos;<literal>*</literal>&apos; significa devolver todos los buzones. Si se pasa
+<parameter>pattern</parameter> como &apos;<literal>*</literal>&apos;, se
+obtendrá una lista de toda la jerarquía del buzón.
 &apos;<literal>&#37;</literal>&apos;
-means to return the current level only.
-&apos;<literal>&#37;</literal>&apos; as the <parameter>pattern</parameter>
-parameter will return only the top level
-mailboxes; &apos;<literal>~/mail/&#37;</literal>&apos; on <literal>UW_IMAPD</literal> will return every mailbox in the <filename>~/mail</filename> directory, but none in subfolders of that directory.</para>'>
+significa devolver solo el nivel actual.
+&apos;<literal>&#37;</literal>&apos; como parámetro <parameter>pattern</parameter>
+devolverá solo los buzones de nivel superior;
+&apos;<literal>~/mail/&#37;</literal>&apos; en <literal>UW_IMAPD</literal> devolverá cada buzón en el directorio <filename>~/mail</filename>, pero ninguno en las subcarpetas de ese directorio.</para>'>
 
 <!ENTITY imap.mailboxname.insecure '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
-Passing untrusted data to this parameter is <emphasis>insecure</emphasis>, unless
-<link linkend="ini.imap.enable-insecure-rsh">imap.enable_insecure_rsh</link> is disabled.
+Pasar datos no confiables a este parámetro es <emphasis>inseguro</emphasis>, a menos que
+<link linkend="ini.imap.enable-insecure-rsh">imap.enable_insecure_rsh</link> esté desactivado.
 </simpara></warning>'>
 
 <!-- intl notes -->
 
-<!ENTITY intl.parameter.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">An <classname>IntlCalendar</classname> instance.</para>'>
+<!ENTITY intl.parameter.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>IntlCalendar</classname>.</para>'>
 
-<!ENTITY intl.error.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">On failure &false; is also returned. To detect error conditions use <function>intl_get_error_code</function>, or set up Intl to throw <link linkend="ini.intl.use-exceptions">exceptions</link>.</para>'>
+<!ENTITY intl.error.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">En caso de fallo, también se devuelve &false;. Para detectar condiciones de error, utilice <function>intl_get_error_code</function>, o configure Intl para lanzar <link linkend="ini.intl.use-exceptions">excepciones</link>.</para>'>
 
-<!ENTITY intl.codepoint.parameter '<para xmlns="http://docbook.org/ns/docbook">The <type>int</type> codepoint value (e.g. <literal>0x2603</literal> for <emphasis>U+2603 SNOWMAN</emphasis>), or the character encoded as a UTF-8 <type>string</type> (e.g. <literal>"\u{2603}"</literal>)</para>'>
+<!ENTITY intl.codepoint.parameter '<para xmlns="http://docbook.org/ns/docbook">El valor <type>int</type> del punto de código (por ejemplo, <literal>0x2603</literal> para <emphasis>U+2603 SNOWMAN</emphasis>), o el carácter codificado como un <type>string</type> UTF-8 (por ejemplo, <literal>"\u{2603}"</literal>)</para>'>
 
-<!ENTITY intl.codepoint.return '<para xmlns="http://docbook.org/ns/docbook">The return type is <type>int</type> unless the code point was passed as a UTF-8 <type>string</type>, in which case a <type>string</type> is returned. Returns &null; on failure.</para>'>
+<!ENTITY intl.codepoint.return '<para xmlns="http://docbook.org/ns/docbook">El tipo de retorno es <type>int</type> a menos que el punto de código haya sido pasado como un <type>string</type> UTF-8, en cuyo caso se devuelve un <type>string</type>. Devuelve &null; en caso de fallo.</para>'>
 
-<!ENTITY intl.codepoint.example 'Testing different code points'>
+<!ENTITY intl.codepoint.example 'Probar diferentes puntos de código'>
 
-<!ENTITY intl.locale-len.return '<para xmlns="http://docbook.org/ns/docbook">Returns &null; when the length of <parameter>locale</parameter> exceeds <constant>INTL_MAX_LOCALE_LEN</constant>.</para>'>
+<!ENTITY intl.locale-len.return '<para xmlns="http://docbook.org/ns/docbook">Devuelve &null; cuando la longitud de <parameter>locale</parameter> excede <constant>INTL_MAX_LOCALE_LEN</constant>.</para>'>
 
-<!ENTITY intl.property.parameter '<para xmlns="http://docbook.org/ns/docbook">The Unicode property to lookup (see the <literal>IntlChar::PROPERTY_*</literal> constants).</para>'>
+<!ENTITY intl.property.parameter '<para xmlns="http://docbook.org/ns/docbook">La propiedad Unicode a buscar (véanse las constantes <literal>IntlChar::PROPERTY_*</literal>).</para>'>
 
-<!ENTITY intl.property.example 'Testing different properties'>
+<!ENTITY intl.property.example 'Probar diferentes propiedades'>
 
-<!ENTITY intl.param.grapheme.locale '<simpara>Locale to use.</simpara>'>
+<!ENTITY intl.param.grapheme.locale '<simpara>La configuración regional a utilizar.</simpara>'>
 
 <!ENTITY intl.changelog.grapheme.locale '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.5.0</entry>
  <entry>
-  The optional parameter <parameter>locale</parameter> has been added.
+  Se ha añadido el parámetro opcional <parameter>locale</parameter>.
  </entry>
 </row>'>
 
 <!-- LDAP notes -->
 
-<!ENTITY ldap.parameter.ldap 'An <classname xmlns="http://docbook.org/ns/docbook">LDAP\Connection</classname> instance, returned by <function xmlns="http://docbook.org/ns/docbook">ldap_connect</function>.'>
+<!ENTITY ldap.parameter.ldap 'Una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Connection</classname>, devuelta por <function xmlns="http://docbook.org/ns/docbook">ldap_connect</function>.'>
 
-<!ENTITY ldap.parameter.result 'An <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance, returned by <function xmlns="http://docbook.org/ns/docbook">ldap_list</function> or <function xmlns="http://docbook.org/ns/docbook">ldap_search</function>.'>
+<!ENTITY ldap.parameter.result 'Una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>, devuelta por <function xmlns="http://docbook.org/ns/docbook">ldap_list</function> o <function xmlns="http://docbook.org/ns/docbook">ldap_search</function>.'>
 
-<!ENTITY ldap.parameter.entry 'An <classname xmlns="http://docbook.org/ns/docbook">LDAP\ResultEntry</classname> instance.'>
+<!ENTITY ldap.parameter.entry 'Una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\ResultEntry</classname>.'>
 
 <!ENTITY ldap.warn.control-paged '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  This function has been <emphasis>DEPRECATED</emphasis> as of PHP 7.4.0, and <emphasis>REMOVED</emphasis> as of PHP 8.0.0.
-  Instead the <parameter>controls</parameter> parameter of <function>ldap_search</function> should be used.
-  See also <link linkend="ldap.controls">LDAP Controls</link> for details.
+  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.4.0, y fue <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0.
+  En su lugar, se debe utilizar el parámetro <parameter>controls</parameter> de <function>ldap_search</function>.
+  Véase también <link linkend="ldap.controls">LDAP Controls</link> para más detalles.
  </simpara>
 </warning>'>
 
 <!ENTITY ldap.changelog.controls-nullable '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>controls</parameter> is nullable now; previously, it defaulted to <literal>[]</literal>.
+  <parameter>controls</parameter> ahora acepta &null;; anteriormente, su valor predeterminado era <literal>[]</literal>.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.ldap-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  The <parameter>ldap</parameter> parameter expects an <classname>LDAP\Connection</classname>
-  instance now; previously, a valid <literal>ldap link</literal> &resource; was expected.
+  El parámetro <parameter>ldap</parameter> ahora espera una instancia de <classname>LDAP\Connection</classname>;
+  anteriormente, se esperaba un &resource; <literal>ldap link</literal> válido.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.entry-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  The <parameter>entry</parameter> parameter expects an <classname>LDAP\ResultEntry</classname>
-  instance now; previously, a valid <literal>ldap result entry</literal> &resource; was expected.
+  El parámetro <parameter>entry</parameter> ahora espera una instancia de <classname>LDAP\ResultEntry</classname>;
+  anteriormente, se esperaba un &resource; <literal>ldap result entry</literal> válido.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.result-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  The <parameter>result</parameter> parameter expects an <classname>LDAP\Result</classname>
-  instance now; previously, a valid <literal>ldap result</literal> &resource; was expected.
+  El parámetro <parameter>result</parameter> ahora espera una instancia de <classname>LDAP\Result</classname>;
+  anteriormente, se esperaba un &resource; <literal>ldap result</literal> válido.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.return-result-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  Returns an <classname>LDAP\Result</classname> instance now;
-  previously, a &resource; was returned.
+  Ahora devuelve una instancia de <classname>LDAP\Result</classname>;
+  anteriormente, se devolvía un &resource;.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.return-result-entry-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  Returns an <classname>LDAP\ResultEntry</classname> instance now;
-  previously, a &resource; was returned.
+  Ahora devuelve una instancia de <classname>LDAP\ResultEntry</classname>;
+  anteriormente, se devolvía un &resource;.
  </entry>
 </row>'>
 
-<!ENTITY ldap.return-result 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance,&return.falseforfailure;.'>
-<!ENTITY ldap.return-result-array 'Returns an <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instance, an array of <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname> instances,&return.falseforfailure;.'>
+<!ENTITY ldap.return-result 'Devuelve una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
+<!ENTITY ldap.return-result-array 'Devuelve una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>, un array de instancias de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
 
-<!ENTITY ldap.return-result-array-info '<para xmlns="http://docbook.org/ns/docbook">It is also possible to perform parallel searches. In this case, the first argument should be an array of
-<classname>LDAP\Connection</classname> instances, rather than a single one.
-If the searches should not all use the same base DN and filter, an array of base DNs and/or an array of filters can be passed as arguments instead.
-These arrays must be of the same size as the <classname>LDAP\Connection</classname> instances array,
-since the first entries of the arrays are used for one search, the second entries are used for another, and so on.
-When doing parallel searches an array of <classname>LDAP\Result</classname> instances is returned, except in case of error, when the return value will be &false;.</para>'>
+<!ENTITY ldap.return-result-array-info '<para xmlns="http://docbook.org/ns/docbook">También es posible realizar búsquedas en paralelo. En este caso, el primer argumento debe ser un array de
+instancias de <classname>LDAP\Connection</classname>, en lugar de una sola.
+Si las búsquedas no deben utilizar todas el mismo DN base y filtro, se puede pasar un array de DN base y/o un array de filtros como argumentos.
+Estos arrays deben tener el mismo tamaño que el array de instancias de <classname>LDAP\Connection</classname>,
+ya que las primeras entradas de los arrays se utilizan para una búsqueda, las segundas entradas para otra, y así sucesivamente.
+Al realizar búsquedas en paralelo, se devuelve un array de instancias de <classname>LDAP\Result</classname>, excepto en caso de error, donde el valor de retorno será &false;.</para>'>
 
 <!-- mbstring notes -->
 
-<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><para>The internal encoding or the
-character encoding specified by <function>mb_regex_encoding</function>
-will be used as the character encoding for this function.</para></note>'>
+<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><para>La codificación interna o la
+codificación de caracteres especificada por <function>mb_regex_encoding</function>
+se utilizará como codificación de caracteres para esta función.</para></note>'>
 
-<!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><para>The
-character encoding specified by <function>mb_regex_encoding</function>
-will be used as the character encoding for this function by default.</para></note>'>
+<!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><para>La
+codificación de caracteres especificada por <function>mb_regex_encoding</function>
+se utilizará como codificación de caracteres para esta función de forma predeterminada.</para></note>'>
 
-<!ENTITY mbstring.encoding.parameter '<para xmlns="http://docbook.org/ns/docbook">The <parameter>encoding</parameter>
-parameter is the character encoding. If it is omitted or &null;, the internal character
-encoding value will be used.</para>'>
+<!ENTITY mbstring.encoding.parameter '<para xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>encoding</parameter>
+es la codificación de caracteres. Si se omite o es &null;, se utilizará el valor de la codificación
+de caracteres interna.</para>'>
 
-<!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><para>Never use the <literal>e</literal> modifier when working on untrusted input. No automatic escaping will happen (as known from <function>preg_replace</function>). Not taking care of this will most likely create remote code execution vulnerabilities in your application.</para></warning>'>
+<!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><para>Nunca utilice el modificador <literal>e</literal> con datos de entrada no confiables. No se realizará ningún escape automático (como se conoce de <function>preg_replace</function>). No tener esto en cuenta probablemente creará vulnerabilidades de ejecución remota de código en la aplicación.</para></warning>'>
 
 <!ENTITY mbstring.changelog.encoding-nullable '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>encoding</parameter> is nullable now.
+  <parameter>encoding</parameter> ahora acepta &null;.
  </entry>
 </row>'>
 
 <!ENTITY mbstring.changelog.needle-empty '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>needle</parameter> now accepts an empty string.
+  <parameter>needle</parameter> ahora acepta una cadena vacía.
  </entry>
 </row>'>
 
 <!-- mcrypt notes -->
 
-<!ENTITY mcrypt.parameter.cipher '<para xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_ciphername</constant> constants, or the name of the algorithm as string.</para>'>
+<!ENTITY mcrypt.parameter.cipher '<para xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_ciphername</constant>, o el nombre del algoritmo como cadena.</para>'>
 
-<!ENTITY mcrypt.parameter.iv '<para xmlns="http://docbook.org/ns/docbook">Used for the initialization in CBC, CFB, OFB modes, and in some algorithms in STREAM mode. If you do not supply an IV, while it is needed for an algorithm, the function issues a warning and uses an IV with all its bytes set to "<literal>\0</literal>".</para>'>
+<!ENTITY mcrypt.parameter.iv '<para xmlns="http://docbook.org/ns/docbook">Utilizado para la inicialización en los modos CBC, CFB, OFB, y en algunos algoritmos en modo STREAM. Si no se proporciona un IV, siendo necesario para un algoritmo, la función emite una advertencia y utiliza un IV con todos sus bytes establecidos a "<literal>\0</literal>".</para>'>
 
-<!ENTITY mcrypt.parameter.iv.strict '<para xmlns="http://docbook.org/ns/docbook">Used for the initialization in CBC, CFB, OFB modes, and in some algorithms in STREAM mode. If the provided IV size is not supported by the chaining mode or no IV was provided, but the chaining mode requires one, the function will emit a warning and return &false;.</para>'>
+<!ENTITY mcrypt.parameter.iv.strict '<para xmlns="http://docbook.org/ns/docbook">Utilizado para la inicialización en los modos CBC, CFB, OFB, y en algunos algoritmos en modo STREAM. Si el tamaño del IV proporcionado no es soportado por el modo de encadenamiento o no se proporcionó un IV, pero el modo de encadenamiento requiere uno, la función emitirá una advertencia y devolverá &false;.</para>'>
 
-<!ENTITY mcrypt.parameter.mode '<para xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_MODE_modename</constant> constants, or one of the following strings: "ecb", "cbc", "cfb", "ofb", "nofb" or "stream".</para>'>
+<!ENTITY mcrypt.parameter.mode '<para xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_MODE_modename</constant>, o una de las siguientes cadenas: "ecb", "cbc", "cfb", "ofb", "nofb" o "stream".</para>'>
 
  <!-- MCVE notes -->
 
 <!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>conn</parameter></term><listitem><para>An MCVE_CONN resource returned by
+<parameter>conn</parameter></term><listitem><para>Un recurso MCVE_CONN devuelto por
 <function>m_initengine</function>.</para></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
 <!ENTITY memcached.note.delete-time '<note xmlns="http://docbook.org/ns/docbook"><simpara>
-       As of memcached 1.3.0 (released 2009) this feature is no longer
-       supported. Passing a non-zero <parameter>time</parameter> will cause
-       the deletion to fail. <methodname>Memcached::getResultCode</methodname>
-       will return <constant>MEMCACHED_INVALID_ARGUMENTS</constant>.
+       A partir de memcached 1.3.0 (publicado en 2009) esta funcionalidad ya no está
+       soportada. Pasar un valor distinto de cero para <parameter>time</parameter> causará
+       que la eliminación falle. <methodname>Memcached::getResultCode</methodname>
+       devolverá <constant>MEMCACHED_INVALID_ARGUMENTS</constant>.
       </simpara></note>
 '>
 
-<!ENTITY memcached.parameter.expiration 'The expiration time, defaults to 0. See <link
- linkend="memcached.expiration" xmlns="http://docbook.org/ns/docbook">Expiration Times</link> for more info.'>
+<!ENTITY memcached.parameter.expiration 'El tiempo de expiración, predeterminado a 0. Véase <link
+ linkend="memcached.expiration" xmlns="http://docbook.org/ns/docbook">Expiration Times</link> para más información.'>
 
-<!ENTITY memcached.parameter.server_key 'The key identifying the server to store the value on or retrieve it from. Instead of hashing on the actual key for the item, we hash on the server key when deciding which memcached server to talk to. This allows related items to be grouped together on a single server for efficiency with multi operations.'>
+<!ENTITY memcached.parameter.server_key 'La clave que identifica el servidor donde almacenar o recuperar el valor. En lugar de calcular el hash sobre la clave real del elemento, se calcula el hash sobre la clave del servidor al decidir con qué servidor memcached comunicarse. Esto permite agrupar elementos relacionados en un solo servidor para mayor eficiencia con operaciones múltiples.'>
 
-<!ENTITY memcached.parameter.items 'An array of key/value pairs to store on the server.'>
+<!ENTITY memcached.parameter.items 'Un array de pares clave/valor para almacenar en el servidor.'>
 
-<!ENTITY memcached.parameter.key 'The key under which to store the value.'>
+<!ENTITY memcached.parameter.key 'La clave bajo la cual almacenar el valor.'>
 
-<!ENTITY memcached.parameter.value 'The value to store.'>
+<!ENTITY memcached.parameter.value 'El valor a almacenar.'>
 
-<!ENTITY memcached.result.getresultcode 'Use <methodname xmlns="http://docbook.org/ns/docbook">Memcached::getResultCode</methodname> if necessary.'>
+<!ENTITY memcached.result.getresultcode 'Utilice <methodname xmlns="http://docbook.org/ns/docbook">Memcached::getResultCode</methodname> si es necesario.'>
 
 <!ENTITY memcached.result.delete-multi '<para xmlns="http://docbook.org/ns/docbook">
-   Returns an array indexed by <parameter>keys</parameter>. Each element
-   is &true; if the corresponding key was deleted, or one of the
-   <constant>Memcached::RES_<replaceable>*</replaceable></constant> constants if the corresponding deletion
-   failed.
+   Devuelve un array indexado por <parameter>keys</parameter>. Cada elemento
+   es &true; si la clave correspondiente fue eliminada, o una de las
+   constantes <constant>Memcached::RES_<replaceable>*</replaceable></constant> si la eliminación correspondiente
+   falló.
    </para>
   <para xmlns="http://docbook.org/ns/docbook">
-   The <methodname>Memcached::getResultCode</methodname> will return
-   the result code for the last executed delete operation, that is, the delete
-   operation for the last element of <parameter>keys</parameter>.
+   <methodname>Memcached::getResultCode</methodname> devolverá
+   el código de resultado de la última operación de eliminación ejecutada, es decir, la operación de eliminación
+   del último elemento de <parameter>keys</parameter>.
   </para>
 '>
 
@@ -4706,20 +4706,20 @@ Anterior a PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</
 
 <!ENTITY strings.errors.vsprintf '
   <para xmlns="http://docbook.org/ns/docbook">
-   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if the number of arguments is zero.
-   Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
+   A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si el número de argumentos es cero.
+   Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
   </para>
   <para xmlns="http://docbook.org/ns/docbook">
-   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if <literal>[width]</literal> is less than zero or bigger than <constant>PHP_INT_MAX</constant>.
-   Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
+   A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si <literal>[width]</literal> es menor que cero o mayor que <constant>PHP_INT_MAX</constant>.
+   Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
   </para>
   <para xmlns="http://docbook.org/ns/docbook">
-   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown if <literal>[precision]</literal> is less than zero or bigger than <constant>PHP_INT_MAX</constant>.
-   Prior to PHP 8.0.0, a <constant>E_WARNING</constant> was emitted instead.
+   A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si <literal>[precision]</literal> es menor que cero o mayor que <constant>PHP_INT_MAX</constant>.
+   Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
   </para>
   <para xmlns="http://docbook.org/ns/docbook">
-   As of PHP 8.0.0, a <classname>ValueError</classname> is thrown when less arguments are given than required.
-   Prior to PHP 8.0.0, &false; was returned and a <constant>E_WARNING</constant> emitted instead.
+   A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> cuando se proporcionan menos argumentos de los requeridos.
+   Anterior a PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</constant> en su lugar.
   </para>
 '>
 
@@ -4914,16 +4914,16 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
 <!ENTITY xml.changelog.handler-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  Passing a non-<type>callable</type> <type>string</type> to
-  <parameter>handler</parameter> is now deprecated,
-  use a proper callable for methods, or &null; to reset the handler.
+  Pasar un <type>string</type> no <type>callable</type> a
+  <parameter>handler</parameter> ahora está obsoleto;
+  utilice un callable apropiado para los métodos, o &null; para reinicializar el gestor.
  </entry>
 </row>
 <row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  The validity of <parameter>handler</parameter> as a <type>callable</type>
-  is now checked when setting the handler instead of checking when calling it.
+  La validez de <parameter>handler</parameter> como <type>callable</type>
+  ahora se verifica al definir el gestor en lugar de verificarse al invocarlo.
  </entry>
 </row>'>
 


### PR DESCRIPTION
Sync language-snippets.ent with latest EN revision (682 entities now match).