### PR TITLE
Translate remaining English text to Spanish

### DIFF
--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -11,9 +11,9 @@
   <itemizedlist>
    <listitem>
     <para>
-     If a parameter with a default value is followed by a required parameter, the default value has
-     no effect. This is deprecated as of PHP 8.0.0 and can generally be resolved by dropping the
-     default value, without a change in functionality:
+     Si un parámetro con un valor predeterminado es seguido por un parámetro obligatorio, el valor predeterminado no
+     tiene efecto. Esto está obsoleto a partir de PHP 8.0.0 y generalmente puede resolverse eliminando el
+     valor predeterminado, sin cambiar la funcionalidad:
     </para>
     <para>
      <programlisting role="php">
@@ -26,9 +26,9 @@ function test($a, $b) {}      // After
      </programlisting>
     </para>
     <para>
-     One exception to this rule are parameters of the form <code>Type $param = null</code>, where
-     the null default makes the type implicitly nullable. This usage remains allowed, but it is
-     recommended to use an explicit nullable type instead:
+     Una excepción a esta regla son los parámetros de la forma <code>Type $param = null</code>, donde
+     el valor predeterminado null hace que el tipo sea implícitamente nullable. Este uso sigue estando permitido, pero se
+     recomienda usar un tipo nullable explícito en su lugar:
     </para>
     <para>
      <programlisting role="php">
@@ -43,9 +43,9 @@ function test(?A $a, $b) {}       // Recommended
    </listitem>
    <listitem>
     <para>
-     Calling <function>get_defined_functions</function> with <parameter>exclude_disabled</parameter>
-     explicitly set to &false; is deprecated and no longer has an effect.
-     <function>get_defined_functions</function> will never include disabled functions.
+     Llamar a <function>get_defined_functions</function> con <parameter>exclude_disabled</parameter>
+     establecido explícitamente a &false; está obsoleto y ya no tiene efecto.
+     <function>get_defined_functions</function> nunca incluirá funciones deshabilitadas.
     </para>
    </listitem>
   </itemizedlist>
@@ -57,34 +57,34 @@ function test(?A $a, $b) {}       // Recommended
   <itemizedlist>
    <listitem>
     <para>
-     <function>enchant_broker_set_dict_path</function> and
+     <function>enchant_broker_set_dict_path</function> y
      <function>enchant_broker_get_dict_path</function>
-     are deprecated, because that functionality is neither available in libenchant &lt; 1.5 nor in
+     están obsoletas, porque esa funcionalidad no está disponible ni en libenchant &lt; 1.5 ni en
      libenchant-2.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_dict_add_to_personal</function> is deprecated; use
-     <function>enchant_dict_add</function> instead.
+     <function>enchant_dict_add_to_personal</function> está obsoleta; use
+     <function>enchant_dict_add</function> en su lugar.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_dict_is_in_session</function> is deprecated; use
-     <function>enchant_dict_is_added</function> instead.
+     <function>enchant_dict_is_in_session</function> está obsoleta; use
+     <function>enchant_dict_is_added</function> en su lugar.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>enchant_broker_free</function> and <function>enchant_broker_free_dict</function> are
-     deprecated; unset the object instead.
+     <function>enchant_broker_free</function> y <function>enchant_broker_free_dict</function> están
+     obsoletas; use unset sobre el objeto en su lugar.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <constant>ENCHANT_MYSPELL</constant> and <constant>ENCHANT_ISPELL</constant> constants are
-     deprecated.
+     Las constantes <constant>ENCHANT_MYSPELL</constant> y <constant>ENCHANT_ISPELL</constant> están
+     obsoletas.
     </para>
    </listitem>
   </itemizedlist>
@@ -94,9 +94,9 @@ function test(?A $a, $b) {}       // Recommended
   <title>LibXML</title>
 
   <para>
-   <function>libxml_disable_entity_loader</function> has been deprecated. As libxml 2.9.0 is now
-   required, external entity loading is guaranteed to be disabled by default, and this function is
-   no longer needed to protect against XXE attacks.
+   <function>libxml_disable_entity_loader</function> ha sido desaprobada. Como ahora se requiere libxml 2.9.0,
+   la carga de entidades externas está garantizada como deshabilitada por defecto, y esta función ya
+   no es necesaria para proteger contra ataques XXE.
   </para>
  </sect2>
 
@@ -106,14 +106,14 @@ function test(?A $a, $b) {}       // Recommended
   <itemizedlist>
    <listitem>
     <para>
-     The constant <constant>PGSQL_LIBPQ_VERSION_STR</constant> now has the same value as
-     <constant>PGSQL_LIBPQ_VERSION</constant>, and thus is deprecated.
+     La constante <constant>PGSQL_LIBPQ_VERSION_STR</constant> ahora tiene el mismo valor que
+     <constant>PGSQL_LIBPQ_VERSION</constant>, y por lo tanto está obsoleta.
     </para>
    </listitem>
    <listitem>
     <para>
-     Function aliases in the pgsql extension have been deprecated.
-     See the following list for which functions should be used instead:
+     Los alias de funciones en la extensión pgsql han sido desaprobados.
+     Consulte la siguiente lista para saber qué funciones deben usarse en su lugar:
     </para>
     <para>
      <simplelist>
@@ -148,14 +148,14 @@ function test(?A $a, $b) {}       // Recommended
  </sect2>
 
  <sect2 xml:id="migration80.deprecated.standard">
-  <title>Standard Library</title>
+  <title>Biblioteca estándar</title>
 
   <itemizedlist>
    <listitem>
     <para>
-     Sort comparison functions that return &true; or &false; will now throw a deprecation warning, and
-     should be replaced with an implementation that returns an integer less than, equal to, or greater
-     than zero.
+     Las funciones de comparación para ordenamiento que devuelven &true; o &false; ahora emitirán una advertencia de obsolescencia, y
+     deberían ser reemplazadas por una implementación que devuelva un entero menor, igual o mayor
+     que cero.
     </para>
     <para>
      <programlisting role="php">
@@ -179,15 +179,15 @@ usort($array, fn($a, $b) => $a <=> $b);
   <itemizedlist>
    <listitem>
     <para>
-     Using an empty file as ZipArchive is deprecated. Libzip 1.6.0 does not accept empty files as
-     valid zip archives any longer. The existing workaround will be removed in the next version.
+     El uso de un archivo vacío como ZipArchive está obsoleto. Libzip 1.6.0 ya no acepta archivos vacíos como
+     archivos zip válidos. La solución alternativa existente será eliminada en la próxima versión.
     </para>
    </listitem>
    <listitem>
     <para>
-     The procedural API of Zip is deprecated. Use <classname>ZipArchive</classname> instead.
-     Iteration over all entries can be accomplished using <methodname>ZipArchive::statIndex</methodname>
-     and a <link linkend="control-structures.for">for</link> loop:
+     La API procedural de Zip está obsoleta. Use <classname>ZipArchive</classname> en su lugar.
+     La iteración sobre todas las entradas puede realizarse usando <methodname>ZipArchive::statIndex</methodname>
+     y un bucle <link linkend="control-structures.for">for</link>:
     </para>
     <para>
      <programlisting role="php">
@@ -213,23 +213,23 @@ for ($i = 0; $entry = $zip->statIndex($i); $i++) {
  </sect2>
 
  <sect2 xml:id="migration80.deprecated.reflection">
-  <title>Reflection</title>
+  <title>Reflexión</title>
 
   <itemizedlist>
    <listitem>
     <para>
-     <methodname>ReflectionFunction::isDisabled</methodname> is deprecated, as it is no longer
-     possible to create a <classname>ReflectionFunction</classname> for a disabled function. This
-     method now always returns &false;.
+     <methodname>ReflectionFunction::isDisabled</methodname> está obsoleto, ya que ya no es posible
+     crear un <classname>ReflectionFunction</classname> para una función deshabilitada. Este
+     método ahora siempre devuelve &false;.
     </para>
    </listitem>
    <listitem>
     <para>
      <methodname>ReflectionParameter::getClass</methodname>,
-     <methodname>ReflectionParameter::isArray</methodname>, and
-     <methodname>ReflectionParameter::isCallable</methodname> are deprecated.
-     <methodname>ReflectionParameter::getType</methodname> and the
-     <classname>ReflectionType</classname> APIs should be used instead.
+     <methodname>ReflectionParameter::isArray</methodname> y
+     <methodname>ReflectionParameter::isCallable</methodname> están obsoletos.
+     En su lugar deberían usarse <methodname>ReflectionParameter::getType</methodname> y las
+     API de <classname>ReflectionType</classname>.
     </para>
    </listitem>
   </itemizedlist>

--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -30,62 +30,61 @@
   </sect3>
 
   <sect3 xml:id="migration80.new-features.core.property-promotion">
-   <title>Constructor Property Promotion</title>
+   <title>Promoción de propiedades en el constructor</title>
 
    <para>
-    Support for <link linkend="language.oop5.decon.constructor.promotion">constructor property promotion</link> (declaring properties in the constructor signature)
-    has been added.
+    Se ha añadido soporte para la <link linkend="language.oop5.decon.constructor.promotion">promoción de propiedades en el constructor</link> (declarar propiedades en la firma del constructor).
     <!-- RFC: https://wiki.php.net/rfc/constructor_promotion -->
    </para>
   </sect3>
 
   <sect3 xml:id="migration80.new-features.core.union-types">
-   <title>Union Types</title>
+   <title>Tipos de unión</title>
 
    <para>
-    Support for <link linkend="language.types.declarations.composite.union">union types</link> has been added.
+    Se ha añadido soporte para los <link linkend="language.types.declarations.composite.union">tipos de unión</link>.
     <!-- RFC: https://wiki.php.net/rfc/union_types_v2 -->
    </para>
   </sect3>
 
   <sect3 xml:id="migration80.new-features.core.match">
-   <title>Match Expression</title>
+   <title>Expresión match</title>
 
    <para>
-    Support for <link linkend="control-structures.match"><literal>match</literal> expressions</link> has been added.
+    Se ha añadido soporte para las <link linkend="control-structures.match">expresiones <literal>match</literal></link>.
     <!-- RFC: https://wiki.php.net/rfc/match_expression_v2 -->
    </para>
   </sect3>
 
   <sect3 xml:id="migration80.new-features.core.nullsafe-operator">
-   <title>Nullsafe Operator</title>
+   <title>Operador nullsafe</title>
 
    <para>
-    Support for the <link linkend="language.oop5.basic.nullsafe">nullsafe operator</link> (<literal>?-></literal>) has been added.
+    Se ha añadido soporte para el <link linkend="language.oop5.basic.nullsafe">operador nullsafe</link> (<literal>?-></literal>).
     <!-- RFC: https://wiki.php.net/rfc/nullsafe_operator -->
    </para>
   </sect3>
 
   <sect3 xml:id="migration80.new-features.core.others">
-   <title>Other new Features</title>
+   <title>Otras nuevas características</title>
 
    <itemizedlist>
     <listitem>
      <para>
       <!-- we cannot use <classname>WeakMap</classname> because that would link to the wrong class -->
-      The <literal>WeakMap</literal> class has been added.
+      Se ha añadido la clase <literal>WeakMap</literal>.
       <!-- RFC: https://wiki.php.net/rfc/weak_maps -->
      </para>
     </listitem>
     <listitem>
      <para>
-      The <classname>ValueError</classname> class has been added.
+      Se ha añadido la clase <classname>ValueError</classname>.
      </para>
     </listitem>
     <listitem>
      <para>
-      Any number of function parameters may now be replaced by a variadic argument, as long as the
-      types are compatible. For example, the following code is now allowed:
+      Cualquier número de parámetros de función ahora puede ser reemplazado por un argumento variádico, siempre que los
+      tipos sean compatibles. Por ejemplo, el siguiente código ahora está permitido:
      </para>
      <para>
       <programlisting role="php">
@@ -104,7 +103,7 @@ class B extends A {
     </listitem>
     <listitem>
      <para>
-      <type>static</type> (as in "late static binding") can now be used as a return type:
+      <type>static</type> (como en "enlace estático en tiempo de ejecución") ahora puede ser usado como tipo de retorno:
      </para>
      <para>
       <programlisting role="php">
@@ -123,43 +122,43 @@ class Test {
     </listitem>
     <listitem>
      <para>
-      It is now possible to fetch the class name of an object using
-      <code>$object::class</code>. The result is the same as <code>get_class($object)</code>.
+      Ahora es posible obtener el nombre de la clase de un objeto usando
+      <code>$object::class</code>. El resultado es el mismo que <code>get_class($object)</code>.
       <!-- RFC: https://wiki.php.net/rfc/class_name_literal_on_object -->
      </para>
     </listitem>
     <listitem>
      <para>
-      &new; and &instanceof; can now be used with arbitrary expressions,
-      using <code>new (expression)(...$args)</code> and <code>$obj instanceof (expression)</code>.
+      &new; e &instanceof; ahora pueden ser usados con expresiones arbitrarias,
+      usando <code>new (expression)(...$args)</code> y <code>$obj instanceof (expression)</code>.
       <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
      </para>
     </listitem>
     <listitem>
      <para>
-      Some consistency fixes to variable syntax have been applied, for example writing
-      <code>Foo::BAR::$baz</code> is now allowed.
+      Se han aplicado algunas correcciones de consistencia en la sintaxis de variables, por ejemplo, escribir
+      <code>Foo::BAR::$baz</code> ahora está permitido.
       <!-- RFC: https://wiki.php.net/rfc/variable_syntax_tweaks -->
      </para>
     </listitem>
     <listitem>
      <para>
-      Added <interfacename>Stringable</interfacename> interface, which is automatically implemented if
-      a class defines a <link linkend="object.tostring">__toString()</link> method.
+      Se ha añadido la interfaz <interfacename>Stringable</interfacename>, que se implementa automáticamente si
+      una clase define un método <link linkend="object.tostring">__toString()</link>.
       <!-- RFC: https://wiki.php.net/rfc/stringable -->
      </para>
     </listitem>
     <listitem>
      <para>
-      Traits can now define abstract private methods.
-      Such methods must be implemented by the class using the trait.
+      Los traits ahora pueden definir métodos privados abstractos.
+      Dichos métodos deben ser implementados por la clase que usa el trait.
       <!-- RFC: https://wiki.php.net/rfc/abstract_trait_method_validation -->
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>throw</literal> can now be used as an expression.
-      That allows usages like:
+      <literal>throw</literal> ahora puede ser usado como una expresión.
+      Esto permite usos como:
       <programlisting role="php">
 <![CDATA[
 <?php
@@ -172,7 +171,7 @@ $user = $session->user ?? throw new Exception('Must have user');
     </listitem>
     <listitem>
      <para>
-      An optional trailing comma is now allowed in parameter lists.
+      Ahora se permite una coma final opcional en las listas de parámetros.
       <programlisting role="php">
 <![CDATA[
 <?php
@@ -188,22 +187,22 @@ function functionWithLongSignature(
     </listitem>
     <listitem>
      <para>
-      It is now possible to write <code>catch (Exception)</code> to catch an exception without storing
-      it in a variable.
+      Ahora es posible escribir <code>catch (Exception)</code> para capturar una excepción sin almacenarla
+      en una variable.
       <!-- RFC: https://wiki.php.net/rfc/non-capturing_catches -->
      </para>
     </listitem>
     <listitem>
      <para>
-      Support for <type>mixed</type> type has been added.
+      Se ha añadido soporte para el tipo <type>mixed</type>.
       <!-- RFC: https://wiki.php.net/rfc/mixed_type_v2 -->
      </para>
     </listitem>
     <listitem>
      <para>
-      Private methods declared on a parent class no longer enforce any inheritance rules on the methods
-      of a child class (with the exception of final private constructors).
-      The following example illustrates which restrictions have been removed:
+      Los métodos privados declarados en una clase padre ya no imponen ninguna regla de herencia sobre los métodos
+      de una clase hija (con la excepción de los constructores privados finales).
+      El siguiente ejemplo ilustra qué restricciones han sido eliminadas:
       <programlisting role="php">
 <![CDATA[
 <?php
@@ -230,8 +229,8 @@ class ChildClass extends ParentClass {
     </listitem>
     <listitem>
      <para>
-      <function>get_resource_id</function> has been added, which returns the same value as
-      <code>(int) $resource</code>. It provides the same functionality under a clearer API.
+      Se ha añadido <function>get_resource_id</function>, que devuelve el mismo valor que
+      <code>(int) $resource</code>. Proporciona la misma funcionalidad con una API más clara.
      </para>
     </listitem>
    </itemizedlist>
@@ -239,20 +238,20 @@ class ChildClass extends ParentClass {
  </sect2>
 
  <sect2 xml:id="migration80.new-features.date">
-  <title>Date and Time</title>
+  <title>Fecha y hora</title>
 
   <itemizedlist>
    <listitem>
     <para>
-     <methodname>DateTime::createFromInterface</methodname> and
-     <methodname>DateTimeImmutable::createFromInterface</methodname> have been added.
+     Se han añadido <methodname>DateTime::createFromInterface</methodname> y
+     <methodname>DateTimeImmutable::createFromInterface</methodname>.
     </para>
    </listitem>
    <listitem>
     <para>
-     The DateTime format specifier <literal>p</literal> has been added, which is the same as
-     <literal>P</literal> but returns <literal>Z</literal> rather than <literal>+00:00</literal>
-     for UTC.
+     Se ha añadido el especificador de formato DateTime <literal>p</literal>, que es igual que
+     <literal>P</literal> pero devuelve <literal>Z</literal> en lugar de <literal>+00:00</literal>
+     para UTC.
     </para>
    </listitem>
   </itemizedlist>
@@ -262,8 +261,8 @@ class ChildClass extends ParentClass {
   <title>DOM</title>
 
   <para>
-   <interfacename>DOMParentNode</interfacename> and <interfacename>DOMChildNode</interfacename> with
-   new traversal and manipulation APIs have been added.
+   Se han añadido <interfacename>DOMParentNode</interfacename> y <interfacename>DOMChildNode</interfacename> con
+   nuevas API de recorrido y manipulación.
    <!-- RFC: https://wiki.php.net/rfc/dom_living_standard_api-->
   </para>
  </sect2>
@@ -272,9 +271,9 @@ class ChildClass extends ParentClass {
   <title>Filter</title>
 
   <para>
-   <constant>FILTER_VALIDATE_BOOL</constant> has been added as an alias for
-   <constant>FILTER_VALIDATE_BOOLEAN</constant>. The new name is preferred, as it uses the canonical
-   type name.
+   Se ha añadido <constant>FILTER_VALIDATE_BOOL</constant> como alias de
+   <constant>FILTER_VALIDATE_BOOLEAN</constant>. Se prefiere el nuevo nombre, ya que utiliza el nombre
+   de tipo canónico.
   </para>
  </sect2>
 
@@ -282,8 +281,8 @@ class ChildClass extends ParentClass {
   <title>Enchant</title>
 
   <para>
-   <function>enchant_dict_add</function>, <function>enchant_dict_is_added</function>, and
-   <constant>LIBENCHANT_VERSION</constant> have been added.
+   Se han añadido <function>enchant_dict_add</function>, <function>enchant_dict_is_added</function> y
+   <constant>LIBENCHANT_VERSION</constant>.
   </para>
  </sect2>
 
@@ -291,9 +290,9 @@ class ChildClass extends ParentClass {
   <title>FPM</title>
 
   <para>
-   Added a new option <literal>pm.status_listen</literal> that allows getting the status from
-   different endpoint (e.g. port or UDS file) which is useful for getting the status when all
-   children are busy with serving long running requests.
+   Se ha añadido una nueva opción <literal>pm.status_listen</literal> que permite obtener el estado desde
+   un endpoint diferente (por ejemplo, un puerto o archivo UDS), lo cual es útil para obtener el estado cuando todos
+   los procesos hijos están ocupados sirviendo peticiones de larga duración.
   </para>
  </sect2>
 
@@ -301,19 +300,18 @@ class ChildClass extends ParentClass {
   <title>Hash</title>
 
   <para>
-   <classname>HashContext</classname> objects can now be serialized.
+   Los objetos <classname>HashContext</classname> ahora pueden ser serializados.
   </para>
  </sect2>
 
  <sect2 xml:id="migration80.new-features.intl">
-  <title>Internationalization Functions</title>
+  <title>Funciones de internacionalización</title>
 
   <para>
-   The <constant>IntlDateFormatter::RELATIVE_FULL</constant>,
+   Se han añadido las constantes <constant>IntlDateFormatter::RELATIVE_FULL</constant>,
    <constant>IntlDateFormatter::RELATIVE_LONG</constant>,
-   <constant>IntlDateFormatter::RELATIVE_MEDIUM</constant>, and
-   <constant>IntlDateFormatter::RELATIVE_SHORT</constant>
-   constants have been added.
+   <constant>IntlDateFormatter::RELATIVE_MEDIUM</constant> y
+   <constant>IntlDateFormatter::RELATIVE_SHORT</constant>.
   </para>
  </sect2>
 
@@ -321,17 +319,17 @@ class ChildClass extends ParentClass {
   <title>LDAP</title>
 
   <para>
-   <function>ldap_count_references</function> has been added, which returns the number
-   of reference messages in a search result.
+   Se ha añadido <function>ldap_count_references</function>, que devuelve el número
+   de mensajes de referencia en un resultado de búsqueda.
   </para>
  </sect2>
  <sect2 xml:id="migration80.new-features.opcache">
   <title>OPcache</title>
 
   <para>
-   If the <!--<link linkend="ini.opcache.record-warnings">-->opcache.record_warnings<!--</link>--> ini setting is
-   enabled, OPcache will record compile-time warnings and replay them on the next include, even if
-   it is served from cache.
+   Si la directiva ini <!--<link linkend="ini.opcache.record-warnings">-->opcache.record_warnings<!--</link>--> está
+   habilitada, OPcache registrará las advertencias en tiempo de compilación y las reproducirá en el siguiente include, incluso si
+   se sirve desde la caché.
   </para>
  </sect2>
 
@@ -339,53 +337,53 @@ class ChildClass extends ParentClass {
   <title>OpenSSL</title>
 
   <para>
-   Added Cryptographic Message Syntax (CMS) (<link xlink:href="&url.rfc;5652">RFC 5652</link>)
-   support composed of functions for encryption, decryption, signing, verifying and reading. The API
-   is similar to the API for PKCS #7 functions with an addition of new encoding constants:
+   Se ha añadido soporte para Cryptographic Message Syntax (CMS) (<link xlink:href="&url.rfc;5652">RFC 5652</link>)
+   compuesto por funciones para cifrado, descifrado, firma, verificación y lectura. La API
+   es similar a la API de las funciones PKCS #7 con la adición de nuevas constantes de codificación:
    <constant>OPENSSL_ENCODING_DER</constant>, <constant>OPENSSL_ENCODING_SMIME</constant>
-   and <constant>OPENSSL_ENCODING_PEM</constant>:
+   y <constant>OPENSSL_ENCODING_PEM</constant>:
    <simplelist>
     <member>
-     <function>openssl_cms_encrypt</function> encrypts the message in the file with the certificates
-     and outputs the result to the supplied file.
+     <function>openssl_cms_encrypt</function> cifra el mensaje en el archivo con los certificados
+     y envía el resultado al archivo proporcionado.
     </member>
     <member>
-     <function>openssl_cms_decrypt</function> that decrypts the S/MIME message in the file and outputs
-     the results to the supplied file.
+     <function>openssl_cms_decrypt</function> descifra el mensaje S/MIME en el archivo y envía
+     los resultados al archivo proporcionado.
     </member>
     <member>
-     <function>openssl_cms_read</function> that exports the CMS file to an array of PEM certificates.
+     <function>openssl_cms_read</function> exporta el archivo CMS a un array de certificados PEM.
     </member>
     <member>
-     <function>openssl_cms_sign</function> that signs the MIME message in the file with a cert and key
-     and output the result to the supplied file.
+     <function>openssl_cms_sign</function> firma el mensaje MIME en el archivo con un certificado y una clave
+     y envía el resultado al archivo proporcionado.
     </member>
     <member>
-     <function>openssl_cms_verify</function> that verifies that the data block is intact, the signer
-     is who they say they are, and returns the certs of the signers.
+     <function>openssl_cms_verify</function> verifica que el bloque de datos está intacto, que el firmante
+     es quien dice ser, y devuelve los certificados de los firmantes.
     </member>
    </simplelist>
   </para>
  </sect2>
 
  <sect2 xml:id="migration80.new-features.pcre">
-  <title>Regular Expressions (Perl-Compatible)</title>
+  <title>Expresiones regulares (compatibles con Perl)</title>
 
   <para>
-   <function>preg_last_error_msg</function> has been added, which returns a human-readable message for the last
-   PCRE error. It complements <function>preg_last_error</function>, which returns an integer enum value
-   instead.
+   Se ha añadido <function>preg_last_error_msg</function>, que devuelve un mensaje legible para el último
+   error PCRE. Complementa a <function>preg_last_error</function>, que devuelve un valor entero de enumeración
+   en su lugar.
   </para>
  </sect2>
 
  <sect2 xml:id="migration80.new-features.reflection">
-  <title>Reflection</title>
+  <title>Reflexión</title>
 
   <itemizedlist>
    <listitem>
     <para>
-     The following methods can now return information about default values of
-     parameters of internal functions:
+     Los siguientes métodos ahora pueden devolver información sobre los valores predeterminados de
+     los parámetros de las funciones internas:
     </para>
     <para>
      <simplelist>
@@ -403,55 +401,55 @@ class ChildClass extends ParentClass {
   <title>SQLite3</title>
 
   <para>
-   <methodname>SQLite3::setAuthorizer</methodname> and respective class constants have been added
-   to set a userland callback that will be used to authorize or not an action on the database.
+   Se han añadido <methodname>SQLite3::setAuthorizer</methodname> y las constantes de clase correspondientes
+   para establecer una función de retorno de llamada de usuario que se utilizará para autorizar o no una acción en la base de datos.
    <!-- PR: https://github.com/php/php-src/pull/4797 -->
   </para>
  </sect2>
 
  <sect2 xml:id="migration80.new-features.standard">
-  <title>Standard Library</title>
+  <title>Biblioteca estándar</title>
 
   <itemizedlist>
    <listitem>
     <para>
-     <function>str_contains</function>, <function>str_starts_with</function> and
-     <function>str_ends_with</function> have been added, which check whether <parameter>haystack</parameter> contains,
-     starts with or ends with <parameter>needle</parameter>, respectively.
+     Se han añadido <function>str_contains</function>, <function>str_starts_with</function> y
+     <function>str_ends_with</function>, que comprueban si <parameter>haystack</parameter> contiene,
+     comienza con o termina con <parameter>needle</parameter>, respectivamente.
      <!-- RFC: https://wiki.php.net/rfc/str_contains -->
      <!-- RFC: https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions -->
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>fdiv</function> has been added, which performs a floating-point division under IEEE 754 semantics.
-     Division by zero is considered well-defined and will return one of <literal>Inf</literal>,
-     <literal>-Inf</literal> or <literal>NaN</literal>.
+     Se ha añadido <function>fdiv</function>, que realiza una división de punto flotante según la semántica IEEE 754.
+     La división por cero se considera bien definida y devolverá uno de <literal>Inf</literal>,
+     <literal>-Inf</literal> o <literal>NaN</literal>.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>get_debug_type</function> has been added, which returns a type useful for error messages. Unlike
-     <function>gettype</function>, it uses canonical type names, returns class names for objects, and
-     indicates the resource type for resources.
+     Se ha añadido <function>get_debug_type</function>, que devuelve un tipo útil para mensajes de error. A diferencia de
+     <function>gettype</function>, utiliza nombres de tipo canónicos, devuelve nombres de clase para objetos e
+     indica el tipo de recurso para los recursos.
      <!-- RFC: https://wiki.php.net/rfc/get_debug_type -->
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>printf</function> and friends now support the <literal>%h</literal> and
-     <literal>%H</literal> format specifiers. These are the same as <literal>%g</literal> and
-     <literal>%G</literal>, but always use <literal>"."</literal> as the decimal separator, rather
-     than determining it through the <constant>LC_NUMERIC</constant> locale.
+     <function>printf</function> y funciones similares ahora soportan los especificadores de formato <literal>%h</literal> y
+     <literal>%H</literal>. Son iguales que <literal>%g</literal> y
+     <literal>%G</literal>, pero siempre usan <literal>"."</literal> como separador decimal, en lugar
+     de determinarlo a través de la configuración regional <constant>LC_NUMERIC</constant>.
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>printf</function> and friends now support using <literal>"*"</literal> as width or
-     precision, in which case the width/precision is passed as an argument to printf. This also allows
-     using precision <literal>-1</literal> with <literal>%g</literal>, <literal>%G</literal>,
-     <literal>%h</literal> and <literal>%H</literal>. For example, the following code can be used to
-     reproduce PHP's default floating point formatting:
+     <function>printf</function> y funciones similares ahora soportan el uso de <literal>"*"</literal> como ancho o
+     precisión, en cuyo caso el ancho/precisión se pasa como argumento a printf. Esto también permite
+     usar precisión <literal>-1</literal> con <literal>%g</literal>, <literal>%G</literal>,
+     <literal>%h</literal> y <literal>%H</literal>. Por ejemplo, el siguiente código puede usarse para
+     reproducir el formato predeterminado de punto flotante de PHP:
     </para>
     <para>
      <programlisting role="php">
@@ -466,9 +464,9 @@ printf("%.*H", (int) ini_get("serialize_precision"), $float);
    </listitem>
    <listitem>
     <para>
-     <function>proc_open</function> now supports pseudo-terminal (PTY) descriptors. The following
-     attaches <literal>stdin</literal>, <literal>stdout</literal> and <literal>stderr</literal> to the
-     same PTY:
+     <function>proc_open</function> ahora soporta descriptores de pseudo-terminal (PTY). Lo siguiente
+     conecta <literal>stdin</literal>, <literal>stdout</literal> y <literal>stderr</literal> al
+     mismo PTY:
     </para>
     <para>
      <programlisting role="php">
@@ -482,8 +480,8 @@ $proc = proc_open($command, [['pty'], ['pty'], ['pty']], $pipes);
    </listitem>
    <listitem>
     <para>
-     <function>proc_open</function> now supports socket pair descriptors. The following attaches a
-     distinct socket pair to <literal>stdin</literal>, <literal>stdout</literal> and
+     <function>proc_open</function> ahora soporta descriptores de pares de sockets. Lo siguiente conecta un
+     par de sockets distinto a <literal>stdin</literal>, <literal>stdout</literal> y
      <literal>stderr</literal>:
     </para>
     <para>
@@ -496,22 +494,22 @@ $proc = proc_open($command, [['socket'], ['socket'], ['socket']], $pipes);
      </programlisting>
     </para>
     <para>
-     Unlike pipes, sockets do not suffer from blocking I/O issues on Windows. However, not all
-     programs may work correctly with stdio sockets.
+     A diferencia de las tuberías, los sockets no sufren problemas de E/S bloqueante en Windows. Sin embargo, no todos
+     los programas pueden funcionar correctamente con sockets stdio.
     </para>
    </listitem>
    <listitem>
     <para>
-     Sorting functions are now stable, which means that equal-comparing elements will retain their
-     original order.
+     Las funciones de ordenamiento ahora son estables, lo que significa que los elementos que se comparan como iguales conservarán su
+     orden original.
      <!-- RFC: https://wiki.php.net/rfc/stable_sorting -->
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>array_diff</function>, <function>array_intersect</function> and their variations can
-     now be used with a single array as argument. This means that usages like the following are now
-     possible:
+     <function>array_diff</function>, <function>array_intersect</function> y sus variaciones ahora pueden
+     ser usadas con un solo array como argumento. Esto significa que usos como los siguientes ahora son
+     posibles:
     </para>
     <para>
      <programlisting role="php">
@@ -528,8 +526,8 @@ array_intersect(...$arrays);
    </listitem>
    <listitem>
     <para>
-     The <parameter>flag</parameter> parameter of <function>ob_implicit_flush</function> was changed
-     to accept a <type>bool</type> rather than an <type>int</type>.
+     El parámetro <parameter>flag</parameter> de <function>ob_implicit_flush</function> fue cambiado
+     para aceptar un <type>bool</type> en lugar de un <type>int</type>.
     </para>
    </listitem>
   </itemizedlist>
@@ -539,8 +537,8 @@ array_intersect(...$arrays);
   <title>Tokenizer</title>
 
   <para>
-   <classname>PhpToken</classname> adds an object-based interface to the tokenizer. It provides a
-   more uniform and ergonomic representation, while being more memory efficient and faster.
+   <classname>PhpToken</classname> añade una interfaz basada en objetos al tokenizer. Proporciona una
+   representación más uniforme y ergonómica, siendo al mismo tiempo más eficiente en memoria y más rápida.
    <!--  RFC: https://wiki.php.net/rfc/token_as_object -->
   </para>
  </sect2>
@@ -551,68 +549,68 @@ array_intersect(...$arrays);
   <itemizedlist>
    <listitem>
     <para>
-     The Zip extension has been updated to version 1.19.1.
+     La extensión Zip ha sido actualizada a la versión 1.19.1.
     </para>
    </listitem>
    <listitem>
     <para>
-     New <methodname>ZipArchive::setMtimeName</methodname> and
-     <methodname>ZipArchive::setMtimeIndex</methodname> to set the modification time of an entry.
+     Nuevos <methodname>ZipArchive::setMtimeName</methodname> y
+     <methodname>ZipArchive::setMtimeIndex</methodname> para establecer la hora de modificación de una entrada.
     </para>
    </listitem>
    <listitem>
     <para>
-     New <methodname>ZipArchive::registerProgressCallback</methodname> to provide updates during archive close.
+     Nuevo <methodname>ZipArchive::registerProgressCallback</methodname> para proporcionar actualizaciones durante el cierre del archivo.
     </para>
    </listitem>
    <listitem>
     <para>
-     New <methodname>ZipArchive::registerCancelCallback</methodname> to allow cancellation during archive
-     close.
+     Nuevo <methodname>ZipArchive::registerCancelCallback</methodname> para permitir la cancelación durante el cierre
+     del archivo.
     </para>
    </listitem>
    <listitem>
     <para>
-     New <methodname>ZipArchive::replaceFile</methodname> to replace an entry content.
+     Nuevo <methodname>ZipArchive::replaceFile</methodname> para reemplazar el contenido de una entrada.
     </para>
    </listitem>
    <listitem>
     <para>
-     New <methodname>ZipArchive::isCompressionMethodSupported</methodname> to check optional compression
-     features.
+     Nuevo <methodname>ZipArchive::isCompressionMethodSupported</methodname> para verificar las características opcionales de
+     compresión.
     </para>
    </listitem>
    <listitem>
     <para>
-     New <methodname>ZipArchive::isEncryptionMethodSupported</methodname> to check optional encryption
-     features.
+     Nuevo <methodname>ZipArchive::isEncryptionMethodSupported</methodname> para verificar las características opcionales de
+     cifrado.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <varname>ZipArchive::lastId</varname> property to get the index value of
-     the last added entry has been added.
+     Se ha añadido la propiedad <varname>ZipArchive::lastId</varname> para obtener el valor del índice
+     de la última entrada añadida.
     </para>
    </listitem>
    <listitem>
     <para>
-     Errors can now be checked after an archive has been closed using the
-     <varname>ZipArchive::status</varname> and
-     <varname>ZipArchive::statusSys</varname> properties, or the
-     <methodname>ZipArchive::getStatusString</methodname> method.
+     Ahora se pueden verificar los errores después de que un archivo ha sido cerrado usando las propiedades
+     <varname>ZipArchive::status</varname> y
+     <varname>ZipArchive::statusSys</varname>, o el método
+     <methodname>ZipArchive::getStatusString</methodname>.
     </para>
    </listitem>
    <listitem>
     <para>
-     The <literal>'remove_path'</literal> option of <methodname>ZipArchive::addGlob</methodname> and
-     <methodname>ZipArchive::addPattern</methodname> is now treated as an arbitrary string prefix (for
-     consistency with the <literal>'add_path'</literal> option), whereas formerly it was treated as a
-     directory name.
+     La opción <literal>'remove_path'</literal> de <methodname>ZipArchive::addGlob</methodname> y
+     <methodname>ZipArchive::addPattern</methodname> ahora se trata como un prefijo de cadena arbitrario (para
+     mantener la consistencia con la opción <literal>'add_path'</literal>), mientras que anteriormente se trataba como un
+     nombre de directorio.
     </para>
    </listitem>
    <listitem>
     <para>
-     Optional compression / encryption features are now listed in phpinfo.
+     Las características opcionales de compresión / cifrado ahora se listan en phpinfo.
     </para>
    </listitem>
   </itemizedlist>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -439,7 +439,6 @@
     <type>bool</type> ahora emite advertencias.
     Esto se debe a que actualmente no tiene ningún efecto, pero se comportará como
     <code>$bool += 1</code> en el futuro.
-    Using the <link linkend="language.operators.increment">increment/decrement</link>
    </para>
 
    <para>

--- a/language/fibers.xml
+++ b/language/fibers.xml
@@ -33,10 +33,7 @@
    objeto <classname>Iterator</classname>.
   </para>
   <para>
-   Una vez suspendido, la ejecución del Fiber puede reanudarse con cualquier valor utilizando <methodname>Fiber::resume</methodname> o lanzando una excepción en el Fiber utilizando <methodname>Fiber::throw</methodname>. El valor se devuelve (o la excepción se lanza) desde <methodname>Fiber::suspend</methodname>
-   Once suspended, execution of the fiber may be resumed with any value using <methodname>Fiber::resume</methodname>
-   or by throwing an exception into the fiber using <methodname>Fiber::throw</methodname>. The value is returned
-   (or exception thrown) from <methodname>Fiber::suspend</methodname>.
+   Una vez suspendido, la ejecución del Fiber puede reanudarse con cualquier valor utilizando <methodname>Fiber::resume</methodname> o lanzando una excepción en el Fiber utilizando <methodname>Fiber::throw</methodname>. El valor se devuelve (o la excepción se lanza) desde <methodname>Fiber::suspend</methodname>.
   </para>
   <note>
    <simpara>

--- a/language/predefined/exception/gettraceasstring.xml
+++ b/language/predefined/exception/gettraceasstring.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the Exception stack trace as a string.
+   Devuelve la traza de la pila de la excepción como una cadena de caracteres.
   </para>
  </refsect1>
 

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -1142,12 +1142,12 @@ $varname.ext;  /* nombre de variable inválido */
      también el capítulo sobre <link linkend="language.types">Tipos</link>.
     </para>
     <para>
-     HTTP being a text protocol, most, if not all, content that comes in
-     <link linkend="language.variables.superglobals">Superglobal arrays</link>,
-     like <varname>$_POST</varname> and <varname>$_GET</varname> will remain
-     as strings. PHP will not try to convert values to a specific type.
-     In the example below, <varname>$_GET["var1"]</varname> will contain the
-     string "null" and <varname>$_GET["var2"]</varname>, the string "123".
+     Dado que HTTP es un protocolo de texto, la mayoría, si no todo, el contenido que llega en
+     <link linkend="language.variables.superglobals">arrays superglobales</link>,
+     como <varname>$_POST</varname> y <varname>$_GET</varname>, permanecerá
+     como cadenas de texto. PHP no intentará convertir los valores a un tipo específico.
+     En el ejemplo siguiente, <varname>$_GET["var1"]</varname> contendrá la
+     cadena "null" y <varname>$_GET["var2"]</varname>, la cadena "123".
      <programlisting>
 <![CDATA[
 /index.php?var1=null&var2=123

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -82,7 +82,7 @@
       <entry><link linkend="ini.apcu.entries-hint">apc.entries_hint</link></entry>
       <entry>512 * apc.shm_size</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>Prior to APcu 5.1.25, the default was 4096</entry>
+      <entry>Anteriormente a APCu 5.1.25, el valor predeterminado era 4096</entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.ttl">apc.ttl</link></entry>

--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -197,11 +197,11 @@
      <term><varname>days</varname></term>
      <listitem>
       <para>
-       If the DateInterval object was created by
-       <methodname>DateTimeImmutable::diff</methodname> or
-       <methodname>DateTime::diff</methodname>, then this is the
-       total number of full days between the start and end dates. Otherwise,
-       <varname>days</varname> will be &false;.
+       Si el objeto DateInterval fue creado por
+       <methodname>DateTimeImmutable::diff</methodname> o
+       <methodname>DateTime::diff</methodname>, entonces este es el
+       número total de días completos entre las fechas de inicio y fin. En caso contrario,
+       <varname>days</varname> será &false;.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/fann/functions/fann-create-shortcut.xml
+++ b/reference/fann/functions/fann-create-shortcut.xml
@@ -18,7 +18,7 @@
    <methodparam rep="repeat"><type>int</type><parameter>num_neuronsN</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Creates a standard backpropagation neural network, which is not fully connected and which also has shortcut connections.
+   Crea una red neuronal de retropropagación estándar que no está completamente conectada y que también posee conexiones de atajo.
   </para>
   <para>
    Las conexiones de atajo son conexiones que saltan capas. Una red completamente conectada con conexiones de atajo es una red

--- a/reference/fann/functions/fann-read-train-from-file.xml
+++ b/reference/fann/functions/fann-read-train-from-file.xml
@@ -68,7 +68,7 @@ if ($train_data) {
 ?>
 ]]>
     </programlisting>
-    <para>Contents of xor.data</para>
+    <para>Contenido de xor.data</para>
     <programlisting role="txt">
 <![CDATA[
 4 2 1

--- a/reference/gearman/gearmanworker/setid.xml
+++ b/reference/gearman/gearmanworker/setid.xml
@@ -58,7 +58,7 @@ $worker->setId('test');
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Run the following command:
+Ejecute el siguiente comando:
 gearadmin --workers
 
 Output:

--- a/reference/ibm_db2/setup.xml
+++ b/reference/ibm_db2/setup.xml
@@ -20,33 +20,33 @@
   <section xml:id="ibm-db2.requirements.unix">
    <title>Requisitos en Linux y Unix</title>
    <simpara>
-    The user invoking the PHP executable or SAPI must specify the DB2 instance
-    before accessing these functions. You can set the name of the DB2 instance
-    in &php.ini; using the <literal>ibm_db2.instance_name</literal>
-    configuration option, or you can source the DB2 instance profile before
-    invoking the PHP executable.
+    El usuario que invoca el ejecutable de PHP o el SAPI debe especificar la instancia
+    de DB2 antes de acceder a estas funciones. Se puede establecer el nombre de la instancia
+    de DB2 en &php.ini; utilizando la opción de configuración
+    <literal>ibm_db2.instance_name</literal>, o se puede cargar el perfil de la instancia
+    de DB2 antes de invocar el ejecutable de PHP.
    </simpara>
    <para>
-    If you created a DB2 instance named <literal>db2inst1</literal> in
-    <filename>/home/db2inst1/</filename>, for example, you can add the
-    following line to &php.ini;:
+    Si se ha creado una instancia de DB2 llamada <literal>db2inst1</literal> en
+    <filename>/home/db2inst1/</filename>, por ejemplo, se puede añadir la
+    siguiente línea a &php.ini;:
     <screen>
 <![CDATA[
 ibm_db2.instance_name=db2inst1
 ]]>
     </screen>
-    If you do not set this option in &php.ini;, you must issue the
-    following command to modify your environment variables to enable access to
+    Si no se establece esta opción en &php.ini;, se debe ejecutar el
+    siguiente comando para modificar las variables de entorno y habilitar el acceso a
     DB2:
     <screen>
 <![CDATA[
 bash$ source /home/db2inst1/sqllib/db2profile
 ]]>
     </screen>
-    To enable your PHP-enabled Web server to access these functions, you must
-    either set the <literal>ibm_db2.instance_name</literal> configuration
-    option in &php.ini;, or source the DB2 instance environment in your Web
-    server start script (typically <filename>/etc/init.d/httpd</filename> or
+    Para permitir que el servidor web con PHP acceda a estas funciones, se debe
+    establecer la opción de configuración <literal>ibm_db2.instance_name</literal>
+    en &php.ini;, o cargar el entorno de la instancia de DB2 en el script de inicio
+    del servidor web (típicamente <filename>/etc/init.d/httpd</filename> o
     <filename>/etc/init.d/apache</filename>).
    </para>
   </section>

--- a/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
@@ -24,7 +24,6 @@
   &reftitle.returnvalues;
   <para>
    Devuelve la opción "hedge" del ReadPreference.
-   Returns the ReadPreference&apos;s "hedge" option.
   </para>
  </refsect1>
 

--- a/reference/oauth/functions/oauth-urlencode.xml
+++ b/reference/oauth/functions/oauth-urlencode.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns an <link xlink:href="&url.rfc;3986">RFC 3986</link> encoded string.
+   Devuelve una cadena codificada según <link xlink:href="&url.rfc;3986">RFC 3986</link>.
   </simpara>
  </refsect1>
 

--- a/reference/rrd/rrdupdater/update.xml
+++ b/reference/rrd/rrdupdater/update.xml
@@ -56,7 +56,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   Throws a <classname>Exception</classname> on error.
+   Lanza una <classname>Exception</classname> en caso de error.
   </simpara>
  </refsect1>
 

--- a/reference/snmp/snmp/geterror.xml
+++ b/reference/snmp/snmp/geterror.xml
@@ -27,7 +27,6 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   String describing error from last SNMP request.
    String que describe el error de la última solicitud SNMP.
   </simpara>
  </refsect1>

--- a/reference/sodium/functions/sodium-crypto-core-ristretto255-from-hash.xml
+++ b/reference/sodium/functions/sodium-crypto-core-ristretto255-from-hash.xml
@@ -39,7 +39,6 @@
   &reftitle.returnvalues;
   <simpara>
    Devuelve una &string; aleatoria de 32 bytes.
-   Returns a 32-byte random &string;.
   </simpara>
  </refsect1>
 

--- a/reference/spl/callbackfilteriterator/construct.xml
+++ b/reference/spl/callbackfilteriterator/construct.xml
@@ -16,8 +16,7 @@
   </constructorsynopsis>
   <para>
    Crea un iterador filtrado usando <parameter>callback</parameter> (llamada de retorno)
-   Creates a filtered iterator using the <parameter>callback</parameter> para determinar
-   que elementos van a ser aceptados o rechazados.
+   para determinar qué elementos van a ser aceptados o rechazados.
   </para>
  </refsect1>
 

--- a/reference/spl/directoryiterator/next.xml
+++ b/reference/spl/directoryiterator/next.xml
@@ -36,7 +36,7 @@
    <example>
     <title>Ejemplo de <methodname>DirectoryIterator::next</methodname></title>
     <para>
-     List the contents of a directory using a while loop.
+     Lista el contenido de un directorio usando un bucle while.
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -151,7 +151,7 @@
       <term><constant>RegexIterator::SPLIT</constant></term>
       <listitem>
        <para>
-        Returns the split values for the current entry (see <function>preg_split</function>).
+        Devuelve los valores divididos de la entrada actual (véase <function>preg_split</function>).
        </para>
       </listitem>
      </varlistentry>
@@ -173,7 +173,7 @@
       <term><constant>RegexIterator::INVERT_MATCH</constant></term>
       <listitem>
        <para>
-        Inverts the return value of <methodname>RegexIterator::accept</methodname>.
+        Invierte el valor de retorno de <methodname>RegexIterator::accept</methodname>.
        </para>
       </listitem>
      </varlistentry>

--- a/reference/spl/regexiterator/setflags.xml
+++ b/reference/spl/regexiterator/setflags.xml
@@ -26,8 +26,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       Las flags a ser establecidas,
-       The flags to set, un bitmask de constantes de la clase.
+       Las flags a establecer, un bitmask de constantes de la clase.
       </para>
       <para>
        Las flags disponibles se enumeran a continuación. El verdadero

--- a/reference/spl/splfileobject/fpassthru.xml
+++ b/reference/spl/splfileobject/fpassthru.xml
@@ -19,8 +19,7 @@
   </para>
   <para>
    Puede que se necesite llamar a <methodname>SplFileObject::rewind</methodname>
-   You may need to call <methodname>SplFileObject::rewind</methodname> para reiniciar el
-   puntero del fichero al inicio de el fichero si se tiene datos escritos en el fichero.
+   para reiniciar el puntero del fichero al inicio del fichero si se tienen datos escritos en el fichero.
   </para>
  </refsect1>
 

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -71,24 +71,24 @@
       <row>
        <entry>8.2.0</entry>
        <entry>
-        The <methodname>SplFixedArray::__serialize</methodname> and
+        Se han añadido los métodos mágicos <methodname>SplFixedArray::__serialize</methodname> y
         <methodname>SplFixedArray::__unserialize</methodname>
-        magic methods have been added to <classname>SplFixedArray</classname>.
+        a <classname>SplFixedArray</classname>.
        </entry>
       </row>
       <row>
        <entry>8.1.0</entry>
        <entry>
-        <classname>SplFixedArray</classname> implements
-        <interfacename>JsonSerializable</interfacename> now.
+        <classname>SplFixedArray</classname> ahora implementa
+        <interfacename>JsonSerializable</interfacename>.
        </entry>
       </row>
       <row>
        <entry>8.0.0</entry>
        <entry>
-        <classname>SplFixedArray</classname> implements
-        <interfacename>IteratorAggregate</interfacename> now.
-        Previously, <interfacename>Iterator</interfacename> was implemented instead.
+        <classname>SplFixedArray</classname> ahora implementa
+        <interfacename>IteratorAggregate</interfacename>.
+        Anteriormente, se implementaba <interfacename>Iterator</interfacename> en su lugar.
        </entry>
       </row>
      </tbody>

--- a/reference/spl/splminheap/compare.xml
+++ b/reference/spl/splminheap/compare.xml
@@ -52,7 +52,7 @@
   <note>
    <para>
     No es recomendable tener múltiples elementos con el mismo valor en el montón.
-    Having multiple elements with the same value in a Heap is not recommended. Estos terminarán en una por sición arbitraria relativa.
+    Estos terminarán en una posición arbitraria relativa.
    </para>
   </note>
  </refsect1>

--- a/reference/tidy/tidy/parsefile.xml
+++ b/reference/tidy/tidy/parsefile.xml
@@ -92,10 +92,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <methodname>tidy::parseFile</methodname> returns &true; on success.
-   <function>tidy_parse_file</function> returns a new <classname>tidy</classname>
-   instance on success.
-   Both, the method and the function return &false; on failure.
+   <methodname>tidy::parseFile</methodname> devuelve &true; en caso de éxito.
+   <function>tidy_parse_file</function> devuelve una nueva instancia de <classname>tidy</classname>
+   en caso de éxito.
+   Tanto el método como la función devuelven &false; en caso de error.
   </para>
  </refsect1>
 

--- a/reference/wincache/functions/wincache-ucache-cas.xml
+++ b/reference/wincache/functions/wincache-ucache-cas.xml
@@ -50,8 +50,7 @@
      <term><parameter>new_value</parameter></term>
      <listitem>
       <para>
-       El nuevo valor que se asigna a una variable
-       New value which will get assigned to variable indicado por la <parameter>key</parameter> si se
+       El nuevo valor que se asignará a la variable indicada por la <parameter>key</parameter> si se
        encuentra una coincidencia. El valor debe ser de tipo <literal>long</literal>, en caso contrario
        la función devolverá &false;.
       </para>

--- a/reference/xmldiff/xmldiff-file/diff.xml
+++ b/reference/xmldiff/xmldiff-file/diff.xml
@@ -28,7 +28,7 @@
     <term><parameter>from</parameter></term>
     <listitem>
      <para>
-      Path to the source document.
+      Ruta al documento fuente.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xmlreader/xmlreader/readinnerxml.xml
+++ b/reference/xmlreader/xmlreader/readinnerxml.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the contents of the current node as a string. Empty string on failure.
+   Devuelve el contenido del nodo actual como una cadena de caracteres. Devuelve una cadena vacía en caso de error.
   </para>
  </refsect1>
 

--- a/reference/xmlrpc/functions/xmlrpc-set-type.xml
+++ b/reference/xmlrpc/functions/xmlrpc-set-type.xml
@@ -27,7 +27,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       Value to set the type
+       Valor para establecer el tipo
       </para>
      </listitem>
     </varlistentry>
@@ -47,14 +47,14 @@
   &reftitle.returnvalues;
   <para>
    &return.success;
-   If successful, <parameter>value</parameter> is converted to an object.
+   Si tiene éxito, <parameter>value</parameter> se convierte en un objeto.
   </para>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Issues E_WARNING with type unsupported by XMLRPC.
+   Emite un E_WARNING con un tipo no soportado por XMLRPC.
   </para>
  </refsect1>
 

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -305,8 +305,8 @@
    </term>
    <listitem>
     <simpara>
-     Open the file when added instead of waiting for archive to be closed.
-     Be aware of file descriptors consumption.
+     Abre el archivo cuando se añade en lugar de esperar a que se cierre el archivo comprimido.
+     Tenga en cuenta el consumo de descriptores de archivo.
      Disponible a partir de PHP 8.3.0 y PECL zip 1.22.1.
     </simpara>
    </listitem>

--- a/reference/zmq/zmq.xml
+++ b/reference/zmq/zmq.xml
@@ -413,8 +413,8 @@
      <varlistentry xml:id="zmq.constants.socket-xpub">
       <term><constant>ZMQ::SOCKET_XPUB</constant></term>
       <listitem>
-       <para>Similar to SOCKET_PUB, except you can receive subscriptions as messages.
-        The subscription message is 0 (unsubscribe) or 1 (subscribe) followed by the topic.</para>
+       <para>Similar a SOCKET_PUB, excepto que se pueden recibir suscripciones como mensajes.
+        El mensaje de suscripción es 0 (cancelar suscripción) o 1 (suscribirse) seguido del tema.</para>
       </listitem>
      </varlistentry>
 

--- a/reference/zmq/zmqdevice/setidlecallback.xml
+++ b/reference/zmq/zmqdevice/setidlecallback.xml
@@ -18,12 +18,6 @@
    <methodparam choice="opt"><type>mixed</type><parameter>user_data</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sets the idle callback function. If idle timeout is defined the idle callback function
-   shall be called if the internal poll loop times out without events. If the callback function
-   returns false or a value that evaluates to false the device is stopped.
-
-   The callback function signature is callback (mixed $user_data).
-
    Establece la función de retrollamada de inactividad. Si el tiempo de espera está definido, la función de retrollamada de inactividad
    será invocada si el bucle de sondeo interno expira sin eventos. Si la función de retrollamada
    devuelve false o un valor que se evalúa como false, el dispositivo se detendrá.

--- a/reference/zmq/zmqpoll/clear.xml
+++ b/reference/zmq/zmqpoll/clear.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the current object.
+   Devuelve el objeto actual.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/construct.xml
+++ b/reference/zmq/zmqsocket/construct.xml
@@ -85,7 +85,7 @@
    <example>
     <title>Un ejemplo de <function>ZMQSocket</function></title>
     <para>
-     Utilizar una callback the bind/connect socket
+     Utilizar una callback para bind/connect del socket
     </para>
     <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
Translate untranslated English prose across 34 files: migration80 appendices, language/, and various reference/ extensions (spl, zmq, fann, xmlrpc, etc.).