### PR TITLE
[ES] Sync get-charset: fix state desc, add set_charset, fix examples

### DIFF
--- a/reference/mysqli/mysqli/get-charset.xml
+++ b/reference/mysqli/mysqli/get-charset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: aa79a143fbe4d33a709e2e918f15b942ce06baa9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.get-charset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -95,7 +95,7 @@
      <term><parameter>state</parameter></term>
      <listitem>
       <para>
-       Estado del juego de caracteres
+       A partir de PHP 8.2.0, es siempre <literal>1</literal>
       </para>
      </listitem>
     </varlistentry>
@@ -113,7 +113,8 @@
 <?php
   $db = mysqli_init();
   $db->real_connect("localhost","root","","test");
-  var_dump(mysqli_get_charset($db));
+  $db->set_charset('latin1');
+  var_dump($db->get_charset());
 ?>
 ]]>
    </programlisting>
@@ -123,7 +124,8 @@
 <?php
   $db = mysqli_init();
   mysqli_real_connect($db, "localhost","root","","test");
-  var_dump($db->get_charset());
+  mysqli_set_charset($db, 'latin1');
+  var_dump(mysqli_get_charset($db));
 ?>
 ]]>
    </programlisting>
@@ -144,7 +146,7 @@ object(stdClass)#2 (7) {
   ["number"]=>
   int(8)
   ["state"]=>
-  int(801)
+  int(1)
 }
 ]]>
    </screen>


### PR DESCRIPTION
Fixes #399