### PR TITLE
Fix untranslated English text in files marked as ready

### DIFF
--- a/language-defs.ent
+++ b/language-defs.ent
@@ -78,7 +78,7 @@
 <!ENTITY InheritedMethods  "Métodos heredados">
 <!ENTITY InheritedProperties "Propiedades heredadas">
 <!ENTITY Properties        "Propiedades">
-<!ENTITY InheritedConstants "Constantaes heredadas constants">
+<!ENTITY InheritedConstants "Constantes heredadas">
 <!ENTITY Constants         "Constantes">
 <!ENTITY Constructor       "Constructor">
 <!ENTITY NotAvailable      "No Disponible">
@@ -88,7 +88,7 @@ supplemental files to mark section titles -->
 <!ENTITY reftitle.changelog    '<title xmlns="http://docbook.org/ns/docbook">&Changelog;</title>'>
 <!ENTITY reftitle.classes      '<title xmlns="http://docbook.org/ns/docbook">Clases predefinidas</title>'>
 <!ENTITY reftitle.classsynopsis '<title xmlns="http://docbook.org/ns/docbook">Sinopsis de la Clase</title>'>
-<!ENTITY reftitle.enumsynopsis '<title xmlns="http://docbook.org/ns/docbook">Enum synopsis</title>'>
+<!ENTITY reftitle.enumsynopsis '<title xmlns="http://docbook.org/ns/docbook">Sinopsis del Enum</title>'>
 <!ENTITY reftitle.constants    '<title xmlns="http://docbook.org/ns/docbook">Constantes predefinidas</title>'>
 <!ENTITY reftitle.constructor  '<title xmlns="http://docbook.org/ns/docbook">Constructor</title>'>
 <!ENTITY reftitle.description  '<title xmlns="http://docbook.org/ns/docbook">Descripción</title>'>

--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -148,7 +148,7 @@ $_ = some_command();
   <section xml:id="nodiscard.seealso">
    &reftitle.seealso;
    <simplelist>
-    <member><link linkend="language.attributes">Attributes overview</link></member>
+    <member><link linkend="language.attributes">Visión general de los atributos</link></member>
    </simplelist>
   </section>
 

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -41,7 +41,7 @@
   </listitem>
   <listitem>
    <simpara>
-    <function>strtotime</function> returns &false; si un número está fuera
+    <function>strtotime</function> devuelve &false; si un número está fuera
     del rango, y <function>DateTimeImmutable::__construct</function> lanza
     una excepción.
    </simpara>
@@ -126,7 +126,7 @@ object(DateTimeImmutable)#1 (3) {
   </listitem>
  </orderedlist>
 
- <!--Time Formats: {{{-->
+ <!--Time Formatos: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.time">
   <title>Formatos para los tiempos (Time)</title>
 
@@ -149,7 +149,7 @@ object(DateTimeImmutable)#1 (3) {
     <thead>
      <row>
       <entry>Descripción</entry>
-      <entry>Formats</entry>
+      <entry>Formatos</entry>
       <entry>Ejemplos</entry>
      </row>
     </thead>
@@ -290,7 +290,7 @@ object(DateTimeImmutable)#1 (3) {
  </sect1>
  <!--}}}-->
 
- <!--Date Formats: {{{-->
+ <!--Date Formatos: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.date">
   <title>Formatos de fechas</title>
 
@@ -383,7 +383,7 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <table>
-   <title>Formats estándar</title>
+   <title>Formatos estándar</title>
    <tgroup cols="2">
     <thead>
      <row>
@@ -659,9 +659,9 @@ object(DateTimeImmutable)#1 (3) {
  </sect1>
  <!--}}}-->
 
- <!--Compound Formats: {{{-->
+ <!--Compound Formatos: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.compound">
-  <title>Formats compuestos</title>
+  <title>Formatos compuestos</title>
 
   <para>
    Esta página describe los diferentes formatos en una sintaxis de tipo BNF que los analizadores de
@@ -682,7 +682,7 @@ object(DateTimeImmutable)#1 (3) {
     <thead>
      <row>
       <entry>Descripción</entry>
-      <entry>Formats</entry>
+      <entry>Formatos</entry>
       <entry>Ejemplos</entry>
      </row>
     </thead>
@@ -862,9 +862,9 @@ object(DateTimeImmutable)#1 (3) {
  </sect1>
  <!--}}}-->
 
- <!--Relative Formats: {{{-->
+ <!--Relative Formatos: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.relative">
-  <title>Formats relativos</title>
+  <title>Formatos relativos</title>
 
   <para>
    Esta página describe los diferentes formatos en una sintaxis de tipo BNF

--- a/reference/dom/dom/dom-attr.xml
+++ b/reference/dom/dom/dom-attr.xml
@@ -90,7 +90,7 @@
     </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Aún no documentado</classsynopsisinfo>
     <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
      <xi:fallback/>
     </xi:include>-->

--- a/reference/eio/book.xml
+++ b/reference/eio/book.xml
@@ -27,7 +27,7 @@
    </warning>
 
    <example>
-    <title>Incorrect requests</title>
+    <title>Peticiones incorrectas</title>
     <programlisting role="php"><![CDATA[
 <?php
 // Petición para crear un enlace simbólico de $nombre_archivo a $enlace

--- a/reference/filter/ini.xml
+++ b/reference/filter/ini.xml
@@ -63,8 +63,6 @@
       Por ejemplo, para configurar el filtro predeterminado para que se comporte exactamente igual que
       <function>htmlspecialchars</function> las flags por omisión deben establecerse a
       <literal>0</literal>, como se muestra a continuación.
-      <function>htmlspecialchars</function> the default flags must be set to
-      <literal>0</literal>, as shown in the example below.
      </simpara>
      <example>
       <title>Configurando el filtro predeterminado para actuar como htmlspecialchars</title>

--- a/reference/gmagick/gmagick/flipimage.xml
+++ b/reference/gmagick/gmagick/flipimage.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   The objeto <classname>Gmagick</classname> volteado.
+   El objeto <classname>Gmagick</classname> volteado.
   </simpara>
  </refsect1>
 

--- a/reference/gmagick/gmagick/flopimage.xml
+++ b/reference/gmagick/gmagick/flopimage.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   The objeto <classname>Gmagick</classname> volteado.
+   El objeto <classname>Gmagick</classname> volteado.
   </simpara>
  </refsect1>
 

--- a/reference/gmp/functions/gmp-div-q.xml
+++ b/reference/gmp/functions/gmp-div-q.xml
@@ -129,7 +129,7 @@ echo gmp_strval($div5) . "\n";
   &reftitle.notes;
   <note>
    <para>
-    This function can also be called as <function>gmp_div</function>.
+    Esta función también puede ser llamada como <function>gmp_div</function>.
    </para>
   </note>
  </refsect1>

--- a/reference/intl/collator/get-strength.xml
+++ b/reference/intl/collator/get-strength.xml
@@ -80,7 +80,7 @@ $strength = collator_get_strength( $coll );
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Constantes de <classname>Collator</classname></link></member>
     <member><function>collator_set_strength</function></member>
     <member><function>collator_get_attribute</function></member>
    </simplelist>

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -945,7 +945,6 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
          Si se especifica un documento vacío para el proveedor KMS <literal>"azure"</literal> o
          <literal>"gcp"</literal>, el controlador intentará configurar el proveedor utilizando
          <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">las credenciales automáticas</link>.
-         If an empty document is specified for the <literal>"azure"</literal> or
         </para>
        </entry>
       </row>

--- a/reference/spl/files.xml
+++ b/reference/spl/files.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: e93feee2870bb551cd11d625271b7f82da3ccb05 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <part xml:id="spl.files" xmlns="http://docbook.org/ns/docbook">
- <title>File Handling</title>
+ <title>Manejo de archivos</title>
 
  <partintro>
   <simpara>

--- a/reference/spl/invalidargumentexception.xml
+++ b/reference/spl/invalidargumentexception.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yago Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <reference xml:id="class.invalidargumentexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>The InvalidArgumentException class</title>
+ <title>La clase InvalidArgumentException</title>
  <titleabbrev>InvalidArgumentException</titleabbrev>
 
  <partintro>

--- a/reference/spl/seekableiterator.xml
+++ b/reference/spl/seekableiterator.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: yes Maintainer: seros -->
 <reference xml:id="class.seekableiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The SeekableIterator interface</title>
+ <title>La interfaz SeekableIterator</title>
  <titleabbrev>SeekableIterator</titleabbrev>
 
  <partintro>

--- a/reference/stomp/stomp/getsessionid.xml
+++ b/reference/stomp/stomp/getsessionid.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-    &string; session id on success&return.falseforfailure;.
+    El identificador de sesión como &string; en caso de éxito&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/yaz/functions/yaz-close.xml
+++ b/reference/yaz/functions/yaz-close.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.yaz-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>yaz_close</refname>
-  <refpurpose>Close YAZ connection</refpurpose>
+  <refpurpose>Cierra una conexión YAZ</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -14,7 +14,7 @@
  </para>
 
  <variablelist xml:id="ziparchive.constants.mode">
-  <title>Archive open modes</title>
+  <title>Modos de apertura de archivos</title>
   <varlistentry xml:id="ziparchive.constants.create">
    <term>
     <constant>ZipArchive::CREATE</constant>
@@ -79,7 +79,7 @@
  </variablelist>
 
  <variablelist xml:id="ziparchive.constants.afl">
-  <title>Archive global flags</title>
+  <title>Flags globales del archivo</title>
   <varlistentry xml:id="ziparchive.constants.afl-rdonly">
    <term>
     <constant>ZipArchive::AFL_RDONLY</constant>
@@ -135,7 +135,7 @@
  </variablelist>
 
  <variablelist xml:id="ziparchive.constants.fl">
-  <title>Archive flags</title>
+  <title>Flags del archivo</title>
   <varlistentry xml:id="ziparchive.constants.fl-nocase">
    <term>
     <constant>ZipArchive::FL_NOCASE</constant>
@@ -189,8 +189,8 @@
     <simpara>
      Forzar la recompresión de los datos.
      Disponible a partir de PHP 8.0.0 y PECL zip 1.18.0.
-     Deprecated as of PHP 8.3.0 and PECL zip 1.22.1,
-     will be removed in a future version of libzip.
+     Obsoleto a partir de PHP 8.3.0 y PECL zip 1.22.1,
+     será eliminado en una futura versión de libzip.
     </simpara>
    </listitem>
   </varlistentry>
@@ -314,7 +314,7 @@
  </variablelist>
 
  <variablelist xml:id="ziparchive.constants.cm">
-  <title>Compression modes</title>
+  <title>Modos de compresión</title>
   <varlistentry xml:id="ziparchive.constants.cm-default">
    <term>
     <constant>ZipArchive::CM_DEFAULT</constant>
@@ -536,7 +536,7 @@
  </variablelist>
 
  <variablelist xml:id="ziparchive.constants.er">
-  <title>Errors</title>
+  <title>Errores</title>
   <varlistentry xml:id="ziparchive.constants.er-ok">
    <term>
     <constant>ZipArchive::ER_OK</constant>
@@ -912,7 +912,7 @@
    </term>
    <listitem>
     <simpara>
-     Operation cancelled.
+     Operación cancelada.
      Disponible a partir de PHP 7.4.3 y PECL zip 1.16.1, respectivamente,
      si se compila con libzip ≥ 1.6.0.
     </simpara>
@@ -959,7 +959,7 @@
   </varlistentry>
  </variablelist>
  <variablelist xml:id="ziparchive.constants.em">
-  <title>Encryption modes</title>
+  <title>Modos de cifrado</title>
   <varlistentry xml:id="ziparchive.constants.em-none">
    <term>
     <constant>ZipArchive::EM_NONE</constant>
@@ -1032,7 +1032,7 @@
  </variablelist>
 
  <variablelist xml:id="ziparchive.constants.length">
-  <title>Length parameter constants</title>
+  <title>Constantes de parámetro de longitud</title>
   <varlistentry xml:id="ziparchive.constants.length-to-end">
    <term>
     <constant>ZipArchive::LENGTH_TO_END</constant>
@@ -1040,7 +1040,7 @@
    </term>
    <listitem>
     <simpara>
-     Use file size, if the file grows additional data is ignored, if the file shrinks an error is raised (<constant>ZipArchive::ER_DATA_LENGTH</constant>).
+     Usa el tamaño del archivo; si el archivo crece, los datos adicionales se ignoran; si el archivo se reduce, se genera un error (<constant>ZipArchive::ER_DATA_LENGTH</constant>).
      Disponible a partir de PHP 8.3.0 y PECL zip 1.22.2.
     </simpara>
    </listitem>
@@ -1052,7 +1052,7 @@
    </term>
    <listitem>
     <simpara>
-     Use all available data.
+     Usa todos los datos disponibles.
      Disponible a partir de PHP 8.3.0 y PECL zip 1.22.2, si se compila con libzip ≥ 1.10.1.
     </simpara>
    </listitem>
@@ -1060,7 +1060,7 @@
  </variablelist>
 
  <variablelist xml:id="ziparchive.constants.other">
-  <title>Other constants</title>
+  <title>Otras constantes</title>
   <varlistentry xml:id="ziparchive.constants.libzip-version">
    <term>
     <constant>ZipArchive::LIBZIP_VERSION</constant>

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -92,8 +92,8 @@
          <literal>"comp_method"</literal>
         </para>
         <para>
-         Compression method, one of the <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>
-         constants, see <link linkend="zip.constants">ZIP constants</link> page.
+         Método de compresión, una de las constantes <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>,
+         ver la página de <link linkend="zip.constants">constantes ZIP</link>.
         </para>
        </listitem>
        <listitem>
@@ -101,7 +101,7 @@
          <literal>"comp_flags"</literal>
         </para>
         <para>
-         Compression level.
+         Nivel de compresión.
         </para>
        </listitem>
        <listitem>
@@ -109,8 +109,8 @@
          <literal>"enc_method"</literal>
         </para>
         <para>
-         Encryption method, one of the <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>
-         constants, see <link linkend="zip.constants">ZIP constants</link> page.
+         Método de cifrado, una de las constantes <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>,
+         ver la página de <link linkend="zip.constants">constantes ZIP</link>.
         </para>
        </listitem>
        <listitem>
@@ -118,7 +118,7 @@
          <literal>"enc_password"</literal>
         </para>
         <para>
-         Password used for encryption.
+         Contraseña utilizada para el cifrado.
         </para>
        </listitem>
       </itemizedlist>
@@ -131,7 +131,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An <type>array</type> of added files on success &return.falseforfailure;
+   Un <type>array</type> de archivos añadidos en caso de éxito &return.falseforfailure;
   </para>
  </refsect1>
 
@@ -150,21 +150,21 @@
       <row>
        <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
-        <literal>"flags"</literal> in <parameter>options</parameter> was added.
+        Se añadió <literal>"flags"</literal> en <parameter>options</parameter>.
        </entry>
       </row>
       <row>
        <entry>8.0.0, PECL zip 1.18.1</entry>
        <entry>
-        <literal>"comp_method"</literal>, <literal>"comp_flags"</literal>,
-        <literal>"enc_method"</literal> and <literal>"enc_password"</literal> in
-        <parameter>options</parameter> were added.
+        Se añadieron <literal>"comp_method"</literal>, <literal>"comp_flags"</literal>,
+        <literal>"enc_method"</literal> y <literal>"enc_password"</literal> en
+        <parameter>options</parameter>.
        </entry>
       </row>
       <row>
        <entry>8.3.0, PECL zip 1.22.1</entry>
        <entry>
-        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant> was added.
+        Se añadió <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        </entry>
       </row>
      </tbody>

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -434,7 +434,7 @@
      <varlistentry xml:id="zookeeper.constants.perm-all">
       <term><constant>Zookeeper::PERM_ALL</constant></term>
       <listitem>
-       <para>Todas las flags anteriores ORd together</para>
+       <para>Todas las flags anteriores combinadas con OR</para>
       </listitem>
      </varlistentry>
 
@@ -444,7 +444,7 @@
 
 <!-- {{{ Constants Create Flags -->
    <section xml:id="zookeeper.constants.create-flags">
-    <title><acronym>ZooKeeper</acronym> Create Flags</title>
+    <title>Flags de creación de <acronym>ZooKeeper</acronym></title>
     <variablelist>
 
      <varlistentry xml:id="zookeeper.constants.ephemeral">
@@ -465,7 +465,7 @@
 
 <!-- {{{ Constants Log Levels -->
    <section xml:id="zookeeper.constants.log-levels">
-    <title><acronym>ZooKeeper</acronym> Log Levels</title>
+    <title>Niveles de log de <acronym>ZooKeeper</acronym></title>
     <variablelist>
 
      <varlistentry xml:id="zookeeper.constants.log-level-error">
@@ -499,7 +499,7 @@
 
 <!-- {{{ Constants States -->
    <section xml:id="zookeeper.constants.states">
-    <title><acronym>ZooKeeper</acronym> States</title>
+    <title>Estados de <acronym>ZooKeeper</acronym></title>
     <variablelist>
 
      <varlistentry xml:id="zookeeper.constants.expired-session-state">


### PR DESCRIPTION
Translate remaining English text found across 19 files marked as `Status: ready`.

Fixes https://github.com/php/doc-es/issues/299