### PR TITLE
Sync ob_end_clean EN-Revision hash

### DIFF
--- a/reference/outcontrol/functions/ob-end-clean.xml
+++ b/reference/outcontrol/functions/ob-end-clean.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86b976d5afaf037868174fe5c242e886eb69baa4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5778b68049cc01810523b09b028398c70115cd56 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-end-clean">


### PR DESCRIPTION
The EN source fixed a typo (`it's` → `its`) in php/doc-en#5449. The Spanish translation already uses the correct phrasing ("ignora su valor de retorno"), so only the EN-Revision hash needs updating.

Fixes #455