### PR TITLE
Sync enums with EN stubs

### DIFF
--- a/reference/math/roundingmode.xml
+++ b/reference/math/roundingmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 15b93836d93f01ea6d90a68cacf04ce0d9fb8eff Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.roundingmode" role="enum">
  <title>La enumeración RoundingMode</title>
@@ -84,7 +84,6 @@
       Redondear al integer más pequeño más grande o igual.
      </enumitemdescription>
     </enumitem>
-
    </enumsynopsis>
   </section>
  </partintro>

--- a/reference/pcntl/pcntl.qosclass.xml
+++ b/reference/pcntl/pcntl.qosclass.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9cab7d56f91b2fd9b549eaabcbf77f7d66e36f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.pcntl-qosclass" role="enum">
  <title>La enumeración Pcntl\QosClass</title>
@@ -16,37 +16,46 @@
 
   <section xml:id="enum.pcntl-qosclass.synopsis">
    &reftitle.enumsynopsis;
-   <enumsynopsis>
-    <enumname>Pcntl\QosClass</enumname>
+   <packagesynopsis>
+    <package>Pcntl</package>
 
-    <enumitem>
-     <enumidentifier>Background</enumidentifier>
-     <enumitemdescription>
-      Inicia el proceso después de que todos los procesos de alta prioridad hayan terminado.
-     </enumitemdescription>
-    </enumitem>
+    <enumsynopsis>
+     <enumname>QosClass</enumname>
 
-    <enumitem>
-     <enumidentifier>Default</enumidentifier>
-     <enumitemdescription>
-      Inicia el proceso después de todos los procesos de alta prioridad pero antes que los procesos de baja prioridad.
-     </enumitemdescription>
-    </enumitem>
-
-    <enumitem>
-     <enumidentifier>UserInteractive</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>UserInteractive</enumidentifier>
+      <enumitemdescription>
       Inicia el proceso con la prioridad más alta.
      </enumitemdescription>
-    </enumitem>
+     </enumitem>
 
-    <enumitem>
-     <enumidentifier>UserInitiated</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>UserInitiated</enumidentifier>
+      <enumitemdescription>
       Inicia el proceso con una prioridad alta pero inferior a UserInteractive.
      </enumitemdescription>
-    </enumitem>
-  </enumsynopsis>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Default</enumidentifier>
+      <enumitemdescription>
+      Inicia el proceso después de todos los procesos de alta prioridad pero antes que los procesos de baja prioridad.
+     </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Utility</enumidentifier>
+      <enumitemdescription>Pcntl\QosClass::Utility description</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Background</enumidentifier>
+      <enumitemdescription>
+      Inicia el proceso después de que todos los procesos de alta prioridad hayan terminado.
+     </enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
   </section>
  </partintro>
 </reference>

--- a/reference/random/random.intervalboundary.xml
+++ b/reference/random/random.intervalboundary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 594f83cb7aff5d87d52426e68691c1fa06963b1d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.random-intervalboundary" role="enum">
  <title>La enumeración Random\IntervalBoundary</title>
@@ -18,44 +18,47 @@
   <section xml:id="enum.random-intervalboundary.synopsis">
    &reftitle.enumsynopsis;
 
-   <enumsynopsis>
-    <enumname>Random\IntervalBoundary</enumname>
+   <packagesynopsis>
+    <package>Random</package>
 
-    <enumitem>
-     <enumidentifier>ClosedOpen</enumidentifier>
-     <enumitemdescription>
+    <enumsynopsis>
+     <enumname>IntervalBoundary</enumname>
+
+     <enumitem>
+      <enumidentifier>ClosedOpen</enumidentifier>
+      <enumitemdescription>
       Un intervalo cerrado a la derecha.
       El límite inferior está incluido en el intervalo,
       el límite superior no lo está.
      </enumitemdescription>
-    </enumitem>
+     </enumitem>
 
-    <enumitem>
-     <enumidentifier>ClosedClosed</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>ClosedClosed</enumidentifier>
+      <enumitemdescription>
       Un intervalo cerrado.
       Ambos valores límite están incluidos en el intervalo.
      </enumitemdescription>
-    </enumitem>
+     </enumitem>
 
-    <enumitem>
-     <enumidentifier>OpenClosed</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>OpenClosed</enumidentifier>
+      <enumitemdescription>
       Un intervalo cerrado a la izquierda.
       El límite superior está incluido en el intervalo,
       el límite inferior no lo está.
      </enumitemdescription>
-    </enumitem>
+     </enumitem>
 
-    <enumitem>
-     <enumidentifier>OpenOpen</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>OpenOpen</enumidentifier>
+      <enumitemdescription>
       Un intervalo abierto.
       Ninguno de los valores límite está incluido en el intervalo.
      </enumitemdescription>
-    </enumitem>
-
-   </enumsynopsis>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
   </section>
  </partintro>
 </reference>

--- a/reference/reflection/propertyhooktype.xml
+++ b/reference/reflection/propertyhooktype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0cc604f2db478345bff5ade4e191111d5cbfbd90 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.propertyhooktype" role="enum">
  <title>La enumeración PropertyHookType</title>
@@ -22,6 +22,7 @@
 
     <enumitem>
      <enumidentifier>Get</enumidentifier>
+     <enumvalue>'get'</enumvalue>
      <enumitemdescription>
       Indica un hook <literal>get</literal>.
      </enumitemdescription>
@@ -29,6 +30,7 @@
 
     <enumitem>
      <enumidentifier>Set</enumidentifier>
+     <enumvalue>'set'</enumvalue>
      <enumitemdescription>
       Indica un hook <literal>set</literal>.
      </enumitemdescription>


### PR DESCRIPTION
Syncs the following enum documentation files with php/doc-en#5443:

- `reference/math/roundingmode.xml` — remove extra blank line before closing tag
- `reference/pcntl/pcntl.qosclass.xml` — add `<packagesynopsis>`, reorder items (UserInteractive, UserInitiated, Default, Utility, Background), add new `Utility` case
- `reference/random/random.intervalboundary.xml` — add `<packagesynopsis>` wrapper
- `reference/reflection/propertyhooktype.xml` — add `<enumvalue>` for Get and Set cases

Fixes #456