### PR TITLE
Sync GD image functions return types (bool → true)

### DIFF
--- a/reference/image/functions/imagechar.xml
+++ b/reference/image/functions/imagechar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.imagechar" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagechar</methodname>
+   <type>true</type><methodname>imagechar</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecharup.xml
+++ b/reference/image/functions/imagecharup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.imagecharup" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecharup</methodname>
+   <type>true</type><methodname>imagecharup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -66,7 +66,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecolordeallocate.xml
+++ b/reference/image/functions/imagecolordeallocate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagecolordeallocate" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecolordeallocate</methodname>
+   <type>true</type><methodname>imagecolordeallocate</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
   </methodsynopsis>
@@ -41,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecolormatch.xml
+++ b/reference/image/functions/imagecolormatch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.imagecolormatch" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecolormatch</methodname>
+   <type>true</type><methodname>imagecolormatch</methodname>
    <methodparam><type>GdImage</type><parameter>image1</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>image2</parameter></methodparam>
   </methodsynopsis>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecopy.xml
+++ b/reference/image/functions/imagecopy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagecopy" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopy</methodname>
+   <type>true</type><methodname>imagecopy</methodname>
      <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
      <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
      <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -95,7 +95,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecopymerge.xml
+++ b/reference/image/functions/imagecopymerge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagecopymerge" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopymerge</methodname>
+   <type>true</type><methodname>imagecopymerge</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -114,7 +114,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagecopymergegray" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopymergegray</methodname>
+   <type>true</type><methodname>imagecopymergegray</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -120,7 +120,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagecopyresampled" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopyresampled</methodname>
+   <type>true</type><methodname>imagecopyresampled</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -132,7 +131,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecopyresized.xml
+++ b/reference/image/functions/imagecopyresized.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.imagecopyresized" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopyresized</methodname>
+   <type>true</type><methodname>imagecopyresized</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -132,7 +131,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagedashedline" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagedashedline</methodname>
+   <type>true</type><methodname>imagedashedline</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -76,7 +76,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagedestroy.xml
+++ b/reference/image/functions/imagedestroy.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 02477ebd441452d6ae057ea63464020e45d88823 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.imagedestroy" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,7 +13,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier role="attribute">#[\Deprecated]</modifier>
-   <type>bool</type><methodname>imagedestroy</methodname>
+   <type>true</type><methodname>imagedestroy</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
   </methodsynopsis>
   &note.resource-migration-8.0-dead-function;
@@ -36,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imageellipse.xml
+++ b/reference/image/functions/imageellipse.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imageellipse" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageellipse</methodname>
+   <type>true</type><methodname>imageellipse</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -74,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagefill.xml
+++ b/reference/image/functions/imagefill.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagefill" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefill</methodname>
+   <type>true</type><methodname>imagefill</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagefilledarc.xml
+++ b/reference/image/functions/imagefilledarc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagefilledarc" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledarc</methodname>
+   <type>true</type><methodname>imagefilledarc</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -118,7 +118,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagefilledellipse.xml
+++ b/reference/image/functions/imagefilledellipse.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagefilledellipse" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledellipse</methodname>
+   <type>true</type><methodname>imagefilledellipse</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -74,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagefilledrectangle.xml
+++ b/reference/image/functions/imagefilledrectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagefilledrectangle" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledrectangle</methodname>
+   <type>true</type><methodname>imagefilledrectangle</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -76,7 +76,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagefilltoborder.xml
+++ b/reference/image/functions/imagefilltoborder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagefilltoborder" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilltoborder</methodname>
+   <type>true</type><methodname>imagefilltoborder</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -68,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imageflip.xml
+++ b/reference/image/functions/imageflip.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.imageflip" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageflip</methodname>
+   <type>true</type><methodname>imageflip</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagegammacorrect.xml
+++ b/reference/image/functions/imagegammacorrect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.imagegammacorrect" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagegammacorrect</methodname>
+   <type>true</type><methodname>imagegammacorrect</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>float</type><parameter>input_gamma</parameter></methodparam>
    <methodparam><type>float</type><parameter>output_gamma</parameter></methodparam>
@@ -47,7 +47,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagelayereffect.xml
+++ b/reference/image/functions/imagelayereffect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagelayereffect" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagelayereffect</methodname>
+   <type>true</type><methodname>imagelayereffect</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>effect</parameter></methodparam>
   </methodsynopsis>
@@ -84,7 +84,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imageline.xml
+++ b/reference/image/functions/imageline.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imageline" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageline</methodname>
+   <type>true</type><methodname>imageline</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -74,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagerectangle" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagerectangle</methodname>
+   <type>true</type><methodname>imagerectangle</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -76,7 +76,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imageresolution.xml
+++ b/reference/image/functions/imageresolution.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b90054e3ebc5332d7dbe510d4d9010dff32c66f7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imageresolution" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +10,7 @@
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>array</type><type>bool</type></type><methodname>imageresolution</methodname>
+   <type class="union"><type>array</type><type>true</type></type><methodname>imageresolution</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>resolution_x</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>resolution_y</parameter><initializer>&null;</initializer></methodparam>
@@ -60,9 +59,8 @@
   <para>
    Cuando se utiliza como recuperador,
    esto devuelve un array indexado con las resoluciones horizontal y
-   vertical en caso de éxito, &return.falseforfailure;.
-   Cuando se utiliza como definidor,
-   esto devuelve &true; en caso de éxito, &return.falseforfailure;.
+   vertical en caso de éxito.
+   Cuando se utiliza como definidor, siempre devuelve &true;.
   </para>
  </refsect1><!-- }}} -->
 

--- a/reference/image/functions/imagesavealpha.xml
+++ b/reference/image/functions/imagesavealpha.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.imagesavealpha" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesavealpha</methodname>
+   <type>true</type><methodname>imagesavealpha</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagesetbrush" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetbrush</methodname>
+   <type>true</type><methodname>imagesetbrush</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>brush</parameter></methodparam>
   </methodsynopsis>
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagesetclip.xml
+++ b/reference/image/functions/imagesetclip.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7f99d5e488d161ce3b12d1dae405a283728933c3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagesetclip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +10,7 @@
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetclip</methodname>
+   <type>true</type><methodname>imagesetclip</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -66,7 +65,7 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1><!-- }}} -->
 

--- a/reference/image/functions/imagesetpixel.xml
+++ b/reference/image/functions/imagesetpixel.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ee0403b08276f179965318623980378033d34d72 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagesetpixel" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetpixel</methodname>
+   <type>true</type><methodname>imagesetpixel</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -56,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagesetthickness.xml
+++ b/reference/image/functions/imagesetthickness.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagesetthickness" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetthickness</methodname>
+   <type>true</type><methodname>imagesetthickness</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>thickness</parameter></methodparam>
   </methodsynopsis>
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagesettile.xml
+++ b/reference/image/functions/imagesettile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.imagesettile" xmlns="http://docbook.org/ns/docbook">
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesettile</methodname>
+   <type>true</type><methodname>imagesettile</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>tile</parameter></methodparam>
   </methodsynopsis>
@@ -58,7 +58,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagestring.xml
+++ b/reference/image/functions/imagestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.imagestring" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagestring</methodname>
+   <type>true</type><methodname>imagestring</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -65,7 +65,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagestringup.xml
+++ b/reference/image/functions/imagestringup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.imagestringup" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagestringup</methodname>
+   <type>true</type><methodname>imagestringup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -67,7 +67,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 


### PR DESCRIPTION
Syncs 31 GD image function files with php/doc-en. The EN source changed the return type from `bool` to `true` for functions that now always return `true` (they throw on error instead of returning `false`).

Changes:
- Return type: `<type>bool</type>` → `<type>true</type>`
- Return values: `&return.success;` → `&return.true.always;`
- Special case: `imageresolution.xml` has union type `array|bool` → `array|true`