### PR TITLE
Sync random extension with packagesynopsis structure

### DIFF
--- a/reference/random/random.brokenrandomengineerror.xml
+++ b/reference/random/random.brokenrandomengineerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-brokenrandomengineerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Random\BrokenRandomEngineError</title>
@@ -20,29 +20,33 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooexception>
-     <exceptionname>Random\BrokenRandomEngineError</exceptionname>
-    </ooexception>
+   <packagesynopsis>
+    <package>Random</package>
 
-    <ooclass>
-     <modifier>extends</modifier>
-     <classname>Random\RandomError</classname>
-    </ooclass>
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>BrokenRandomEngineError</exceptionname>
+     </ooexception>
 
-    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Random\RandomError</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.cryptosafeengine.xml
+++ b/reference/random/random.cryptosafeengine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-cryptosafeengine" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La interfaz Random\CryptoSafeEngine</title>
@@ -20,21 +20,25 @@
    &reftitle.interfacesynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="interface">
-    <oointerface>
-     <interfacename>Random\CryptoSafeEngine</interfacename>
-    </oointerface>
+   <packagesynopsis>
+    <package>Random</package>
 
-    <oointerface>
-     <modifier>extends</modifier>
-     <interfacename>Random\Engine</interfacename>
-    </oointerface>
+    <classsynopsis class="interface">
+     <oointerface>
+      <interfacename>CryptoSafeEngine</interfacename>
+     </oointerface>
 
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <oointerface>
+      <modifier>extends</modifier>
+      <interfacename>Random\Engine</interfacename>
+     </oointerface>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.engine.mt19937.xml
+++ b/reference/random/random.engine.mt19937.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-engine-mt19937" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Random\Engine\Mt19937</title>
@@ -20,25 +20,29 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>Random\Engine\Mt19937</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>Random\Engine</package>
 
-    <oointerface>
-     <modifier>implements</modifier>
-     <interfacename>Random\Engine</interfacename>
-    </oointerface>
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Mt19937</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Mt19937'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Mt19937'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <oointerface>
+      <modifier>implements</modifier>
+      <interfacename>Random\Engine</interfacename>
+     </oointerface>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Mt19937'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Mt19937'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.engine.pcgoneseq128xslrr64.xml
+++ b/reference/random/random.engine.pcgoneseq128xslrr64.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-engine-pcgoneseq128xslrr64" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Random\Engine\PcgOneseq128XslRr64</title>
@@ -21,25 +21,29 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>Random\Engine\PcgOneseq128XslRr64</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>Random\Engine</package>
 
-    <oointerface>
-     <modifier>implements</modifier>
-     <interfacename>Random\Engine</interfacename>
-    </oointerface>
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>PcgOneseq128XslRr64</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <oointerface>
+      <modifier>implements</modifier>
+      <interfacename>Random\Engine</interfacename>
+     </oointerface>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.engine.secure.xml
+++ b/reference/random/random.engine.secure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-engine-secure" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Random\Engine\Secure</title>
@@ -29,22 +29,26 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>Random\Engine\Secure</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>Random\Engine</package>
 
-    <oointerface>
-     <modifier>implements</modifier>
-     <interfacename>Random\CryptoSafeEngine</interfacename>
-    </oointerface>
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Secure</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-secure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Secure'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <oointerface>
+      <modifier>implements</modifier>
+      <interfacename>Random\CryptoSafeEngine</interfacename>
+     </oointerface>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-secure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Secure'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.engine.xml
+++ b/reference/random/random.engine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-engine" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La interfaz Random\Engine</title>
@@ -34,16 +34,20 @@
    &reftitle.interfacesynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="interface">
-    <oointerface>
-     <interfacename>Random\Engine</interfacename>
-    </oointerface>
+   <packagesynopsis>
+    <package>Random</package>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+    <classsynopsis class="interface">
+     <oointerface>
+      <interfacename>Engine</interfacename>
+     </oointerface>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.engine.xoshiro256starstar.xml
+++ b/reference/random/random.engine.xoshiro256starstar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-engine-xoshiro256starstar" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Random\Engine\Xoshiro256StarStar</title>
@@ -20,25 +20,29 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>Random\Engine\Xoshiro256StarStar</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>Random\Engine</package>
 
-    <oointerface>
-     <modifier>implements</modifier>
-     <interfacename>Random\Engine</interfacename>
-    </oointerface>
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Xoshiro256StarStar</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <oointerface>
+      <modifier>implements</modifier>
+      <interfacename>Random\Engine</interfacename>
+     </oointerface>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.randomerror.xml
+++ b/reference/random/random.randomerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-randomerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Random\RandomError</title>
@@ -20,29 +20,33 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooexception>
-     <exceptionname>Random\RandomError</exceptionname>
-    </ooexception>
+   <packagesynopsis>
+    <package>Random</package>
 
-    <ooclass>
-     <modifier>extends</modifier>
-     <classname>Error</classname>
-    </ooclass>
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>RandomError</exceptionname>
+     </ooexception>
 
-    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Error</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.randomexception.xml
+++ b/reference/random/random.randomexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-randomexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Random\RandomException</title>
@@ -20,29 +20,33 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooexception>
-     <exceptionname>Random\RandomException</exceptionname>
-    </ooexception>
+   <packagesynopsis>
+    <package>Random</package>
 
-    <ooclass>
-     <modifier>extends</modifier>
-     <classname>Exception</classname>
-    </ooclass>
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>RandomException</exceptionname>
+     </ooexception>
 
-    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Exception</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>

--- a/reference/random/random.randomizer.xml
+++ b/reference/random/random.randomizer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c8e3b2ccadcf79d3c9d53c532ca02572b02f741d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.random-randomizer" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Random\Randomizer</title>
@@ -20,28 +20,32 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>Random\Randomizer</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>Random</package>
 
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>readonly</modifier>
-     <type>Random\Engine</type>
-     <varname linkend="random-randomizer.props.engine">engine</varname>
-    </fieldsynopsis>
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Randomizer</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Randomizer'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Randomizer'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>readonly</modifier>
+      <type>Random\Engine</type>
+      <varname linkend="random-randomizer.props.engine">engine</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Randomizer'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Randomizer'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
 <!-- }}} -->
 
   </section>


### PR DESCRIPTION
Syncs 10 random extension files with the new `<packagesynopsis>` DocBook pattern from php/doc-en.

Changes:
- `<classsynopsis>` wrapped in `<packagesynopsis>` with `<package>Random</package>` or `<package>Random\Engine</package>`
- Class names shortened (e.g. `Random\Randomizer` → `Randomizer`)