### PR TITLE
Sync PDO and PgSql with packagesynopsis structure

### DIFF
--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 379d23588def29a360fca16d5daec6c659e13509 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdo-dblib" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Pdo\Dblib</title>
@@ -20,69 +20,77 @@
   <section xml:id="pdo-dblib.synopsis">
    &reftitle.classsynopsis;
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <classname>Pdo\Dblib</classname>
-    </ooclass>
-    <ooclass>
-     <modifier>extends</modifier>
-     <classname>PDO</classname>
-    </ooclass>
-    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-dblib.constants.attr-connection-timeout">Pdo\Dblib::ATTR_CONNECTION_TIMEOUT</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-dblib.constants.attr-query-timeout">Pdo\Dblib::ATTR_QUERY_TIMEOUT</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-dblib.constants.attr-stringify-uniqueidentifier">Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-dblib.constants.attr-version">Pdo\Dblib::ATTR_VERSION</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-dblib.constants.attr-tds-version">Pdo\Dblib::ATTR_TDS_VERSION</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-dblib.constants.attr-skip-empty-rowsets">Pdo\Dblib::ATTR_SKIP_EMPTY_ROWSETS</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-dblib.constants.attr-datetime-convert">Pdo\Dblib::ATTR_DATETIME_CONVERT</varname>
-    </fieldsynopsis>
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>Pdo</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <classname>Dblib</classname>
+     </ooclass>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>PDO</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-connection-timeout">Pdo\Dblib::ATTR_CONNECTION_TIMEOUT</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-query-timeout">Pdo\Dblib::ATTR_QUERY_TIMEOUT</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-stringify-uniqueidentifier">Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-version">Pdo\Dblib::ATTR_VERSION</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-tds-version">Pdo\Dblib::ATTR_TDS_VERSION</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-skip-empty-rowsets">Pdo\Dblib::ATTR_SKIP_EMPTY_ROWSETS</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-datetime-convert">Pdo\Dblib::ATTR_DATETIME_CONVERT</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pdo_firebird/pdo-firebird.xml
+++ b/reference/pdo_firebird/pdo-firebird.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bac0ba3a4628caa32dbf5750e0f142743f8e7011 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdo-firebird" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Pdo\Firebird</title>
@@ -20,84 +20,88 @@
   <section xml:id="pdo-firebird.synopsis">
    &reftitle.classsynopsis;
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <classname>Pdo\Firebird</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>Pdo</package>
 
-    <ooclass>
-     <modifier>extends</modifier>
-     <classname>PDO</classname>
-    </ooclass>
+    <classsynopsis class="class">
+     <ooclass>
+      <classname>Firebird</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>PDO</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-firebird.constants.attr-date-format">Pdo\Firebird::ATTR_DATE_FORMAT</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-firebird.constants.attr-time-format">Pdo\Firebird::ATTR_TIME_FORMAT</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-firebird.constants.attr-timestamp-format">Pdo\Firebird::ATTR_TIMESTAMP_FORMAT</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-firebird.constants.transaction-isolation-level">Pdo\Firebird::TRANSACTION_ISOLATION_LEVEL</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-firebird.constants.read-committed">Pdo\Firebird::READ_COMMITTED</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-firebird.constants.repeatable-read">Pdo\Firebird::REPEATABLE_READ</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-firebird.constants.serializable">Pdo\Firebird::SERIALIZABLE</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-firebird.constants.writable-transaction">Pdo\Firebird::WRITABLE_TRANSACTION</varname>
-    </fieldsynopsis>
+     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+      <xi:fallback/>
+     </xi:include>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-firebird')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Firebird'])">
-     <xi:fallback/>
-    </xi:include>
+     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-firebird.constants.attr-date-format">Pdo\Firebird::ATTR_DATE_FORMAT</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-firebird.constants.attr-time-format">Pdo\Firebird::ATTR_TIME_FORMAT</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-firebird.constants.attr-timestamp-format">Pdo\Firebird::ATTR_TIMESTAMP_FORMAT</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-firebird.constants.transaction-isolation-level">Pdo\Firebird::TRANSACTION_ISOLATION_LEVEL</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-firebird.constants.read-committed">Pdo\Firebird::READ_COMMITTED</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-firebird.constants.repeatable-read">Pdo\Firebird::REPEATABLE_READ</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-firebird.constants.serializable">Pdo\Firebird::SERIALIZABLE</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-firebird.constants.writable-transaction">Pdo\Firebird::WRITABLE_TRANSACTION</varname>
+     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-firebird')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Firebird'])">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pdo_mysql/pdo-mysql.xml
+++ b/reference/pdo_mysql/pdo-mysql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b2a7a5fab7231fa8634096f111ae0fa0dc60bcfe Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdo-mysql" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Pdo\Mysql</title>

--- a/reference/pdo_odbc/pdo-odbc.xml
+++ b/reference/pdo_odbc/pdo-odbc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 220e1d0ef80ba8f68254db56ee9f2203be4cd8e6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdo-odbc" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Pdo\Odbc</title>
@@ -21,61 +21,65 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <classname>Pdo\Odbc</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>Pdo</package>
 
-    <ooclass>
-     <modifier>extends</modifier>
-     <classname>PDO</classname>
-    </ooclass>
+    <classsynopsis class="class">
+     <ooclass>
+      <classname>Odbc</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>PDO</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-odbc.constants.attr-use-cursor-library">Pdo\Odbc::ATTR_USE_CURSOR_LIBRARY</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-odbc.constants.attr-assume-utf8">Pdo\Odbc::ATTR_ASSUME_UTF8</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-odbc.constants.sql-use-if-needed">Pdo\Odbc::SQL_USE_IF_NEEDED</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-odbc.constants.sql-use-driver">Pdo\Odbc::SQL_USE_DRIVER</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-odbc.constants.sql-use-odbc">Pdo\Odbc::SQL_USE_ODBC</varname>
-    </fieldsynopsis>
+     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+      <xi:fallback/>
+     </xi:include>
 
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-odbc.constants.attr-use-cursor-library">Pdo\Odbc::ATTR_USE_CURSOR_LIBRARY</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-odbc.constants.attr-assume-utf8">Pdo\Odbc::ATTR_ASSUME_UTF8</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-odbc.constants.sql-use-if-needed">Pdo\Odbc::SQL_USE_IF_NEEDED</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-odbc.constants.sql-use-driver">Pdo\Odbc::SQL_USE_DRIVER</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-odbc.constants.sql-use-odbc">Pdo\Odbc::SQL_USE_ODBC</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9ec2c28f9400490fe1b70fb88e50e23de97905f1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdo-pgsql" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Pdo\Pgsql</title>
@@ -53,78 +53,82 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <classname>Pdo\Pgsql</classname>
-    </ooclass>
+   <packagesynopsis>
+    <package>Pdo</package>
 
-    <ooclass>
-     <modifier>extends</modifier>
-     <classname>PDO</classname>
-    </ooclass>
+    <classsynopsis class="class">
+     <ooclass>
+      <classname>Pgsql</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>PDO</classname>
+     </ooclass>
 
-    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-pgsql.constants.attr-disable-prepares">Pdo\Pgsql::ATTR_DISABLE_PREPARES</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-pgsql.constants.attr-result-memory-size">Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-pgsql.constants.transaction-idle">Pdo\Pgsql::TRANSACTION_IDLE</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-pgsql.constants.transaction-active">Pdo\Pgsql::TRANSACTION_ACTIVE</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-pgsql.constants.transaction-intrans">Pdo\Pgsql::TRANSACTION_INTRANS</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-pgsql.constants.transaction-inerror">Pdo\Pgsql::TRANSACTION_INERROR</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
-     <varname linkend="pdo-pgsql.constants.transaction-unknown">Pdo\Pgsql::TRANSACTION_UNKNOWN</varname>
-    </fieldsynopsis>
+     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+      <xi:fallback/>
+     </xi:include>
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-pgsql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Pgsql'])">
-     <xi:fallback/>
-    </xi:include>
+     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-pgsql.constants.attr-disable-prepares">Pdo\Pgsql::ATTR_DISABLE_PREPARES</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-pgsql.constants.attr-result-memory-size">Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-pgsql.constants.transaction-idle">Pdo\Pgsql::TRANSACTION_IDLE</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-pgsql.constants.transaction-active">Pdo\Pgsql::TRANSACTION_ACTIVE</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-pgsql.constants.transaction-intrans">Pdo\Pgsql::TRANSACTION_INTRANS</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-pgsql.constants.transaction-inerror">Pdo\Pgsql::TRANSACTION_INERROR</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-pgsql.constants.transaction-unknown">Pdo\Pgsql::TRANSACTION_UNKNOWN</varname>
+     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-   </classsynopsis>
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-pgsql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Pgsql'])">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 51610360d58ed09bc9d1312f419057c0d1d1a998 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdo-sqlite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Pdo\Sqlite</title>

--- a/reference/pgsql/pgsql.connection.xml
+++ b/reference/pgsql/pgsql.connection.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pgsql-connection" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>La clase PgSql\Connection</title>
@@ -21,12 +21,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>PgSql\Connection</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>PgSql</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Connection</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pgsql/pgsql.lob.xml
+++ b/reference/pgsql/pgsql.lob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pgsql-lob" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>La clase PgSql\Lob</title>
@@ -21,12 +21,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>PgSql\Lob</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>PgSql</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Lob</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/pgsql/pgsql.result.xml
+++ b/reference/pgsql/pgsql.result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pgsql-result" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>La clase PgSql\Result</title>
@@ -21,12 +21,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>PgSql\Result</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>PgSql</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Result</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>


### PR DESCRIPTION
Syncs 9 PDO and PgSql files with the new `<packagesynopsis>` DocBook pattern from php/doc-en.

- 4 PDO + 3 PgSql files: `<classsynopsis>` wrapped in `<packagesynopsis>`, class names shortened
- 2 PDO files (pdo-mysql, pdo-sqlite): hash-only update (no content diff)