### PR TITLE
Sync miscellaneous files with EN source

### DIFF
--- a/language/predefined/attribute/construct.xml
+++ b/language/predefined/attribute/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 681fd84dbdef6c0f8fe92848677d95a993b66143 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 0eb433f1dec35ba1c0daf2d8b30b47f284ad5670 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="attribute.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   &reftitle.description;
   <constructorsynopsis role="Attribute">
    <modifier>public</modifier> <methodname>Attribute::__construct</methodname>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>Attribute::TARGET_ALL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>Attribute::TARGET_ALL</constant></initializer></methodparam>
   </constructorsynopsis>
   <para>
    Construye una nueva instancia de <classname>Attribute</classname>.

--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 30bda33771e1c8fa8fc8a5ee7559fd7fa189caa0 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.nodiscard" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>El atributo NoDiscard</title>
@@ -40,6 +40,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[\Attribute]</modifier>
      <modifier>final</modifier>
      <classname>NoDiscard</classname>
     </ooclass>

--- a/language/predefined/exception.xml
+++ b/language/predefined/exception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c4752c0aea6bfdd6795213785e7d7cc07d160ae Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 462d2bcb3fa7e76dd84baadf261146bc62574ca9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: PhilDaiguille -->
 <reference xml:id="class.exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Exception</title>

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6bbb5b9685d27ac9df744702e06525047a163d4b Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: a69d8c2c891e70c03c33cbe251a208dd7d185af9 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 
 <reference xml:id="class.datetimeinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -161,7 +161,7 @@
      <term><constant>DATE_ATOM</constant></term>
      <listitem>
       <simpara>
-       Atom (ejemplo: <literal>2005-08-15T15:52:01+00:00</literal>); compatible con ISO-8601, RFC 3399 y XML Schema
+       Atom (ejemplo: <literal>2005-08-15T15:52:01+00:00</literal>); compatible con ISO-8601, RFC 3339 y XML Schema
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/fileinfo/functions/finfo-close.xml
+++ b/reference/fileinfo/functions/finfo-close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5b7646656eb183ea568b8261d6d87a10a1b961c7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.finfo-close">
  <refnamediv>
@@ -18,7 +18,9 @@
   </methodsynopsis>
 
   <simpara>
-   Esta función cierra la instancia abierta por <function>finfo_open</function>.
+   Esta función se utilizaba para cerrar la instancia abierta por <function>finfo_open</function> hasta PHP 7.4,
+   pero es una operación sin efecto (no-op) desde la conversión del recurso <classname>finfo</classname> a objeto realizada en PHP 8.0,
+   y ha sido declarada obsoleta en PHP 8.5.
   </simpara>
 
  </refsect1>

--- a/reference/ftp/functions/ftp-set-option.xml
+++ b/reference/ftp/functions/ftp-set-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5b7646656eb183ea568b8261d6d87a10a1b961c7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ftp-set-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -88,6 +88,15 @@
   &reftitle.returnvalues;
   <para>
    &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Se lanza una excepción <exceptionname>ValueError</exceptionname> si la <parameter>option</parameter>
+   no es soportada. Se lanza una excepción <exceptionname>TypeError</exceptionname> si el
+   <parameter>value</parameter> proporcionado no corresponde al tipo esperado para la <parameter>option</parameter> dada.
   </para>
  </refsect1>
 

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b890f28c0c6d2856eadcdc34b3faf83a846b3d79 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.pcntl-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>pcntl_exec</methodname>
+   <type>false</type><methodname>pcntl_exec</methodname>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>args</parameter><initializer>[]</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>env_vars</parameter><initializer>[]</initializer></methodparam>
@@ -52,7 +52,7 @@
       <para>
        <parameter>env_vars</parameter> es un array de strings que son pasadas
        al programa como variables de entorno.
-       El array es de la forma nombre => valor, la clave es el nombre de la variable de entorno
+       El array es de la forma nombre =&gt; valor, la clave es el nombre de la variable de entorno
        y el valor es el valor de esta variable.
       </para>
      </listitem>


### PR DESCRIPTION
Syncs 7 files with php/doc-en:

- `exception.xml`: hash-only update
- `attribute/construct.xml`: wrapped default value in `<constant>` tag
- `attributes/nodiscard.xml`: added `#[\Attribute]` modifier
- `datetimeinterface.xml`: fixed typo "RFC 3399" → "RFC 3339"
- `finfo-close.xml`: updated description (no-op since PHP 8.0, deprecated in 8.5)
- `ftp-set-option.xml`: added errors section (ValueError/TypeError)
- `pcntl-exec.xml`: return type `bool` → `false`, fixed `=>` encoding