### PR TITLE
XML schema correction: fix inline tag types in reference/

### DIFF
--- a/reference/apache/functions/apache-lookup-uri.xml
+++ b/reference/apache/functions/apache-lookup-uri.xml
@@ -44,7 +44,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un objeto con la información relativa al URI. Las propiedades del objeto son
+   Un <type>object</type> con la información relativa al URI. Las propiedades de
+   este <type>object</type> son
    las siguientes :
   </para>
   <para>

--- a/reference/array/functions/array-combine.xml
+++ b/reference/array/functions/array-combine.xml
@@ -17,7 +17,7 @@
    <methodparam><type>array</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crea un array, donde las claves son los valores de
+   Crea un <type>array</type>, donde las claves son los valores de
    <parameter>keys</parameter>, y los valores son los valores
    de <parameter>values</parameter>.
   </para>
@@ -33,7 +33,7 @@
      <listitem>
       <para>
        Array de claves a utilizar. Los valores ilegales para las claves serán
-       convertidos en &string;.
+       convertidos en <type>string</type>.
       </para>
      </listitem>
     </varlistentry>
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve el array combinado.
+   Devuelve el <type>array</type> combinado.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-count-values.xml
+++ b/reference/array/functions/array-count-values.xml
@@ -15,9 +15,9 @@
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve un array que contiene los valores del array
+   <function>array_count_values</function> devuelve un array que contiene los valores del array
    <parameter>array</parameter> (que deben ser &integer;s o &string;s)
-   como claves y su frecuencia como valores.
+   como claves y su frecuencia en <parameter>array</parameter> como valores.
   </para>
  </refsect1>
 
@@ -51,7 +51,7 @@
   &reftitle.errors;
   <para>
    Lanza una alerta de nivel <constant>E_WARNING</constant> para cada elemento que
-   no es una &string; o un &integer;.
+   no es <type>string</type> o <type>int</type>.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-diff-assoc.xml
+++ b/reference/array/functions/array-diff-assoc.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un array que contiene todos los valores del array
+   Devuelve un <type>array</type> que contiene todos los valores del array
    <parameter>array</parameter> que no están presentes en los
    otros arrays.
   </para>

--- a/reference/array/functions/array-diff-key.xml
+++ b/reference/array/functions/array-diff-key.xml
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un array que contiene todas las entradas del array
+   Devuelve un <type>array</type> que contiene todas las entradas del array
    <parameter>array</parameter> cuyas claves están ausentes en
    todos los otros arrays.
   </para>

--- a/reference/array/functions/array-fill-keys.xml
+++ b/reference/array/functions/array-fill-keys.xml
@@ -33,7 +33,7 @@
      <listitem>
       <para>
        Array de valores que será utilizado como claves. Los valores
-       ilegales para las claves serán convertidos en strings.
+       ilegales para las claves serán convertidos en <type>string</type>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-flip.xml
+++ b/reference/array/functions/array-flip.xml
@@ -15,14 +15,14 @@
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>array_flip</function> devuelve un array cuyas
-   claves son los valores del array anterior <parameter>array</parameter>,
-   y los valores son las claves.
+   <function>array_flip</function> devuelve un <type>array</type> invertido,
+   es decir, las claves de <parameter>array</parameter> se convierten en valores y los valores de
+   <parameter>array</parameter> se convierten en claves.
   </para>
   <para>
    Téngase en cuenta que los valores de <parameter>array</parameter> deben
-   ser claves válidas, es decir, deben ser &integer; o &string;.
-   Se emitirá una alerta si un valor es de un tipo que
+   ser claves válidas, es decir, deben ser <type>int</type> o
+   <type>string</type>. Se emitirá una alerta si un valor es de un tipo que
    no es adecuado y la pareja en cuestión <emphasis>no será incluida en el resultado</emphasis>.
   </para>
   <para>

--- a/reference/array/functions/array-intersect-assoc.xml
+++ b/reference/array/functions/array-intersect-assoc.xml
@@ -118,6 +118,7 @@ Array
    Los dos valores del par <literal>clave =&gt; valor</literal> se consideran iguales solo si <literal>(string) $elem1 === (string) $elem2</literal>.
    En otras palabras, se realiza una comparación estricta en las representaciones
    de los índices, con el tipo string.
+   <!-- TODO: example of it... -->
   </simpara>
  </refsect1>
 

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -208,7 +208,7 @@ Array
     <member><function>array_merge_recursive</function></member>
     <member><function>array_replace</function></member>
     <member><function>array_combine</function></member>
-    <member>los <link linkend="language.operators.array">operadores de array</link></member>
+    <member><link linkend="language.operators.array">operadores de array</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/array/functions/array-multisort.xml
+++ b/reference/array/functions/array-multisort.xml
@@ -23,7 +23,7 @@
    siguiendo una u otra de sus dimensiones.
   </para>
   <para>
-   Las claves asociativas (&string;) serán mantenidas, pero
+   Las claves asociativas (<type>string</type>) serán mantenidas, pero
    las claves numéricas serán reindexadas.
   </para>
   &note.sort-unstable;
@@ -38,7 +38,7 @@
      <term><parameter>array1</parameter></term>
      <listitem>
       <para>
-       Un &array; a ordenar.
+       Un <type>array</type> a ordenar.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-walk-recursive.xml
+++ b/reference/array/functions/array-walk-recursive.xml
@@ -124,7 +124,7 @@ La clave sour contiene el elemento lemon
     <para>
      Se habrá notado que la clave '<literal>sweet</literal>'
      nunca es mostrada. Cualquier clave que esté asociada
-     a un &array; no es pasada a la función de retrollamada.
+     a un <type>array</type> no es pasada a la función de retrollamada.
     </para>
    </example>
   </para>

--- a/reference/array/functions/next.xml
+++ b/reference/array/functions/next.xml
@@ -31,7 +31,7 @@
      <term><parameter>array</parameter></term>
      <listitem>
       <para>
-       El array a tratar.
+       El <type>array</type> a tratar.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/range.xml
+++ b/reference/array/functions/range.xml
@@ -189,8 +189,7 @@
       <entry>
        Ahora se emite un <constant>E_WARNING</constant> si
        <parameter>start</parameter> o <parameter>end</parameter>
-       es una cadena no-<link linkend="language.types.numeric-strings">numérica</link>
-       con más de un byte.
+       es una cadena no-numérica con más de un byte.
       </entry>
      </row>
      <row>

--- a/reference/array/sorting.xml
+++ b/reference/array/sorting.xml
@@ -14,7 +14,7 @@
  <para>
   <simplelist>
    <member>
-    Algunos de los ordenamientos de array están basados en las claves, mientras que
+    Algunos de los ordenamientos de <type>array</type> están basados en las claves, mientras que
     otros están basados en los valores:
     <literal>$array['clave'] = 'valor';</literal>
    </member>

--- a/reference/calendar/functions/easter-days.xml
+++ b/reference/calendar/functions/easter-days.xml
@@ -65,7 +65,7 @@
        1752 cuando se define como <constant>CAL_EASTER_ROMAN</constant>.
        Ver las <link linkend="calendar.constants">constantes
         de los calendarios</link> para más constantes válidas.
-     </para>
+      </para>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/cubrid/functions/cubrid-error-code-facility.xml
+++ b/reference/cubrid/functions/cubrid-error-code-facility.xml
@@ -34,7 +34,6 @@
    <constant>CUBRID_FACILITY_DBMS</constant>, <constant>CUBRID_FACILITY_CAS</constant>,
    <constant>CUBRID_FACILITY_CCI</constant>, <constant>CUBRID_FACILITY_CLIENT</constant>.
   </simpara>
-  <simpara/>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -91,10 +91,7 @@
     una solicitud a un origen alternativo solo si este origen está correctamente alojado en HTTPS.
     Definir un bit activará el motor alt-svc.
     Definido en una de las constantes
-    <constant>CURLALTSVC_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLALTSVC_<replaceable>*</replaceable></constant>.
     Por omisión, la gestión Alt-Svc está desactivada.
     Disponible a partir de PHP 8.2.0 y cURL 7.64.1.
    </para>
@@ -949,10 +946,7 @@
    <para>
     Definir el método de autenticación FTP sobre SSL (si está activado) en una de las
     constantes
-    <constant>CURLFTPAUTH_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLFTPAUTH_<replaceable>*</replaceable></constant>.
     El valor por omisión es <constant>CURLFTPAUTH_DEFAULT</constant>.
    </para>
   </listitem>
@@ -1010,10 +1004,7 @@
     Indica a curl qué método usar para alcanzar un fichero en un servidor FTP(S).
     Los valores posibles son
     una de las constantes
-    <constant>CURLFTPMETHOD_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLFTPMETHOD_<replaceable>*</replaceable></constant>.
     El valor por omisión es <constant>CURLFTPMETHOD_MULTICWD</constant>.
     Disponible a partir de cURL 7.15.1.
    </para>
@@ -1075,10 +1066,7 @@
     que detiene la capa SSL/TLS después de la autenticación
     dejando el resto de la comunicación del canal de control sin cifrar.
     Usar una de las constantes
-    <constant>CURLFTPSSL_CCC_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLFTPSSL_CCC_<replaceable>*</replaceable></constant>.
     Por omisión en <constant>CURLFTPSSL_CCC_NONE</constant>.
     Disponible a partir de cURL 7.16.1.
    </para>
@@ -1248,10 +1236,7 @@
     Enviar los encabezados HTTP tanto al proxy como al host o por separado.
     Los valores posibles son cualquiera de las
     constantes
-    <constant>CURLHEADER_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLHEADER_<replaceable>*</replaceable></constant>.
     Por omisión en <constant>CURLHEADER_SEPARATE</constant> a partir de cURL
     7.42.1, y <constant>CURLHEADER_UNIFIED</constant> antes de eso.
     Disponible a partir de PHP 7.0.7 y cURL 7.37.0.
@@ -1282,10 +1267,7 @@
    <para>
     Acepta una máscara de bits de las características HSTS (HTTP Strict Transport Security)
     definidas por las constantes
-    <constant>CURLHSTS_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLHSTS_<replaceable>*</replaceable></constant>.
     Disponible a partir de PHP 8.2.0 y cURL 7.74.0.
    </para>
   </listitem>
@@ -1434,10 +1416,7 @@
   <listitem>
    <para>
     Definir en una de las constantes
-    <constant>CURL_HTTP_VERSION_
-     <replaceable>*</replaceable>
-    </constant>
-    para que cURL use la versión HTTP especificada.
+    <constant>CURL_HTTP_VERSION_<replaceable>*</replaceable></constant> para que cURL use la versión HTTP especificada.
     Disponible a partir de cURL 7.9.1.
    </para>
   </listitem>
@@ -1511,10 +1490,7 @@
     la resolución de nombres de host. Esto solo es interesante al utilizar nombres de host que
     resuelven direcciones usando más de una versión de IP.
     Definir en una de las constantes
-    <constant>CURL_IPRESOLVE_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURL_IPRESOLVE_<replaceable>*</replaceable></constant>.
     El valor por omisión es <constant>CURL_IPRESOLVE_WHATEVER</constant>.
     Disponible a partir de cURL 7.10.8.
    </para>
@@ -1939,10 +1915,7 @@
   <listitem>
    <para>
     Definir un valor a una máscara de bits de las constantes
-    <constant>CURLMIMEOPT_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLMIMEOPT_<replaceable>*</replaceable></constant>.
     Actualmente, solo hay una opción disponible: <constant>CURLMIMEOPT_FORMESCAPE</constant>.
     Disponible a partir de PHP 8.3.0 y cURL 7.81.0.
    </para>
@@ -2467,10 +2440,7 @@
   <listitem>
    <para>
     Un bitmask de valores
-    <constant>CURLPROTO_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLPROTO_<replaceable>*</replaceable></constant>.
     Si se usa, este bitmask limita los protocolos que cURL puede usar en la transferencia.
     Por omisión, esto vale <constant>CURLPROTO_ALL</constant>, es decir, cURL aceptará todos los protocolos que soporta.
     Ver <constant>CURLOPT_REDIR_PROTOCOLS</constant>.
@@ -2616,10 +2586,7 @@
    <para>
     Un bitmask de los métodos de autenticación HTTP
     (
-    <constant>CURLAUTH_
-     <replaceable>*</replaceable>
-    </constant>
-    )
+    <constant>CURLAUTH_<replaceable>*</replaceable></constant> )
     a usar para la conexión al proxy.
     Para la autenticación por proxy, solo <constant>CURLAUTH_BASIC</constant> y
     <constant>CURLAUTH_NTLM</constant>
@@ -2676,10 +2643,7 @@
   <listitem>
    <para>
     Establece el tipo de proxy a una de las constantes
-    <constant>CURLPROXY_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLPROXY_<replaceable>*</replaceable></constant>.
     Por omisión, es <constant>CURLPROXY_HTTP</constant>.
     Disponible a partir de cURL 7.10.
    </para>
@@ -2951,10 +2915,7 @@
   <listitem>
    <para>
     Establece la versión TLS del proxy HTTPS preferida en una de las constantes
-    <constant>CURL_SSLVERSION_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant>.
     Por defecto, esto corresponde a <constant>CURL_SSLVERSION_DEFAULT</constant>.
     <warning>
      <simpara>
@@ -2990,10 +2951,7 @@
    <para>
     Establece las opciones de comportamiento SSL del proxy, que es un bitmask de las
     constantes
-    <constant>CURLSSLOPT_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLSSLOPT_<replaceable>*</replaceable></constant>.
     Disponible a partir de PHP 7.3.0 y cURL 7.52.0.
    </para>
   </listitem>
@@ -3284,10 +3242,7 @@
   <listitem>
    <para>
     Una máscara de bits de valores
-    <constant>CURLPROTO_
-     <replaceable>*</replaceable>
-    </constant>
-    que
+    <constant>CURLPROTO_<replaceable>*</replaceable></constant> que
     limita los protocolos que cURL puede usar en una transferencia que sigue en una
     redirección cuando <constant>CURLOPT_FOLLOWLOCATION</constant> está activado.
     Esto permite limitar ciertas transferencias para que solo usen un subconjunto de protocolos durante las
@@ -3521,10 +3476,7 @@
    <para>
     Define el tipo de solicitud RTSP a realizar.
     Debe ser una de las constantes
-    <constant>CURL_RTSPREQ_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURL_RTSPREQ_<replaceable>*</replaceable></constant>.
     Disponible a partir de cURL 7.20.0.
    </para>
   </listitem>
@@ -3816,10 +3768,7 @@
       <listitem>
        <simpara>
         Uno de los tipos de clave
-        <constant>CURLKHTYPE_
-         <replaceable>*</replaceable>
-        </constant>
-        .
+        <constant>CURLKHTYPE_<replaceable>*</replaceable></constant>.
        </simpara>
       </listitem>
      </varlistentry>
@@ -4093,10 +4042,7 @@
    <para>
     Una de
     las constantes siguientes
-    <constant>CURL_SSLVERSION_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant>.
     <warning>
      <simpara>
       Es preferible no definir esta opción y dejar los valores por omisión.
@@ -4193,10 +4139,7 @@
    <para>
     Definir las opciones de comportamiento SSL, que son una máscara de bits de las
     constantes
-    <constant>CURLSSLOPT_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLSSLOPT_<replaceable>*</replaceable></constant>.
     Por omisión, ninguno de los bits está definido.
     Disponible a partir de PHP 7.0.7 y cURL 7.25.0.
    </para>
@@ -4732,10 +4675,7 @@
     Estos son todos protocolos que comienzan en texto claro
     y son "mejorados" en SSL utilizando el comando STARTTLS.
     Definir en una de las constantes
-    <constant>CURLUSESSL_
-     <replaceable>*</replaceable>
-    </constant>
-    .
+    <constant>CURLUSESSL_<replaceable>*</replaceable></constant>.
     Disponible a partir de cURL 7.17.0.
    </para>
   </listitem>

--- a/reference/curl/functions/curl-setopt-array.xml
+++ b/reference/curl/functions/curl-setopt-array.xml
@@ -30,7 +30,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       Un array que especifica qué opciones establecer con sus valores. Las
+       Un <type>array</type> que especifica qué opciones establecer con sus valores. Las
        claves deberían ser constantes válidas de
        <function>curl_setopt</function> o sus enteros equivalentes.
       </para>

--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -30,7 +30,7 @@
      <term><parameter>option</parameter></term>
      <listitem>
       <para>
-       La opción <literal>CURLOPT_<replaceable>*</replaceable></literal> a definir.
+       La opción <constant>CURLOPT_<replaceable>*</replaceable></constant> a definir.
       </para>
      </listitem>
     </varlistentry>
@@ -42,29 +42,6 @@
        Ver la descripción de las
        constantes <constant>CURLOPT_<replaceable>*</replaceable></constant>
        para detalles sobre el tipo de valores esperados por cada constante.
-      </para>
-      <para>
-       Otros valores:
-       <informaltable>
-        <tgroup cols="3">
-         <thead>
-          <row>
-           <entry>Option</entry>
-           <entry>Define el parámetro <parameter>value</parameter> en</entry>
-          </row>
-         </thead>
-         <tbody>
-          <row>
-           <entry valign="top"><constant>CURLOPT_SHARE</constant></entry>
-           <entry valign="top">
-            Un resultado de la función <function>curl_share_init</function>.
-            Hace que el gestor cURL utilice los datos desde
-            el gestor compartido.
-           </entry>
-          </row>
-         </tbody>
-        </tgroup>
-       </informaltable>
       </para>
      </listitem>
     </varlistentry>
@@ -193,9 +170,9 @@ curl_exec($ch);
    <para>
     El hecho de pasar un array a la constante
     <constant>CURLOPT_POSTFIELDS</constant> codificará los datos como
-    <emphasis><literal>multipart/form-data</literal></emphasis>, mientras que el hecho de pasar
+    <emphasis>multipart/form-data</emphasis>, mientras que el hecho de pasar
     una cadena codificada URL codificará los datos como
-    <emphasis><literal>application/x-www-form-urlencoded</literal></emphasis>.
+    <emphasis>application/x-www-form-urlencoded</emphasis>.
    </para>
   </note>
  </refsect1>

--- a/reference/curl/functions/curl-share-init-persistent.xml
+++ b/reference/curl/functions/curl-share-init-persistent.xml
@@ -66,7 +66,7 @@
     <simpara>
      Si <parameter>share_options</parameter> contiene un valor que no corresponde
      a una <constant>CURL_LOCK_DATA_<replaceable>*</replaceable></constant>,
-     esta función lanza una <exceptionname>ValueError</exceptionname>.
+     esta función lanza una <classname>ValueError</classname>.
     </simpara>
    </listitem>
    <listitem>

--- a/reference/curl/functions/curl-version.xml
+++ b/reference/curl/functions/curl-version.xml
@@ -67,7 +67,7 @@
       </row>
       <row>
        <entry>features</entry>
-       <entry>Una máscara de constantes <literal>CURL_VERSION_<replaceable>*</replaceable></literal></entry>
+       <entry>Una máscara de constantes <constant>CURL_VERSION_<replaceable>*</replaceable></constant></entry>
       </row>
       <row>
        <entry>protocols</entry>

--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -100,8 +100,8 @@
      <simpara>
       Este formato no es compatible con el ISO-8601, aunque se deja por
       razones de retrocompatibilidad. Use
-      <constant>DateTimeInterface::ISO8601_EXPANDED</constant>,
-      <constant>DateTimeInterface::ATOM</constant> en su lugar para que sea
+      <constant>DATE_ISO8601_EXPANDED</constant>,
+      <constant>DATE_ATOM</constant> en su lugar para que sea
       compatible con el ISO-8601. (ref ISO8601:2004 section 4.3.3 clause d)
      </simpara>
     </note>

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="dateperiod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DatePeriod::__construct</refname>
-  <refpurpose>Crea un nuevo objeto <classname>DatePeriod</classname></refpurpose>
+  <refpurpose>Crea un nuevo objeto DatePeriod</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -38,7 +38,7 @@
    </simpara>
   </warning>
   <para>
-   Crea un nuevo objeto <classname>DatePeriod</classname>.
+   Crea un nuevo objeto DatePeriod.
   </para>
   <para>
    Los objetos <classname>DatePeriod</classname> pueden ser utilizados como iterador para

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -337,7 +337,6 @@
      <listitem>
       <simpara>
        RSS (ejemplo: <literal>Mon, 15 Aug 2005 15:52:01 +0000</literal>).
-       &Alias; <constant>DATE_RFC1123</constant>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -351,7 +350,6 @@
      <listitem>
       <simpara>
        World Wide Web Consortium (ejemplo: <literal>2005-08-15T15:52:01+00:00</literal>).
-       &Alias; <constant>DATE_RFC3339</constant>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -387,7 +385,7 @@
        <entry>7.2.0</entry>
        <entry>
         Las constantes de clase de <classname>DateTime</classname> ahora están
-        definidas en <classname>DateTimeInterface</classname>.
+        definidas en <interfacename>DateTimeInterface</interfacename>.
        </entry>
       </row>
      </tbody>

--- a/reference/datetime/datetimeinterface/diff.xml
+++ b/reference/datetime/datetimeinterface/diff.xml
@@ -178,7 +178,8 @@ Días completos: 364
    <title>Comparación de objetos <classname>DateTime</classname></title>
    <note>
     <para>
-     Los objetos DateTime se pueden comparar usando los
+     Los objetos <classname>DateTimeImmutable</classname> y
+     <classname>DateTime</classname> se pueden comparar usando los
      <link linkend="language.operators.comparison">operadores de comparación</link>.
     </para>
    </note>

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -44,7 +44,7 @@
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       El formato de la fecha deseada. Ver las opciones de formato a continuación.
+       El formato de la fecha deseada en forma de <type>string</type>. Ver las opciones de formato a continuación.
        Existen también numerosas
        <link linkend="datetimeinterface.constants.types">constantes de fechas</link>
        que pueden ser utilizadas, lo que hace que <constant>DATE_RSS</constant>
@@ -266,7 +266,7 @@
             Microsegundos. Tenga en cuenta que la función
             <function>date</function> generará siempre
             <literal>000000</literal> ya que toma un parámetro de tipo
-            entero, mientras que el método <methodname>DateTimeInterface::format</methodname>
+            <type>int</type>, mientras que el método <methodname>DateTimeInterface::format</methodname>
             soporta microsegundos si un objeto de tipo
             <interfacename>DateTimeInterface</interfacename> fue creado con microsegundos.
            </entry>
@@ -357,7 +357,7 @@
       </para>
       <note>
        <para>
-        Sabiendo que esta función solo acepta enteros en forma de timestamp,
+        Sabiendo que esta función solo acepta timestamps de tipo <type>int</type>,
         el carácter <literal>u</literal> solo es útil al utilizar la función
         <function>date_format</function> con un timestamp de usuario creado con la función
         <function>date_create</function>.

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -51,7 +51,7 @@
   &reftitle.errors;
   <para>
    Si el sello de tiempo no puede ser representado como un &integer;,
-   se lanza una <classname>DateRangeError</classname>.
+   se lanza una <exceptionname>DateRangeError</exceptionname>.
    Anterior a PHP 8.3.0, se lanzaba una <exceptionname>ValueError</exceptionname>.
    Y anterior a PHP 8.0.0, se devolvía &false; en este caso.
    Sin embargo, el sello de tiempo puede ser obtenido como un &string; utilizando

--- a/reference/datetime/datetimezone/construct.xml
+++ b/reference/datetime/datetimezone/construct.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>DateTimeZone::__construct</refname>
   <refname>timezone_open</refname>
-  <refpurpose>Crea un nuevo objeto <classname>DateTimeZone</classname></refpurpose>
+  <refpurpose>Crea un nuevo objeto DateTimeZone</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -21,7 +21,7 @@
    <methodparam><type>string</type><parameter>timezone</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crea un nuevo objeto <classname>DateTimeZone</classname>.
+   Crea un nuevo objeto DateTimeZone.
   </para>
   <para>
    Un objeto DateTimeZone proporciona acceso a tres tipos diferentes de reglas
@@ -65,7 +65,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Este método lanza una <classname>DateInvalidTimeZoneException</classname>
+   Este método lanza una <exceptionname>DateInvalidTimeZoneException</exceptionname>
    si la zona horaria proporcionada no es reconocida como una zona horaria válida.
    Anteriormente a PHP 8.3, esto era una <exceptionname>Exception</exceptionname>.
   </para>

--- a/reference/datetime/datetimezone/getoffset.xml
+++ b/reference/datetime/datetimezone/getoffset.xml
@@ -22,10 +22,10 @@
    <methodparam><type>DateTimeInterface</type><parameter>datetime</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>timezone_offset_get</function> retorna el desplazamiento horario
-   respecto al GMT para el argumento <parameter>datetime</parameter>. El
+   Esta función retorna el desplazamiento GMT para la fecha/hora especificada
+   en el parámetro <parameter>datetime</parameter>. El
    desplazamiento GMT se calcula a partir de las informaciones de zona horaria
-   contenidas en el objeto <classname>DateTime</classname>.
+   contenidas en el objeto DateTimeZone utilizado.
   </para>
  </refsect1>
 
@@ -38,8 +38,7 @@
      <term><parameter>datetime</parameter></term>
      <listitem>
       <para>
-       Objeto <classname>DateTime</classname> que contiene la fecha
-       para la cual se debe calcular el desplazamiento.
+       DateTime que contiene la fecha/hora desde la cual se debe calcular el desplazamiento.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna un &array; que contiene información sobre la fecha/hora analizada.
+   Retorna un <type>array</type> que contiene información sobre la fecha/hora analizada.
   </para>
   <para>
    El array retornado tiene claves para <literal>year</literal>,
@@ -70,6 +70,16 @@
    <literal>tz_abbr</literal> y <literal>is_dst</literal> son añadidos. Para el tipo
    <literal>3</literal> (identificador de zona horaria) los campos
    <literal>tz_abbr</literal> y <literal>tz_id</literal> son añadidos.
+  </para>
+  <para>
+   Si elementos de tiempo relativo están presentes en la cadena
+   <parameter>datetime</parameter>, como <literal>+3 days</literal>,
+   el array retornado incluye un array anidado con la clave
+   <literal>relative</literal>. Este array contiene entonces las claves
+   <literal>year</literal>, <literal>month</literal>, <literal>day</literal>,
+   <literal>hour</literal>, <literal>minute</literal>,
+   <literal>second</literal>, y si es necesario <literal>weekday</literal>, y
+   <literal>weekdays</literal>, dependiendo de la cadena pasada.
   </para>
   <para>
    El array incluye los campos <literal>warning_count</literal> y

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -66,17 +66,17 @@
          <tbody>
           <row>
            <entry>SUNFUNCS_RET_STRING</entry>
-           <entry>Devuelve el resultado como &string;</entry>
+           <entry>Devuelve el resultado como <type>string</type></entry>
            <entry>16:46</entry>
           </row>
           <row>
            <entry>SUNFUNCS_RET_DOUBLE</entry>
-           <entry>Devuelve el resultado como &float;</entry>
+           <entry>Devuelve el resultado como <type>float</type></entry>
            <entry>16.78243132</entry>
           </row>
           <row>
            <entry>SUNFUNCS_RET_TIMESTAMP</entry>
-           <entry>Devuelve el resultado como &integer; (timestamp)</entry>
+           <entry>Devuelve el resultado como <type>int</type> (timestamp)</entry>
            <entry>1095034606</entry>
           </row>
          </tbody>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -68,17 +68,17 @@
          <tbody>
           <row>
            <entry>SUNFUNCS_RET_STRING</entry>
-           <entry>Devuelve el resultado en forma de &string;</entry>
+           <entry>Devuelve el resultado en forma de <type>string</type></entry>
            <entry>16:46</entry>
           </row>
           <row>
            <entry>SUNFUNCS_RET_DOUBLE</entry>
-           <entry>Devuelve el resultado en forma de &float;</entry>
+           <entry>Devuelve el resultado en forma de <type>float</type></entry>
            <entry>16.78243132</entry>
           </row>
           <row>
            <entry>SUNFUNCS_RET_TIMESTAMP</entry>
-           <entry>Devuelve el resultado en forma de &integer; (timestamp)</entry>
+           <entry>Devuelve el resultado en forma de <type>int</type> (timestamp)</entry>
            <entry>1095034606</entry>
           </row>
          </tbody>

--- a/reference/datetime/functions/getdate.xml
+++ b/reference/datetime/functions/getdate.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un array asociativo que contiene las informaciones
+   Devuelve un <type>array</type> asociativo que contiene las informaciones
    de fecha y hora del timestamp <parameter>timestamp</parameter>.
    Los elementos del array asociativo devuelto son los siguientes:
   </para>

--- a/reference/datetime/functions/gettimeofday.xml
+++ b/reference/datetime/functions/gettimeofday.xml
@@ -39,8 +39,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Por omisión, se devuelve un &array;. Si el argumento <parameter>as_float</parameter>
-   está definido, entonces se devolverá un &float;.
+   Por omisión, se devuelve un <type>array</type>. Si el argumento <parameter>as_float</parameter>
+   está definido, entonces se devolverá un <type>float</type>.
   </para>
   <para>
    Claves del array :

--- a/reference/datetime/functions/gmdate.xml
+++ b/reference/datetime/functions/gmdate.xml
@@ -16,9 +16,8 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>timestamp</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>gmdate</function> es idéntico a la función
-   <function>date</function>, excepto que el tiempo
-   devuelto es GMT (<literal>Greenwich Mean Time</literal>).
+   Idéntico a la función <function>date</function>, excepto que el tiempo
+   devuelto es Greenwich Mean Time (GMT).
   </para>
  </refsect1>
 
@@ -30,7 +29,7 @@
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       El formato de la fecha de salida. Ver las opciones de formato para la función
+       El formato de la fecha de salida en forma de <type>string</type>. Ver las opciones de formato para la función
        <function>date</function>.
       </para>
      </listitem>

--- a/reference/datetime/functions/gmstrftime.xml
+++ b/reference/datetime/functions/gmstrftime.xml
@@ -60,9 +60,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &string; formateado según el formato dado por el
-   argumento <parameter>timestamp</parameter> o la fecha actual
-   si no se proporciona ningún argumento <parameter>timestamp</parameter>.
+   Devuelve un &string; formateado según el formato dado utilizando el
+   argumento <parameter>timestamp</parameter> o la hora local actual
+   si no se proporciona ningún timestamp.
    Los nombres de los meses, días de la semana y otras cadenas
    dependientes de una localización dada, respetan la localización
    actual definida por la función <function>setlocale</function>.

--- a/reference/datetime/functions/idate.xml
+++ b/reference/datetime/functions/idate.xml
@@ -16,12 +16,11 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>timestamp</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>idate</function> devuelve un número formateado con el
-   formato <parameter>format</parameter> y que representa el timestamp
-   <parameter>timestamp</parameter> o la hora actual si
-   <parameter>timestamp</parameter> es omitido.
-   En otras palabras, el parámetro <parameter>timestamp</parameter> es opcional
-   y el valor por omisión es el valor devuelto por la función <function>time</function>.
+   Devuelve un número formateado según el formato
+   <parameter>format</parameter> dado con el timestamp entero dado
+   <parameter>timestamp</parameter> o la hora actual
+   si no se da un timestamp. En otras palabras, <parameter>timestamp</parameter>
+   es opcional y el valor por omisión es el valor devuelto por <function>time</function>.
   </para>
   <para>
    A diferencia de la función <function>date</function>, <function>idate</function>
@@ -150,7 +149,7 @@
    Devuelve un <type>int</type> en caso de éxito, &return.falseforfailure;.
   </para>
   <para>
-   Dado que <function>idate</function> siempre devuelve un &integer;
+   Dado que <function>idate</function> siempre devuelve un <type>int</type>
    y no puede comenzar con <literal>0</literal>,
    <function>idate</function> puede devolver menos dígitos de los
    que se podrían esperar. Ver el ejemplo a continuación.

--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -33,7 +33,7 @@
      <listitem>
       <para>
        Si se utiliza y se define como &true;, <function>microtime</function> devolverá
-       un número de coma flotante en lugar de un &string;, tal como se describe
+       un <type>float</type> en lugar de un <type>string</type>, tal como se describe
        en la sección de valores devueltos a continuación.
       </para>
      </listitem>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Por omisión, <function>microtime</function> devuelve un &string; en
+   Por omisión, <function>microtime</function> devuelve un <type>string</type> en
    el formato "msec sec", donde <literal>sec</literal> es el número de segundos
    desde la época Unix (1 de Enero de 1970, 00:00:00 GMT),
    y <literal>msec</literal> es el número de microsegundos que han transcurrido
@@ -54,7 +54,7 @@
   </para>
   <para>
    Si <parameter>as_float</parameter> se define como &true;, entonces
-   <function>microtime</function> devuelve un número de coma flotante,
+   <function>microtime</function> devuelve un <type>float</type>,
    que representa el tiempo actual, en segundos, desde la época Unix, con precisión
    de microsegundo.
   </para>

--- a/reference/datetime/functions/strftime.xml
+++ b/reference/datetime/functions/strftime.xml
@@ -384,6 +384,9 @@
    actual si no se proporciona ningún timestamp. Los nombres de los meses, de los días de la
    semana pero también de otras cadenas dependientes de la localización, respetarán
    la localización actual definida por la función <function>setlocale</function>.
+   La función devuelve &false; si <parameter>format</parameter> está vacío, contiene especificadores
+   de conversión no soportados, o si la longitud de la cadena devuelta sería mayor que
+   <literal>4095</literal>.
   </para>
  </refsect1>
 

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -15,9 +15,8 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>baseTimestamp</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   La función <function>strtotime</function> intenta leer una
-   fecha en formato inglés proporcionada por el parámetro <parameter>time</parameter>,
-   y transformarla en un timestamp Unix (el número de segundos desde
+   La función espera recibir una cadena que contiene una fecha en inglés
+   e intentará leerla y transformarla en un timestamp Unix (el número de segundos desde
    el 1 de enero de 1970 a 00:00:00 UTC), relativo al timestamp
    <parameter>baseTimestamp</parameter>, o a la fecha actual si este último
    es omitido. El análisis de la cadena de fecha está definido en

--- a/reference/datetime/functions/timezone-version-get.xml
+++ b/reference/datetime/functions/timezone-version-get.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   <function>timezone_version_get</function> lee la versión de la timezonedb.
+   Devuelve la versión actual de la timezonedb.
   </para>
  </refsect1>
 
@@ -28,8 +28,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &string; en formato <literal>YYYY.increment</literal>,
-   como <literal>2022.2</literal>.
+   Devuelve un <type>string</type> en formato
+   <literal>YYYY.increment</literal>, como <literal>2022.2</literal>.
   </para>
   <para>
    Si se tiene una versión antigua de la base de datos de zonas horarias

--- a/reference/dba/functions/dba-delete.xml
+++ b/reference/dba/functions/dba-delete.xml
@@ -16,9 +16,7 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>dba_delete</function> elimina la entrada
-   especificada por la clave <parameter>key</parameter>,
-   en la base identificada por <parameter>handle</parameter>.
+   <function>dba_delete</function> elimina la entrada especificada de la base de datos.
   </simpara>
  </refsect1>
 

--- a/reference/dba/functions/dba-exists.xml
+++ b/reference/dba/functions/dba-exists.xml
@@ -15,9 +15,8 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>dba_exists</function> verifica si la clave
-   <parameter>key</parameter> existe en la base identificada
-   por <parameter>handle</parameter>.
+   <function>dba_exists</function> verifica si la
+   <parameter>key</parameter> especificada existe en la base de datos.
   </simpara>
  </refsect1>
 

--- a/reference/dba/functions/dba-firstkey.xml
+++ b/reference/dba/functions/dba-firstkey.xml
@@ -15,9 +15,9 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>dba_firstkey</function> devuelve la primera clave
-   de la base de datos especificada por <parameter>handle</parameter>
-   y coloca el puntero interno de clave. Esto permitirá recorrer la base.
+   <function>dba_firstkey</function> devuelve la primera clave de la base de datos
+   y reinicia el puntero interno de clave. Esto permite una búsqueda lineal
+   a través de toda la base de datos.
   </simpara>
  </refsect1>
 

--- a/reference/dba/functions/dba-insert.xml
+++ b/reference/dba/functions/dba-insert.xml
@@ -17,10 +17,9 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>dba_insert</function> inserta la entrada descrita
-   por la clave <parameter>key</parameter> y el valor
-   <parameter>value</parameter> en la base especificada
-   por <parameter>handle</parameter>.
+   <function>dba_insert</function> inserta la entrada descrita con
+   <parameter>key</parameter> y <parameter>value</parameter> en la
+   base de datos.
   </simpara>
  </refsect1>
 

--- a/reference/dba/functions/dba-optimize.xml
+++ b/reference/dba/functions/dba-optimize.xml
@@ -15,8 +15,7 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>dba_optimize</function> optimiza la base de datos
-   identificada por <parameter>handle</parameter>.
+   <function>dba_optimize</function> optimiza la base de datos subyacente.
   </simpara>
  </refsect1>
 

--- a/reference/dba/functions/dba-sync.xml
+++ b/reference/dba/functions/dba-sync.xml
@@ -15,9 +15,8 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>dba_sync</function> sincroniza la base de datos
-   especificada por <parameter>handle</parameter>. Si es admisible,
-   esto probablemente iniciará una operación de reescritura física del fichero.
+   <function>dba_sync</function> sincroniza la base de datos. Esto probablemente
+   iniciará una escritura física en el disco, si es admisible.
   </simpara>
  </refsect1>
 

--- a/reference/dir/functions/chroot.xml
+++ b/reference/dir/functions/chroot.xml
@@ -15,9 +15,9 @@
    <methodparam><type>string</type><parameter>directory</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>chroot</function> cambia la raíz del script en curso,
-   y la reemplaza por <parameter>directory</parameter>, luego cambia el directorio
-   de trabajo actual a "/".
+   Cambia el directorio raíz del proceso actual a
+   <parameter>directory</parameter>, y cambia el directorio de trabajo
+   actual a "/".
   </para>
   <para>
    Esta función solo está disponible en sistemas GNU y BSD y cuando se utiliza

--- a/reference/dir/functions/scandir.xml
+++ b/reference/dir/functions/scandir.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type class="union"><type>resource</type><type>null</type></type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve un array de ficheros y directorios, provenientes de <parameter>directory</parameter>.
+   Devuelve un <type>array</type> de ficheros y directorios provenientes de <parameter>directory</parameter>.
   </para>
  </refsect1>
 
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un array de ficheros en caso de éxito o &false; en caso de
+   Devuelve un <type>array</type> de nombres de ficheros en caso de éxito o &false; en caso de
    fallo. Si <parameter>directory</parameter> no es un directorio, entonces
    se devuelve un valor booleano &false; y se genera un error de nivel
    <constant>E_WARNING</constant>.

--- a/reference/dom/domattr.xml
+++ b/reference/dom/domattr.xml
@@ -114,7 +114,7 @@
     <varlistentry xml:id="domattr.props.specified">
      <term><varname>specified</varname></term>
      <listitem>
-      <para>Aún no implementado, siempre vale &null;.</para>
+      <para>Aún no implementado, siempre vale &true;.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domattr.props.value">
@@ -125,7 +125,7 @@
        <para>
         Tenga en cuenta que las entidades XML se expanden cuando se define un valor.
         Por lo tanto, el carácter <literal>&amp;</literal> tiene un significado especial.
-        Establecer <varname>valor</varname> a sí mismo fallará cuando <varname>valor</varname> contiene un <constant>&amp;</constant>.
+        Establecer <varname>valor</varname> a sí mismo fallará cuando <varname>valor</varname> contiene un <literal>&amp;</literal>.
         Para evitar la expansión de entidades, utilice en su lugar <methodname>DOMElement::setAttribute</methodname>.
        </para>
       </note>

--- a/reference/dom/domattr/construct.xml
+++ b/reference/dom/domattr/construct.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>string</type><parameter>value</parameter><initializer>""</initializer></methodparam>
   </constructorsynopsis>
   <para>
-   Crea un nuevo objeto <classname>DOMAttr</classname>.
+   Crea un nuevo objeto DOMAttr.
    Este objeto es de solo lectura. Puede ser añadido a un documento, pero los
    nodos adicionales no pueden ser añadidos a este nodo mientras este nodo esté asociado a un documento. Para crear un nodo accesible en escritura,
    utilice <xref linkend="domdocument.createattribute"/>.

--- a/reference/dom/domcomment.xml
+++ b/reference/dom/domcomment.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: d75a54118772b34c7a538962ac5f994900c99690 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.domcomment" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La clase <classname>DOMComment</classname></title>
+ <title>La clase DOMComment</title>
  <titleabbrev>DOMComment</titleabbrev>
 
  <partintro>

--- a/reference/dom/domelement.xml
+++ b/reference/dom/domelement.xml
@@ -68,7 +68,6 @@
      <modifier>readonly</modifier>
      <type>mixed</type>
      <varname linkend="domelement.props.schematypeinfo">schemaTypeInfo</varname>
-     <initializer>null</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>

--- a/reference/dom/domelement/setattributenode.xml
+++ b/reference/dom/domelement/setattributenode.xml
@@ -37,8 +37,7 @@
   &reftitle.returnvalues;
   <para>
    Devuelve el atributo antiguo si ha sido reemplazado o &null; si no había un atributo antiguo.
-   Si se produce un error <constant>DOM_WRONG_DOCUMENT_ERR</constant> y <varname
-   linkend="domdocument.props.stricterrorchecking">strictErrorChecking</varname> es &false;, entonces &false; es devuelto.
+   Si se produce un error <constant>DOM_WRONG_DOCUMENT_ERR</constant> y <varname linkend="domdocument.props.stricterrorchecking">strictErrorChecking</varname> es &false;, entonces &false; es devuelto.
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domelement/setattributenodens.xml
+++ b/reference/dom/domelement/setattributenodens.xml
@@ -37,8 +37,7 @@
   &reftitle.returnvalues;
   <para>
    Devuelve el antiguo atributo si ha sido reemplazado o &null; si no había un atributo anterior.
-   Si se produce un error <constant>DOM_WRONG_DOCUMENT_ERR</constant> y <varname
-   linkend="domdocument.props.stricterrorchecking">strictErrorChecking</varname> es &false;, entonces se devuelve &false;.
+   Si se produce un error <constant>DOM_WRONG_DOCUMENT_ERR</constant> y <varname linkend="domdocument.props.stricterrorchecking">strictErrorChecking</varname> es &false;, entonces se devuelve &false;.
   </para>
  </refsect1>
  <refsect1 role="errors">

--- a/reference/dom/domentityreference.xml
+++ b/reference/dom/domentityreference.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: d75a54118772b34c7a538962ac5f994900c99690 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.domentityreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La clase <classname>DOMEntityReference</classname></title>
+ <title>La clase DOMEntityReference</title>
  <titleabbrev>DOMEntityReference</titleabbrev>
 
  <partintro>

--- a/reference/dom/domimplementation.xml
+++ b/reference/dom/domimplementation.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 2d9ab8da82569e467b77dd146e83904e80f03913 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.domimplementation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La clase <classname>DOMImplementation</classname></title>
+ <title>La clase DOMImplementation</title>
  <titleabbrev>DOMImplementation</titleabbrev>
 
  <partintro>

--- a/reference/dom/domnamednodemap.xml
+++ b/reference/dom/domnamednodemap.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 <reference xml:id="class.domnamednodemap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La clase <classname>DOMNamedNodeMap</classname></title>
+ <title>La clase DOMNamedNodeMap</title>
  <titleabbrev>DOMNamedNodeMap</titleabbrev>
 
  <partintro>

--- a/reference/dom/domnotation.xml
+++ b/reference/dom/domnotation.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: dfd5bd438d56bf6b5d7a956b57824ca2216c1969 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.domnotation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La clase <classname>DOMNotation</classname></title>
+ <title>La clase DOMNotation</title>
  <titleabbrev>DOMNotation</titleabbrev>
 
  <partintro>

--- a/reference/dom/domprocessinginstruction.xml
+++ b/reference/dom/domprocessinginstruction.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: a4eaf3b12b3ce22372a37f8add3cf41511f3af68 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.domprocessinginstruction" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La clase <classname>DOMProcessingInstruction</classname></title>
+ <title>La clase DOMProcessingInstruction</title>
  <titleabbrev>DOMProcessingInstruction</titleabbrev>
 
  <partintro>

--- a/reference/dom/functions/dom-import-simplexml.xml
+++ b/reference/dom/functions/dom-import-simplexml.xml
@@ -6,7 +6,8 @@
  <refnamediv>
   <refname>dom_import_simplexml</refname>
   <refpurpose>
-   Transforma un objeto SimpleXMLElement en un objeto <classname>DOMAttr</classname> o <classname>DOMElement</classname>
+   Obtiene un objeto <classname>DOMAttr</classname> o <classname>DOMElement</classname> desde un objeto
+   <classname>SimpleXMLElement</classname>
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">

--- a/reference/ds/ds.queue.xml
+++ b/reference/ds/ds.queue.xml
@@ -85,7 +85,7 @@
        <row>
         <entry>PECL ds 1.3.0</entry>
         <entry>
-         Esta clase implementa ahora <interfacename>ArrayAccess</interfacename>.
+         Esta clase implementa ahora <classname>ArrayAccess</classname>.
         </entry>
        </row>
       </tbody>

--- a/reference/ds/ds.set.xml
+++ b/reference/ds/ds.set.xml
@@ -120,7 +120,7 @@
        <row>
         <entry>PECL ds 1.3.0</entry>
         <entry>
-         Esta clase implementa ahora <interfacename>ArrayAccess</interfacename>.
+         Esta clase implementa ahora <classname>ArrayAccess</classname>.
         </entry>
        </row>
        <row>

--- a/reference/ds/ds.stack.xml
+++ b/reference/ds/ds.stack.xml
@@ -65,7 +65,7 @@
        <row>
         <entry>PECL ds 1.3.0</entry>
         <entry>
-         Esta clase ahora implementa <interfacename>ArrayAccess</interfacename>.
+         Esta clase ahora implementa <classname>ArrayAccess</classname>.
         </entry>
        </row>
       </tbody>

--- a/reference/ds/ds/map/putAll.xml
+++ b/reference/ds/ds/map/putAll.xml
@@ -14,7 +14,7 @@
    <methodparam><type>mixed</type><parameter>pairs</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Asocia todas las parejas clave-valor de un objeto <classname>traversable</classname> o de un &array;.
+    Asocia todas las <parameter>pairs</parameter> clave-valor de un objeto <classname>traversable</classname> o de un &array;.
   </para>
 
   <note>

--- a/reference/ds/ds/queue/construct.xml
+++ b/reference/ds/ds/queue/construct.xml
@@ -26,7 +26,7 @@
     <term><parameter>values</parameter></term>
     <listitem>
      <para>
-      Un objeto <classname>traversable</classname> o un &array; para los valores iniciales.
+      Un objeto traversable o un &array; para los valores iniciales.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/set/construct.xml
+++ b/reference/ds/ds/set/construct.xml
@@ -27,7 +27,7 @@
     <term><parameter>values</parameter></term>
     <listitem>
      <para>
-        Un objeto <classname>traversable</classname> o un &array; a utilizar para los valores iniciales.
+        Un objeto traversable o un &array; a utilizar para los valores iniciales.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/stack/construct.xml
+++ b/reference/ds/ds/stack/construct.xml
@@ -26,7 +26,7 @@
     <term><parameter>values</parameter></term>
     <listitem>
      <para>
-      Un objeto <classname>traversable</classname> o un &array; a utilizar para los valores iniciales.
+      Un objeto traversable o un &array; a utilizar para los valores iniciales.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/vector/construct.xml
+++ b/reference/ds/ds/vector/construct.xml
@@ -26,7 +26,7 @@
     <term><parameter>values</parameter></term>
     <listitem>
      <para>
-      Un objeto <classname>traversable</classname> o un &array; a utilizar para los valores iniciales.
+      Un objeto traversable o un &array; a utilizar para los valores iniciales.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ev/evwatcher.xml
+++ b/reference/ev/evwatcher.xml
@@ -12,7 +12,7 @@
     La clase <classname>EvWatcher</classname> es una clase base
     para todos los watchers (<classname>EvCheck</classname>, <classname>EvChild</classname>
     etc.). Dado que el constructor de la clase <classname>EvWatcher</classname>
-    es <modifier>abstracto</modifier>, no se puede
+    es <modifier>abstract</modifier>, no se puede
     (y no se debe) crear objetos EvWatcher directamente.
    </simpara>
   </section>

--- a/reference/gmagick/gmagick/borderimage.xml
+++ b/reference/gmagick/gmagick/borderimage.xml
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   El objeto <classname>GmagickPixel</classname> con el borde definido
+   El objeto <classname>Gmagick</classname> con el borde definido
   </simpara>
  </refsect1>
 

--- a/reference/gmp/functions/gmp-random-range.xml
+++ b/reference/gmp/functions/gmp-random-range.xml
@@ -52,8 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un número GMP aleatorio.
-   Devuelve un objeto GMP que contiene un entero seleccionado uniformemente
+   Devuelve un objeto <classname>GMP</classname> que contiene un entero seleccionado uniformemente
    en el intervalo cerrado
    [<parameter>min</parameter>, <parameter>max</parameter>].
    <parameter>min</parameter> y <parameter>max</parameter> son

--- a/reference/gnupg/reference.xml
+++ b/reference/gnupg/reference.xml
@@ -20,7 +20,7 @@
    <note>
     <simpara>
      Como alternativa a las funciones que utilizan explícitamente los
-     <type>resource</type>, también puede utilizarse un estilo orientado a objetos mediante objetos <classname>GnuPG</classname>.
+     <type>resource</type>, también puede utilizarse un estilo orientado a objetos mediante objetos <classname>gnupg</classname>.
     </simpara>
    </note>
   </partintro>

--- a/reference/imap/functions/imap-delete.xml
+++ b/reference/imap/functions/imap-delete.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imap_delete</methodname>
+   <type>true</type><methodname>imap_delete</methodname>
    <methodparam><type>IMAP\Connection</type><parameter>imap</parameter></methodparam>
    <methodparam><type>string</type><parameter>message_nums</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -204,7 +204,7 @@
 
  <variablelist xml:id="constant.ini-mode" role="constant_list">
   <title>Constantes modo INI</title>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-user">
    <term>
     <constant>INI_USER</constant>
     (<type>int</type>)
@@ -217,7 +217,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-perdir">
    <term>
     <constant>INI_PERDIR</constant>
     (<type>int</type>)
@@ -228,7 +228,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-system">
    <term>
     <constant>INI_SYSTEM</constant>
     (<type>int</type>)
@@ -239,7 +239,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-all">
    <term>
     <constant>INI_ALL</constant>
     (<type>int</type>)

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -209,6 +209,7 @@
       Lanza una excepción <classname>AssertionError</classname> cuando una
       aserción falla.
      </para>
+     &warn.deprecated.feature-8-3-0;
     </listitem>
    </varlistentry>
 

--- a/reference/intl/constants.xml
+++ b/reference/intl/constants.xml
@@ -606,7 +606,537 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.u-misplaced-compound-filter">
+<varlistentry xml:id="constant.u-error-limit">
+    <term>
+     <constant>U_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_PLUGIN_ERROR_LIMIT</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-error-warning-limit">
+    <term>
+     <constant>U_ERROR_WARNING_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      This must always be the last warning value to indicate
+      the limit for UErrorCode warnings (last warning code +1).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-error-warning-start">
+    <term>
+     <constant>U_ERROR_WARNING_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Start of information results (semantically successful).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-file-access-error">
+    <term>
+     <constant>U_FILE_ACCESS_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The requested file cannot be found.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-fmt-parse-error-limit">
+    <term>
+     <constant>U_FMT_PARSE_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The limit for format library errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-fmt-parse-error-start">
+    <term>
+     <constant>U_FMT_PARSE_ERROR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Start of format library errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-ace-prefix-error">
+    <term>
+     <constant>U_IDNA_ACE_PREFIX_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-check-bidi-error">
+    <term>
+     <constant>U_IDNA_CHECK_BIDI_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-domain-name-too-long-error">
+    <term>
+     <constant>U_IDNA_DOMAIN_NAME_TOO_LONG_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-error-limit">
+    <term>
+     <constant>U_IDNA_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-error-start">
+    <term>
+     <constant>U_IDNA_ERROR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-label-too-long-error">
+    <term>
+     <constant>U_IDNA_LABEL_TOO_LONG_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-prohibited-error">
+    <term>
+     <constant>U_IDNA_PROHIBITED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-std3-ascii-rules-error">
+    <term>
+     <constant>U_IDNA_STD3_ASCII_RULES_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-unassigned-error">
+    <term>
+     <constant>U_IDNA_UNASSIGNED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-verification-error">
+    <term>
+     <constant>U_IDNA_VERIFICATION_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-idna-zero-length-label-error">
+    <term>
+     <constant>U_IDNA_ZERO_LENGTH_LABEL_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-argument-error">
+    <term>
+     <constant>U_ILLEGAL_ARGUMENT_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Indicates an incorrect argument value.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-char-found">
+    <term>
+     <constant>U_ILLEGAL_CHAR_FOUND</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Character conversion: Illegal input sequence.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-char-in-segment">
+    <term>
+     <constant>U_ILLEGAL_CHAR_IN_SEGMENT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-character">
+    <term>
+     <constant>U_ILLEGAL_CHARACTER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A special character is outside its allowed context.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-escape-sequence">
+    <term>
+     <constant>U_ILLEGAL_ESCAPE_SEQUENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ISO-2022 illlegal escape sequence.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-illegal-pad-position">
+    <term>
+     <constant>U_ILLEGAL_PAD_POSITION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Pad symbol misplaced in number pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-index-outofbounds-error">
+    <term>
+     <constant>U_INDEX_OUTOFBOUNDS_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Trying to access the index that is out of bounds.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-internal-program-error">
+    <term>
+     <constant>U_INTERNAL_PROGRAM_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Indicates a bug in the library code.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-internal-transliterator-error">
+    <term>
+     <constant>U_INTERNAL_TRANSLITERATOR_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Internal transliterator system error.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-char-found">
+    <term>
+     <constant>U_INVALID_CHAR_FOUND</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Character conversion: Unmappable input sequence. In other APIs: Invalid character.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-format-error">
+    <term>
+     <constant>U_INVALID_FORMAT_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Data format is not what is expected.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-function">
+    <term>
+     <constant>U_INVALID_FUNCTION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <literal>'&amp;fn()'</literal> rule specifies an unknown transliterator.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-id">
+    <term>
+     <constant>U_INVALID_ID</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <literal>'::id'</literal> rule specifies an unknown transliterator.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-property-pattern">
+    <term>
+     <constant>U_INVALID_PROPERTY_PATTERN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-rbt-syntax">
+    <term>
+     <constant>U_INVALID_RBT_SYNTAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <literal>'::id'</literal> rule was passed to the RuleBasedTransliterator parser.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-state-error">
+    <term>
+     <constant>U_INVALID_STATE_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Requested operation can not be completed with ICU in its current state.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-table-file">
+    <term>
+     <constant>U_INVALID_TABLE_FILE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Conversion table file not found.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invalid-table-format">
+    <term>
+     <constant>U_INVALID_TABLE_FORMAT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Conversion table file found, but corrupted.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-invariant-conversion-error">
+    <term>
+     <constant>U_INVARIANT_CONVERSION_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unable to convert a <code>UChar*</code> string to <code>char*</code>
+      with the invariant converter.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-exponential-pattern">
+    <term>
+     <constant>U_MALFORMED_EXPONENTIAL_PATTERN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Grouping symbol in exponent pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-pragma">
+    <term>
+     <constant>U_MALFORMED_PRAGMA</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <literal>'use'</literal> pragma is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-rule">
+    <term>
+     <constant>U_MALFORMED_RULE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Elements of a rule are misplaced.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-set">
+    <term>
+     <constant>U_MALFORMED_SET</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <code>UnicodeSet</code> pattern is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-symbol-reference">
+    <term>
+     <constant>U_MALFORMED_SYMBOL_REFERENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-unicode-escape">
+    <term>
+     <constant>U_MALFORMED_UNICODE_ESCAPE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A Unicode escape pattern is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-variable-definition">
+    <term>
+     <constant>U_MALFORMED_VARIABLE_DEFINITION</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A variable definition is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-malformed-variable-reference">
+    <term>
+     <constant>U_MALFORMED_VARIABLE_REFERENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A variable reference is invalid.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-memory-allocation-error">
+    <term>
+     <constant>U_MEMORY_ALLOCATION_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Memory allocation error.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-message-parse-error">
+    <term>
+     <constant>U_MESSAGE_PARSE_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unable to parse a message (message format).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-mismatched-segment-delimiters">
+    <term>
+     <constant>U_MISMATCHED_SEGMENT_DELIMITERS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-misplaced-anchor-start">
+    <term>
+     <constant>U_MISPLACED_ANCHOR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A start anchor appears at an illegal position.
+     </simpara>
+    </listitem>
+   </varlistentry>
+      <varlistentry xml:id="constant.u-misplaced-compound-filter">
     <term>
      <constant>U_MISPLACED_COMPOUND_FILTER</constant>
      (<type>int</type>)
@@ -881,6 +1411,505 @@
      </simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.u-regex-error-limit">
+    <term>
+     <constant>U_REGEX_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      This must always be the last value to indicate the limit for regexp errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-error-start">
+    <term>
+     <constant>U_REGEX_ERROR_START</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Start of codes indicating Regexp failures.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-internal-error">
+    <term>
+     <constant>U_REGEX_INTERNAL_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      An internal error (bug) was detected.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-invalid-back-ref">
+    <term>
+     <constant>U_REGEX_INVALID_BACK_REF</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Back-reference to a non-existent capture group.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-invalid-flag">
+    <term>
+     <constant>U_REGEX_INVALID_FLAG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Invalid value for match mode flags.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-invalid-state">
+    <term>
+     <constant>U_REGEX_INVALID_STATE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      <code>RegexMatcher</code> in invalid state for requested operation.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-look-behind-limit">
+    <term>
+     <constant>U_REGEX_LOOK_BEHIND_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Look-Behind pattern matches must have a bounded maximum length.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-max-lt-min">
+    <term>
+     <constant>U_REGEX_MAX_LT_MIN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      In <literal>{min,max}</literal>, max is less than min.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-mismatched-paren">
+    <term>
+     <constant>U_REGEX_MISMATCHED_PAREN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Incorrectly nested parentheses in regexp pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-number-too-big">
+    <term>
+     <constant>U_REGEX_NUMBER_TOO_BIG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Decimal number is too large.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-property-syntax">
+    <term>
+     <constant>U_REGEX_PROPERTY_SYNTAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Incorrect Unicode property.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-rule-syntax">
+    <term>
+     <constant>U_REGEX_RULE_SYNTAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Syntax error in regexp pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-set-contains-string">
+    <term>
+     <constant>U_REGEX_SET_CONTAINS_STRING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Regexps cannot have <code>UnicodeSet</code>s containing strings.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-regex-unimplemented">
+    <term>
+     <constant>U_REGEX_UNIMPLEMENTED</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Use of regexp feature that is not yet implemented.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-resource-type-mismatch">
+    <term>
+     <constant>U_RESOURCE_TYPE_MISMATCH</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      An operation is requested over a resource that does not support it.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-rule-mask-error">
+    <term>
+     <constant>U_RULE_MASK_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A rule is hidden by an earlier more general rule.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-safeclone-allocated-warning">
+    <term>
+     <constant>U_SAFECLONE_ALLOCATED_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A <code>SafeClone</code> operation required allocating memory (informational only).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-sort-key-too-short-warning">
+    <term>
+     <constant>U_SORT_KEY_TOO_SHORT_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Number of levels requested in <code>getBound</code> is higher
+      than the number of levels in the sort key.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-standard-error-limit">
+    <term>
+     <constant>U_STANDARD_ERROR_LIMIT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      This must always be the last value to indicate the limit for standard errors.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-state-old-warning">
+    <term>
+     <constant>U_STATE_OLD_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ICU has to use compatibility layer to construct the service.
+      Expect performance/memory usage degradation.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-state-too-old-error">
+    <term>
+     <constant>U_STATE_TOO_OLD_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ICU cannot construct a service from this state, as it is no longer supported.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-string-not-terminated-warning">
+    <term>
+     <constant>U_STRING_NOT_TERMINATED_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      An output string could not be NUL-terminated because output <code>length==destCapacity</code>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-stringprep-check-bidi-error">
+    <term>
+     <constant>U_STRINGPREP_CHECK_BIDI_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_IDNA_CHECK_BIDI_ERROR</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-stringprep-prohibited-error">
+    <term>
+     <constant>U_STRINGPREP_PROHIBITED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_IDNA_PROHIBITED_ERROR</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-stringprep-unassigned-error">
+    <term>
+     <constant>U_STRINGPREP_UNASSIGNED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Alias of <constant>U_IDNA_UNASSIGNED_ERROR</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-too-many-aliases-error">
+    <term>
+     <constant>U_TOO_MANY_ALIASES_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      There are too many aliases in the path to the requested resource.
+      It is very possible that a circular alias definition has occured.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-trailing-backslash">
+    <term>
+     <constant>U_TRAILING_BACKSLASH</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A dangling backslash.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-truncated-char-found">
+    <term>
+     <constant>U_TRUNCATED_CHAR_FOUND</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Character conversion: Incomplete input sequence.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unclosed-segment">
+    <term>
+     <constant>U_UNCLOSED_SEGMENT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A closing <literal>')'</literal> is missing.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-undefined-segment-reference">
+    <term>
+     <constant>U_UNDEFINED_SEGMENT_REFERENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A segment reference does not correspond to a defined segment.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-undefined-variable">
+    <term>
+     <constant>U_UNDEFINED_VARIABLE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A variable reference does not correspond to a defined variable.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unexpected-token">
+    <term>
+     <constant>U_UNEXPECTED_TOKEN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Syntax error in format pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unmatched-braces">
+    <term>
+     <constant>U_UNMATCHED_BRACES</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Braces do not match in message pattern.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unquoted-special">
+    <term>
+     <constant>U_UNQUOTED_SPECIAL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A special character was not quoted or escaped.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unsupported-attribute">
+    <term>
+     <constant>U_UNSUPPORTED_ATTRIBUTE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unsupported-error">
+    <term>
+     <constant>U_UNSUPPORTED_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Requested operation not supported in current context.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unsupported-escape-sequence">
+    <term>
+     <constant>U_UNSUPPORTED_ESCAPE_SEQUENCE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      ISO-2022 unsupported escape sequence.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unsupported-property">
+    <term>
+     <constant>U_UNSUPPORTED_PROPERTY</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unused as of ICU 2.4.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-unterminated-quote">
+    <term>
+     <constant>U_UNTERMINATED_QUOTE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A closing single quote is missing.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-useless-collator-error">
+    <term>
+     <constant>U_USELESS_COLLATOR_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Collator is options only and no base is specified.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-using-default-warning">
+    <term>
+     <constant>U_USING_DEFAULT_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A resource bundle lookup returned a result from the root locale (not an error).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-using-fallback-warning">
+    <term>
+     <constant>U_USING_FALLBACK_WARNING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      A resource bundle lookup returned a fallback result (not an error).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-variable-range-exhausted">
+    <term>
+     <constant>U_VARIABLE_RANGE_EXHAUSTED</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Too many stand-ins generated for the given variable range.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-variable-range-overlap">
+    <term>
+     <constant>U_VARIABLE_RANGE_OVERLAP</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      The variable range overlaps characters used in rules.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.u-zero-error">
+    <term>
+     <constant>U_ZERO_ERROR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      No error, no warning.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
   </variablelist>
  </para>
 </appendix>

--- a/reference/intl/dateformatter.xml
+++ b/reference/intl/dateformatter.xml
@@ -119,6 +119,28 @@
 
   </section>
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Se añadió <constant>IntlDateFormatter::PATTERN</constant>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
   <section xml:id="intldateformatter.seealso">
    &reftitle.seealso;
    <para>
@@ -147,12 +169,6 @@
       </row>
      </thead>
      <tbody>
-      <row>
-       <entry>8.4.0</entry>
-       <entry>
-        Se añadió <constant>IntlDateFormatter::PATTERN</constant>.
-       </entry>
-      </row>
       <row>
        <entry>8.4.0</entry>
        <entry>

--- a/reference/intl/dateformatter/settimezone.xml
+++ b/reference/intl/dateformatter/settimezone.xml
@@ -15,7 +15,7 @@
    &style.oop;
   </para>
   <methodsynopsis role="IntlDateFormatter">
-   <modifier>public</modifier> <type class="union"><type>bool</type><type>null</type></type><methodname>IntlDateFormatter::setTimeZone</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>IntlDateFormatter::setTimeZone</methodname>
    <methodparam><type class="union"><type>IntlTimeZone</type><type>DateTimeZone</type><type>string</type><type>null</type></type><parameter>timezone</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/mail/ini.xml
+++ b/reference/mail/ini.xml
@@ -130,6 +130,11 @@
       parámetro adicional para sendmail. Estos parámetros reemplazarán
       al quinto parámetro de la función <function>mail</function>.
      </para>
+     <simpara>
+      Además del comportamiento predeterminado para <constant>INI_SYSTEM</constant>,
+      este valor también se puede establecer con <literal>php_value</literal>
+      en <filename>httpd.conf</filename> (aunque no se recomienda).
+     </simpara>
     </listitem>
    </varlistentry>
 

--- a/reference/mail/setup.xml
+++ b/reference/mail/setup.xml
@@ -10,8 +10,8 @@
  <section xml:id="mail.requirements">
   &reftitle.required;
   <para>
-   Para que la función <function>mail</function> esté disponible,
-   es necesario que PHP tenga acceso al servicio <literal>sendmail</literal>
+   Para que las funciones Mail estén disponibles,
+   es necesario que PHP tenga acceso al binario <literal>sendmail</literal>
    en el servidor durante la compilación. Si se utiliza otro programa de correo,
    como <productname>qmail</productname> o <productname>postfix</productname>,
    asegúrese de utilizar las API correctas. PHP comenzará a buscar sendmail en el <envar>PATH</envar>,

--- a/reference/math/functions/log.xml
+++ b/reference/math/functions/log.xml
@@ -16,8 +16,9 @@
   </methodsynopsis>
   <para>
    Si el argumento opcional <parameter>base</parameter> es
-   especificado, <function>log</function> devuelve entonces el
-   logaritmo en base <parameter>base</parameter>, de lo contrario
+   especificado, <function>log</function> devuelve entonces
+   log<subscript><parameter>base</parameter></subscript>
+   <parameter>num</parameter>, de lo contrario
    <function>log</function> devuelve el logaritmo natural
    (o neperiano) de <parameter>num</parameter>.
   </para>

--- a/reference/math/functions/log.xml
+++ b/reference/math/functions/log.xml
@@ -17,7 +17,7 @@
   <para>
    Si el argumento opcional <parameter>base</parameter> es
    especificado, <function>log</function> devuelve entonces
-   log<subscript><parameter>base</parameter></subscript>
+   log<subscript>base</subscript>
    <parameter>num</parameter>, de lo contrario
    <function>log</function> devuelve el logaritmo natural
    (o neperiano) de <parameter>num</parameter>.

--- a/reference/mbstring/book.xml
+++ b/reference/mbstring/book.xml
@@ -36,7 +36,7 @@
    <literal>mbstring</literal> controla la conversión de la codificación de caracteres entre
    los posibles esquemas de codificación. <literal>mbstring</literal> está diseñada para
    manejar codificaciones basadas en Unicode, tales como UTF-8 y UCS-2, y, por conveniencia,
-   varias codificaciones de un solo byte (enumeradas más adelante).
+   varias codificaciones de un solo byte (enumeradas en <link linkend="mbstring.supported-encodings">Codificaciones de caracteres soportadas</link>).
   </para>
  </preface>
  <!-- }}} -->

--- a/reference/memcached/memcached/setoption.xml
+++ b/reference/memcached/memcached/setoption.xml
@@ -16,7 +16,7 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>Memcached::setOption</function> configura un valor de la opción Memcached
+   Este método configura un valor de la opción Memcached
    <parameter>option</parameter> con el valor <parameter>value</parameter>.
    Algunas opciones corresponden a las definidas en libmemcached, y otras
    son específicas de la extensión.

--- a/reference/mongodb/bson/binary.xml
+++ b/reference/mongodb/bson/binary.xml
@@ -240,6 +240,15 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.2.0</entry>
+        <entry>
+         Adición de <constant>MongoDB\BSON\Binary::TYPE_VECTOR</constant>, así como las funciones
+         <methodname>MongoDB\BSON\Binary::fromVector</methodname>,
+         <methodname>MongoDB\BSON\Binary::getVectorType</methodname> y
+         <methodname>MongoDB\BSON\Binary::toArray</methodname>.
+        </entry>
+       </row>
        &mongodb.changelog.serializable-interface-removed;
        <row>
         <entry>PECL mongodb 1.17.0</entry>

--- a/reference/mqseries/constants.xml
+++ b/reference/mqseries/constants.xml
@@ -12,7 +12,7 @@
   Application Programming Reference red books".
  </simpara>
  <simpara>El nombre de las constantes mqseries se forma prefijando el nombre de la constante
- WebSphere MQ con <literal>MQSERIES_</literal>. Por ejemplo, las constantes
+ WebSphere MQ con MQSERIES_, por ejemplo, las constantes
  de CompletionCode son:
  </simpara>
  <table>
@@ -26,19 +26,19 @@
    </thead>
    <tbody>
     <row xml:id="constant.mqseries-mqcc-ok">
-     <entry>MQSERIES_MQCC_OK</entry>
+     <entry><constant>MQSERIES_MQCC_OK</constant></entry>
      <entry>MQCC_OK</entry>
     </row>
     <row xml:id="constant.mqseries-mqcc-warning">
-     <entry>MQSERIES_MQCC_WARNING</entry>
+     <entry><constant>MQSERIES_MQCC_WARNING</constant></entry>
      <entry>MQCC_WARNING</entry>
     </row>
     <row xml:id="constant.mqseries-mqcc-failed">
-     <entry>MQSERIES_MQCC_FAILED</entry>
+     <entry><constant>MQSERIES_MQCC_FAILED</constant></entry>
      <entry>MQCC_FAILED</entry>
     </row>
     <row xml:id="constant.mqseries-mqcc-unknown">
-     <entry>MQSERIES_MQCC_UNKNOWN</entry>
+     <entry><constant>MQSERIES_MQCC_UNKNOWN</constant></entry>
      <entry>MQCC_UNKNOWN</entry>
     </row>
    </tbody>

--- a/reference/mysql/functions/mysql-connect.xml
+++ b/reference/mysql/functions/mysql-connect.xml
@@ -191,7 +191,7 @@ mysql_close($enlace);
     Windows). Si se quiere usar TCP/IP, se ha de utilizar &quot;127.0.0.1&quot;
     en lugar de &quot;localhost&quot;. Si la biblioteca cliente de MySQL intenta
     conectarse al socket local erróneo, se debería establecer el ruta correcta como
-    <xref linkend="ini.mysql.default-host"/> en la configuración de PHP y dejar el campo del servidor en
+    <link linkend="ini.mysql.default-host">mysql.default_host</link> en &php.ini; y dejar el campo del servidor en
     blanco.
    </simpara>
   </note>
@@ -200,13 +200,6 @@ mysql_close($enlace);
     El enlace al servidor se cerrará tan pronto finalice la ejecución
     del script, a menos que se cierre antes por una llamada explícita a
     <function>mysql_close</function>.
-   </simpara>
-  </note>
-  <note>
-   <simpara>
-    Se pPuede suprimir el mensaje de error en caso de fallo anteponiendo
-    un <link linkend="language.operators.errorcontrol">@</link>
-    al nombre de la función.
    </simpara>
   </note>
   <note>

--- a/reference/mysqli/mysqli_stmt/affected-rows.xml
+++ b/reference/mysqli/mysqli_stmt/affected-rows.xml
@@ -52,7 +52,7 @@
   <note>
    <para>
     Si el número de filas afectadas es mayor que el valor máximo
-    (<constant>PHP_INT_MAX</constant>) que puede tomar un entero, el número
+    de un entero PHP, el número
     de filas afectadas será devuelto como una cadena de caracteres.
    </para>
   </note>

--- a/reference/oauth/oauth/fetch.xml
+++ b/reference/oauth/oauth/fetch.xml
@@ -45,9 +45,8 @@
     <term><parameter>http_method</parameter></term>
     <listitem>
      <simpara>
-      Una de las constantes <link linkend="oauth.constants">OAUTH constants</link>
-      <constant>OAUTH_HTTP_METHOD_<replaceable>*</replaceable></constant>, incluyendo
-      GET, POST, PUT, HEAD, o DELETE.
+      Una de las constantes <constant>OAUTH_HTTP_METHOD_<replaceable>*</replaceable></constant>
+      OAUTH, incluyendo GET, POST, PUT, HEAD, o DELETE.
      </simpara>
      <simpara>
       HEAD (<constant>OAUTH_HTTP_METHOD_HEAD</constant>) puede ser útil

--- a/reference/oauth/oauthprovider/checkoauthrequest.xml
+++ b/reference/oauth/oauthprovider/checkoauthrequest.xml
@@ -38,8 +38,8 @@
     <term><parameter>method</parameter></term>
     <listitem>
      <simpara>
-      El método <acronym>HTTP</acronym>. Opcional; pase una constante entre las
-      <link linkend="oauth.constants">constantes OAuth</link> <constant>OAUTH_HTTP_METHOD_<replaceable>*</replaceable></constant>.
+      El método <acronym>HTTP</acronym>. Opcional; pase una de las constantes OAuth
+      <constant>OAUTH_HTTP_METHOD_<replaceable>*</replaceable></constant>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/oci8/dtrace.xml
+++ b/reference/oci8/dtrace.xml
@@ -370,8 +370,8 @@ php*:::oci8-execute-mode
   </para>
 
   <para>
-   Cuando la monitorización está completa, el script D puede terminarse con un
-   <literal>^C</literal>.
+   Cuando la monitorización está completa, el script D puede terminarse con
+   <keycombo action='simul'><keycap>CTRL</keycap><keycap>C</keycap></keycombo>.
   </para>
 
  </section>

--- a/reference/oci8/ocilob/append.xml
+++ b/reference/oci8/ocilob/append.xml
@@ -17,7 +17,7 @@
    Añade datos a un LOB Oracle.
   </para>
   <para>
-   La escritura en un LOB con <function>OCI-Lob->append</function> fallará
+   La escritura en un LOB con este método fallará
    si la bufferización ha sido previamente activada. Se debe desactivar
    la bufferización antes de añadir datos. Puede ser necesario vaciar los buffers
    con la función <xref linkend="ocilob.flush"/>

--- a/reference/oci8/ocilob/load.xml
+++ b/reference/oci8/ocilob/load.xml
@@ -18,7 +18,7 @@
    <link linkend="ini.memory-limit">memory_limit</link>, si este
    último excede el límite. En la mayoría de los casos, se
    recomienda utilizar la función
-   <xref linkend="ocilob.read"/> en su lugar. En caso de error, <function>OCI-Lob->load</function> devuelve &false;.
+   <xref linkend="ocilob.read"/> en su lugar.
   </para>
  </refsect1>
 

--- a/reference/oci8/ocilob/truncate.xml
+++ b/reference/oci8/ocilob/truncate.xml
@@ -26,10 +26,8 @@
      <term><parameter>length</parameter></term>
      <listitem>
       <para>
-       Si <parameter>length</parameter> es proporcionado,
-       <function>OCI-Lob->truncate</function> trunca el LOB a
-       <parameter>length</parameter> bytes. De lo contrario,
-       <function>OCI-Lob->truncate</function> vacía completamente el LOB.
+       Si <parameter>length</parameter> es proporcionado, este método truncará el LOB a
+       <parameter>length</parameter> bytes. De lo contrario, vaciará completamente el LOB.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -62,7 +62,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>salt</literal> - para proporcionar manualmente un salt a utilizar durante el hash de
+      <literal>salt</literal> (<type>string</type>) - para proporcionar manualmente un salt a utilizar durante el hash de
       la contraseña. Tenga en cuenta que esta opción evitará la generación automática.
      </para>
      <para>
@@ -79,7 +79,7 @@
     </listitem>
     <listitem>
      <para>
-      <literal>cost</literal> - determina el costo algorítmico que debe ser utilizado.
+      <literal>cost</literal> (<type>int</type>) - determina el costo algorítmico que debe ser utilizado.
       Ejemplos de estos valores pueden ser encontrados en la página de documentación
       de la función <function>crypt</function>.
      </para>

--- a/reference/pcntl/book.xml
+++ b/reference/pcntl/book.xml
@@ -22,7 +22,7 @@
    sobre el control de procesos Unix, se recomienda consultar
    la documentación del sistema, incluyendo especialmente
    fork(2), waitpid(2) y signal(2), o bien consultar una obra de referencia
-   como <literal>"Advanced Programming in the UNIX Environment"</literal>
+   como "Advanced Programming in the UNIX Environment"
    de W. Richard Stevens, publicada por Addison-Wesley.
   </para>
   <para>

--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -74,30 +74,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.sigckpt">
-   <term>
-    <constant>SIGCKPT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Genera/restituye un punto de control.
-     Disponible a partir de PHP 8.4.0 (uniquely on DragonFlyBSD).
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.sigckptexit">
-   <term>
-    <constant>SIGCKPTEXIT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Genera/restituye un punto de control y sale.
-     Disponible a partir de PHP 8.4.0 (uniquely on DragonFlyBSD).
-    </simpara>
-   </listitem>
-  </varlistentry>
  </variablelist>
 
  <variablelist xml:id="pcntl.constants.sig">
@@ -578,6 +554,30 @@
    </term>
    <listitem>
     <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sigckpt">
+   <term>
+    <constant>SIGCKPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Genera/restituye un punto de control.
+     Disponible a partir de PHP 8.4.0 (uniquely on DragonFlyBSD).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sigckptexit">
+   <term>
+    <constant>SIGCKPTEXIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Genera/restituye un punto de control y sale.
+     Disponible a partir de PHP 8.4.0 (uniquely on DragonFlyBSD).
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pcntl/functions/pcntl-alarm.xml
+++ b/reference/pcntl/functions/pcntl-alarm.xml
@@ -17,8 +17,8 @@
   </methodsynopsis>
   <para>
    Crea una cuenta atrás que enviará una señal
-   <constant>SIGALRM</constant> al proceso después de
-   <parameter>seconds</parameter> segundos.
+   <constant>SIGALRM</constant> al proceso después del
+   número de segundos dado.
    Cualquier llamada a <function>pcntl_alarm</function> anulará las
    cuentas atrás previamente configuradas.
   </para>
@@ -33,7 +33,7 @@
      <listitem>
       <para>
        El número de segundos a esperar. Si <parameter>seconds</parameter>
-       vale <literal>0</literal>, no se creará ninguna nueva alarma.
+       vale cero, no se creará ninguna nueva alarma.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -31,8 +31,8 @@
       <para>
        <parameter>path</parameter> debe ser la ruta hacia un binario ejecutable
        o un script con una ruta válida apuntando a un ejecutable en la primera línea
-       (por ejemplo, <literal>#!/usr/local/bin/perl</literal>).
-       Ver las páginas de ayuda de su sistema concernientes a <literal>execve(2)</literal>
+       (por ejemplo, #!/usr/local/bin/perl).
+       Ver las páginas de ayuda de su sistema concernientes a execve(2)
        para más información.
       </para>
      </listitem>

--- a/reference/pcntl/functions/pcntl-rfork.xml
+++ b/reference/pcntl/functions/pcntl-rfork.xml
@@ -53,6 +53,17 @@
          <constant>RFLINUXTHPN</constant>: Si está definido, el núcleo devolverá SIGUSR1 en lugar de SIGCHILD al salir del hilo para el hijo.
          Esto está destinado a hacer la notificación de salida del padre de salida del hilo Linux clone.
         </member>
+        <member>
+         <constant>RFTSIGZMB</constant>: Si está definido, el núcleo enviará la señal especificada
+         por el parámetro <parameter>signal</parameter> al padre al salir el hijo,
+         en lugar del SIGCHLD por omisión. Especificar el número de señal 0 desactiva
+         la entrega de señal al salir el hijo.
+        </member>
+        <member>
+         <constant>RFTHREAD</constant>: Si está definido, el nuevo proceso comparte el descriptor de fichero
+         a la tabla de líderes de proceso con su padre. Solo se aplica cuando ni
+         <constant>RFFDG</constant> ni <constant>RFCFDG</constant> están definidos.
+        </member>
        </simplelist>
       </para>
      </listitem>
@@ -61,7 +72,9 @@
      <term><parameter>signal</parameter></term>
      <listitem>
       <para>
-       El número del signal.
+       El número de señal a enviar al padre cuando el hijo sale.
+       Solo se usa cuando el indicador <constant>RFTSIGZMB</constant> está definido.
+       Especificar <literal>0</literal> desactiva la entrega de señal al salir el hijo.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pcntl/functions/pcntl-signal.xml
+++ b/reference/pcntl/functions/pcntl-signal.xml
@@ -67,7 +67,7 @@
          <term><parameter>siginfo</parameter></term>
          <listitem>
           <simpara>
-           Si el sistema operativo soporta las estructuras siginfo_t, esto será un &array; de información de la señal que depende de la señal.
+           Si el sistema operativo soporta las estructuras siginfo_t, esto será un array de información de la señal que depende de la señal.
           </simpara>
          </listitem>
         </varlistentry>
@@ -86,8 +86,7 @@
      <term><parameter>restart_syscalls</parameter></term>
      <listitem>
       <para>
-       El parámetro opcional <parameter>restart_syscalls</parameter>
-       especifica si la llamada al sistema de reinicio (restarting) debe ser utilizada
+       Especifica si la llamada al sistema de reinicio (restarting) debe ser utilizada
        cuando llega esta señal.
       </para>
      </listitem>
@@ -213,7 +212,7 @@ echo "Hecho\n";
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link xlink:href="https://fr.wikipedia.org/wiki/Signal_(informatique)">Signal (IPC)</link> en Wikipedia</member>
+    <member><link xlink:href="https://en.wikipedia.org/wiki/Signal_(IPC)">Signal (IPC)</link> en Wikipedia</member>
     <member><function>pcntl_async_signals</function></member>
     <member><function>pcntl_fork</function></member>
     <member><function>pcntl_signal_dispatch</function></member>

--- a/reference/pcntl/functions/pcntl-wait.xml
+++ b/reference/pcntl/functions/pcntl-wait.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>array</type><parameter role="reference">resource_usage</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>pcntl_wait</function> suspende la ejecución del proceso
+   La función wait suspende la ejecución del proceso
    actual hasta que uno de los procesos hijos haya terminado, o hasta que
    se envíe una señal para terminar el proceso actual o
    para llamar a un gestor. Si el proceso ya ha terminado en el momento
@@ -30,8 +30,9 @@
   <note>
    <para>
     Esta función es equivalente a llamar a la función
-    <function>pcntl_waitpid</function> con un <parameter>process_id</parameter>
-    valiendo <literal>-1</literal> y sin <parameter>flags</parameter>.
+    <function>pcntl_waitpid</function>
+    con un <literal>-1</literal> <parameter>process_id</parameter> y sin
+    <parameter>flags</parameter>.
    </para>
   </note>
  </refsect1>
@@ -66,7 +67,7 @@
        wait() será utilizado para la llamada al sistema. Si wait3 no está disponible,
        el parámetro <parameter>flags</parameter> no tendrá efecto. El valor
        de <parameter>flags</parameter> es la combinación de cero o más
-       de las siguientes constantes:
+       de las siguientes dos constantes con el operador <literal>OR</literal>:
        <table>
         <title>Valores posibles para <parameter>flags</parameter></title>
         <tgroup cols="2">

--- a/reference/pcntl/functions/pcntl-waitpid.xml
+++ b/reference/pcntl/functions/pcntl-waitpid.xml
@@ -80,8 +80,8 @@
       </para>
       <note>
        <para>
-        Si <parameter>process_id</parameter> vale <literal>-1</literal>, esto equivale
-        a utilizar la función <function>pcntl_wait</function> (menos
+        Especificando <literal>-1</literal> como <parameter>process_id</parameter>, esto equivale
+        a la funcionalidad que proporciona <function>pcntl_wait</function> (menos
         <parameter>flags</parameter>).
        </para>
       </note>

--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -28,7 +28,7 @@
       que corresponden a la primera paréntesis capturante y así sucesivamente. Esta
       constante se utiliza con <function>preg_match_all</function>.
      </entry>
-     <entry></entry>
+     <entry/>
     </row>
     <row xml:id="constant.preg-set-order">
      <entry>
@@ -42,7 +42,7 @@
       segunda, etc.
       Esta constante se utiliza con <function>preg_match_all</function>.
      </entry>
-     <entry></entry>
+     <entry/>
     </row>
     <row xml:id="constant.preg-offset-capture">
      <entry>
@@ -50,13 +50,11 @@
       (<type>int</type>)
      </entry>
      <entry>
-      <para>
-       Si esta opción está activada, para cada coincidencia encontrada,
-       el desplazamiento del byte correspondiente también será devuelto.
-       Tenga en cuenta que esto modifica los valores de retorno: cada elemento del array
-       se convierte en un array que contiene la cadena correspondiente en el offset 0
-       y su desplazamiento en la cadena analizada en el offset 1.
-      </para>
+      Si esta opción está activada, para cada coincidencia encontrada,
+      el desplazamiento del byte correspondiente también será devuelto.
+      Tenga en cuenta que esto modifica los valores de retorno: cada elemento del array
+      se convierte en un array que contiene la cadena correspondiente en el offset 0
+      y su desplazamiento en la cadena analizada en el offset 1.
      </entry>
      <entry/>
     </row>
@@ -77,12 +75,10 @@
       (<type>int</type>)
      </entry>
      <entry>
-      <para>
-       Ver la descripción de <constant>PREG_OFFSET_CAPTURE</constant>.
-       Esta bandera solo se utiliza con <function>preg_split</function>.
-      </para>
+      Esta bandera indica a <function>preg_split</function> que capture
+      también las expresiones entre paréntesis del patrón delimitador.
      </entry>
-     <entry></entry>
+     <entry/>
     </row>
     <row xml:id="constant.preg-split-offset-capture">
      <entry>
@@ -90,10 +86,8 @@
       (<type>int</type>)
      </entry>
      <entry>
-      Si esta constante se utiliza con <function>preg_split</function>,
-      el desplazamiento de inicio del resultado será devuelto, además de la cadena
-      resultado. Tenga en cuenta que esto cambia la naturaleza del resultado devuelto a
-      un array que contiene una cadena en el offset 0 y una cadena que contiene un desplazamiento en el offset 1.
+      Ver la descripción de <constant>PREG_OFFSET_CAPTURE</constant>.
+      Esta bandera solo se utiliza con <function>preg_split</function>.
      </entry>
      <entry/>
     </row>

--- a/reference/pcre/functions/preg-filter.xml
+++ b/reference/pcre/functions/preg-filter.xml
@@ -36,13 +36,13 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &array; si el parámetro <parameter>subject</parameter>
-   es de tipo &array; o una &string; en otro caso.
+   Devuelve un <type>array</type> si el parámetro <parameter>subject</parameter>
+   es de tipo <type>array</type> o una <type>string</type> en otro caso.
   </para>
   <para>
    Si ninguna ocurrencia es encontrada o si ocurre un error,
-   un &array; vacío será devuelto cuando el parámetro
-   <parameter>subject</parameter> es un &array; o &null; en otro caso.
+   un <type>array</type> vacío será devuelto cuando el parámetro
+   <parameter>subject</parameter> es un <type>array</type> o &null; en otro caso.
   </para>
  </refsect1>
 

--- a/reference/pcre/functions/preg-grep.xml
+++ b/reference/pcre/functions/preg-grep.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>preg_grep</function> devuelve un &array; que contiene
+   Devuelve el array que contiene
    los elementos de <parameter>array</parameter>
    que satisfacen el patrón <parameter>pattern</parameter>.
   </para>
@@ -31,7 +31,7 @@
      <term><parameter>pattern</parameter></term>
      <listitem>
       <para>
-       El patrón a buscar, en forma de &string;.
+       El patrón a buscar, en forma de cadena.
       </para>
      </listitem>
     </varlistentry>
@@ -48,8 +48,7 @@
      <listitem>
       <para>
        Si esta opción tiene el valor <constant>PREG_GREP_INVERT</constant>,
-       esta función devuelve los elementos del array
-       <parameter>input</parameter> que <emphasis>no</emphasis> coinciden
+       esta función devuelve los elementos del array de entrada que <emphasis>no</emphasis> coinciden
        con el patrón
        <parameter>pattern</parameter>.
       </para>
@@ -62,8 +61,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &array; indexado, utilizando las claves del
-   array <parameter>array</parameter> de entrada, &return.falseforfailure;.
+   Devuelve un array indexado, utilizando las claves del
+   <parameter>array</parameter> de entrada, &return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -38,7 +38,7 @@
      <term><parameter>pattern</parameter></term>
      <listitem>
       <para>
-       La máscara a buscar, en forma de &string;.
+       La máscara a buscar, en forma de cadena.
       </para>
      </listitem>
     </varlistentry>
@@ -105,7 +105,7 @@ ejemplo : , esto es una prueba
             <para>
              Así, <varname>$out[0]</varname> es un array que contiene los resultados que
              satisfacen la máscara completa, y <varname>$out[1]</varname> es un array que contiene
-             las etiquetas entre &gt; y &lt;.
+             las etiquetas entre los caracteres de mayor y menor que.
             </para>
            </informalexample>
           </para>
@@ -249,8 +249,8 @@ Array
          <term><constant>PREG_UNMATCHED_AS_NULL</constant></term>
          <listitem>
           <para>
-           Si este flag es pasado, las subexpresiones no satisfechas son reportadas como &null; ;
-           de lo contrario, son reportadas como &string; vacía.
+           Si este flag es pasado, las subexpresiones no satisfechas son reportadas como &null;;
+           de lo contrario, son reportadas como una <type>string</type> vacía.
           </para>
          </listitem>
         </varlistentry>
@@ -262,8 +262,8 @@ Array
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       Normalmente, la búsqueda comienza al inicio de la cadena
-       <parameter>subject</parameter>. El parámetro opcional
+       Normalmente, la búsqueda comienza al inicio de la cadena subject.
+       El parámetro opcional
        <parameter>offset</parameter> puede ser usado para especificar
        una posición para el inicio de la búsqueda (en bytes).
       </para>
@@ -272,7 +272,7 @@ Array
         Usar el parámetro <parameter>offset</parameter> no equivale
         a pasar <code>substr($subject, $offset)</code> a
         <function>preg_match_all</function> en lugar de la cadena
-        <parameter>subject</parameter>, ya que
+        subject, ya que
         <parameter>pattern</parameter> puede contener aserciones como
         <emphasis>^</emphasis>, <emphasis>$</emphasis> o
         <emphasis>(?&lt;=x)</emphasis>. Consulte la documentación

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -32,7 +32,7 @@
      <term><parameter>pattern</parameter></term>
      <listitem>
       <para>
-       El patrón a buscar, en forma de &string;.
+       El patrón a buscar, en forma de cadena.
       </para>
      </listitem>
     </varlistentry>
@@ -123,7 +123,7 @@ Array
          <listitem>
           <para>
            Si este flag es pasado, los subpatrones no coincidentes son reportados como &null;;
-           de lo contrario son reportados como &string; vacío.
+           de lo contrario son reportados como una <type>string</type> vacía.
            <informalexample>
             <programlisting role="php">
 <![CDATA[
@@ -172,8 +172,8 @@ array(4) {
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       Normalmente, la búsqueda comienza al inicio de la cadena
-       <parameter>subject</parameter>. El parámetro opcional
+       Normalmente, la búsqueda comienza al inicio de la cadena subject.
+       El parámetro opcional
        <parameter>offset</parameter> puede ser utilizado para especificar
        una posición para el inicio de la búsqueda (en bytes).
       </para>
@@ -181,9 +181,8 @@ array(4) {
        <para>
         Utilizar el parámetro <parameter>offset</parameter> no es equivalente
         a pasar <code>substr($subject, $offset)</code> a
-        <function>preg_match_all</function> en lugar de la cadena
-        <parameter>subject</parameter>, ya que
-        <parameter>pattern</parameter> puede contener aserciones como
+        <function>preg_match_all</function> en lugar de la cadena subject,
+        ya que <parameter>pattern</parameter> puede contener aserciones como
         <emphasis>^</emphasis>, <emphasis>$</emphasis> o
         <emphasis>(?&lt;=x)</emphasis>.
         Compare:
@@ -253,7 +252,7 @@ Array
   &reftitle.returnvalues;
   <para>
    <function>preg_match</function> devuelve 1 si el <parameter>pattern</parameter>
-   proporcionado coincide, 0 si no coincide,&return.falseforfailure;.
+   coincide con el <parameter>subject</parameter> dado, 0 si no coincide,&return.falseforfailure;.
   </para>
   &return.falseproblem;
  </refsect1>

--- a/reference/pcre/functions/preg-replace-callback-array.xml
+++ b/reference/pcre/functions/preg-replace-callback-array.xml
@@ -42,7 +42,7 @@
      <term><parameter>subject</parameter></term>
      <listitem>
       <para>
-       La &string; o &array; que contiene los &string; a buscar y reemplazar.
+       La cadena o un array que contiene las cadenas a buscar y reemplazar.
       </para>
      </listitem>
     </varlistentry>
@@ -51,7 +51,7 @@
      <listitem>
       <para>
        El número máximo de reemplazos para cada patrón en cada
-       &string; <parameter>subject</parameter>. Por omisión
+       <parameter>subject</parameter>. Por omisión
        <literal>-1</literal> (sin límite).
       </para>
      </listitem>
@@ -86,7 +86,7 @@
   <para>
    <function>preg_replace_callback_array</function> devuelve un array si
    el parámetro <parameter>subject</parameter> es un array, o de lo contrario
-   una &string;. En caso de error, el valor devuelto es &null;.
+   una cadena. En caso de error, el valor devuelto es &null;.
   </para>
   <para>
    Si se encuentran coincidencias, el nuevo sujeto será devuelto, de lo contrario

--- a/reference/pcre/functions/preg-replace-callback.xml
+++ b/reference/pcre/functions/preg-replace-callback.xml
@@ -19,7 +19,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   El comportamiento de <function>preg_replace_callback</function> es casi
+   El comportamiento de esta función es casi
    idéntico al de <function>preg_replace</function>, con la excepción de que
    en lugar del argumento <parameter>replacement</parameter>, se debe
    especificar una función de retrollamada <parameter>callback</parameter>
@@ -35,7 +35,7 @@
      <term><parameter>pattern</parameter></term>
      <listitem>
       <para>
-       El patrón a buscar. Puede ser un &string; o un array que contenga
+       El patrón a buscar. Puede ser una cadena o un array que contenga
        cadenas.
       </para>
      </listitem>
@@ -141,7 +141,7 @@ fclose($fp);
   &reftitle.returnvalues;
   <para>
    <function>preg_replace_callback</function> devuelve un array si el argumento
-   <parameter>subject</parameter> es un &array;, o, de lo contrario, un &string;.
+   <parameter>subject</parameter> es un array, o de lo contrario, una cadena.
    Si ocurre un error, el valor devuelto será &null;.
   </para>
   <para>

--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -180,7 +180,7 @@
         Esta opción activa funcionalidades adicionales de PCRE que no son compatibles con Perl.
         La cadena de entrada y el patrón son tratados como cadenas UTF-8.
         Una cadena de entrada inválida tendrá como consecuencia una ausencia de coincidencia en las funciones preg_*.
-        Un patrón inválido levantará un error de nivel <constant>E_WARNING</constant>.
+        Un patrón inválido levantará un error de nivel E_WARNING.
         Las secuencias UTF-8 de cinco y seis octetos son consideradas inválidas.
        </simpara>
       </listitem>

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -484,7 +484,7 @@
   <para>
    Un carácter de "palabra" es cualquier letra o dígito o el carácter de subrayado,
    es decir, cualquier carácter que pueda ser parte de
-   una "palabra" de Perl. La definición de letras y dígitos está
+   una "<emphasis>palabra</emphasis>" de Perl. La definición de letras y dígitos está
    controlada por las tablas de caracteres de PCRE, y puede variar si se está realizando una coincidencia específica de la configuración regional. Por ejemplo, en la configuración regional "fr" (francés), algunos códigos de caracteres mayores que 128 se usan para letras acentuadas,
    y estas coinciden con <literal>\w</literal>.
   </para>

--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -312,10 +312,10 @@ JOIN table2 ON table1.table2id = table2.id
    <classname>PDOStatement</classname> para su uso con
    <constant>PDO::ATTR_STATEMENT_CLASS</constant>.
   </simpara>
-  <simpara>
+  <para>
    Este valor no se puede usar con
    <constant>PDO::ATTR_DEFAULT_FETCH_MODE</constant>.
-  </simpara>
+  </para>
  </section>
 
  <section xml:id="pdo.constants.fetch-assoc" annotations="chunk:false">

--- a/reference/pdo/drivers.xml
+++ b/reference/pdo/drivers.xml
@@ -8,7 +8,7 @@
 
  <partintro>
   <para>
-   Los siguientes <literal>driver</literal> están actualmente implementados
+   Los siguientes controladores están actualmente implementados
    en la interfaz PDO:
    <informaltable>
     <tgroup cols="2">
@@ -45,7 +45,7 @@
       </row>
       <row>
        <entry><link linkend="ref.pdo-oci">PDO_OCI</link></entry>
-       <entry><literal>Oracle Call Interface</literal></entry>
+       <entry>Oracle Call Interface</entry>
       </row>
       <row>
        <entry><link linkend="ref.pdo-odbc">PDO_ODBC</link></entry>

--- a/reference/pdo/pdo/construct.xml
+++ b/reference/pdo/pdo/construct.xml
@@ -29,7 +29,7 @@
      <term><parameter>dsn</parameter></term>
      <listitem>
       <para>
-       El <literal>Data Source Name</literal>, o DSN, que contiene las
+       El Data Source Name, o DSN, que contiene las
        informaciones requeridas para conectarse a la base de datos.
       </para>
       <para>
@@ -102,7 +102,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       Un array clave=>valor con las opciones específicas de conexión.
+       Un array clave=&gt;valor con las opciones específicas de conexión.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pdo/pdo/errorcode.xml
+++ b/reference/pdo/pdo/errorcode.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <methodname>PDO::errorCode</methodname> devuelve un SQLSTATE,
+   Devuelve un SQLSTATE,
    un identificador alfanumérico de cinco caracteres definido en el estándar ANSI SQL.
    Brevemente, un SQLSTATE consiste en un valor de clase de dos caracteres seguido
    por un valor de subclase de tres caracteres. Un valor de clase de 01 indica
@@ -38,7 +38,7 @@
   <para>
    <methodname>PDO::errorCode</methodname> devuelve únicamente los códigos de error
    para operaciones ejecutadas directamente sobre el manejador de la base de datos.
-   Si se crea un objeto <classname>PDOStatement</classname> con la función
+   Si se crea un objeto PDOStatement con la función
    <methodname>PDO::prepare</methodname> o la función
    <methodname>PDO::query</methodname> y se invoca un error
    sobre el manejador de consulta, <methodname>PDO::errorCode</methodname> no

--- a/reference/pdo/pdo/errorinfo.xml
+++ b/reference/pdo/pdo/errorinfo.xml
@@ -66,7 +66,7 @@
   <para>
    <methodname>PDO::errorInfo</methodname> devuelve únicamente las informaciones de
    los errores para las operaciones ejecutadas directamente sobre un manejador de base de
-   datos. Si se crea un objeto <classname>PDOStatement</classname> con la función
+   datos. Si se crea un objeto PDOStatement con la función
    <methodname>PDO::prepare</methodname> o la función
    <methodname>PDO::query</methodname> y se invoca un error sobre
    el manejador de consulta, <methodname>PDO::errorInfo</methodname> no devolverá

--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -17,7 +17,7 @@
 
   <para>
    Esta función devuelve el valor de un atributo de una conexión a una base
-   de datos. Para recuperar los atributos <classname>PDOStatement</classname>, consúltese
+   de datos. Para recuperar los atributos PDOStatement, consúltese
    la función <methodname>PDOStatement::getAttribute</methodname>.
   </para>
 
@@ -68,7 +68,7 @@
   &reftitle.returnvalues;
   <para>
    Una llamada exitosa devuelve el valor del atributo PDO solicitado.
-   Una llamada que ha fallado devuelve el valor &null;.
+   Una llamada que ha fallado devuelve el valor <literal>null</literal>.
   </para>
  </refsect1>
 

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -19,8 +19,8 @@
   <para>
    Prepara una consulta SQL para ser ejecutada por el método
    <methodname>PDOStatement::execute</methodname>. El modelo de declaración puede contener
-   cero o más parámetros nombrados (<literal>:nombre</literal>) o marcadores
-   (<literal>?</literal>) para los cuales los valores reales serán sustituidos
+   cero o más parámetros nombrados (:nombre) o marcadores
+   (?) para los cuales los valores reales serán sustituidos
    cuando la consulta sea ejecutada.
    El uso tanto de parámetros nombrados como de marcadores es
    imposible en un modelo de declaración; solo uno u otro estilo de parámetro.
@@ -93,7 +93,7 @@
      <listitem>
       <para>
        Este array contiene una o más parejas clave=&gt;valor para definir
-       los valores de los atributos para el objeto <classname>PDOStatement</classname>
+       los valores de los atributos para el objeto PDOStatement
        que esta método devuelve. Puede utilizarse esto para definir el valor
        <literal>PDO::ATTR_CURSOR</literal> a
        <literal>PDO::CURSOR_SCROLL</literal> para solicitar un cursor desplazable.

--- a/reference/pdo/pdo/setattribute.xml
+++ b/reference/pdo/pdo/setattribute.xml
@@ -149,7 +149,7 @@
      <term><constant>PDO::ATTR_STATEMENT_CLASS</constant></term>
      <listitem>
       <para>
-       Configura la clase de resultado derivada de <classname>PDOStatement</classname>
+       Configura la clase de resultado derivada de PDOStatement
        y definida por el usuario.
        <!-- TODO improve description of the value it takes, or refer to other docs -->
        Requiere <literal>array(string classname, array(mixed constructor_args))</literal>.

--- a/reference/pdo/pdoexception.xml
+++ b/reference/pdo/pdoexception.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 3c4752c0aea6bfdd6795213785e7d7cc07d160ae Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdoexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La clase <classname>PDOException</classname></title>
+ <title>La clase PDOException</title>
  <titleabbrev>PDOException</titleabbrev>
 
  <partintro>

--- a/reference/pdo/pdostatement/bindcolumn.xml
+++ b/reference/pdo/pdostatement/bindcolumn.xml
@@ -40,7 +40,7 @@
     las aplicaciones deben llamar a este método
     <emphasis>antes</emphasis> de llamar
     <methodname>PDOStatement::execute</methodname>, de lo contrario se recibirá
-    el objeto OID en forma de &integer;.
+    el objeto OID en forma de un entero.
    </para>
   </note>
  </refsect1>

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -19,7 +19,7 @@
 
   <para>
    Recupera una línea desde un conjunto de resultados asociado al objeto
-   <literal>PDOStatement</literal>. El argumento
+   PDOStatement. El argumento
    <parameter>mode</parameter> determina la forma en que PDO devuelve
    la línea.
   </para>
@@ -64,8 +64,11 @@
          si existe; de lo contrario, se creará una propiedad pública dinámica.
          Sin embargo, cuando <constant>PDO::FETCH_PROPS_LATE</constant>
          también está especificado, el constructor se llama <emphasis>antes</emphasis> de
-         que las propiedades sean pobladas.
-         </para></listitem>
+         que las propiedades sean pobladas. Si <parameter>mode</parameter> incluye
+         <constant>PDO::FETCH_CLASSTYPE</constant> (p.ej.
+         <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), el nombre
+         de la clase se determina a partir del valor de la primera columna.
+        </para></listitem>
         <listitem><para>
          <literal>PDO::FETCH_INTO</literal> : actualiza una instancia existente
          de la clase solicitada, vinculando las columnas del conjunto de resultados a los nombres de las propiedades

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -131,8 +131,8 @@
    puede aumentar el uso de recursos del sistema, pero también estos recursos.
    En lugar de recuperar todas las datos y manipularlas con PHP,
    se utiliza el servidor de base de datos para manipular los conjuntos de resultados.
-   Por ejemplo, se utilizan las cláusulas <literal>WHERE</literal> y
-   <literal>ORDER BY</literal> en las consultas SQL para restringir los resultados
+   Por ejemplo, se utilizan las cláusulas WHERE y
+   ORDER BY en las consultas SQL para restringir los resultados
    antes de recuperarlos y procesarlos con PHP.
   </para>
  </refsect1>

--- a/reference/pdo_dblib/reference.xml
+++ b/reference/pdo_dblib/reference.xml
@@ -12,8 +12,7 @@
   <section xml:id="ref.pdo-dblib.intro">
    &reftitle.intro;
    <para>
-    PDO_DBLIB es un controlador que implementa la <link
-    linkend="intro.pdo">interfaz de PHP Data Objects (PDO)</link> para
+    PDO_DBLIB es un controlador que implementa la <link linkend="intro.pdo">interfaz de PHP Data Objects (PDO)</link> para
     permitir el acceso de PHP a Microsoft SQL Server y bases de datos Sybase
     mediante la biblioteca FreeTDS.
    </para>
@@ -86,9 +85,9 @@
       <term><literal>appname</literal></term>
       <listitem>
        <para>
-        El nombre de la aplicación (utilizado en <literal>sysprocesses</literal>).
-        Por omisión, <literal>"PHP Generic DB-lib"</literal> o
-        <literal>"PHP freetds"</literal>.
+        El nombre de la aplicación (utilizado en sysprocesses).
+        Por omisión, "PHP Generic DB-lib" o
+        "PHP freetds".
        </para>
       </listitem>
      </varlistentry>

--- a/reference/pdo_firebird/reference.xml
+++ b/reference/pdo_firebird/reference.xml
@@ -13,7 +13,7 @@
    &reftitle.intro;
     <para>
      PDO_FIREBIRD es un controlador que implementa la interfaz de
-     <literal>PHP Data Objects</literal> (PDO) para
+     PHP Data Objects (PDO) para
      permitir el acceso de PHP a las bases de datos Firebird.
     </para>
    </section>

--- a/reference/pdo_ibm/reference.xml
+++ b/reference/pdo_ibm/reference.xml
@@ -12,8 +12,8 @@
   <section xml:id="pdo-ibm.intro">
    &reftitle.intro;
    <para>
-    PDO_IBM es un driver que implementa la interfaz <link linkend="intro.pdo">
-    <literal>PHP Data Objects</literal> (PDO)</link> para habilitar el acceso
+    PDO_IBM es un driver que implementa la interfaz <link linkend="intro.pdo">PHP Data
+    Objects (PDO)</link> para habilitar el acceso
     desde PHP a las bases de datos IBM.
    </para>
   </section>

--- a/reference/pdo_informix/reference.xml
+++ b/reference/pdo_informix/reference.xml
@@ -12,8 +12,8 @@
    <section xml:id="pdo-informix.intro">
     &reftitle.intro;
     <para>
-     PDO_INFORMIX es un controlador que implementa la <link
-     linkend="intro.pdo">interfaz de <literal>PHP Data Objects</literal> (PDO)</link>
+     PDO_INFORMIX es un controlador que implementa la <link linkend="intro.pdo">interfaz de PHP Data
+     Objects (PDO)</link>
      para permitir el acceso de PHP a las bases de datos Informix.
     </para>
    </section>
@@ -48,7 +48,8 @@
      El Data Source Name (DSN) de PDO_INFORMIX se basa en la cadena de
      caracteres DSN de Informix ODBC. Los detalles sobre la configuración de un DSN
      Informix ODBC están disponibles en
-     <link xlink:href="&url.informix.dsn;"><literal>Informix Dynamic Server Information Center</literal></link>.
+     <link xlink:href="&url.informix.dsn;">Informix Dynamic Server Information
+      Center</link>.
      Los componentes principales del DSN de PDO_INFORMIX son:
      <variablelist>
       <varlistentry>
@@ -65,7 +66,7 @@
         <para>
          El DSN puede ser una fuente de datos de configuración
          utilizando <filename>odbc.ini</filename> o una <link
-         xlink:href="&url.informix.connectionstring;">cadena de
+          xlink:href="&url.informix.connectionstring;">cadena de
          conexión</link> completa.
         </para>
        </listitem>

--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -11,9 +11,9 @@
    <section xml:id="ref.pdo-mysql.intro">
    &reftitle.intro;
     <para>
-     PDO_MYSQL es un controlador que implementa la <link
-     linkend="intro.pdo">interfaz de PHP Data Objects (PDO)</link> para
-     permitir el acceso de PHP a las bases de datos MySQL.
+     PDO_MYSQL es un controlador que implementa la <link linkend="intro.pdo">PHP
+     Data Objects (PDO)</link>
+     para permitir el acceso de PHP a las bases de datos MySQL.
     </para>
     <para>
      PDO_MYSQL utiliza consultas preparadas emuladas por omisión.
@@ -161,9 +161,11 @@ mysql:unix_socket=/tmp/mysql.sock;dbname=testdb
      <title>Solo Unix:</title>
      <para>
       Cuando el nombre de host es <literal>"localhost"</literal>, la conexión se realiza a través de un socket
-      Unix. Si PDO_MYSQL está compilado con <literal>libmysqlclient</literal>, entonces el archivo de socket es el especificado durante
-      la compilación de <literal>libmysqlclient</literal>. Si PDO_MYSQL está compilado con <literal>mysqlnd</literal>, un socket por omisión puede ser
-      indicado a través del parámetro <link linkend="ini.pdo-mysql.default-socket">pdo_mysql.default_socket</link>.
+      Unix. Si PDO_MYSQL está compilado con libmysqlclient, entonces el archivo de socket es el especificado durante
+      la compilación de libmysqlclient. Si PDO_MYSQL está compilado con
+      mysqlnd, un socket por omisión puede ser
+      indicado a través del parámetro <link linkend="ini.pdo-mysql.default-socket">
+      pdo_mysql.default_socket</link>.
      </para>
     </note>
    </refsect1>

--- a/reference/pdo_oci/configure.xml
+++ b/reference/pdo_oci/configure.xml
@@ -26,7 +26,8 @@
   <title>PHP &lt; 8.4</title>
   <para>
    Utilícese <option role="configure">--with-pdo-oci[=DIR]</option> para instalar
-   la extensión PDO Oracle OCI, donde la opción [=DIR] es el directorio Oracle Home. <literal>[=DIR]</literal> corresponde por omisión
+   la extensión PDO Oracle OCI, donde la opción <literal>[=DIR]</literal>
+   es el directorio Oracle Home. <literal>[=DIR]</literal> corresponde por omisión
    a la variable de entorno <varname>$ORACLE_HOME</varname>.
   </para>
   <para>

--- a/reference/pdo_odbc/configure.xml
+++ b/reference/pdo_odbc/configure.xml
@@ -20,9 +20,9 @@
 ./configure --with-pdo-odbc=ibm-db2,/opt/IBM/db2/V8.1/
 ]]>
         </screen>
-        Para construir PDO_ODBC con el sabor ibm-db2, deben haberse instalado previamente los encabezados de desarrollo de la aplicación DB2 en la misma máquina donde se compila PDO_ODBC. Los encabezados de desarrollo de la aplicación DB2 son una opción de instalación en los servidores DB2 y también están disponibles como <literal>DB2 Application Development Client</literal> gratuitamente disponibles para descarga desde el
+        Para construir PDO_ODBC con el sabor ibm-db2, deben haberse instalado previamente los encabezados de desarrollo de la aplicación DB2 en la misma máquina donde se compila PDO_ODBC. Los encabezados de desarrollo de la aplicación DB2 son una opción de instalación en los servidores DB2 y también están disponibles como parte de DB2 Application Development Client
+        gratuitamente disponibles para descarga desde el IBM developerWorks
         <link xlink:href="&url.ibm.db2.client;">sitio</link>.
-        <literal>IBM developerWorks</literal>.
        </para>
        <para>
         Si no se especifica una ubicación para las bibliotecas y los encabezados de DB2 en el comando <command>configure</command>, PDO_ODBC tomará por omisión

--- a/reference/pdo_odbc/reference.xml
+++ b/reference/pdo_odbc/reference.xml
@@ -12,9 +12,9 @@
    <section xml:id="ref.pdo-odbc.intro">
    &reftitle.intro;
     <para>
-     PDO_ODBC es un controlador que implementa la <link
-     linkend="intro.pdo">interfaz de PHP Data Objects (PDO)</link> para
-     permitir el acceso de PHP a las bases de datos mediante los controladores de ODBC
+     PDO_ODBC es un controlador que implementa la <link linkend="intro.pdo">PHP Data
+     Objects (PDO)</link>
+     para permitir el acceso de PHP a las bases de datos mediante los controladores de ODBC
      o mediante la biblioteca de interfaz IBM DB2 Call Level (DB2 CLI). PDO_ODBC
      actualmente soporta tres "sabores" diferentes de los controladores de bases de
      datos:
@@ -23,7 +23,7 @@
        <term>ibm-db2</term>
        <listitem>
         <para>
-         Permite el acceso a <literal>IBM DB2 Universal Database</literal>,
+         Permite el acceso a IBM DB2 Universal Database,
          Cloudscape y Apache Derby Server utilizando el cliente gratuito DB2 express-C.
         </para>
        </listitem>

--- a/reference/pdo_pgsql/pdo/pgsql/getnotify.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/getnotify.xml
@@ -70,7 +70,7 @@
    <parameter>timeoutMilliseconds</parameter> es inferior a <literal>0</literal>.
   </simpara>
   <simpara>
-   Se lanza una <exceptionname>Warning</exceptionname> si
+   Se lanza una <constant>E_WARNING</constant> cuando
    <parameter>timeoutMilliseconds</parameter> es superior al valor
    que puede contener un entero firmado de 32 bits, en cuyo caso será
    el valor máximo de un entero firmado de 32 bits.

--- a/reference/pdo_sqlite/configure.xml
+++ b/reference/pdo_sqlite/configure.xml
@@ -13,6 +13,12 @@
   Anteriormente, si libsqlite incluido podría haberse usado en su lugar, por omisión,
   si <literal>[=DIR]</literal> era omitido.
  </para>
+ <note>
+  <title>Configuración adicional en Windows a partir de PHP 7.4.0</title>
+  <para>
+   &ext.windows.path.dll; <filename>libsqlite3.dll</filename>.
+  </para>
+ </note>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pgsql/constants.xml
+++ b/reference/pgsql/constants.xml
@@ -755,7 +755,7 @@
    <listitem>
     <simpara>
      Pasada a <function>pg_convert</function>.
-     Utiliza &null; en lugar de una cadena de caracteres vacía.
+     Utiliza SQL &null; en lugar de una <type>string</type> vacía.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pgsql/functions/pg-copy-to.xml
+++ b/reference/pgsql/functions/pg-copy-to.xml
@@ -46,7 +46,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>delimiter</parameter></term>
+     <term><parameter>separator</parameter></term>
      <listitem>
       <para>
        El marcador que separa los valores para cada campo en cada
@@ -71,7 +71,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
    <para>
-    Un &array; con un elemento para cada línea de datos
+    Un <type>array</type> con un elemento para cada línea de datos
     <literal>COPY</literal>, &return.falseforfailure;.
    </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-delete.xml
+++ b/reference/pgsql/functions/pg-delete.xml
@@ -63,7 +63,7 @@
      <term><parameter>conditions</parameter></term>
      <listitem>
       <para>
-       Un &array; donde las claves son los nombres de los campos de la tabla
+       Un <type>array</type> donde las claves son los nombres de los campos de la tabla
        <parameter>table_name</parameter> y donde los valores son los valores
        de estos campos que deben ser eliminados.
       </para>
@@ -95,7 +95,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;  Devuelve un &string; si <constant>PGSQL_DML_STRING</constant>
+   &return.success;  Devuelve un <type>string</type> si <constant>PGSQL_DML_STRING</constant>
    es pasado en el parámetro <parameter>flags</parameter>.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-escape-identifier.xml
+++ b/reference/pgsql/functions/pg-escape-identifier.xml
@@ -44,7 +44,7 @@
      <term><parameter>data</parameter></term>
      <listitem>
       <para>
-       Una &string; que contiene texto a proteger.
+       Una <type>string</type> que contiene texto a proteger.
       </para>
      </listitem>
     </varlistentry>
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Una &string; que contiene los datos protegidos.
+   Una <type>string</type> que contiene los datos protegidos.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-fetch-all.xml
+++ b/reference/pgsql/functions/pg-fetch-all.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    <function>pg_fetch_all</function> devuelve un array que contiene
-   todas las líneas de <parameter>result</parameter>.
+   todas las filas (registros) de la instancia de <classname>PgSql\Result</classname>.
   </para>
   &database.fetch-null;
  </refsect1>

--- a/reference/pgsql/functions/pg-fetch-array.xml
+++ b/reference/pgsql/functions/pg-fetch-array.xml
@@ -68,10 +68,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un array con índice numérico (comenzando por 0), asociativo (indexado con
+   Un <type>array</type> con índice numérico (comenzando por 0), asociativo (indexado con
    el nombre de los campos) o ambos.
-   Cada valor en el array está representado como un string
-   (&string;). Los valores &null; de la base de datos son
+   Cada valor en el <type>array</type> está representado como un
+   <type>string</type>. Los valores &null; de la base de datos son
    devueltos como &null;.
   </para>
   <para>

--- a/reference/pgsql/functions/pg-fetch-assoc.xml
+++ b/reference/pgsql/functions/pg-fetch-assoc.xml
@@ -62,8 +62,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un array con índice asociativo (por nombre de campo). Cada valor en el
-   array es representado como un &string;. Los valores
+   Un <type>array</type> con índice asociativo (por nombre de campo). Cada valor en el
+   <type>array</type> es representado como un <type>string</type>. Los valores
    &null; de la base de datos son devueltos &null;.
   </para>
   <para>

--- a/reference/pgsql/functions/pg-fetch-row.xml
+++ b/reference/pgsql/functions/pg-fetch-row.xml
@@ -55,8 +55,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un array de tipo <type>array</type>, indexado desde 0, con cada
-   valor representado como un string (&string;).
+   Un <type>array</type>, indexado desde 0, con cada
+   valor representado como un <type>string</type>.
    Los valores &null; de la base de datos son retornados como &null;.
   </para>
   <para>

--- a/reference/pgsql/functions/pg-field-prtlen.xml
+++ b/reference/pgsql/functions/pg-field-prtlen.xml
@@ -31,8 +31,8 @@
   </para>
     <para>
      El parámetro <parameter>field_name_or_number</parameter> puede ser pasado
-     ya sea como &integer; o como &string;.
-     Si es pasado como &integer;, PHP lo identifica como el número de un campo,
+     ya sea como <type>int</type> o como <type>string</type>.
+     Si es pasado como <type>int</type>, PHP lo identifica como el número de un campo,
      de lo contrario, como el nombre de un campo.
     </para>
     <para>

--- a/reference/pgsql/functions/pg-get-notify.xml
+++ b/reference/pgsql/functions/pg-get-notify.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &array; que contiene el nombre del mensaje <literal>NOTIFY</literal>.
+   Un <type>array</type> que contiene el nombre del mensaje <literal>NOTIFY</literal>.
    Si el servidor lo soporta, el array contiene también la versión del servidor y la carga útil (payload).
    De lo contrario, si no hay ningún <literal>NOTIFY</literal> pendiente, se devolverá &false;.
   </para>

--- a/reference/pgsql/functions/pg-insert.xml
+++ b/reference/pgsql/functions/pg-insert.xml
@@ -65,7 +65,7 @@
      <term><parameter>values</parameter></term>
      <listitem>
       <para>
-       Un &array; cuyas claves son los nombres de los campos en la tabla <parameter>table_name</parameter>,
+       Un <type>array</type> cuyas claves son los nombres de los campos en la tabla <parameter>table_name</parameter>,
        y cuyos valores son los valores de esos campos que serán insertados.
       </para>
      </listitem>

--- a/reference/pgsql/functions/pg-last-notice.xml
+++ b/reference/pgsql/functions/pg-last-notice.xml
@@ -68,11 +68,11 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &string; que contiene la última nota en la conexión
+   Una <type>string</type> que contiene la última nota en la conexión
    <parameter>connection</parameter> con
    <constant>PGSQL_NOTICE_LAST</constant>,
-   un &array; con <constant>PGSQL_NOTICE_ALL</constant>,
-   un &boolean; con <constant>PGSQL_NOTICE_CLEAR</constant>.
+   un <type>array</type> con <constant>PGSQL_NOTICE_ALL</constant>,
+   un <type>bool</type> con <constant>PGSQL_NOTICE_CLEAR</constant>.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-last-oid.xml
+++ b/reference/pgsql/functions/pg-last-oid.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &integer; o &string; que contiene el OID asignado a la línea más reciente insertada en
+   Un <type>int</type> o <type>string</type> que contiene el OID asignado a la línea más reciente insertada en
    la conexión <parameter>connection</parameter> especificada o &false; en caso
    de error o de OID no disponible.
   </para>

--- a/reference/pgsql/functions/pg-pconnect.xml
+++ b/reference/pgsql/functions/pg-pconnect.xml
@@ -29,14 +29,14 @@
   </para>
   <para>
    Para activar las conexiones persistentes, la directiva de configuración
-   <link linkend="ini.pgsql.allow-persistent"><option>pgsql.allow_persistent</option></link>
+   <link linkend="ini.pgsql.allow-persistent">pgsql.allow_persistent</link>
    del &php.ini; debe establecerse en <literal>On</literal> (que es su valor por omisión).
    El número máximo de conexiones puede limitarse mediante
    la directiva de configuración
-   <link linkend="ini.pgsql.max-persistent"><option>pgsql.max_persistent</option></link>
+   <link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link>
    en el archivo &php.ini; (por omisión, su valor es <literal>-1</literal>, es decir, sin límite).
    El número total de conexiones puede configurarse con la directiva
-   <link linkend="ini.pgsql.max-links"><option>pgsql.max_links</option></link> del archivo
+   <link linkend="ini.pgsql.max-links">pgsql.max_links</link> del archivo
    &php.ini;.
   </para>
   <para>

--- a/reference/pgsql/functions/pg-result-error.xml
+++ b/reference/pgsql/functions/pg-result-error.xml
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &string;. Devuelve una cadena vacía si no hay ningún error.
+   Devuelve un <type>string</type>. Devuelve una cadena vacía si no hay ningún error.
    Si hay un error asociado con el parámetro
    <parameter>result</parameter>, se devolverá &false;.
   </para>

--- a/reference/pgsql/functions/pg-result-seek.xml
+++ b/reference/pgsql/functions/pg-result-seek.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>pg_result_seek</methodname>
-   <methodparam><type>resource</type><parameter>result</parameter></methodparam>
+   <methodparam><type>PgSql\Result</type><parameter>result</parameter></methodparam>
    <methodparam><type>int</type><parameter>row</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -35,9 +35,8 @@
      <term><parameter>row</parameter></term>
      <listitem>
       <para>
-       Línea a la que se moverá la posición interna en el conjunto de resultados
-       <parameter>result</parameter>. Las líneas están numeradas a partir de
-       cero.
+       Línea a la que se moverá la posición interna en la instancia de <classname>PgSql\Result</classname>.
+       Las líneas están numeradas a partir de cero.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pgsql/functions/pg-result-status.xml
+++ b/reference/pgsql/functions/pg-result-status.xml
@@ -15,9 +15,8 @@
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>PGSQL_STATUS_LONG</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>pg_result_status</function> devuelve el estado del resultado
-   <parameter>result</parameter> o el comando de ejecución de PostgreSQL
-   asociado al resultado.
+   <function>pg_result_status</function> devuelve el estado de la instancia de <classname>PgSql\Result</classname>,
+   o la etiqueta de comando PostgreSQL asociada al resultado.
   </para>
  </refsect1>
 
@@ -56,7 +55,7 @@
    <constant>PGSQL_COPY_IN</constant>, <constant>PGSQL_BAD_RESPONSE</constant>,
    <constant>PGSQL_NONFATAL_ERROR</constant> y <constant>PGSQL_FATAL_ERROR</constant>
    si <constant>PGSQL_STATUS_LONG</constant> se
-   especifica. De lo contrario, se devuelve un string que contiene la etiqueta del comando PostgreSQL.
+   especifica. De lo contrario, se devuelve un <type>string</type> que contiene la etiqueta del comando PostgreSQL.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-socket.xml
+++ b/reference/pgsql/functions/pg-socket.xml
@@ -16,7 +16,7 @@
    <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
   </methodsynopsis>
   <para>
-   La función <function>pg_socket</function> devuelve una recurso
+   <function>pg_socket</function> devuelve un <type>resource</type>
    de solo lectura correspondiente al socket subyacente de la conexión
    PostgreSQL proporcionada.
   </para>

--- a/reference/pgsql/functions/pg-unescape-bytea.xml
+++ b/reference/pgsql/functions/pg-unescape-bytea.xml
@@ -38,7 +38,7 @@
      <term><parameter>string</parameter></term>
      <listitem>
       <para>
-       Un &string; que contiene los datos bytea de PostgreSQL a ser convertidos
+       Una <type>string</type> que contiene los datos bytea de PostgreSQL a ser convertidos
        en &string; binario de PHP.
       </para>
      </listitem>
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &string; que contiene los datos protegidos.
+   Una <type>string</type> que contiene los datos protegidos.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-update.xml
+++ b/reference/pgsql/functions/pg-update.xml
@@ -107,7 +107,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;  Devuelve una &string; si <constant>PGSQL_DML_STRING</constant> es pasado
+   &return.success;  Devuelve una <type>string</type> si <constant>PGSQL_DML_STRING</constant> es pasado
    a través del argumento <parameter>flags</parameter>.
   </para>
  </refsect1>

--- a/reference/phar/Phar/buildFromIterator.xml
+++ b/reference/phar/Phar/buildFromIterator.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.buildfromiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -19,9 +19,9 @@
    Rellena un archivo phar a partir de un iterador. Dos estilos de iterador
    son soportados: los iteradores que hacen corresponder el nombre de archivo
    dentro del phar con el nombre de un archivo en el disco, y los iteradores
-   como <classname>DirectoryIterator</classname> que devuelven objetos
-   <classname>SplFileInfo</classname>. Para los iteradores que devuelven
-   objetos <classname>SplFileInfo</classname>, el segundo parámetro es
+   como DirectoryIterator que devuelven objetos
+   SplFileInfo. Para los iteradores que devuelven
+   objetos SplFileInfo, el segundo parámetro es
    obligatorio.
   </para>
  </refsect1>
@@ -35,7 +35,7 @@
      <listitem>
       <para>
        Un iterador que asocia un archivo con una posición, o bien
-       devuelve objetos <classname>SplFileInfo</classname>.
+       devuelve objetos SplFileInfo.
       </para>
      </listitem>
     </varlistentry>
@@ -44,7 +44,7 @@
      <listitem>
       <para>
        Para los iteradores que devuelven objetos
-       <classname>SplFileInfo</classname>, la porción de ruta absoluta
+       SplFileInfo, la porción de ruta absoluta
        de cada archivo que debe ser eliminada al añadir al
        archivo phar.
       </para>
@@ -70,7 +70,7 @@
    cuando el iterador devuelve valores falsos, tales como una clave
    entera en lugar de una cadena; una excepción
    <classname>BadMethodCallException</classname> cuando un iterador
-   basado en <classname>SplFileInfo</classname> es pasado sin parámetro
+   basado en SplFileInfo es pasado sin parámetro
    <parameter>baseDirectory</parameter>, o una excepción
    <classname>PharException</classname> si ha habido errores al
    guardar el archivo phar.
@@ -108,7 +108,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
    <example>
-    <title>Ejemplo con <function>Phar::buildFromIterator</function> y <classname>SplFileInfo</classname></title>
+    <title>Ejemplo con <function>Phar::buildFromIterator</function> y SplFileInfo</title>
     <para>
      Para la mayoría de archivos phar, el archivo refleja la estructura
      de un directorio, y el segundo estilo es el más útil. Por ejemplo,

--- a/reference/phar/PharData/buildFromIterator.xml
+++ b/reference/phar/PharData/buildFromIterator.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phardata.buildfromiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -100,7 +100,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo con <function>PharData::buildFromIterator</function> y <classname>SplFileInfo</classname></title>
+   <title>Ejemplo con <function>PharData::buildFromIterator</function> y SplFileInfo</title>
    <para>
     Para la mayoría de los archivos tar/zip, el archivo reflejará la estructura
     de directorio actual y el segundo estilo es el más útil. Por
@@ -152,7 +152,7 @@ $phar->buildFromIterator(
    <para>
     Se debe notar que <function>Phar::buildFromIterator</function> también
     puede ser utilizado para copiar el contenido de un archivo phar, tar o zip
-    existente, ya que el objeto <classname>PharData</classname> es derivado
+    existente, ya que el objeto PharData es derivado
     de <classname>DirectoryIterator</classname>:
    </para>
    <para>

--- a/reference/pthreads/worker.xml
+++ b/reference/pthreads/worker.xml
@@ -17,8 +17,8 @@
     pueden ser utilizados mediante Threads en la mayoría de los casos.
    </simpara>
    <simpara>
-    Cuando un Worker es iniciado, el método <methodname>run</methodname> será
-    ejecutado, pero el <classname>Thread</classname> no
+    Cuando un Worker es iniciado, el método run será
+    ejecutado, pero el Thread no
     se detendrá hasta que una de las siguientes condiciones se cumpla:
    </simpara>
    <itemizedlist>
@@ -26,7 +26,7 @@
      <simpara>el Worker está fuera de alcance (no hay referencias restantes);</simpara>
     </listitem>
     <listitem>
-     <simpara>el desarrollador llama a <methodname>shutdown</methodname>;</simpara>
+     <simpara>el desarrollador llama a shutdown;</simpara>
     </listitem>
     <listitem>
      <simpara>el script muere.</simpara>
@@ -35,8 +35,8 @@
    <simpara>
     Esto significa que el desarrollador puede reutilizar el contexto durante
     toda la ejecución; colocar objetos en la pila del
-    <classname>Worker</classname> hará que el <classname>Worker</classname>
-    ejecute el método <methodname>run</methodname> sobre los objetos apilados.
+    Worker hará que el Worker
+    ejecute el método run sobre los objetos apilados.
    </simpara>
   </section>
   <!-- }}} -->

--- a/reference/tidy/constants.xml
+++ b/reference/tidy/constants.xml
@@ -7,7 +7,7 @@
  &reftitle.constants;
  &extension.constants;
  <para>
-  Cada <literal>TIDY_TAG_<replaceable>*</replaceable></literal> representa una etiqueta HTML. Por ejemplo,
+  Cada <constant>TIDY_TAG_<replaceable>*</replaceable></constant> representa una etiqueta HTML. Por ejemplo,
   <constant>TIDY_TAG_A</constant> representa una etiqueta
   <literal>"&lt;a href="XX"&gt;link&lt;/a&gt;"</literal>.
  </para>

--- a/reference/tokenizer/functions/token-get-all.xml
+++ b/reference/tokenizer/functions/token-get-all.xml
@@ -49,22 +49,6 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
-     <term><parameter>flags</parameter></term>
-     <listitem>
-      <para>
-       Valores válidos:
-       <itemizedlist>
-        <listitem>
-         <simpara>
-          <constant>TOKEN_PARSE</constant> - Reconoce la capacidad de usar
-           palabras reservadas en contextos específicos.
-         </simpara>
-        </listitem>
-       </itemizedlist>
-      </para>
-     </listitem>
-    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -180,52 +164,6 @@ T_LNUMBER
    </example>
    Sin la bandera <constant>TOKEN_PARSE</constant>, el penúltimo
    token (<constant>T_STRING</constant>) habría sido
-   <constant>T_PUBLIC</constant>.
-  </para>
-  <para>
-   <example>
-    <title>
-     ejemplo de <function>token_get_all</function> usado en una clase con una palabra reservada
-    </title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-
-$source = <<<'code'
-<?php
-
-class A
-{
-    const PUBLIC = 1;
-}
-code;
-
-$tokens = token_get_all($source, TOKEN_PARSE);
-
-foreach ($tokens as $token) {
-    if (is_array($token)) {
-        echo token_name($token[0]) , PHP_EOL;
-    }
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs.similar;
-    <screen>
-<![CDATA[
-T_OPEN_TAG
-T_WHITESPACE
-T_CLASS
-T_WHITESPACE
-T_STRING
-T_CONST
-T_WHITESPACE
-T_STRING
-T_LNUMBER
-]]>
-    </screen>
-   </example>
-   Sin el uso de <constant>TOKEN_PARSE</constant>, el penúltimo token (<constant>T_STRING</constant>) hubiese sido
    <constant>T_PUBLIC</constant>.
   </para>
  </refsect1>

--- a/reference/uodbc/functions/odbc-data-source.xml
+++ b/reference/uodbc/functions/odbc-data-source.xml
@@ -33,8 +33,7 @@
      <term><parameter>fetch_type</parameter></term>
      <listitem>
       <para>
-       El parámetro <parameter>connection_id</parameter> es una conexión
-       ODBC válida. El parámetro <parameter>fetch_type</parameter> puede ser una de las
+       El parámetro <parameter>fetch_type</parameter> puede ser una de las
        dos constantes siguientes: <constant>SQL_FETCH_FIRST</constant> o
        <constant>SQL_FETCH_NEXT</constant>. Utilice <constant>SQL_FETCH_FIRST</constant>
        la primera vez que se llama a la función, luego <constant>SQL_FETCH_NEXT</constant>.

--- a/reference/uodbc/functions/odbc-execute.xml
+++ b/reference/uodbc/functions/odbc-execute.xml
@@ -101,7 +101,7 @@
     </title>
     <para>
      En el script siguiente, <varname>$success</varname> solo será
-     posible si los tres parámetros de <literal>maproc</literal>
+     posible si los tres parámetros de myproc
      son parámetros de tipo IN:
     </para>
     <programlisting role="php">
@@ -110,7 +110,7 @@
 $a = 1;
 $b = 2;
 $c = 3;
-$stmt    = odbc_prepare($conn, 'CALL maproc(?,?,?)');
+$stmt    = odbc_prepare($conn, 'CALL myproc(?,?,?)');
 $success = odbc_execute($stmt, array($a, $b, $c));
 ?>
 ]]>

--- a/reference/uodbc/functions/odbc-fetch-array.xml
+++ b/reference/uodbc/functions/odbc-fetch-array.xml
@@ -17,8 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>row</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>odbc_fetch_array</function> lee una línea de resultado
-   en un array asociativo desde una consulta ODBC.
+   Lee un <type>array</type> asociativo desde una consulta ODBC.
   </para>
  </refsect1>
 

--- a/reference/uodbc/functions/odbc-fetch-into.xml
+++ b/reference/uodbc/functions/odbc-fetch-into.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>row</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Lee una línea de resultado y la coloca en un array.
+   Lee una línea de resultado y la coloca en un <type>array</type>.
   </para>
  </refsect1>
 
@@ -38,8 +38,8 @@
      <term><parameter>array</parameter></term>
      <listitem>
       <para>
-       Puede ser de cualquier tipo, ya que será convertido
-       en array. El array contendrá los valores de las columnas, estas
+       El <type>array</type> de resultado que puede ser de cualquier tipo,
+       ya que será convertido en array. El array contendrá los valores de las columnas, estas
        últimas están numeradas a partir de 0.
       </para>
      </listitem>

--- a/reference/uodbc/functions/odbc-fetch-object.xml
+++ b/reference/uodbc/functions/odbc-fetch-object.xml
@@ -17,8 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>row</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>odbc_fetch_object</function> lee una línea de resultado
-   en un objeto desde una consulta ODBC.
+   Lee un <type>object</type> desde una consulta ODBC.
   </para>
  </refsect1>
 

--- a/reference/uodbc/functions/odbc-fetch-row.xml
+++ b/reference/uodbc/functions/odbc-fetch-row.xml
@@ -15,10 +15,8 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>row</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Lee una línea en el resultado identificado por
-   <parameter>result_id</parameter> y devuelto por
-   <function>odbc_do</function> o
-   <function>odbc_exec</function>. Tras
+   Lee una línea de los datos devueltos por <function>odbc_do</function>
+   o <function>odbc_exec</function>. Tras
    <function>odbc_fetch_row</function>, los campos serán accesibles
    con la función <function>odbc_result</function>.
   </para>

--- a/reference/uodbc/functions/odbc-prepare.xml
+++ b/reference/uodbc/functions/odbc-prepare.xml
@@ -84,7 +84,7 @@
     <title>Ejemplo con <function>odbc_prepare</function> y <function>odbc_execute</function></title>
     <para>
      En el código siguiente, <varname>$res</varname> solo será
-     válido si los tres parámetros para <literal>myproc</literal>
+     válido si los tres parámetros para myproc
      son parámetros IN:
     </para>
     <programlisting role="php">

--- a/reference/uodbc/functions/odbc-result-all.xml
+++ b/reference/uodbc/functions/odbc-result-all.xml
@@ -20,7 +20,8 @@
    <methodparam choice="opt"><type>string</type><parameter>format</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Muestra todas las filas de un resultado. La visualización se realiza en formato HTML.
+   Muestra todas las filas de un resultado producido por
+   <function>odbc_exec</function>. La visualización se realiza en formato HTML.
    Los datos <emphasis>no están</emphasis> escapados.
   </para>
   <para>

--- a/reference/uodbc/functions/odbc-result.xml
+++ b/reference/uodbc/functions/odbc-result.xml
@@ -80,10 +80,10 @@
   <para>
    La primera llamada a <function>odbc_result</function> devuelve
    el valor del tercer campo de la fila actual del
-   resultado <parameter>result_id</parameter>. La segunda
+   resultado de la consulta. La segunda
    llamada a <function>odbc_result</function> devuelve el valor del
    tercer campo cuyo nombre es "val" de la fila actual del
-   resultado <parameter>result_id</parameter>. Se produce un error si
+   resultado de la consulta. Se produce un error si
    el parámetro de columna es inferior a 1, o
    supera el número de columnas del resultado. De la misma
    manera, se produce un error si el nombre del campo pasado no

--- a/reference/uodbc/functions/odbc-setoption.xml
+++ b/reference/uodbc/functions/odbc-setoption.xml
@@ -53,8 +53,8 @@
       <para>
        Un identificador de conexión, o un identificador
        de resultado, para el cual se desea modificar opciones.
-       Para <literal>SQLSetConnectOption()</literal>, es un identificador de conexión.
-       Para <literal>SQLSetStmtOption()</literal>, es un identificador de resultado.
+       Para SQLSetConnectOption(), es un identificador de conexión.
+       Para SQLSetStmtOption(), es un identificador de resultado.
       </para>
      </listitem>
     </varlistentry>
@@ -63,8 +63,8 @@
      <listitem>
       <para>
        Función ODBC a utilizar.
-       El valor debe ser 1 para usar <literal>SQLSetConnectOption()</literal> y 2
-       para <literal>SQLSetStmtOption()</literal>.
+       El valor debe ser 1 para SQLSetConnectOption() y 2
+       para SQLSetStmtOption().
       </para>
      </listitem>
     </varlistentry>
@@ -80,7 +80,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       El valor para la opción dada.
+       El valor para el parámetro <parameter>option</parameter> dado.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/uopz/functions/uopz_set_static.xml
+++ b/reference/uopz/functions/uopz_set_static.xml
@@ -48,7 +48,7 @@
     <term><parameter>static</parameter></term>
     <listitem>
      <para>
-      El array asociativo de nombres de variables mapeados a sus valores.
+      El <type>array</type> asociativo de nombres de variables mapeados a sus valores.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -60,9 +60,9 @@
        <constant>PHP_URL_USER</constant>, <constant>PHP_URL_PASS</constant>,
        <constant>PHP_URL_PATH</constant>, <constant>PHP_URL_QUERY</constant>
        o <constant>PHP_URL_FRAGMENT</constant> para recuperar únicamente
-       una parte de la URL como string (excepto cuando
+       una parte de la URL como <type>string</type> (excepto cuando
        se proporciona <constant>PHP_URL_PORT</constant>; en este caso, el valor devuelto
-       será un &integer;).
+       será un <type>int</type>).
       </para>
      </listitem>
     </varlistentry>
@@ -125,8 +125,8 @@
   </para>
   <para>
    Si el parámetro <parameter>component</parameter> está especificado, <function>parse_url</function>
-   devuelve un <type>string</type> (o un &integer; en el caso de uso de la
-   constante <constant>PHP_URL_PORT</constant>) en lugar de un <type>array</type>. Si el componente
+   devuelve un <type>string</type> (o un <type>int</type>, en el caso de
+   <constant>PHP_URL_PORT</constant>) en lugar de un <type>array</type>. Si el componente
    solicitado no existe en la URL, &null; será devuelto.
    A partir de PHP 8.0.0, <function>parse_url</function> distingue entre los
    fragmentos y consultas ausentes y vacíos:

--- a/reference/v8js/v8js/construct.xml
+++ b/reference/v8js/v8js/construct.xml
@@ -39,7 +39,7 @@
     <listitem>
      <para>
       Una lista de variables PHP que estarán disponibles en Javascript. Debe ser un
-      array asociativo en el formato <literal>array("nombre-para-js" => "nombre-de-la-variable-php")</literal>.
+      <type>array</type> asociativo en el formato <literal>array("nombre-para-js" => "nombre-de-la-variable-php")</literal>.
       Por omisión, un array vacío.
      </para>
     </listitem>

--- a/reference/var/functions/get-resource-type.xml
+++ b/reference/var/functions/get-resource-type.xml
@@ -44,7 +44,7 @@
   </para>
   <para>
    Esta función devolverá &null; y generará un error si
-   <parameter>resource</parameter> no es una &resource;.
+   <parameter>resource</parameter> no es una <type>resource</type>.
   </para>
  </refsect1>
 

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>base</parameter><initializer>10</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve el valor &integer; de <parameter>value</parameter> utilizando
+   Devuelve el valor <type>int</type> de <parameter>value</parameter> utilizando
    la <parameter>base</parameter> proporcionada para la conversión (por omisión
    en base 10). <function>intval</function> no debería ser utilizada
    con objetos; en estos casos, se emitirá un error de nivel <constant>E_WARNING</constant>
@@ -83,7 +83,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un valor de tipo &integer; de <parameter>value</parameter> en caso de
+   Un valor de tipo <type>int</type> de <parameter>value</parameter> en caso de
    éxito o 0 en caso de fallo. Los arrays vacíos devuelven 0,
    los arrays no vacíos devuelven 1.
   </para>

--- a/reference/var/functions/is-scalar.xml
+++ b/reference/var/functions/is-scalar.xml
@@ -24,7 +24,7 @@
   </para>
   <note>
    <para>
-    <function>is_scalar</function> no considera los valores de tipo &resource;
+    <function>is_scalar</function> no considera los valores de tipo <type>resource</type>
     como escalares, dado que los recursos son tipos abstractos,
     basados en enteros. Esto es susceptible de cambiar.
    </para>

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -56,13 +56,13 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Si se proporciona una &string;, un &integer; o un &float;, se mostrará su valor. Si se proporciona
-   un &array;, los valores se mostrarán en un formato que permite ver las claves y los elementos. Un formato
-   similar se utilizará asimismo para los objetos.
+   Si se proporciona una <type>string</type>, un <type>int</type> o un <type>float</type>, se mostrará su valor. Si se proporciona
+   un <type>array</type>, los valores se mostrarán en un formato que permite ver las claves y los elementos. Un formato
+   similar se utilizará asimismo para los <type>object</type>s.
   </para>
   <para>
    Cuando el parámetro <parameter>return</parameter> vale &true;, esta función
-   retornará una &string;. De lo contrario, el valor de retorno será &true;.
+   retornará una <type>string</type>. De lo contrario, el valor de retorno será &true;.
   </para>
  </refsect1>
 

--- a/reference/var/functions/serialize.xml
+++ b/reference/var/functions/serialize.xml
@@ -33,7 +33,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       El valor a serializar. <function>serialize</function> acepta todos los tipos excepto los recursos &resource; y ciertos &object;s (ver nota a continuación). Asimismo, es posible serializar un array que contenga referencias a sí mismo. Las referencias cíclicas en arrays/objetos también serán almacenadas. Todas las demás referencias se perderán.
+       El valor a serializar. <function>serialize</function> acepta todos los tipos excepto los de tipo <type>resource</type> y ciertos <type>object</type>s (ver nota a continuación). Asimismo, es posible serializar un array que contenga referencias a sí mismo. Las referencias cíclicas en arrays/objetos también serán almacenadas. Todas las demás referencias se perderán.
       </para>
       <para>
        Al serializar un objeto, PHP intentará llamar a las funciones miembro <link linkend="object.serialize">__serialize()</link> o <link linkend="object.sleep">__sleep()</link> antes de serializar. Esto permite al objeto realizar una última limpieza, etc. antes de ser serializado. De manera similar, cuando el objeto es restaurado utilizando <function>unserialize</function>, se llama a la función miembro <link linkend="object.unserialize">__unserialize()</link> o <link linkend="object.wakeup">__wakeup()</link>.
@@ -52,7 +52,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un string que contiene una representación en forma de flujo de bytes que puede ser almacenada en cualquier lugar.
+   Devuelve un string que contiene una representación en forma de flujo de bytes de
+   <parameter>value</parameter> que puede ser almacenada en cualquier lugar.
   </para>
   <para>
    Cabe señalar que se trata de una cadena binaria que puede incluir bytes nulos, y por lo tanto debe ser almacenada y gestionada como tal. Por ejemplo, la salida de <function>serialize</function> generalmente debe ser almacenada en un campo de tipo BLOB de una base de datos, en lugar de en un campo de tipo CHAR o TEXT.

--- a/reference/var/functions/settype.xml
+++ b/reference/var/functions/settype.xml
@@ -57,17 +57,17 @@
         </listitem>
         <listitem>
          <simpara>
-          "<literal>string</literal>"
+          "string"
          </simpara>
         </listitem>
         <listitem>
          <simpara>
-          "<literal>array</literal>"
+          "array"
          </simpara>
         </listitem>
         <listitem>
          <simpara>
-          "<literal>object</literal>"
+          "object"
          </simpara>
         </listitem>
         <listitem>

--- a/reference/var/functions/strval.xml
+++ b/reference/var/functions/strval.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Obtiene el valor de la variable <parameter>value</parameter>,
-   en formato string. Consulte la documentación sobre strings para obtener más información sobre la conversión a string.
+   en formato string. Consulte la documentación sobre <type>string</type> para obtener más información sobre la conversión a string.
   </simpara>
   <simpara>
    Esta función no realiza ningún formateo en el valor devuelto.
@@ -33,11 +33,11 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       La variable a convertir en &string;.
+       La variable a convertir en <type>string</type>.
       </para>
       <para>
        <parameter>value</parameter> puede ser un escalar, <type>null</type>,
-       o un <type>objeto</type> que implemente el método mágico <link linkend="object.tostring">__toString()</link>.
+       o un <type>object</type> que implemente el método mágico <link linkend="object.tostring">__toString()</link>.
        No se puede utilizar la función <function>strval</function> con arrays
        o objetos que no implementen el método mágico
        <link linkend="object.tostring">__toString()</link>.
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   El valor de la variable <parameter>value</parameter> en forma de &string;.
+   El valor <type>string</type> del argumento <parameter>value</parameter>.
   </para>
  </refsect1>
 

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -92,7 +92,7 @@
           <entry><type class="union"><type>array</type><type>bool</type></type></entry>
           <entry>
            <simpara>
-            Puede ser un array de nombres de clases que deben ser aceptados, &false;
+            Puede ser un <type>array</type> de nombres de clases que deben ser aceptados, &false;
             para no aceptar ninguna clase, o &true; para aceptar todas las
             clases. Si esta opción está definida, y
             <function>unserialize</function> encuentra un objeto de una clase
@@ -129,8 +129,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   El valor convertido es retornado por la función, y puede ser de
-   tipo &boolean;, &integer;, &float;, &string;, &array; o &object;.
+   El valor convertido es retornado por la función, y puede ser un <type>bool</type>,
+   <type>int</type>, <type>float</type>, <type>string</type>,
+   <type>array</type> o <type>object</type>.
   </para>
   <para>
    Si la cadena pasada no puede ser deserializada, esta función retorna
@@ -242,7 +243,7 @@ if (!odbc_execute($stmt, $sqldata) || !odbc_fetch_into($stmt, $tmp)) {
   </para>
   <para>
    <example>
-    <title>Ejemplo con la directiva <option>unserialize_callback_func</option></title>
+    <title>Ejemplo con la directiva unserialize_callback_func</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -241,7 +241,7 @@ object(A)#2 (2) {
   &reftitle.notes;
   <note>
    <para>
-    Las variables de tipo &resource; no pueden ser exportadas por esta
+    Las variables de tipo <type>resource</type> no pueden ser exportadas por esta
     función.
    </para>
   </note>

--- a/reference/win32service/constants.xml
+++ b/reference/win32service/constants.xml
@@ -394,7 +394,7 @@
       <entry><literal>0x00000004</literal></entry>
       <entry>
        Un servicio que no puede ser iniciado. Los intentos para iniciar
-       devuelven un código de error <constant>WIN32_ERROR_SERVICE_DISABLED </constant>.
+       devuelven un código de error <constant>WIN32_ERROR_SERVICE_DISABLED</constant>.
       </entry>
      </row>
     </tbody>

--- a/reference/win32service/functions/win32-get-last-control-message.xml
+++ b/reference/win32service/functions/win32-get-last-control-message.xml
@@ -103,8 +103,7 @@
       <row>
        <entry>PECL win32service 0.2.0</entry>
        <entry>
-        Esta función solo funciona en línea de
-        comandos.
+        Esta función solo funciona en el SAPI <literal>"cli"</literal>.
        </entry>
       </row>
      </tbody>

--- a/reference/win32service/functions/win32-set-service-status.xml
+++ b/reference/win32service/functions/win32-set-service-status.xml
@@ -131,8 +131,7 @@
       <row>
        <entry>PECL win32service 0.2.0</entry>
        <entry>
-        Esta función solo funciona en línea de
-        comandos ("cli" SAPI).
+        Esta función solo funciona en el SAPI <literal>"cli"</literal>.
        </entry>
       </row>
      </tbody>

--- a/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
+++ b/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
@@ -133,8 +133,7 @@
       <row>
        <entry>PECL win32service 0.2.0</entry>
        <entry>
-        Esta función solo funciona en línea de
-        comandos ("cli" SAPI).
+        Esta función solo funciona en el SAPI <literal>"cli"</literal>.
        </entry>
       </row>
      </tbody>

--- a/reference/xml/encoding.xml
+++ b/reference/xml/encoding.xml
@@ -5,12 +5,12 @@
  <title>Codificación de caracteres</title>
  <para>
 La extensión de PHP XML es compatible con el conjunto de caracteres <link
-  xlink:href="&url.unicode;">Unicode</link> a través de diferentes codificaciones de caracteres. Hay dos tipos de codificaciones de caracteres: la codificación fuente y la codificación de destino. La representación interna de PHP del documento está siempre codificada con
+  xlink:href="&url.unicode;">Unicode</link> a través de diferentes <glossterm>codificaciones de caracteres</glossterm>. Hay dos tipos de codificaciones de caracteres: la <glossterm>codificación fuente</glossterm> y la <glossterm>codificación de destino</glossterm>. La representación interna de PHP del documento está siempre codificada con
   <literal>UTF-8</literal>.
  </para>
  <para>
 La codificación fuente se hace cuando un documento XML es <link
-  linkend="function.xml-parse">analizado</link>. Una vez <link  linkend="function.xml-parser-create">creado un intérprete XML</link>, la codificación fuente puede ser especificada (esta codificación no puede ser cambiada más adelante en la vida del intérprete XML). Las codificaciones fuente soportadas son <literal>ISO-8859-1</literal>,
+  linkend="function.xml-parse">analizado</link>. Una vez <link linkend="function.xml-parser-create">creado un intérprete XML</link>, la codificación fuente puede ser especificada (esta codificación no puede ser cambiada más adelante en la vida del intérprete XML). Las codificaciones fuente soportadas son <literal>ISO-8859-1</literal>,
   <literal>US-ASCII</literal> y <literal>UTF-8</literal>. Las dos primeras son codificaciones de un solo byte, lo cual significa que cada caracter se representa por un solo byte.
   <literal>UTF-8</literal> puede codificar caracteres compuestos por un número variable de bits (hasta 21) de uno a cuatro bytes. La codificación fuente por defecto usada por PHP es <literal>ISO-8859-1</literal>.
 

--- a/reference/xml/functions/xml-set-object.xml
+++ b/reference/xml/functions/xml-set-object.xml
@@ -20,10 +20,10 @@
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Permite que el analizador <parameter>parser</parameter>
-   sea utilizable desde un objeto. Todos los métodos de retrollamada,
-   asignados por <function>xml_set_element_handler</function>,
-   serán los métodos de este objeto.
+   Permite utilizar <parameter>parser</parameter> dentro de
+   <parameter>object</parameter>. Todas las funciones de retrollamada podrán ser definidas con
+   <function>xml_set_element_handler</function>, etc., y se considerarán
+   métodos de <parameter>object</parameter>.
   </para>
  </refsect1>
 

--- a/reference/xpass/functions/crypt-checksalt.xml
+++ b/reference/xpass/functions/crypt-checksalt.xml
@@ -39,7 +39,7 @@
   &reftitle.returnvalues;
   <simpara>
    Devuelve una de las constantes
-   <constant>CRYPT_SALT_*</constant>
+   <constant>CRYPT_SALT_<replaceable>*</replaceable></constant>
    como <type>int</type>.
   </simpara>
  </refsect1>

--- a/reference/yaconf/book.xml
+++ b/reference/yaconf/book.xml
@@ -12,7 +12,7 @@
   <para>
    <literal>Otro contenedor de configuraciones</literal>
    (<acronym>Yaconf</acronym>) es un contenedor de configuraciones,
-   analiza los archivos INI, y almacena el resultado
+   analiza los archivos <literal>INI</literal>, y almacena el resultado
    en PHP cuando se inicia PHP, el resultado vive con el
    todo el ciclo de vida de PHP.
   </para>

--- a/reference/yaml/functions/yaml-parse-file.xml
+++ b/reference/yaml/functions/yaml-parse-file.xml
@@ -57,7 +57,7 @@
      <listitem>
       <para>
        Controlador de contenido para los nodos YAML. Es un <type>array</type> asociativo de
-       etiquetas YAML =&gt; asociando sus <type>callback</type> correspondientes. Ver
+       etiquetas YAML =&gt; asociando sus <type>callable</type> correspondientes. Ver
        <link linkend="yaml.callbacks.parse">Analizar callbacks</link> para más
        información.
       </para>

--- a/reference/yaml/functions/yaml-parse-url.xml
+++ b/reference/yaml/functions/yaml-parse-url.xml
@@ -62,7 +62,7 @@
      <listitem>
       <para>
        Controlador de contenido para los nodos YAML. Es un <type>array</type> asociativo de
-       etiquetas YAML =&gt; asociando sus <type>callback</type> correspondientes. Ver
+       etiquetas YAML =&gt; asociando sus <type>callable</type> correspondientes. Ver
        <link linkend="yaml.callbacks.parse">Analizar callbacks</link> para más información
       </para>
      </listitem>

--- a/reference/yaml/functions/yaml-parse.xml
+++ b/reference/yaml/functions/yaml-parse.xml
@@ -57,7 +57,7 @@
      <listitem>
       <para>
        Controlador de contenido para los nodos YAML. Es un <type>array</type> asociativo de
-       etiquetas YAML =&gt; asociando sus <type>callback</type> correspondientes. Ver
+       etiquetas YAML =&gt; asociando sus <type>callable</type> correspondientes. Ver
        <link linkend="yaml.callbacks.parse">Analizar callbacks</link> para más
        información.
       </para>

--- a/reference/yaml/ini.xml
+++ b/reference/yaml/ini.xml
@@ -67,7 +67,7 @@
       <varlistentry xml:id="ini.yaml.decode-binary">
         <term>
           <parameter>yaml.decode_binary</parameter>
-          <type>boolean</type>
+          <type>bool</type>
         </term>
         <listitem>
           <para>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -7,8 +7,9 @@
 
  <para>
   <classname>ZipArchive</classname> usa constantes de clase.
-  Existen tres tipos de constantes:
+  Existen varios tipos de constantes, los principales son:
   Flags (prefijadas con <literal>FL_</literal>),
+  Flags globales (prefijadas con <literal>AFL_</literal>),
   errores (prefijados con <literal>ER_</literal>) y
   modos (sin prefijo).
  </para>

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -48,8 +48,7 @@
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
-       <constant>ZipArchive::FL_ENC_CP437</constant>,
-       <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
+       <constant>ZipArchive::FL_ENC_CP437</constant>.
        El comportamiento de estas constantes se describe en
        la página de <link linkend="zip.constants">constantes ZIP</link>.
       </para>

--- a/reference/zip/ziparchive/isencryptionmethoddupported.xml
+++ b/reference/zip/ziparchive/isencryptionmethoddupported.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xml:id="ziparchive.isencryptionmethodsupported" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="ziparchive.isencryptionmethoddupported" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::isEncryptionMethodSupported</refname>
   <refpurpose>Verifica si un método de cifrado es soportado por libzip</refpurpose>
@@ -12,7 +12,7 @@
   <methodsynopsis role="ZipArchive">
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>ZipArchive::isEncryptionMethodSupported</methodname>
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>true</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Verifica si un método de cifrado es soportado por libzip.
@@ -36,7 +36,7 @@
      <term><parameter>enc</parameter></term>
      <listitem>
       <para>
-       Si es <literal>true</literal>, verifica el cifrado; si es <literal>false</literal>, verifica el
+       Si es &true;, verifica el cifrado; si es &false;, verifica el
        descifrado.
       </para>
      </listitem>

--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -65,7 +65,6 @@
      <listitem>
       <para>
        Máscara de bits compuesta por
-       <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
        <constant>ZipArchive::FL_ENC_CP437</constant>,

--- a/reference/zlib/functions/ob-gzhandler.xml
+++ b/reference/zlib/functions/ob-gzhandler.xml
@@ -21,7 +21,7 @@
    el envío de datos comprimidos a los navegadores que soportan páginas
    comprimidas. Antes de que <function>ob_gzhandler</function> envíe los datos
    comprimidos, determina los tipos de codificación que son soportados por el
-   navegador (<literal>"gzip"</literal>, <literal>"deflate"</literal> o ninguno)
+   navegador ("gzip", "deflate" o ninguno)
    y devuelve el contenido de los búferes
    de manera apropiada. Todos los navegadores son manejados, ya que es responsabilidad
    de los navegadores enviar un encabezado indicando los tipos de páginas soportadas.


### PR DESCRIPTION
## Summary

- Fix incorrect inline markup tags in `reference/` to match `doc-en` structure
- `<literal>` → `<constant>` for PHP constants
- `<literal>` → `<type>` for PHP types  
- Add missing `<emphasis>`, `<acronym>`, `<classname>` tags
- Remove extra `<function>` self-references in descriptions
- Fix `<parameter>` names to match EN