### PR TITLE
XML schema correction: fix XML declarations and attribute consistency

### DIFF
--- a/reference/cmark/book.xml
+++ b/reference/cmark/book.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 876a6a393125efc9d771cebdae1c02fec37c8ef7 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: julionc -->
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="book.cmark"> <?phpdoc extension-membership="pecl" ?>
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="book.cmark">
+ <?phpdoc extension-membership="pecl" ?>
  <title>CommonMark</title>
  <titleabbrev>CommonMark</titleabbrev>
 

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 3a5f4322449f2d4c5caa61afb4e4188872389728 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <reference xml:id="class.domnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La clase <classname>DOMNode</classname></title>
+ <title>La clase DOMNode</title>
  <titleabbrev>DOMNode</titleabbrev>
 
  <partintro>
@@ -278,7 +278,7 @@
     <varlistentry xml:id="domnode.props.nodetype">
      <term><varname>nodeType</varname></term>
      <listitem>
-      <para>Recupera el tipo del nódo. Una de las <link linkend="dom.constants">constantes XML_<replaceable>*</replaceable>_NODE</link></para>
+      <para>Recupera el tipo del nódo. Una de las constantes predefinidas <constant>XML_<replaceable>*</replaceable>_NODE</constant></para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domnode.props.parentnode">

--- a/reference/dom/domtext.xml
+++ b/reference/dom/domtext.xml
@@ -7,8 +7,6 @@
 
  <partintro>
 
-<!-- }}} -->
-
 <!-- {{{ DOMText intro -->
   <section xml:id="domtext.intro">
    &reftitle.intro;

--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.hash-pbkdf2">
  <refnamediv>
   <refname>hash_pbkdf2</refname>
   <refpurpose>Genera una clave PBKDF2 derivada de la contraseña proporcionada</refpurpose>

--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -99,7 +99,12 @@
     <varlistentry xml:id="mysqli-driver.props.reconnect">
      <term><varname>reconnect</varname></term>
      <listitem>
-      <para>Permite o no la reconexión (ver la directiva INI mysqli.reconnect)</para>
+      <para>Permite o no la reconexión (ver la directiva INI <link linkend="ini.mysqli.reconnect">mysqli.reconnect</link>)</para>
+      <warning>
+       <simpara>Esta propiedad ha sido <emphasis>eliminada</emphasis>
+        junto con la directiva INI <link linkend="ini.mysqli.reconnect">mysqli.reconnect</link> a partir de PHP 8.2.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="mysqli-driver.props.report-mode">
@@ -118,6 +123,47 @@
    </variablelist>
   </section>
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.2.0</entry>
+       <entry>
+        <property>mysqli_driver::$reconnect</property> fue eliminada.
+       </entry>
+      </row>
+      <row>
+       <entry>8.1.0</entry>
+       <entry>
+        <property>mysqli_driver::$driver_version</property> ha sido marcada como obsoleta.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        <property>mysqli_driver::$embedded</property> fue eliminada.
+       </entry>
+      </row>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        <methodname>mysqli_driver::embedded_server_start</methodname> y
+        <methodname>mysqli_driver:embedded_server_end</methodname> fueron eliminadas.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -38,7 +38,7 @@
    nombres diferentes a las columnas.
   </para>
 
-  <note>
+  <note xmlns="http://docbook.org/ns/docbook">
    <simpara>
     Esta función afecta las propiedades del objeto
     antes de llamar a su constructor.

--- a/reference/pdo/pdo/exec.xml
+++ b/reference/pdo/pdo/exec.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 28529d3539b850e870e3aa97570f4db0e53daa03 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="pdo.exec" xmlns="http://docbook.org/ns/docbook">
@@ -25,7 +25,7 @@
    SELECT. Para una consulta SELECT que se necesite una sola vez en
    el programa, utilice en su lugar la función <methodname>PDO::query</methodname>.
    Para una consulta que se necesite varias veces, prepare un objeto
-   <classname>PDOStatement</classname> con la función <methodname>PDO::prepare</methodname> y ejecute
+   PDOStatement con la función <methodname>PDO::prepare</methodname> y ejecute
    la consulta con la función <methodname>PDOStatement::execute</methodname>.
   </para>
 

--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<reference xml:id="class.pdo-dblib" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-dblib" role="class">
  <title>La clase Pdo\Dblib</title>
  <titleabbrev>Pdo\Dblib</titleabbrev>
 

--- a/reference/pdo_firebird/pdo-firebird.xml
+++ b/reference/pdo_firebird/pdo-firebird.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<reference xml:id="class.pdo-firebird" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-firebird" role="class">
  <title>La clase Pdo\Firebird</title>
  <titleabbrev>Pdo\Firebird</titleabbrev>
 

--- a/reference/pdo_odbc/pdo-odbc.xml
+++ b/reference/pdo_odbc/pdo-odbc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<reference xml:id="class.pdo-odbc" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-odbc" role="class">
  <title>La clase Pdo\Odbc</title>
  <titleabbrev>Pdo\Odbc</titleabbrev>
 

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<reference xml:id="class.pdo-pgsql" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-pgsql" role="class">
  <title>La clase Pdo\Pgsql</title>
  <titleabbrev>Pdo\Pgsql</titleabbrev>
 

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -11,9 +11,9 @@
    <section xml:id="ref.pdo-pgsql.intro">
    &reftitle.intro;
     <para>
-     PDO_PGSQL es un controlador que implementa la <link
-     linkend="intro.pdo">interfaz de PHP Data Objects (PDO)</link> para
-     permitir el acceso de PHP a las bases de datos PostgreSQL.
+     PDO_PGSQL es un controlador que implementa la <link linkend="intro.pdo">PHP
+     Data Objects (PDO)</link>
+     para permitir el acceso de PHP a las bases de datos PostgreSQL.
     </para>
    </section>
 
@@ -138,6 +138,15 @@
        <programlisting>
 <![CDATA[
 pgsql:host=localhost;port=5432;dbname=testdb;user=bruce;password=mypass
+]]>
+       </programlisting>
+      </para>
+      <para>
+       El siguiente ejemplo muestra un PDO_PGSQL DSN para conectarse a una
+       base de datos PostgreSQL a través del socket Unix <filename>/tmp/.s.PGSQL.5432</filename> :
+       <programlisting>
+<![CDATA[
+pgsql:host=/tmp;port=5432;dbname=testdb;user=bruce;password=mypass
 ]]>
        </programlisting>
       </para>

--- a/reference/pdo_sqlite/reference.xml
+++ b/reference/pdo_sqlite/reference.xml
@@ -12,8 +12,8 @@
    <section xml:id="ref.pdo-sqlite.intro">
    &reftitle.intro;
     <para>
-     PDO_SQLITE es un controlador que implementa la <link
-     linkend="intro.pdo">interfaz de PHP Data Objects (PDO)</link> para
+     PDO_SQLITE es un controlador que implementa la <link linkend="intro.pdo">PHP
+     Data Objects (PDO)</link> para
      permitir el acceso de PHP a las bases de datos SQLite 3.
     </para>
     <note>

--- a/reference/pgsql/pgsql.connection.xml
+++ b/reference/pgsql/pgsql.connection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<reference xml:id="class.pgsql-connection" role="class" xmlns="http://docbook.org/ns/docbook">
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="class.pgsql-connection" role="class">
  <title>La clase PgSql\Connection</title>
  <titleabbrev>PgSql\Connection</titleabbrev>
 

--- a/reference/pgsql/pgsql.lob.xml
+++ b/reference/pgsql/pgsql.lob.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<reference xml:id="class.pgsql-lob" role="class" xmlns="http://docbook.org/ns/docbook">
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="class.pgsql-lob" role="class">
  <title>La clase PgSql\Lob</title>
  <titleabbrev>PgSql\Lob</titleabbrev>
 

--- a/reference/pgsql/pgsql.result.xml
+++ b/reference/pgsql/pgsql.result.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<reference xml:id="class.pgsql-result" role="class" xmlns="http://docbook.org/ns/docbook">
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="class.pgsql-result" role="class">
  <title>La clase PgSql\Result</title>
  <titleabbrev>PgSql\Result</titleabbrev>
 

--- a/reference/phar/Phar/convertToData.xml
+++ b/reference/phar/Phar/convertToData.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.converttodata" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/phar/Phar/copy.xml
+++ b/reference/phar/Phar/copy.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 8d09722b6d95d2545d5a4c9415c6955efc3a464e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="phar.copy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/phar/Phar/createDefaultStub.xml
+++ b/reference/phar/Phar/createDefaultStub.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.createdefaultstub" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/Phar/getModified.xml
+++ b/reference/phar/Phar/getModified.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.getmodified" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/Phar/getSignature.xml
+++ b/reference/phar/Phar/getSignature.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.getsignature" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/Phar/getStub.xml
+++ b/reference/phar/Phar/getStub.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.getstub" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/Phar/interceptFileFuncs.xml
+++ b/reference/phar/Phar/interceptFileFuncs.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.interceptfilefuncs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/phar/Phar/isCompressed.xml
+++ b/reference/phar/Phar/isCompressed.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.iscompressed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/phar/Phar/mapPhar.xml
+++ b/reference/phar/Phar/mapPhar.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.mapphar" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/Phar/offsetGet.xml
+++ b/reference/phar/Phar/offsetGet.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes  -->
 <refentry xml:id="phar.offsetget" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/Phar/setMetadata.xml
+++ b/reference/phar/Phar/setMetadata.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="phar.setmetadata">

--- a/reference/phar/Phar/setSignatureAlgorithm.xml
+++ b/reference/phar/Phar/setSignatureAlgorithm.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.setsignaturealgorithm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/phar/Phar/webPhar.xml
+++ b/reference/phar/Phar/webPhar.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 5beaad9885973652023784f1a4656a5e497779fb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phar.webphar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -127,7 +127,7 @@ $mimes = array(
      <listitem>
       <para>
        La función de reescritura que se pasa toma como único argumento un string
-       y debe devolver un string o false.
+       y debe devolver un <type>string</type> o false.
       </para>
       <para>
        Si se utiliza fast-cgi o cgi, el argumento pasado a la función es el valor de la

--- a/reference/phar/PharData/addFromString.xml
+++ b/reference/phar/PharData/addFromString.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 88773698060b9bb3e9900bbd7cb8a3da588f1288 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phardata.addfromstring" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/PharData/buildFromDirectory.xml
+++ b/reference/phar/PharData/buildFromDirectory.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phardata.buildfromdirectory" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/phar/PharData/decompress.xml
+++ b/reference/phar/PharData/decompress.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="phardata.decompress" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="phardata.setsignaturealgorithm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -35,26 +35,6 @@
        Un algoritmo entre <literal>Phar::MD5</literal>,
        <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
        <literal>Phar::SHA512</literal>, o <literal>Phar::OPENSSL</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>privateKey</parameter></term>
-     <listitem>
-      <para>
-       El contenido de una clave privada OpenSSL, como extraída desde un
-       certificado o un fichero de clave OpenSSL:
-       <programlisting role="php">
-<![CDATA[
-<?php
-$private = openssl_get_privatekey(file_get_contents('private.pem'));
-$pkey = '';
-openssl_pkey_export($private, $pkey);
-$p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
-?>
-]]>
-       </programlisting>
-       Ver la <link linkend="phar.using">introducción Phar</link> para consignas de nombramiento y ubicación de ficheros de clave pública.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/phar/PharFileInfo/construct.xml
+++ b/reference/phar/PharFileInfo/construct.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pharfileinfo.construct" xmlns="http://docbook.org/ns/docbook">
@@ -14,7 +14,7 @@
   </constructorsynopsis>
   <para>
    Este método no debe ser llamado directamente. En su lugar, un objeto
-   <classname>PharFileInfo</classname> es inicializado llamando
+   PharFileInfo es inicializado llamando
    <function>Phar::offsetGet</function> mediante un acceso de tipo array.
   </para>
  </refsect1>

--- a/reference/phar/PharFileInfo/decompress.xml
+++ b/reference/phar/PharFileInfo/decompress.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: c8ba91f7e546462dc66c2a11a7eab6f55c93915b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pharfileinfo.decompress" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/PharFileInfo/getCRC32.xml
+++ b/reference/phar/PharFileInfo/getCRC32.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pharfileinfo.getcrc32" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/PharFileInfo/setMetadata.xml
+++ b/reference/phar/PharFileInfo/setMetadata.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pharfileinfo.setmetadata" xmlns="http://docbook.org/ns/docbook">

--- a/reference/phar/using.xml
+++ b/reference/phar/using.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- EN-Revision: e9f972da6918eabb189ba377822a1d6ad982c96d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->

--- a/reference/trader/functions/trader-get-unstable-period.xml
+++ b/reference/trader/functions/trader-get-unstable-period.xml
@@ -27,7 +27,7 @@
     <term><parameter>functionId</parameter></term>
     <listitem>
      <para>
-      El ID de la función por la que leer el factor. Se debería usar la serie de constantes TRADER_FUNC_UNST_*.
+      El ID de la función por la que leer el factor. Se debería usar la serie de constantes <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_FUNC_UNST_*</link>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/trader/functions/trader-set-unstable-period.xml
+++ b/reference/trader/functions/trader-set-unstable-period.xml
@@ -28,7 +28,7 @@
     <term><parameter>functionId</parameter></term>
     <listitem>
      <para>
-      El ID de la función para la cual debería establecerse el factor. Se pueden usar la serie de constantes TRADER_FUNC_UNST_* para afectar a la función correspondiente.
+      El ID de la función para la cual debería establecerse el factor. Se pueden usar la serie de constantes <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_FUNC_UNST_*</link> para afectar a la función correspondiente.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
## Summary

- Single quotes → double quotes in XML declarations
- Fix attribute ordering to match doc-en
- Fix namespace declarations