### PR TITLE
XML schema correction: fix indentation and whitespace

### DIFF
--- a/reference/apcu/functions/apcu-add.xml
+++ b/reference/apcu/functions/apcu-add.xml
@@ -75,7 +75,7 @@
     <term><parameter>values</parameter></term>
     <listitem>
      <simpara>
-      Los nombres son proporcionados por las claves del array <parameter>values</parameter>,
+      Los nombres son proporcionados por las claves del array values,
       las variables por los valores.
      </simpara>
     </listitem>

--- a/reference/com/constants.xml
+++ b/reference/com/constants.xml
@@ -661,7 +661,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-</variablelist>
+ </variablelist>
 </chapter>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/com/functions/com-print-typeinfo.xml
+++ b/reference/com/functions/com-print-typeinfo.xml
@@ -43,7 +43,7 @@
      <term><parameter>display_sink</parameter></term>
      <listitem>
       <para>
-       Si el parámetro <parameter>wantsink</parameter> vale &true;, se mostrará la interfaz de sumidero correspondiente en su lugar.
+       Si se establece a &true;, se mostrará la interfaz de sumidero correspondiente en su lugar.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnode/replacechild.xml
+++ b/reference/dom/domnode/replacechild.xml
@@ -31,7 +31,7 @@
      <listitem>
       <para>
        El nuevo nodo. Debe ser miembro del documento destino, es decir,
-       creado por una de las métodos de DOMDocument->createXXX() o importado
+       creado por una de las métodos de DOMDocument-&gt;createXXX() o importado
        en el documento por <xref linkend="domdocument.importnode"/>.
       </para>
      </listitem>

--- a/reference/ldap/book.xml
+++ b/reference/ldap/book.xml
@@ -78,7 +78,7 @@
    <listitem>
     <para>
      Internet Engineering Taskforce RFCs
-     <link xlink:href="&url.rfc;rfc4510">4510</link> a <link xlink:href="&url.rfc;rfc4519">4519</link>.
+     <link xlink:href="&url.rfc;4510">4510</link> a <link xlink:href="&url.rfc;4519">4519</link>.
     </para>
    </listitem>
   </itemizedlist>

--- a/reference/ldap/functions/ldap-parse-result.xml
+++ b/reference/ldap/functions/ldap-parse-result.xml
@@ -85,7 +85,7 @@
      <term><parameter>controls</parameter></term>
      <listitem>
       <para>
-       Array de <link linkend="ldap.controls">Controles LDAP</link> a enviar con la consulta.
+       Un array de Controles LDAP que han sido enviados con la respuesta.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -194,7 +194,7 @@ foreach ($managers as $manager) {
    <para>
     A pesar de sus carencias con las conexiones SSL persistentes y la información
     de topología, esta versión de la extensión soporta todas las
-    <link xlink:href="context.ssl">opciones de contexto SSL</link> ya que utiliza la API de flujos PHP.
+    <link linkend="context.ssl">opciones de contexto SSL</link> ya que utiliza la API de flujos PHP.
    </para>
   </section>
  </section>
@@ -653,7 +653,7 @@ class UpperClass implements MongoDB\BSON\Persistable
           <para>
            La funcionalidad <property>__pclass</property> se basa en el hecho
            de que la propiedad sea parte de un documento MongoDB recuperado. Si utiliza una
-           <link xlink:href="mongodb-driver-query.construct-queryOptions">proyección</link>
+           <link linkend="mongodb-driver-query.construct-queryOptions">proyección</link>
            al buscar documentos, debe incluir el campo
            <property>__pclass</property> en la proyección para que esta
            funcionalidad funcione.

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -80,11 +80,8 @@
      <term><parameter>password</parameter></term>
      <listitem>
       <para>
-       Si la contraseña no se especifica (se pasa el valor &null;),
-       el servidor MySQL intentará identificar al usuario examinando solo
-       los registros donde los usuarios no tienen contraseña. Esto permite
-       a un usuario disfrutar de múltiples permisos (dependiendo de si se proporciona
-       una contraseña o no).
+       La contraseña MySQL o &null; para asumir la contraseña basándose en la
+       opción ini <link linkend="ini.mysqli.default-pw">mysqli.default_pw</link>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pcre/book.xml
+++ b/reference/pcre/book.xml
@@ -14,7 +14,7 @@
    mucho a la de Perl. Las expresiones estarán rodeadas
    de delimitadores, como la barra (/), por ejemplo. Un delimitador puede
    ser cualquier carácter, siempre que no sea alfanumérico, un carácter blanco,
-   la barra invertida (&#92;) o el carácter nulo (\0).
+   la barra invertida (\) o el carácter nulo (\0).
    Si un delimitador debe ser utilizado en
    la expresión, deberá protegerse con una barra invertida.
    Los delimitadores a la Perl (), {}, [], y &lt;&gt; también pueden ser utilizados.
@@ -35,7 +35,8 @@
   <warning>
    <para>
     Deben tenerse en cuenta las limitaciones de PCRE.
-    Consulte <link xlink:href="&url.pcre.man;">&url.pcre.man;</link> para más detalles.
+    Consulte <link
+     xlink:href="&url.pcre.man;">&url.pcre.man;</link> para más detalles.
    </para>
   </warning>
   <!-- FIXME: Check what Perl version implementation corresponds -->

--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -58,7 +58,7 @@
        <parameter>replacement</parameter> asociado.
        Si <parameter>replacement</parameter> tiene menos elementos
        que <parameter>pattern</parameter>, entonces una cadena vacía es
-       utilizada para el resto de los valores.
+       utilizada para los <parameter>pattern</parameter> adicionales.
       </para>
       <para>
        <parameter>replacement</parameter> puede contener referencias
@@ -95,8 +95,8 @@
        La cadena o el array que contiene las cadenas a buscar y reemplazar.
       </para>
       <para>
-       Si <parameter>subject</parameter> es un array, entonces la operación
-       será aplicada a cada uno de los elementos del array, y el array será devuelto.
+       Si <parameter>subject</parameter> es un array, entonces la búsqueda y el reemplazo
+       se realiza en cada entrada de <parameter>subject</parameter>, y el array será devuelto.
       </para>
       <para>
        Si el array <parameter>subject</parameter> es asociativo, entonces las claves

--- a/reference/pcre/functions/preg-split.xml
+++ b/reference/pcre/functions/preg-split.xml
@@ -30,7 +30,7 @@
      <term><parameter>pattern</parameter></term>
      <listitem>
       <para>
-       El patrón a buscar, en forma de &string;.
+       El patrón a buscar, en forma de cadena.
       </para>
      </listitem>
     </varlistentry>
@@ -46,9 +46,9 @@
      <term><parameter>limit</parameter></term>
      <listitem>
       <para>
-       Si <parameter>limit</parameter> está especificado, entonces solo se devuelven
-       las <parameter>limit</parameter> primeras sub-caenas con el resto de la cadena
-       colocado en la última sub-caena.
+       Si se especifica, entonces solo se devuelven las primeras sub-cadenas
+       hasta <parameter>limit</parameter> con el resto de la cadena
+       colocado en la última sub-cadena.
        Un <parameter>limit</parameter> de -1 o 0 significa "sin límite".
       </para>
      </listitem>

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -29,7 +29,7 @@
   </step>
   <step>
    <para>
-    Al instalar PDO como módulo compartido, el archivo &php.ini;
+    Al instalar PDO como módulo compartido, el archivo php.ini
     debe ser actualizado para cargar la extensión PDO automáticamente
     cuando PHP se inicie. Asimismo, se deben activar los controladores específicos de su base de datos; asegúrese de que estos controladores estén listados después de la línea extension=pdo, ya que PDO debe ser inicializado antes de cargar las extensiones específicas de las bases de datos. Si compila PDO y las extensiones relativas a las bases de datos de forma estática, puede omitir este paso.
     <screen>

--- a/reference/pdo/ini.xml
+++ b/reference/pdo/ini.xml
@@ -8,7 +8,7 @@
  &extension.runtime;
  <para>
   <table>
-   <title>&ConfigureOptions; PDO</title>
+   <title>Opciones de configuración de PDO</title>
    <tgroup cols="4">
     <thead>
      <row>

--- a/reference/pdo/pdostatement.xml
+++ b/reference/pdo/pdostatement.xml
@@ -53,7 +53,7 @@
      <term><varname>queryString</varname></term>
      <listitem>
       <para>
-       &string; utilizada para la consulta.
+       Cadena de consulta utilizada.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pdo/pdostatement/errorinfo.xml
+++ b/reference/pdo/pdostatement/errorinfo.xml
@@ -59,7 +59,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Muestra los campos de <methodname>errorInfo</methodname> para una conexión
+    <title>Muestra los campos de errorInfo() para una conexión
     PDO_ODBC sobre una base de datos DB2</title>
     <programlisting role="php">
 <![CDATA[

--- a/reference/pdo_mysql/pdo-mysql.xml
+++ b/reference/pdo_mysql/pdo-mysql.xml
@@ -448,3 +448,23 @@ foreach ($unbufferedResult as $row) {
  &reference.pdo-mysql.pdo.entities.mysql;
 
 </reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pdo_sqlsrv/configure.xml
+++ b/reference/pdo_sqlsrv/configure.xml
@@ -22,7 +22,6 @@
  <simpara>
   En Linux y macOS, la extensión PDO_SQLSRV puede ser instalada utilizando &link.pecl;.
   Consúltese el <link xlink:href="&url.sqlsrv.linux-mac;">tutorial de instalación</link> para más detalles.
-  <link xlink:href="&url.sqlsrv.linuxodbc;">controlador ODBC del servidor SQL de Microsoft para Linux</link>.
  </simpara>
 </section>
 <!-- Keep this comment at the end of the file

--- a/reference/pgsql/functions/pg-send-query.xml
+++ b/reference/pgsql/functions/pg-send-query.xml
@@ -44,9 +44,7 @@
     <varlistentry>
      <term><parameter>connection</parameter></term>
      <listitem>
-      <para>
-       El recurso de conexión de la base de datos PostgreSQL.
-      </para>
+      &pgsql.parameter.connection;
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/uodbc/functions/odbc-error.xml
+++ b/reference/uodbc/functions/odbc-error.xml
@@ -36,8 +36,7 @@
   &reftitle.returnvalues;
   <para>
    Si <parameter>odbc</parameter> está especificado, se devuelve el último
-   estado ODBC de esta conexión. Si
-   <parameter>connection_id</parameter> se omite, se devuelve el último
+   estado de esa conexión, de lo contrario se devuelve el último
    estado de cualquier conexión.
   </para>
   <para>

--- a/reference/uopz/functions/uopz-function.xml
+++ b/reference/uopz/functions/uopz-function.xml
@@ -93,7 +93,7 @@ echo my_strlen("Hello World");
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
+   &example.outputs;
    <screen>
 <![CDATA[
 11

--- a/reference/xmlreader/setup.xml
+++ b/reference/xmlreader/setup.xml
@@ -17,8 +17,6 @@
   &reftitle.install;
   <para>
    La extensión XMLReader viene con el código fuente PHP.
-  </para>
-  <para>
    &installation.enabled.disable;
    <option role="configure">--disable-xmlreader</option>
   </para>

--- a/reference/xsl/xsltprocessor/transformtodoc.xml
+++ b/reference/xsl/xsltprocessor/transformtodoc.xml
@@ -40,8 +40,7 @@
        Este parámetro opcional puede ser utilizado para que
        <methodname>XSLTProcessor::transformToDoc</methodname>
        devuelva un objeto de la clase especificada.
-       Esta clase debe extender la clase de <parameter>document</parameter>,
-       o ser la misma clase que la de <parameter>document</parameter>.
+       Esta clase debe extender o ser la misma clase que la de <parameter>document</parameter>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zookeeper/zookeeperconfig/remove.xml
+++ b/reference/zookeeper/zookeeperconfig/remove.xml
@@ -30,7 +30,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>versión</parameter></term>
+    <term><parameter>version</parameter></term>
     <listitem>
      <para>
       La versión esperada del nodo. La función fallará si la versión actual del nodo no coincide con la versión esperada.


### PR DESCRIPTION
## Summary

- Correct indentation levels to match doc-en structure
- Fix nesting alignment
- Remove spurious blank lines