### PR TITLE
XML schema correction: fix missing/extra sections and elements

### DIFF
--- a/reference/apache/functions/apache-get-modules.xml
+++ b/reference/apache/functions/apache-get-modules.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un array que contiene los módulos Apache cargados.
+   Un <type>array</type> que contiene los módulos Apache cargados.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-diff-uassoc.xml
+++ b/reference/array/functions/array-diff-uassoc.xml
@@ -67,8 +67,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &array; que contiene todas las entradas del array
-   <parameter>array1</parameter> que no están presentes en
+   Devuelve un <type>array</type> que contiene todas las entradas del array
+   <parameter>array</parameter> que no están presentes en
    ningún otro array.
   </para>
  </refsect1>

--- a/reference/array/functions/array-diff-ukey.xml
+++ b/reference/array/functions/array-diff-ukey.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un array que contiene todas las entradas del array <parameter>array</parameter> que no están presentes en ningún otro array.
+   Devuelve un <type>array</type> que contiene todas las entradas del array <parameter>array</parameter> que no están presentes en ningún otro array.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-filter.xml
+++ b/reference/array/functions/array-filter.xml
@@ -24,7 +24,7 @@
    Las claves del array son preservadas, y puede causar anomalías si el array <parameter>array</parameter> estaba indexado. El array resultante
    puede ser reindexado utilizando la función <function>array_values</function>.
   </para>
-</refsect1>
+ </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/array/functions/array-replace-recursive.xml
+++ b/reference/array/functions/array-replace-recursive.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &array;.
+   Devuelve un <type>array</type>.
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/array/functions/array-replace.xml
+++ b/reference/array/functions/array-replace.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &array;.
+   Devuelve un <type>array</type>.
   </para>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/array/functions/each.xml
+++ b/reference/array/functions/each.xml
@@ -8,8 +8,8 @@
   <refpurpose>Devuelve cada par clave/valor de un array</refpurpose>
  </refnamediv>
 
-  <refsynopsisdiv>
-   &warn.deprecated.function-7-2-0.removed-8-0-0;
+ <refsynopsisdiv>
+  &warn.deprecated.function-7-2-0.removed-8-0-0;
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/array/functions/shuffle.xml
+++ b/reference/array/functions/shuffle.xml
@@ -42,7 +42,7 @@
    &return.true.always;
   </para>
  </refsect1>
-<refsect1 role="changelog">
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>

--- a/reference/bzip2/functions/bzcompress.xml
+++ b/reference/bzip2/functions/bzcompress.xml
@@ -16,8 +16,8 @@
    <methodparam choice="opt"><type>int</type><parameter>work_factor</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>bzcompress</function> comprime la cadena
-   <parameter>source</parameter> y devuelve los datos así codificados.
+   <function>bzcompress</function> comprime la cadena dada
+   y devuelve los datos así codificados.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/bzip2/functions/bzdecompress.xml
+++ b/reference/bzip2/functions/bzdecompress.xml
@@ -15,8 +15,8 @@
    <methodparam choice="opt"><type>bool</type><parameter>use_less_memory</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>bzdecompress</function> descomprime la cadena
-   <parameter>source</parameter>, que contiene datos comprimidos bzip2.
+   <function>bzdecompress</function> descomprime la cadena dada
+   que contiene datos comprimidos bzip2.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/bzip2/functions/bzwrite.xml
+++ b/reference/bzip2/functions/bzwrite.xml
@@ -16,9 +16,8 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>length</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>bzwrite</function> escribe el contenido del string
-   <parameter>data</parameter> en el archivo bzip2 representado
-   por <parameter>bz</parameter>.
+   <function>bzwrite</function> escribe una cadena en el flujo de
+   archivo bzip2 dado.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/calendar/functions/jdtounix.xml
+++ b/reference/calendar/functions/jdtounix.xml
@@ -15,9 +15,8 @@
    <methodparam><type>int</type><parameter>julian_day</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve un timestamp UNIX correspondiente al día Juliano
-   <parameter>julian_day</parameter> o &false; si <parameter>julian_day</parameter>
-   no está dentro del intervalo permitido. El tiempo devuelto es UTC.
+   Esta función devuelve un timestamp UNIX correspondiente al día Juliano
+   dado en <parameter>julian_day</parameter>. El tiempo devuelto es UTC.
   </para>
  </refsect1>
 
@@ -53,7 +52,7 @@
   <para>
    Si <parameter>julian_day</parameter> está fuera del intervalo permitido,
    se lanza una <classname>ValueError</classname>.
- </para>
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -144,8 +144,8 @@ bool(true)
     <literal>MyClass</literal>, la llamada <code>class_alias('MyClass', 'MyClassAlias')</code>
     declarará un nuevo alias de clase llamado <literal>myclassalias</literal>.
    </para>
- </note>
-</refsect1>
+  </note>
+ </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/classobj/functions/get-called-class.xml
+++ b/reference/classobj/functions/get-called-class.xml
@@ -29,7 +29,7 @@
   &reftitle.returnvalues;
   <para>
    Devuelve el nombre de la clase.
-   </para>
+  </para>
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;

--- a/reference/datetime/dateperiod/getdateinterval.xml
+++ b/reference/datetime/dateperiod/getdateinterval.xml
@@ -15,7 +15,7 @@
   <para>&style.oop;</para>
   <methodsynopsis role="DatePeriod">
    <modifier>public</modifier> <type>DateInterval</type><methodname>DatePeriod::getDateInterval</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Devuelve un <type>objeto</type> <classname>DateInterval</classname> que representa el intervalo utilizado para el período.

--- a/reference/datetime/dateperiod/getstartdate.xml
+++ b/reference/datetime/dateperiod/getstartdate.xml
@@ -15,7 +15,7 @@
   <para>&style.oop;</para>
   <methodsynopsis role="DatePeriod">
    <modifier>public</modifier> <type>DateTimeInterface</type><methodname>DatePeriod::getStartDate</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>
    Obtiene la fecha de inicio de un período.

--- a/reference/datetime/datetime/createfromformat.xml
+++ b/reference/datetime/datetime/createfromformat.xml
@@ -67,30 +67,6 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>5.3.9</entry>
-       <entry>
-        Se añadió el especficador + para <parameter>format</parameter>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
   <informaltable>
    <tgroup cols="2">
     <thead>

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>dayOfWeek</parameter><initializer>1</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve un nuevo objeto <classname>DateTimeImmutable</classname> con la fecha establecida de acuerdo al
+   Devuelve un nuevo objeto DateTimeImmutable con la fecha establecida de acuerdo al
    estándar ISO 8601 - usando semanas y desplazamientos de días en lugar de fechas específicas.
   </para>
  </refsect1>

--- a/reference/datetime/datetimezone/getname.xml
+++ b/reference/datetime/datetimezone/getname.xml
@@ -14,7 +14,7 @@
   <para>&style.oop;</para>
   <methodsynopsis role="DateTimeZone">
    <modifier>public</modifier> <type>string</type><methodname>DateTimeZone::getName</methodname>
-   <void />
+   <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>

--- a/reference/datetime/functions/date-default-timezone-get.xml
+++ b/reference/datetime/functions/date-default-timezone-get.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un &string;.
+   Devuelve un <type>string</type>.
   </para>
  </refsect1>
 

--- a/reference/datetime/functions/gmmktime.xml
+++ b/reference/datetime/functions/gmmktime.xml
@@ -114,7 +114,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna un timestamp Unix, en forma de un &integer;, o &false; si
+   Retorna un timestamp Unix de tipo <type>int</type>, o &false; si
    el timestamp no cabe en un entero PHP.
   </para>
  </refsect1>

--- a/reference/datetime/functions/time.xml
+++ b/reference/datetime/functions/time.xml
@@ -15,9 +15,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   <function>time</function> devuelve la hora actual, medida
-   en segundos desde el inicio de la época UNIX, (1 de
-   enero de 1970 00:00:00 GMT).
+   Devuelve la hora actual medida en el número de segundos desde
+   el inicio de la época UNIX (1 de enero de 1970 00:00:00 GMT).
   </para>
   <note>
    <para>

--- a/reference/dba/functions/dba-close.xml
+++ b/reference/dba/functions/dba-close.xml
@@ -14,9 +14,8 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>dba_close</function> cierra la conexión establecida con
-   la base de datos y libera todos los recursos del
-   <parameter>handle</parameter>.
+   <function>dba_close</function> cierra la base de datos establecida y libera
+   todos los recursos del gestor de base de datos especificado.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/dba/functions/dba-nextkey.xml
+++ b/reference/dba/functions/dba-nextkey.xml
@@ -14,9 +14,8 @@
    <methodparam><type>Dba\Connection</type><parameter>dba</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>dba_nextkey</function> devuelve la clave siguiente,
-   en la base identificada por <parameter>handle</parameter> y
-   incrementa el puntero de clave.
+   <function>dba_nextkey</function> devuelve la clave siguiente de la base de datos
+   y avanza el puntero interno de clave.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/dba/functions/dba-open.xml
+++ b/reference/dba/functions/dba-open.xml
@@ -218,17 +218,18 @@
    </varlistentry>
   </variablelist>
  </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve una instancia <classname>Dba\Connection</classname> en caso de éxito&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
    &false; es devuelto y se emite un error de nivel <constant>E_WARNING</constant> cuando
    el parámetro <parameter>handler</parameter> es &null;, pero no hay ningún gestor por defecto disponible.
-  </simpara>
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <simpara>
-   Devuelve una instancia <classname>Dba\Connection</classname> en caso de éxito&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/dom/domchildnode/replacewith.xml
+++ b/reference/dom/domchildnode/replacewith.xml
@@ -15,7 +15,6 @@
   </methodsynopsis>
   <para>
    Reemplaza el nodo por los nuevos <parameter>nodes</parameter>.
-   Una combinación de <methodname>DOMChildNode::remove</methodname> y <methodname>DOMChildNode::append</methodname>.
   </para>
  </refsect1>
 

--- a/reference/dom/domnode/isdefaultnamespace.xml
+++ b/reference/dom/domnode/isdefaultnamespace.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis role="DOMNode">
    <modifier>public</modifier> <type>bool</type><methodname>DOMNode::isDefaultNamespace</methodname>
-   <methodparam><type>string</type><parameter>namespaceURI</parameter></methodparam>
+   <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
   </methodsynopsis>
 
   <para>

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -26,13 +26,6 @@
 
  </refsect1>
 
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <simpara>
-   <function>eio_fdatasync</function> devuelve un recurso de petición en caso de éxito,&return.falseforfailure;.
-  </simpara>
- </refsect1>
-
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
@@ -81,6 +74,13 @@
     </listitem>
    </varlistentry>
   </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_fdatasync</function> devuelve un recurso de petición en caso de éxito,&return.falseforfailure;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/enchant/functions/enchant-dict-is-in-session.xml
+++ b/reference/enchant/functions/enchant-dict-is-in-session.xml
@@ -9,7 +9,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-  &warn.deprecated.function-8-0-0;
+  &warn.deprecated.alias-8-0-0;
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/filesystem/functions/fgetss.xml
+++ b/reference/filesystem/functions/fgetss.xml
@@ -9,7 +9,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-   &warn.deprecated.function-7-3-0;
+   &warn.deprecated.function-7-3-0.removed-8-0-0;
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/funchand/functions/forward-static-call.xml
+++ b/reference/funchand/functions/forward-static-call.xml
@@ -11,9 +11,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>mixed</type><methodname>forward_static_call</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>parameter</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <para>
    Llama a una función o método definido por el usuario, dado por el parámetro
@@ -29,7 +28,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
        La función o método a ser llamado. Este parámetro puede ser una matriz,
@@ -39,7 +38,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>parameter</parameter></term>
+     <term><parameter>args</parameter></term>
      <listitem>
       <para>
        Cero o más parámetros a ser pasados a la función.

--- a/reference/gmagick/gmagick/drawimage.xml
+++ b/reference/gmagick/gmagick/drawimage.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   El objeto Gmagick dibujado
+   El objeto <classname>Gmagick</classname> dibujado
   </simpara>
  </refsect1>
 

--- a/reference/gmagick/gmagickdraw/getfillcolor.xml
+++ b/reference/gmagick/gmagickdraw/getfillcolor.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>GmagickDraw::getfillcolor</methodname>
+   <modifier>public</modifier> <type>GmagickPixel</type><methodname>GmagickDraw::getfillcolor</methodname>
    <void/>
   </methodsynopsis>
   <simpara>

--- a/reference/gnupg/functions/gnupg-decrypt.xml
+++ b/reference/gnupg/functions/gnupg-decrypt.xml
@@ -44,7 +44,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   &return.success;
+   En caso de éxito, esta función devuelve el texto descifrado.
+   En caso de error, esta función devuelve &false;.
   </simpara>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-commit.xml
+++ b/reference/ibm_db2/functions/db2-commit.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve &true; en caso de éxito, o &false; en caso de error.
+   &return.success;
   </simpara>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-statistics.xml
+++ b/reference/ibm_db2/functions/db2-statistics.xml
@@ -73,7 +73,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Lo que devuelve la función, primero en caso de éxito, luego en caso de fallo. Véase también la entidad &return.success;
+   Devuelve un recurso de sentencia con un conjunto de resultados que contiene filas que describen
+   las estadísticas e índices para las tablas base que coinciden con los
+   parámetros especificados. Las filas están compuestas por las columnas siguientes:
    <informaltable>
     <tgroup cols="2">
      <thead>

--- a/reference/imagick/imagick/getimagegreenprimary.xml
+++ b/reference/imagick/imagick/getimagegreenprimary.xml
@@ -15,7 +15,6 @@
    <modifier>public</modifier> <type>array</type><methodname>Imagick::getImageGreenPrimary</methodname>
    <void/>
   </methodsynopsis>
-  &warn.undocumented.func;
   <para>
    Devuelve la cromaticidad del color verde.
    Devuelve un array con las claves "x" y "y".

--- a/reference/imagick/imagick/getquantumdepth.xml
+++ b/reference/imagick/imagick/getquantumdepth.xml
@@ -14,7 +14,6 @@
    <modifier>public</modifier> <modifier>static</modifier> <type>array</type><methodname>Imagick::getQuantumDepth</methodname>
    <void/>
   </methodsynopsis>
-  &warn.undocumented.func;
   <para>
    Devuelve la profundidad cuántica.
   </para>

--- a/reference/imagick/imagick/identifyimage.xml
+++ b/reference/imagick/imagick/identifyimage.xml
@@ -11,8 +11,8 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>Imagick::identifyImage</methodname>
-   <methodparam choice="opt"><type>bool</type><parameter>appendRawOutput</parameter><initializer>false</initializer></methodparam>
+   <modifier>public</modifier> <type>array</type><methodname>Imagick::identifyImage</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>appendRawOutput</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Identifica una imagen y devuelve los atributos. Los atributos incluyen

--- a/reference/info/functions/phpinfo.xml
+++ b/reference/info/functions/phpinfo.xml
@@ -139,7 +139,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/intl/intlbreakiterator/geterrormessage.xml
+++ b/reference/intl/intlbreakiterator/geterrormessage.xml
@@ -17,7 +17,7 @@
    </methodsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>
-   <type>int</type><methodname>intl_get_error_message</methodname>
+   <type>string</type><methodname>intl_get_error_message</methodname>
    <void/>
   </methodsynopsis>
   <para>

--- a/reference/intl/intlbreakiterator/settext.xml
+++ b/reference/intl/intlbreakiterator/settext.xml
@@ -28,11 +28,18 @@
     <term><parameter>text</parameter></term>
     <listitem>
      <para>
-      &return.success;
+
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -56,13 +63,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-
   </para>
  </refsect1>
 

--- a/reference/json/functions/json-last-error-msg.xml
+++ b/reference/json/functions/json-last-error-msg.xml
@@ -14,10 +14,6 @@
    <type>string</type><methodname>json_last_error_msg</methodname>
    <void/>
   </methodsynopsis>
-  <methodsynopsis>
-   <type>string</type><methodname>json_last_error_msg</methodname>
-   <void/>
-  </methodsynopsis>
   <para>
    Devuelve el string de error del último llamado a <function>json_validate</function>, <function>json_encode</function> o <function>json_decode</function>,
    que no haya especificado <constant>JSON_THROW_ON_ERROR</constant>.

--- a/reference/ldap/functions/ldap-explode-dn.xml
+++ b/reference/ldap/functions/ldap-explode-dn.xml
@@ -17,8 +17,8 @@
    <methodparam><type>int</type><parameter>with_attrib</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sirve para extraer los diferentes componentes del DN
-   <parameter>dn</parameter>. Cada componente se denomina Nombre Distinguido Relativo (Relative Distinguished Name o RDN).
+   Divide el DN devuelto por <function>ldap_get_dn</function> y lo descompone
+   en sus componentes. Cada componente se denomina Nombre Distinguido Relativo (Relative Distinguished Name o RDN).
   </para>
  </refsect1>
 

--- a/reference/mcrypt/functions/mcrypt-module-is-block-algorithm.xml
+++ b/reference/mcrypt/functions/mcrypt-module-is-block-algorithm.xml
@@ -19,8 +19,7 @@
    <methodparam choice="opt"><type>string</type><parameter>lib_dir</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>mcrypt_module_is_block_algorithm</function> devuelve &true;
-   si <parameter>algorithm</parameter> es un algoritmo por bloques,
+   Esta función devuelve &true; si <parameter>algorithm</parameter> es un algoritmo por bloques,
    o &false; si es un algoritmo por flujo.
   </simpara>
  </refsect1>

--- a/reference/mongodb/functions/bson/tocanonicalextendedjson.xml
+++ b/reference/mongodb/functions/bson/tocanonicalextendedjson.xml
@@ -25,7 +25,7 @@
   </methodsynopsis>
   <para>
    Convierte una cadena BSON en su
-   <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extendedjson-example">representación JSON extendida canónica</link>.
+   <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">representación JSON extendida canónica</link>.
    El formato canónico privilegia la fidelidad de los tipos en detrimento de la
    concisión de la salida y es el más adecuado para producir una salida que
    puede ser convertida en BSON sin pérdida de información de tipo (por ejemplo,

--- a/reference/mysqli/mysqli/next-result.xml
+++ b/reference/mysqli/mysqli/next-result.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="mysqli">
-   <type>bool</type><methodname>mysqli::next_result</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::next_result</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>
@@ -45,16 +45,16 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &mysqli.conditionalexception;
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
    Véase <function>mysqli_multi_query</function>.
   </para>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  &mysqli.conditionalexception;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/oci8/ocilob/flush.xml
+++ b/reference/oci8/ocilob/flush.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flag</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Escribe los LOB Oracle en el disco.
+   <function>OCILob::flush</function> escribe los datos en el servidor.
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-free-key.xml
+++ b/reference/openssl/functions/openssl-free-key.xml
@@ -8,6 +8,10 @@
   <refpurpose>Libera los recursos</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/openssl/functions/openssl-pkey-derive.xml
+++ b/reference/openssl/functions/openssl-pkey-derive.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>openssl_pkey_derive</methodname>
    <methodparam><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>public_key</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>private_key</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>private_key</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>key_length</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/openssl/functions/openssl-pkey-free.xml
+++ b/reference/openssl/functions/openssl-pkey-free.xml
@@ -8,6 +8,10 @@
   <refpurpose>Libera una clave privada</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/openssl/functions/openssl-x509-free.xml
+++ b/reference/openssl/functions/openssl-x509-free.xml
@@ -8,6 +8,10 @@
   <refpurpose>Libera los recursos tomados por un certificado</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/parallel/parallel/runtime/construct.xml
+++ b/reference/parallel/parallel/runtime/construct.xml
@@ -11,6 +11,13 @@
   &reftitle.description;
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>parallel\Runtime::__construct</methodname>
+   <void/>
+  </constructorsynopsis>
+  <simpara>
+   Construye una ejecución sin cargador automático.
+  </simpara>
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>parallel\Runtime::__construct</methodname>
    <methodparam><type>string</type><parameter>bootstrap</parameter></methodparam>
   </constructorsynopsis>
   <simpara>

--- a/reference/pcntl/functions/pcntl-get-last-error.xml
+++ b/reference/pcntl/functions/pcntl-get-last-error.xml
@@ -21,8 +21,6 @@
    número de error puede ser verificado con la función <function>pcntl_strerror</function>.
   </para>
 
-  &warn.undocumented.func;
-
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/pcntl/functions/pcntl-setpriority.xml
+++ b/reference/pcntl/functions/pcntl-setpriority.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    <function>pcntl_setpriority</function> cambia la prioridad de
-   <parameter>process_id</parameter> a <parameter>priority</parameter>.
+   <parameter>process_id</parameter>.
   </para>
  </refsect1>
 

--- a/reference/pcntl/functions/pcntl-wifexited.xml
+++ b/reference/pcntl/functions/pcntl-wifexited.xml
@@ -16,8 +16,7 @@
    <methodparam><type>int</type><parameter>status</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve &true; si el proceso hijo ha devuelto un código que representa
-   una finalización normal.
+   Verifica si el código de estado del proceso hijo representa una finalización normal.
   </para>
  </refsect1>
 

--- a/reference/pcntl/functions/pcntl-wifsignaled.xml
+++ b/reference/pcntl/functions/pcntl-wifsignaled.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.pcntl-wifsignaled" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_wifsignaled</refname>
-  <refpurpose>Devuelve &true; si el código de estado representa una terminación debido a una señal</refpurpose>
+  <refpurpose>Verifica si el código de estado representa una terminación debido a una señal</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>status</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve &true; si el proceso hijo termina porque una señal no pudo ser recibida.
+   Verifica si el proceso hijo termina porque una señal no pudo ser recibida.
   </para>
  </refsect1>
 

--- a/reference/pcntl/functions/pcntl-wifstopped.xml
+++ b/reference/pcntl/functions/pcntl-wifstopped.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve true si el proceso hijo está detenido, false en caso contrario.
+   Devuelve &true; si el proceso hijo está detenido, &false; en caso contrario.
   </para>
  </refsect1>
 

--- a/reference/pdo/pdo/begintransaction.xml
+++ b/reference/pdo/pdo/begintransaction.xml
@@ -15,8 +15,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   <methodname>PDO::beginTransaction</methodname> desactiva el modo
-   <literal>autocommit</literal>. Cuando el autocommit está desactivado,
+   Desactiva el modo
+   autocommit. Mientras el autocommit está desactivado,
    las modificaciones realizadas en la base de datos mediante las instancias
    de los objetos PDO no se aplican hasta que se finaliza la transacción
    llamando a la función <methodname>PDO::commit</methodname>.

--- a/reference/pdo/pdo/commit.xml
+++ b/reference/pdo/pdo/commit.xml
@@ -15,8 +15,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   <methodname>PDO::commit</methodname> valida una transacción, restablece la conexión
-   en modo <literal>autocommit</literal> hasta que se llame a la función
+   Valida una transacción, restableciendo la conexión
+   en modo autocommit hasta que se llame a la función
    <methodname>PDO::beginTransaction</methodname> para iniciar una nueva transacción.
   </para>
  </refsect1>

--- a/reference/pdo_cubrid/pdo_overloaded/cubrid-schema.xml
+++ b/reference/pdo_cubrid/pdo_overloaded/cubrid-schema.xml
@@ -439,7 +439,7 @@
    proceso se ha ejecutado con éxito.
   </simpara>
   <simpara>
-   &false; será devuelto si ocurre un error.
+   FALSE será devuelto si ocurre un error.
   </simpara>
  </refsect1>
 

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
@@ -22,13 +22,6 @@
    &info.method.alias; <methodname>Pdo\Pgsql::copyFromArray</methodname>.
   </simpara>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Devuelve &true; en caso de éxito,&return.falseforfailure;.
-  </para>
- </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
@@ -22,13 +22,6 @@
    &info.method.alias; <methodname>Pdo\Pgsql::copyFromFile</methodname>.
   </simpara>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Devuelve &true; en caso de éxito,&return.falseforfailure;.
-  </para>
- </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
@@ -21,13 +21,6 @@
    &info.method.alias; <methodname>Pdo\Pgsql::copyToArray</methodname>.
   </simpara>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Devuelve un &array; de líneas,&return.falseforfailure;.
-  </para>
- </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
@@ -22,13 +22,6 @@
    &info.method.alias; <methodname>Pdo\Pgsql::copyToFile</methodname>.
   </simpara>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Devuelve &true; en caso de éxito,&return.falseforfailure;.
-  </para>
- </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
@@ -19,15 +19,6 @@
    &info.method.alias; <methodname>Pdo\Pgsql::getNotify</methodname>.
   </simpara>
  </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Si una o varias notificaciones están en espera, se devuelve una sola fila
-   con los campos <literal>message</literal> y <literal>pid</literal>, de lo contrario,
-   se devuelve &false;.
-  </para>
- </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/pdo_sqlite/pdo/sqlite/createaggregate.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/createaggregate.xml
@@ -257,3 +257,23 @@ var_dump($db->query('SELECT max_len(a) from strings')->fetchAll());
  </refsect1>
 
 </refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-convert.xml
+++ b/reference/pgsql/functions/pg-convert.xml
@@ -80,7 +80,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &array; de valores convertidos, &return.falseforfailure;.
+   Un <type>array</type> de valores convertidos, &return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-escape-literal.xml
+++ b/reference/pgsql/functions/pg-escape-literal.xml
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &string; que contiene los datos protegidos.
+   Una <type>string</type> que contiene los datos protegidos.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-fetch-all-columns.xml
+++ b/reference/pgsql/functions/pg-fetch-all-columns.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    <function>pg_fetch_all_columns</function> devuelve un array que contiene todas las filas
-   (registros) de una columna particular de un recurso de resultados.
+   (registros) de una columna particular de una instancia de <classname>PgSql\Result</classname>.
   </para>
   &database.fetch-null;
  </refsect1>
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &array; que contiene todos los valores de una columna del resultado.
+   Un <type>array</type> que contiene todos los valores de una columna del resultado.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-host.xml
+++ b/reference/pgsql/functions/pg-host.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Una cadena que contiene el nombre del host de
+   Una <type>string</type> que contiene el nombre del host de
    <parameter>connection</parameter> o una cadena vacía en caso de error.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-last-error.xml
+++ b/reference/pgsql/functions/pg-last-error.xml
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &string; que contiene el último mensaje de error en la conexión
+   Una <type>string</type> que contiene el último mensaje de error en la conexión
    <parameter>connection</parameter>.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-lo-read.xml
+++ b/reference/pgsql/functions/pg-lo-read.xml
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un string que contiene <parameter>length</parameter> bytes del objeto de gran tamaño o &false; en caso de error.
+   Una <type>string</type> que contiene <parameter>length</parameter> bytes del objeto de gran tamaño o &false; en caso de error.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-meta-data.xml
+++ b/reference/pgsql/functions/pg-meta-data.xml
@@ -57,7 +57,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &array; de la definición de la tabla, &return.falseforfailure;.
+   Un <type>array</type> de la definición de la tabla, &return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-options.xml
+++ b/reference/pgsql/functions/pg-options.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un string que contiene las opciones de <parameter>connection</parameter>.
+   Una <type>string</type> que contiene las opciones de <parameter>connection</parameter>.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-parameter-status.xml
+++ b/reference/pgsql/functions/pg-parameter-status.xml
@@ -52,7 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Una cadena que contiene el valor del parámetro, &false; en caso de fallo o si el parámetro <parameter>param_name</parameter> es inválido.
+   Una <type>string</type> que contiene el valor del parámetro, &false; en caso de fallo o si el parámetro <parameter>param_name</parameter> es inválido.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-port.xml
+++ b/reference/pgsql/functions/pg-port.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &string; que contiene el número de puerto del servidor de base de datos
+   Una <type>string</type> que contiene el número de puerto del servidor de base de datos
    identificado por <parameter>connection</parameter> o una cadena vacía en caso de error.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-result-error-field.xml
+++ b/reference/pgsql/functions/pg-result-error-field.xml
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve una cadena que contiene el contenido del campo de error, &null; si
+   Devuelve una <type>string</type> que contiene el contenido del campo de error, &null; si
    el campo no existe o &false; en caso de fallo.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-tty.xml
+++ b/reference/pgsql/functions/pg-tty.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Una cadena que contiene el depurador TTY de la conexión
+   Una <type>string</type> que contiene el depurador TTY de la conexión
    <parameter>connection</parameter>.
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getgrgid.xml
+++ b/reference/posix/functions/posix-getgrgid.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>posix_getgrgid</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>posix_getgrgid</methodname>
    <methodparam><type>int</type><parameter>gid</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/posix/functions/posix-getgrnam.xml
+++ b/reference/posix/functions/posix-getgrnam.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>posix_getgrnam</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>posix_getgrnam</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/posix/functions/posix-ttyname.xml
+++ b/reference/posix/functions/posix-ttyname.xml
@@ -15,7 +15,7 @@
    <methodparam><type class="union"><type>resource</type><type>int</type></type><parameter>file_descriptor</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve un &string; para la ruta absoluta del terminal actual que
+   Devuelve un <type>string</type> para la ruta absoluta del terminal actual que
    está abierto en el puntero de fichero <parameter>file_descriptor</parameter>.
   </para>
  </refsect1>
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   En caso de éxito, devuelve un &string; correspondiente a la ruta absoluta de
+   En caso de éxito, devuelve un <type>string</type> correspondiente a la ruta absoluta de
    <parameter>file_descriptor</parameter>. En caso de error, devuelve &false;.
   </para>
  </refsect1>

--- a/reference/reflection/reflectionreference.xml
+++ b/reference/reflection/reflectionreference.xml
@@ -24,25 +24,18 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>ReflectionReference</classname></ooclass>
-
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <modifier>final</modifier> <classname>ReflectionReference</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>ReflectionReference</classname>
+    </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <!--
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionReference'])">
+     <xi:fallback/>
     </xi:include>
-    -->
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionReference'])">
+     <xi:fallback/>
     </xi:include>
    </classsynopsis>
 <!-- }}} -->

--- a/reference/uodbc/functions/odbc-close.xml
+++ b/reference/uodbc/functions/odbc-close.xml
@@ -15,8 +15,7 @@
    <methodparam><type>Odbc\Connection</type><parameter>odbc</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Cierra la conexión con la fuente de datos representada por
-   el identificador de conexión <parameter>connection_id</parameter>.
+   Cierra la conexión con la base de datos del servidor.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/uodbc/functions/odbc-commit.xml
+++ b/reference/uodbc/functions/odbc-commit.xml
@@ -15,8 +15,7 @@
    <methodparam><type>Odbc\Connection</type><parameter>odbc</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Valida todas las transacciones en curso en la conexión
-   <parameter>connection_id</parameter>.
+   Valida todas las transacciones en curso en la conexión.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/uodbc/functions/odbc-cursor.xml
+++ b/reference/uodbc/functions/odbc-cursor.xml
@@ -14,8 +14,7 @@
    <methodparam><type>Odbc\Result</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>odbc_cursor</function> lee el nombre del puntero de resultado
-   actual para el resultado <parameter>result_id</parameter>.
+   Lee el nombre del puntero del resultado actual.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/uodbc/functions/odbc-exec.xml
+++ b/reference/uodbc/functions/odbc-exec.xml
@@ -15,9 +15,7 @@
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>odbc_exec</function> envía un comando SQL
-   a la fuente de datos ODBC, representada por
-   <parameter>connection_id</parameter>.
+   Envía una sentencia SQL al servidor de base de datos.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/uodbc/functions/odbc-field-scale.xml
+++ b/reference/uodbc/functions/odbc-field-scale.xml
@@ -16,9 +16,7 @@
    <methodparam><type>int</type><parameter>field</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Lee la escala del campo referenciado por su número de campo
-   <parameter>field_number</parameter> en el resultado ODBC
-   <parameter>result_id</parameter>.
+   Lee la escala del campo referenciado por número en el resultado ODBC dado.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/uodbc/functions/odbc-foreignkeys.xml
+++ b/reference/uodbc/functions/odbc-foreignkeys.xml
@@ -21,8 +21,9 @@
    <methodparam><type>string</type><parameter>fk_table</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Lista las claves foráneas utilizadas en la tabla
-   <parameter>pk_table</parameter>.
+   Devuelve una lista de claves foráneas en la tabla especificada o una lista de
+   claves foráneas en otras tablas que hacen referencia a la clave primaria en la
+   tabla especificada.
   </para>
  </refsect1>
 

--- a/reference/uodbc/functions/odbc-rollback.xml
+++ b/reference/uodbc/functions/odbc-rollback.xml
@@ -15,7 +15,7 @@
    <methodparam><type>Odbc\Connection</type><parameter>odbc</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Anula todas las transacciones en la conexión <parameter>connection_id</parameter>.
+   Anula todas las transacciones en la conexión.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/var/functions/boolval.xml
+++ b/reference/var/functions/boolval.xml
@@ -15,7 +15,7 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve el valor &boolean; de la variable proporcionada en el
+   Devuelve el valor <type>bool</type> de la variable proporcionada en el
    argumento <parameter>value</parameter>.
   </para>
  </refsect1>
@@ -27,7 +27,7 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <para>
-      El valor escalar que será convertido a &boolean;.
+      El valor escalar que será convertido a <type>bool</type>.
      </para>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   El valor &boolean; del argumento <parameter>value</parameter>.
+   El valor <type>bool</type> del argumento <parameter>value</parameter>.
   </para>
  </refsect1>
 

--- a/reference/var/functions/is-bool.xml
+++ b/reference/var/functions/is-bool.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna &true; si <parameter>value</parameter> es un &boolean;,
+   Retorna &true; si <parameter>value</parameter> es un <type>bool</type>,
    &false; en caso contrario.
   </para>
  </refsect1>

--- a/reference/var/functions/is-float.xml
+++ b/reference/var/functions/is-float.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna &true; si <parameter>value</parameter> es un &float;,
+   Retorna &true; si <parameter>value</parameter> es un <type>float</type>,
    &false; en caso contrario.
   </para>
  </refsect1>

--- a/reference/var/functions/is-int.xml
+++ b/reference/var/functions/is-int.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna &true; si <parameter>value</parameter> es un &integer;,
+   Retorna &true; si <parameter>value</parameter> es un <type>int</type>,
    &false; en caso contrario.
   </para>
  </refsect1>

--- a/reference/var/functions/is-null.xml
+++ b/reference/var/functions/is-null.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve &true; si <parameter>value</parameter> es &null;, &false;
+   Devuelve &true; si <parameter>value</parameter> es <type>null</type>, &false;
    en caso contrario.
   </para>
  </refsect1>

--- a/reference/var/functions/is-object.xml
+++ b/reference/var/functions/is-object.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna &true; si <parameter>value</parameter> es un &object;,
+   Retorna &true; si <parameter>value</parameter> es un <type>object</type>,
    &false; en caso contrario.
   </para>
  </refsect1>

--- a/reference/var/functions/is-resource.xml
+++ b/reference/var/functions/is-resource.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna &true; si <parameter>value</parameter> es un &resource;, &false;
+   Retorna &true; si <parameter>value</parameter> es un <type>resource</type>, &false;
    de lo contrario.
   </para>
  </refsect1>

--- a/reference/var/functions/is-string.xml
+++ b/reference/var/functions/is-string.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve &true; si <parameter>value</parameter> es un &string;,
+   Devuelve &true; si <parameter>value</parameter> es un <type>string</type>,
    &false; en caso contrario.
   </para>
  </refsect1>

--- a/reference/xhprof/functions/xhprof-disable.xml
+++ b/reference/xhprof/functions/xhprof-disable.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un array de datos xhprof, procedentes de su ejecución.
+   Un <type>array</type> de datos xhprof, procedentes de su ejecución.
    Devuelve &null; si el perfilado no está activado.
   </para>
  </refsect1>

--- a/reference/xhprof/functions/xhprof-sample-disable.xml
+++ b/reference/xhprof/functions/xhprof-sample-disable.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un &array; de datos de muestreo xhprof, procedentes de su ejecución.
+   Un <type>array</type> de datos de muestreo xhprof, procedentes de su ejecución.
    Devuelve &null; si el perfilado no está activado.
   </para>
  </refsect1>

--- a/reference/xmlwriter/xmlwriter/openuri.xml
+++ b/reference/xmlwriter/xmlwriter/openuri.xml
@@ -20,7 +20,7 @@
    <methodparam><type>string</type><parameter>uri</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crea un nuevo XMLWriter, utilizando el <parameter>uri</parameter> para la visualización.
+   Crea un nuevo <classname>XMLWriter</classname>, utilizando el <parameter>uri</parameter> para la visualización.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/yaf/yaf_loader/registernamespace.xml
+++ b/reference/yaf/yaf_loader/registernamespace.xml
@@ -13,7 +13,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yaf_Loader::registerNamespace</methodname>
-   <methodparam><type>string|array</type><parameter>namespaces</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>namespaces</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/yaf/yaf_route_regex/construct.xml
+++ b/reference/yaf/yaf_route_regex/construct.xml
@@ -60,6 +60,14 @@
     </listitem>
    </varlistentry>
    <varlistentry>
+    <term><parameter>verify</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
     <term><parameter>reverse</parameter></term>
     <listitem>
      <para>
@@ -70,14 +78,6 @@
        este parametro se introdujo en 2.3.0
        </para>
       </note>
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>verify</parameter></term>
-    <listitem>
-     <para>
-
      </para>
     </listitem>
    </varlistentry>

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>boolean</type><methodname>Yar_Concurrent_Client::reset</methodname>
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yar_Concurrent_Client::reset</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/zip/functions/zip-read.xml
+++ b/reference/zip/functions/zip-read.xml
@@ -44,10 +44,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un recurso de entrada de archivo,
-   para usar más tarde con otras funciones de la biblioteca,
-   &false; si no hay más entradas para leer en el archivo ZIP o el número
-   de error si ocurre un error.
+   Devuelve un recurso de entrada de directorio para usar más tarde con las
+   funciones <literal>zip_entry_...</literal>, o &false; si no hay más entradas
+   para leer, o un código de error si ocurre un error.
   </para>
  </refsect1>
 

--- a/reference/zip/ziparchive/iscompressionmethoddupported.xml
+++ b/reference/zip/ziparchive/iscompressionmethoddupported.xml
@@ -12,7 +12,7 @@
   <methodsynopsis role="ZipArchive">
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>ZipArchive::isCompressionMethodSupported</methodname>
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>true</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Verifica si un método de compresión es soportado por libzip.

--- a/reference/zookeeper/zookeeperconfig/add.xml
+++ b/reference/zookeeper/zookeeperconfig/add.xml
@@ -13,7 +13,7 @@
    <modifier>public</modifier>
    <type>void</type><methodname>ZookeeperConfig::add</methodname>
    <methodparam><type>string</type><parameter>members</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>versión</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>version</parameter><initializer>-1</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
  </refsect1>
@@ -31,7 +31,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>versión</parameter></term>
+    <term><parameter>version</parameter></term>
     <listitem>
      <para>
       La versión esperada del nodo. La función fallará si la versión actual del nodo no coincide con la versión esperada. Si se utiliza -1, no se realizará la comprobación de la versión.


### PR DESCRIPTION
## Summary

- Remove extra `refsect1` sections not present in doc-en
- Fix `methodsynopsis` signatures (parameter names, types, void tags)
- Add missing `refsynopsisdiv` deprecation warnings
- Fix section ordering to match doc-en