### PR TITLE
XML schema correction: fix structure in language/ and appendices/

### DIFF
--- a/appendices/about.xml
+++ b/appendices/about.xml
@@ -158,7 +158,7 @@ Devuelve el tamaño de la cadena $string.
        </entry>
        <entry>
         El primer (y aquí el único) parámetro a proporcionar a esta función es el parámetro <parameter>string</parameter>, que debe ser del tipo
-        &string;.
+        <type>string</type>.
        </entry>
       </row>
       <row>
@@ -167,7 +167,7 @@ Devuelve el tamaño de la cadena $string.
        </entry>
        <entry>
         Tipo de valor devuelto por esta función, que es, en este caso,
-        un &integer; (es decir, el tamaño de una cadena se mide por
+        un <type>int</type> (es decir, el tamaño de una cadena se mide por
         un número).
        </entry>
       </row>
@@ -198,7 +198,7 @@ Devuelve el tamaño de la cadena $string.
    </screen>
   </para>
   <para>
-   ¿Qué significa esto? <function>in_array</function> devuelve
+   ¿Qué significa esto? in_array() devuelve
    un <link linkend="language.types.boolean">booléano</link> &true; en
    caso de éxito (el parámetro
    <parameter>needle</parameter> se encontró en el array
@@ -209,8 +209,8 @@ Devuelve el tamaño de la cadena $string.
    de diferentes <link linkend="language.types">tipos</link>: por lo tanto, lleva la mención <emphasis>mixed</emphasis>.
    El parámetro <parameter>needle</parameter> (lo que estamos buscando)
    puede ser un valor escalar ( &string;, &integer;,
-   o <link linkend="language.types.float">float</link>), o incluso un <type>array</type>.
-   <parameter>haystack</parameter> (el <link linkend="language.types.array">array</link>,
+   o <link linkend="language.types.float">float</link>), o incluso un <link linkend="language.types.array">array</link>.
+   <parameter>haystack</parameter> (el array,
    en el que estamos buscando) es
    el segundo parámetro. El tercer parámetro, <emphasis>opcional</emphasis>,
    <parameter>strict</parameter>,
@@ -396,7 +396,7 @@ Devuelve el tamaño de la cadena $string.
    Los contribuyentes a la documentación parten de los códigos fuente
    <acronym>XML</acronym> disponibles en
    <link xlink:href="&url.php.git.mirror;doc-en">&url.php.git.mirror;doc-en</link>.
-   luego traducen a su idioma. No utilizan
+   luego traducen a su idioma. <emphasis>No</emphasis> utilizan
    las versiones generadas (como el <acronym>HTML</acronym> o el texto plano)
    ya que es el sistema de edición el que se encarga de hacer las
    conversiones del formato <acronym>XML</acronym> a un formato legible.

--- a/appendices/comparisons.xml
+++ b/appendices/comparisons.xml
@@ -17,9 +17,9 @@
  <para>
   Antes de utilizar estas tablas, es importante comprender los tipos
   y su significado. Por ejemplo, <literal>"42"</literal> es un
-  &string;, mientras que <literal>42</literal> es un
-  &integer;. &false; es <type>bool</type> mientras que
-  <literal>"false"</literal> es un &string;.
+  <type>string</type>, mientras que <literal>42</literal> es un
+  <type>int</type>. &false; es <type>bool</type> mientras que
+  <literal>"false"</literal> es un <type>string</type>.
  </para>
  <note>
   <para>
@@ -65,7 +65,7 @@
     <tbody>
      <row>
       <entry><literal>$x = "";</literal></entry>
-      <entry>&string;</entry>
+      <entry><type>string</type></entry>
       <entry>&true;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -129,7 +129,7 @@
      </row>
      <row>
       <entry><literal>$x = 1;</literal></entry>
-      <entry>&integer;</entry>
+      <entry><type>int</type></entry>
       <entry>&false;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -137,7 +137,7 @@
      </row>
      <row>
       <entry><literal>$x = 42;</literal></entry>
-      <entry>&integer;</entry>
+      <entry><type>int</type></entry>
       <entry>&false;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -145,7 +145,7 @@
      </row>
      <row>
       <entry><literal>$x = 0;</literal></entry>
-      <entry>&integer;</entry>
+      <entry><type>int</type></entry>
       <entry>&true;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -153,7 +153,7 @@
      </row>
      <row>
       <entry><literal>$x = -1;</literal></entry>
-      <entry>&integer;</entry>
+      <entry><type>int</type></entry>
       <entry>&false;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -161,7 +161,7 @@
      </row>
      <row>
       <entry><literal>$x = "1";</literal></entry>
-      <entry>&string;</entry>
+      <entry><type>string</type></entry>
       <entry>&false;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -169,7 +169,7 @@
      </row>
      <row>
       <entry><literal>$x = "0";</literal></entry>
-      <entry>&string;</entry>
+      <entry><type>string</type></entry>
       <entry>&true;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -177,7 +177,7 @@
      </row>
      <row>
       <entry><literal>$x = "-1";</literal></entry>
-      <entry>&string;</entry>
+      <entry><type>string</type></entry>
       <entry>&false;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -185,7 +185,7 @@
      </row>
      <row>
       <entry><literal>$x = "php";</literal></entry>
-      <entry>&string;</entry>
+      <entry><type>string</type></entry>
       <entry>&false;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>
@@ -193,7 +193,7 @@
      </row>
      <row>
       <entry><literal>$x = "true";</literal></entry>
-      <entry>&string;</entry>
+      <entry><type>string</type></entry>
       <entry>&false;</entry>
       <entry>&false;</entry>
       <entry>&true;</entry>

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -195,15 +195,15 @@
        <type>string</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         Esta directiva le permite deshabilitar ciertas funciones. Toma una lista de nombres de funciones separados por comas.
-       </para>
-       <para>
+       </simpara>
+       <simpara>
         Solo las <link linkend="functions.internal">funciones internas</link> pueden deshabilitarse usando esta directiva. Las <link linkend="functions.user-defined">funciones definidas por el usuario</link> no se ven afectadas.
-       </para>
-       <para>
+       </simpara>
+       <simpara>
         Esta directiva debe definirse en el &php.ini;. Por ejemplo, no puede definirse en el archivo &httpd.conf;.
-       </para>
+       </simpara>
        <warning>
         <simpara>
          Esta directiva puede ser eludida y no debe considerarse una
@@ -219,9 +219,12 @@
        <type>string</type>
       </term>
       <listitem>
-       <simpara>
+       <para>
         Esta directiva le permite deshabilitar ciertas clases. Toma una lista de nombres de clases separados por comas.
-       </simpara>
+       </para>
+       <para>
+        Solo las clases internas pueden deshabilitarse usando esta directiva. Las clases definidas por el usuario no se ven afectadas.
+       </para>
        <simpara>
         Esta directiva debe definirse en el &php.ini;. Por ejemplo, no puede definirse en el archivo &httpd.conf;.
        </simpara>
@@ -334,7 +337,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
       </term>
       <listitem>
        <para>
-        Verifica el <literal>BOM (Byte Order Mark)</literal> y mira si el archivo contiene caracteres multibyte válidos. Esta detección se realiza antes de que se ejecute la función <function>__halt_compiler</function>. Disponible solo en modo multibyte de Zend.
+        Verifica el BOM (Byte Order Mark) y mira si el archivo contiene caracteres multibyte válidos. Esta detección se realiza antes de que se ejecute la función <function>__halt_compiler</function>. Disponible solo en modo multibyte de Zend.
        </para>
       </listitem>
      </varlistentry>
@@ -525,7 +528,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <row>
         <entry><link linkend="ini.request-order">request_order</link></entry>
         <entry>""</entry>
-        <entry><constant>INI_SYSTEM</constant>|<constant>INI_PERDIR</constant></entry>
+        <entry><constant>INI_PERDIR</constant></entry>
         <entry></entry>
        </row>
        <row>
@@ -732,7 +735,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        &ini.shorthandbytes;
 
        <simpara>
-        Si el tamaño de los datos recibidos por el método POST es mayor que <parameter>post_max_size</parameter>, las <link linkend="language.variables.superglobals">superglobales</link> <varname>$_POST</varname> y <varname>$_FILES</varname> estarán vacías. Esto se puede monitorear de diferentes formas, por ejemplo, pasando una variable <varname>$_GET</varname> al script que procesa los datos, es decir, <literal>&lt;form action="edit.php?processed=1"&gt;</literal>, y luego verificar si <varname>$_GET['processed']</varname> está definido.
+        Si el tamaño de los datos recibidos por el método POST es mayor que post_max_size, <varname>$_POST</varname> y <varname>$_FILES</varname> <link linkend="language.variables.superglobals">superglobales</link> estarán vacías. Esto se puede monitorear de diferentes formas, por ejemplo, pasando una variable <varname>$_GET</varname> al script que procesa los datos, es decir, <literal>&lt;form action="edit.php?processed=1"&gt;</literal>, y luego verificar si <varname>$_GET['processed']</varname> está definido.
        </simpara>
        <para>
         <note>
@@ -799,7 +802,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         El valor especial <literal>none</literal> desactiva la adición automática.
         <note>
          <simpara>
-          Si el script termina con la función <function>exit</function>, no se realizará la adición automática.
+          Si el script termina con la función <function>exit</function>, <emphasis>no</emphasis> se realizará la adición automática.
          </simpara>
         </note>
        </para>
@@ -1018,7 +1021,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
       </term>
       <listitem>
        <para>
-        Especifica una lista de directorios donde las funciones <function>require</function>, <function>include</function>, <function>fopen</function>, <function>file</function>, <function>readfile</function> y <function>file_get_contents</function> buscarán los archivos. El formato es idéntico a la variable de entorno del sistema <envar>PATH</envar>: una lista de directorios separados por dos puntos (<literal>:</literal>) en Unix o por un punto y coma (<literal>;</literal>) en Windows.
+        Especifica una lista de directorios donde las funciones <function>require</function>, <function>include</function>, <function>fopen</function>, <function>file</function>, <function>readfile</function> y <function>file_get_contents</function> buscarán los archivos. El formato es idéntico a la variable de entorno del sistema <envar>PATH</envar>: una lista de directorios separados por dos puntos en Unix o por un punto y coma en Windows.
        </para>
        <para>
         PHP considera cada entrada del camino de inclusión por separado al buscar archivos para incluir. Verificará el primer camino y, si no encuentra el archivo, verificará el siguiente camino, hasta encontrar el archivo para incluir o devolver una alerta de tipo <constant>E_WARNING</constant> o de tipo <constant>E_ERROR</constant> usando la función <function>set_include_path</function>.
@@ -1080,7 +1083,7 @@ include_path = ".:${USER}/pear/php"
         Cuando un script intenta acceder a un archivo con, por ejemplo, la función <function>include</function> o la función <function>fopen</function>, la ruta al archivo se analiza. Cuando el archivo se encuentra fuera de la estructura de directorios especificada, PHP se negará a acceder a él. Todos los enlaces simbólicos se resuelven, por lo que no es posible eludir esta restricción con un enlace simbólico. Si el archivo no existe, entonces el enlace simbólico no se puede resolver y el nombre del archivo se compara con <option>open_basedir</option>.
        </para>
        <para>
-        La opción <option>open_basedir</option> puede afectar más que las funciones del sistema de archivos; por ejemplo, si MySQL está configurado para usar el controlador mysqlnd, <literal>LOAD DATA INFILE</literal> se verá afectado por la opción <option>open_basedir</option>. La mayoría de las extensiones de PHP usan la opción <literal>open_basedir</literal> de esta manera.
+        La opción <option>open_basedir</option> puede afectar más que las funciones del sistema de archivos; por ejemplo, si <literal>MySQL</literal> está configurado para usar el controlador <literal>mysqlnd</literal>, <literal>LOAD DATA INFILE</literal> se verá afectado por la opción <option>open_basedir</option>. La mayoría de las extensiones de PHP usan la opción <literal>open_basedir</literal> de esta manera.
        </para>
        <para>
         El valor especial <systemitem class="filesystem">.</systemitem> indica que se usará el directorio actual del script como directorio base. Sin embargo, esto es ligeramente peligroso en el sentido de que el directorio actual puede cambiarse fácilmente con la función <function>chdir</function>.
@@ -1099,10 +1102,10 @@ include_path = ".:${USER}/pear/php"
        </para>
        <note>
         <simpara>
-         <option>open_basedir</option> puede afinarse en el momento de la ejecución. Esto significa que si <option>open_basedir</option> se establece en <literal>/www/</literal> en el archivo &php.ini;, un script puede afinar la configuración en <literal>/www/tmp/</literal> en el momento de la ejecución usando la función <function>ini_set</function>. Al recorrer varios directorios, puede usar la constante <constant>PATH_SEPARATOR</constant> según el sistema operativo.
+         open_basedir puede afinarse en el momento de la ejecución. Esto significa que si open_basedir se establece en <literal>/www/</literal> en el archivo &php.ini;, un script puede afinar la configuración en <literal>/www/tmp/</literal> en el momento de la ejecución usando la función <function>ini_set</function>. Al recorrer varios directorios, puede usar la constante <constant>PATH_SEPARATOR</constant> según el sistema operativo.
         </simpara>
         <simpara>
-         A partir de PHP 8.3.0, <option>open_basedir</option> ya no acepta rutas que contengan el directorio padre (<literal>..</literal>) cuando se establece en tiempo de ejecución.
+         A partir de PHP 8.3.0, <option>open_basedir</option> ya no acepta rutas que contengan el directorio padre (<literal>..</literal>) cuando se establece en tiempo de ejecución usando <function>ini_set</function>.
         </simpara>
        </note>
        <note>
@@ -1125,7 +1128,7 @@ include_path = ".:${USER}/pear/php"
       </term>
       <listitem>
        <para>
-        El directorio raíz de PHP en el servidor. Solo se usa si no está vacío. Si PHP no se compiló con FORCE_REDIRECT, debe definir el doc_root si usa PHP como CGI bajo cualquier servidor web (distinto de IIS). Alternativamente, puede usar la configuración <link linkend="ini.cgi.force-redirect">cgi.force_redirect</link>.
+        El directorio raíz de PHP en el servidor. Solo se usa si no está vacío. Si PHP no se compiló con FORCE_REDIRECT, <emphasis>debe</emphasis> definir el doc_root si usa PHP como CGI bajo cualquier servidor web (distinto de IIS). Alternativamente, puede usar la configuración <link linkend="ini.cgi.force-redirect">cgi.force_redirect</link>.
        </para>
       </listitem>
      </varlistentry>
@@ -1207,7 +1210,7 @@ include_path = ".:${USER}/pear/php"
       </term>
       <listitem>
        <para>
-        Controla si PHP CGI verifica la línea que comienza con <literal>#!</literal> (shebang) en la parte superior del script ejecutado. Esta línea es necesaria si el script está destinado a ejecutarse de forma independiente y a través de un PHP CGI. PHP en modo CGI no lee esta línea y omite su contenido si esta directiva está activa.
+        Controla si PHP <acronym>CGI</acronym> verifica la línea que comienza con <literal>#!</literal> (shebang) en la parte superior del script ejecutado. Esta línea es necesaria si el script está destinado a ejecutarse de forma independiente y a través de un PHP <acronym>CGI</acronym>. PHP en modo <acronym>CGI</acronym> no lee esta línea y omite su contenido si esta directiva está activa.
        </para>
       </listitem>
      </varlistentry>
@@ -1231,7 +1234,7 @@ include_path = ".:${USER}/pear/php"
       </term>
       <listitem>
        <para>
-        Proporciona un <emphasis>real</emphasis> <literal>PATH_INFO</literal>/<literal>PATH_TRANSLATED</literal> para CGI. El comportamiento anterior de PHP era establecer <literal>PATH_TRANSLATED</literal> en <literal>SCRIPT_FILENAME</literal> y no llenar <literal>PATH_INFO</literal>. Para obtener más información sobre <literal>PATH_INFO</literal>, consulte las especificaciones CGI. Si se establece en <literal>1</literal>, PHP CGI corregirá este camino según las especificaciones. Si se establece en <literal>0</literal>, PHP aplicará el comportamiento anterior. De manera predeterminada, esta directiva está activada. Debe modificar sus scripts para usar <literal>SCRIPT_FILENAME</literal> en lugar de <literal>PATH_TRANSLATED</literal>.
+        Proporciona un <emphasis>real</emphasis> <literal>PATH_INFO</literal>/<literal>PATH_TRANSLATED</literal> para <acronym>CGI</acronym>. El comportamiento anterior de PHP era establecer <literal>PATH_TRANSLATED</literal> en <literal>SCRIPT_FILENAME</literal> y no llenar <literal>PATH_INFO</literal>. Para obtener más información sobre <literal>PATH_INFO</literal>, consulte las especificaciones <acronym>CGI</acronym>. Si se establece en <literal>1</literal>, PHP <acronym>CGI</acronym> corregirá este camino según las especificaciones. Si se establece en 0, PHP aplicará el comportamiento anterior. De manera predeterminada, esta directiva está activada. Debe modificar sus scripts para usar <literal>SCRIPT_FILENAME</literal> en lugar de <literal>PATH_TRANSLATED</literal>.
        </para>
       </listitem>
      </varlistentry>
@@ -1243,7 +1246,7 @@ include_path = ".:${USER}/pear/php"
       </term>
       <listitem>
        <para>
-        cgi.force_redirect es necesario por razones de seguridad al usar PHP en modo CGI bajo la mayoría de los servidores web. Si no lo establece, PHP lo activará automáticamente de manera predeterminada. Puede desactivarlo <emphasis>bajo su propio riesgo</emphasis>.
+        cgi.force_redirect es necesario por razones de seguridad al usar PHP en modo <acronym>CGI</acronym> bajo la mayoría de los servidores web. Si no lo establece, PHP lo activará automáticamente de manera predeterminada. Puede desactivarlo <emphasis>bajo su propio riesgo</emphasis>.
        </para>
        <note>
         <para>

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -39,13 +39,13 @@
      </row>
      <row>
       <entry><link linkend="ini.arg-separator.input">arg_separator.input</link></entry>
-      <entry>"&amp;"</entry>
+      <entry><literal>"&amp;"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.arg-separator.output">arg_separator.output</link></entry>
-      <entry>"&amp;"</entry>
+      <entry><literal>"&amp;"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -172,49 +172,49 @@
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dba.configuration.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry><link linkend="ini.default-charset">default_charset</link></entry>
-      <entry>"UTF-8"</entry>
+      <entry><literal>"UTF-8"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Por defecto "UTF-8".</entry>
      </row>
      <row>
       <entry><link linkend="ini.input-encoding">input_encoding</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.output-encoding">output_encoding</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.internal-encoding">internal_encoding</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.default-mimetype">default_mimetype</link></entry>
-      <entry>"text/html"</entry>
+      <entry><literal>"text/html"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.default-socket-timeout">default_socket_timeout</link></entry>
-      <entry>"60"</entry>
+      <entry><literal>"60"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry>&php.ini; solo</entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.disable-functions">disable_functions</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry>&php.ini; solo</entry>
       <entry></entry>
      </row>
@@ -234,13 +234,13 @@
      </row>
      <row>
       <entry><link linkend="ini.docref-ext">docref_ext</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.docref-root">docref_root</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -258,7 +258,7 @@
      </row>
      <row>
       <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>
-      <entry>On</entry>
+      <entry><literal>"On"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
@@ -282,7 +282,7 @@
      </row>
      <row>
       <entry><link linkend="ini.error-log-mode">error_log_mode</link></entry>
-      <entry>0o644</entry>
+      <entry><literal>0o644</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Disponible a partir de PHP 8.2.0</entry>
      </row>
@@ -301,7 +301,7 @@
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exif.configuration.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -320,7 +320,7 @@
      </row>
      <row>
       <entry><link linkend="ini.extension-dir">extension_dir</link></entry>
-      <entry>"/path/to/php"</entry>
+      <entry><literal>"/path/to/php"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -345,7 +345,7 @@
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('filter.configuration.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry><link linkend="ini.from">from</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -353,37 +353,37 @@
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('geoip.configuration.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry>hard_timeout</entry>
-      <entry>"2"</entry>
+      <entry><literal>"2"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Disponible a partir de 7.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.comment</link></entry>
-      <entry>"#FF8000"</entry>
+      <entry><literal>"#FF8000"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.default</link></entry>
-      <entry>"#0000BB"</entry>
+      <entry><literal>"#0000BB"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.html</link></entry>
-      <entry>"#000000"</entry>
+      <entry><literal>"#000000"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.keyword</link></entry>
-      <entry>"#007700"</entry>
+      <entry><literal>"#007700"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.syntax-highlighting">highlight.string</link></entry>
-      <entry>"#DD0000"</entry>
+      <entry><literal>"#DD0000"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -422,7 +422,7 @@
      </row>
      <row>
       <entry><link linkend="ini.include-path">include_path</link></entry>
-      <entry>".:/path/to/php/pear"</entry>
+      <entry><literal>".:/path/to/php/pear"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -442,7 +442,7 @@
      </row>
      <row>
       <entry><link linkend="ini.log-errors-max-len">log_errors_max_len</link></entry>
-      <entry>"1024"</entry>
+      <entry><literal>"1024"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -455,36 +455,36 @@
      <row>
       <entry>mail.force_extra_parameters</entry>
       <entry>&null;</entry>
-      <entry>&php.ini; solo</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.mail.log">mail.log</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.max-execution-time">max_execution_time</link></entry>
-      <entry>"30"</entry>
+      <entry><literal>"30"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.max-input-nesting-level">max_input_nesting_level</link></entry>
-      <entry>"64"</entry>
+      <entry><literal>"64"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.max-input-vars">max_input_vars</link></entry>
-      <entry>1000</entry>
+      <entry><literal>1000</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.max-input-time">max_input_time</link></entry>
-      <entry>"-1"</entry>
+      <entry><literal>"-1"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
@@ -493,7 +493,7 @@
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('memcache.ini.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry><link linkend="ini.memory-limit">memory_limit</link></entry>
-      <entry>"128M"</entry>
+      <entry><literal>"128M"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -528,25 +528,25 @@
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('phar.configuration.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry><link linkend="ini.post-max-size">post_max_size</link></entry>
-      <entry>"8M"</entry>
+      <entry><literal>"8M"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.precision">precision</link></entry>
-      <entry>"14"</entry>
+      <entry><literal>"14"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.realpath-cache-size">realpath_cache_size</link></entry>
-      <entry>"16K"</entry>
+      <entry><literal>"16K"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.realpath-cache-ttl">realpath_cache_ttl</link></entry>
-      <entry>"120"</entry>
+      <entry><literal>"120"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -570,7 +570,7 @@
      </row>
      <row>
       <entry><link linkend="ini.request-order">request_order</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
@@ -583,16 +583,16 @@
      </row>
      <row>
       <entry><link linkend="ini.sendmail-path">sendmail_path</link></entry>
-      <entry>"/usr/sbin/sendmail -t -i"</entry>
+      <entry><literal>"/usr/sbin/sendmail -t -i"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.serialize-precision">serialize_precision</link></entry>
-      <entry>"-1"</entry>
+      <entry><literal>"-1"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>
-       Anterior a PHP 7.1.0, el valor predeterminado era 17.
+       Anterior a PHP 7.1.0, el valor predeterminado era <literal>17</literal>.
       </entry>
      </row>
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('session.configuration.list')/*)"><xi:fallback/></xi:include>
@@ -604,13 +604,13 @@
      </row>
      <row>
       <entry><link linkend="ini.smtp">SMTP</link></entry>
-      <entry>"localhost"</entry>
+      <entry><literal>"localhost"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.smtp-port">smtp_port</link></entry>
-      <entry>"25"</entry>
+      <entry><literal>"25"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -624,25 +624,25 @@
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sqlite3.configuration.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry><link linkend="ini.syslog.facility">syslog.facility</link></entry>
-      <entry>"LOG_USER"</entry>
+      <entry><literal>"LOG_USER"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Disponible a partir de PHP 7.3.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.syslog.filter">syslog.filter</link></entry>
-      <entry>"no-ctrl"</entry>
+      <entry><literal>"no-ctrl"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Disponible a partir de PHP 7.3.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.syslog.ident">syslog.ident</link></entry>
-      <entry>"php"</entry>
+      <entry><literal>"php"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry>Disponible a partir de PHP 7.3.0.</entry>
      </row>
      <row>
       <entry>sys_temp_dir</entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -657,19 +657,19 @@
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry>uploadprogress.file.filename_template</entry>
-      <entry>"/tmp/upt_%s.txt"</entry>
+      <entry><literal>"/tmp/upt_%s.txt"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.upload-max-filesize">upload_max_filesize</link></entry>
-      <entry>"2M"</entry>
+      <entry><literal>"2M"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.max-file-uploads">max_file_uploads</link></entry>
-      <entry>20</entry>
+      <entry><literal>20</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
@@ -681,15 +681,15 @@
      </row>
      <row>
       <entry><link linkend="ini.url-rewriter.hosts">url_rewriter.hosts</link></entry>
-      <entry>""</entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Disponible a partir de PHP 7.1.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.url-rewriter.tags">url_rewriter.tags</link></entry>
-      <entry>"form="</entry>
+      <entry><literal>"form="</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Anterior a PHP 7.1.0, el valor predeterminado era "a=href,area=href,frame=src,form=,fieldset=".</entry>
+      <entry>Anterior a PHP 7.1.0, el valor predeterminado era <literal>"a=href,area=href,frame=src,form=,fieldset="</literal>.</entry>
      </row>
      <row>
       <entry><link linkend="ini.user-agent">user_agent</link></entry>
@@ -705,20 +705,20 @@
      </row>
      <row>
       <entry><link linkend="ini.user-ini.cache-ttl">user_ini.cache_ttl</link></entry>
-      <entry>"300"</entry>
+      <entry><literal>"300"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.user-ini.filename">user_ini.filename</link></entry>
-      <entry>".user.ini"</entry>
+      <entry><literal>".user.ini"</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('uopz.configuration.list')/*)"><xi:fallback/></xi:include>
      <row>
       <entry><link linkend="ini.variables-order">variables_order</link></entry>
-      <entry>"EGPCS"</entry>
+      <entry><literal>"EGPCS"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
      </row>
@@ -748,7 +748,7 @@
      </row>
      <row>
       <entry>yaz.keepalive</entry>
-      <entry>"120"</entry>
+      <entry><literal>"120"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry></entry>
      </row>
@@ -793,6 +793,12 @@
       <entry><literal>"0"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
       <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.zend.reserved-stack-size">zend.reserved_stack_size</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>Disponible a partir de PHP 8.3.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.zend.script-encoding">zend.script_encoding</link></entry>

--- a/appendices/ini.xml
+++ b/appendices/ini.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- EN-Revision: 2ede3417729b130cf72d1c370abde76040990c8b Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: yes Maintainer: andresdzphp -->

--- a/appendices/migration56/new-features.xml
+++ b/appendices/migration56/new-features.xml
@@ -48,7 +48,7 @@ El valor de TRES es 3
   </informalexample>
 
  <para>
-   También es posible definir una constante &array; usando la palabra clave <literal>const</literal>:
+   También es posible definir una constante <type>array</type> usando la palabra clave <literal>const</literal>:
   </para>
 
   <informalexample>

--- a/appendices/migration70/changed-functions.xml
+++ b/appendices/migration70/changed-functions.xml
@@ -23,7 +23,7 @@
    <listitem>
     <simpara>
      La función <function>dirname</function> ahora toma un segundo parámetro opcional,
-     <parameter>depth</parameter>, para indicar el número de niveles más alto (en relación con el directorio actual) para alcanzar el nombre del directorio en el árbol.
+     <parameter>depth</parameter>, para obtener el nombre del directorio a <parameter>depth</parameter> niveles por encima del directorio actual.
     </simpara>
    </listitem>
    <listitem>
@@ -70,7 +70,7 @@
     <simpara>
      <function>substr</function> y <function>iconv_substr</function> ahora devuelven
      una &string; vacía, si
-     la longitud de la cadena es igual a <parameter>$start</parameter>.
+     la longitud de la cadena es igual a $start.
     </simpara>
    </listitem>
    <listitem>

--- a/appendices/migration70/incompatible/integers.xml
+++ b/appendices/migration70/incompatible/integers.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes Maintainer: girgias -->
 
 <sect2 xml:id="migration70.incompatible.integers">
- <title>Modificaciones en la gestión de &integer;</title>
+ <title>Modificaciones en la gestión de <type>int</type></title>
 
  <sect3 xml:id="migration70.incompatible.integers.invalid-octals">
   <title>Literales octales no válidos</title>
@@ -55,7 +55,7 @@ Stack trace:
 
   <para>
    Los desplazamientos de bits (en ambos sentidos) más allá del ancho de bits de un
-   &integer; siempre devolverán 0. Anteriormente, el comportamiento de estos
+   <type>int</type> siempre devolverán 0. Anteriormente, el comportamiento de estos
    desplazamientos dependía de la arquitectura.
   </para>
  </sect3>

--- a/appendices/migration70/incompatible/strings.xml
+++ b/appendices/migration70/incompatible/strings.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes Maintainer: girgias -->
 
 <sect2 xml:id="migration70.incompatible.strings">
- <title>Modificaciones en el manejo de &string;</title>
+ <title>Modificaciones en el manejo de <type>string</type></title>
 
  <sect3 xml:id="migration70.incompatible.strings.hex">
   <title>Las cadenas hexadecimales ya no se consideran numéricas</title>
@@ -47,9 +47,9 @@ string(3) "foo"
   </informalexample>
 
   <para>
-   <function>filter_var</function> puede ser utilizado para verificar si una &string;
-   contiene un número hexadecimal, y también para convertir una &string; de este tipo
-   en un &integer;:
+   <function>filter_var</function> puede ser utilizado para verificar si una <type>string</type>
+   contiene un número hexadecimal, y también para convertir una cadena de este tipo
+   en un <type>int</type>:
   </para>
 
   <informalexample>

--- a/appendices/migration70/incompatible/variable-handling.xml
+++ b/appendices/migration70/incompatible/variable-handling.xml
@@ -194,10 +194,10 @@ list($x, list(), $y) = $a;
   </sect4>
 
   <sect4 xml:id="migration70.incompatible.variable-handling.list.string">
-   <title><function>list</function> no puede descomponer &string;</title>
+   <title><function>list</function> no puede descomponer <type>string</type>s</title>
 
    <para>
-    <function>list</function> ya no puede descomponer variables de &string;.
+    <function>list</function> ya no puede descomponer variables de <type>string</type>.
     Debe usarse <function>str_split</function> en su lugar.
    </para>
   </sect4>

--- a/appendices/migration70/new-features.xml
+++ b/appendices/migration70/new-features.xml
@@ -632,7 +632,7 @@ session_start([
   </informalexample>
  </sect2>
 
- <sect2 xml:id="migration70.new-features.preg-replace-callback-array-function">
+ <sect2 xml:id="migration70.new-features.preg-repace-callback-array-function">
   <title><function>preg_replace_callback_array</function></title>
 
   <para>

--- a/appendices/migration71/incompatible.xml
+++ b/appendices/migration71/incompatible.xml
@@ -325,7 +325,7 @@ array(2) {
  <sect2 xml:id="migration71.incompatible.unserialize">
   <title>Parámetro $options de unserialize()</title>
   <para>
-   El elemento <literal>allowed_classes</literal> del parámetro $options de <function>unserialize</function> ahora es estrictamente tipado, es decir, si se da un valor distinto de un array o un boolean, unserialize() devuelve false y emite un <constant>E_WARNING</constant>.
+   El elemento <literal>allowed_classes</literal> del parámetro $options de <function>unserialize</function> ahora es estrictamente tipado, es decir, si se da un valor distinto de un <type>array</type> o un <type>bool</type>, unserialize() devuelve false y emite un <constant>E_WARNING</constant>.
   </para>
  </sect2>
 

--- a/appendices/migration73/incompatible.xml
+++ b/appendices/migration73/incompatible.xml
@@ -71,7 +71,7 @@ while ($foo) {
    <para>
     Los accesos de &array; del tipo <literal>$obj["123"]</literal>, donde
     <literal>$obj</literal> implementa <classname>ArrayAccess</classname> y
-    <literal>"123"</literal> es una &string; de &integer; literal ya no
+    <literal>"123"</literal> es una <type>string</type> de &integer; literal ya no
     resultarán en una conversión implícita a &integer;, es decir,
     <literal>$obj->offsetGet("123")</literal> será llamado en lugar de
     <literal>$obj->offsetGet(123)</literal>. Esto corresponde al comportamiento
@@ -314,8 +314,8 @@ foo(...gen());
   <para>
    Las operaciones matemáticas que implican los objetos <link
    linkend="book.simplexml">SimpleXML</link> tratarán ahora el texto
-   como un &integer; o un &float;, según lo que sea más apropiado.
-   Anteriormente, los valores eran tratados como un &integer; sin condición.
+   como un <type>int</type> o un <type>float</type>, según lo que sea más apropiado.
+   Anteriormente, los valores eran tratados como un <type>int</type> sin condición.
   </para>
  </sect2>
 

--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -26,9 +26,9 @@ class User {
      </programlisting>
     </informalexample>
     El ejemplo anterior asegura que <literal>$user->id</literal> solo puede
-    recibir valores de tipo &integer; y
+    recibir valores de tipo <type>int</type> y
     <literal>$user->name</literal> solo puede recibir valores de tipo
-    &string;.
+    <type>string</type>.
    </para>
   </sect3>
 

--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -96,7 +96,10 @@ function test(?A $a, $b) {}       // Recommended
   <para>
    <function>libxml_disable_entity_loader</function> ha sido desaprobada. Como ahora se requiere libxml 2.9.0,
    la carga de entidades externas está garantizada como deshabilitada por defecto, y esta función ya
-   no es necesaria para proteger contra ataques XXE.
+   no es necesaria para proteger contra ataques XXE, a menos que se utilice
+   <constant>LIBXML_NOENT</constant>.
+   En ese caso, se recomienda refactorizar el código usando
+   <function>libxml_set_external_entity_loader</function> para suprimir la carga de entidades externas.
   </para>
  </sect2>
 

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -74,6 +74,11 @@
     </listitem>
     <listitem>
      <para>
+      <literal>mixed</literal> ahora es una palabra reservada, por lo que no puede ser utilizada para nombrar una clase, interfaz o trait, y tampoco está permitida en espacios de nombres.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       Los fallos de aserción ahora lanzan una excepción por defecto. Si se desea el comportamiento
       anterior, se puede establecer <code>assert.exception=0</code> en la configuración INI.
      </para>
@@ -301,6 +306,12 @@ function test(int $arg = null) {}
        <member>
         Intentar acceder a constantes no calificadas que no están definidas. Anteriormente, el acceso
         a constantes no calificadas resultaba en una advertencia y se interpretaban como cadenas.
+       </member>
+       <member>
+        Pasar un número incorrecto de argumentos a una función interna no variádica lanzará un <classname>ArgumentCountError</classname>.
+       </member>
+       <member>
+        Pasar tipos no contables inválidos a <function>count</function> lanzará un <classname>TypeError</classname>.
        </member>
       </simplelist>
      </para>
@@ -798,15 +809,34 @@ $array["key"];
   </para>
   <para>
    <simplelist>
-    <member>DOMNameList</member>
-    <member>DomImplementationList</member>
-    <member>DOMConfiguration</member>
-    <member>DomError</member>
-    <member>DomErrorHandler</member>
-    <member>DOMImplementationSource</member>
-    <member>DOMLocator</member>
-    <member>DOMUserDataHandler</member>
-    <member>DOMTypeInfo</member>
+    <member><classname>DOMNameList</classname></member>
+    <member><classname>DomImplementationList</classname></member>
+    <member><classname>DOMConfiguration</classname></member>
+    <member><classname>DomError</classname></member>
+    <member><classname>DomErrorHandler</classname></member>
+    <member><classname>DOMImplementationSource</classname></member>
+    <member><classname>DOMLocator</classname></member>
+    <member><classname>DOMUserDataHandler</classname></member>
+    <member><classname>DOMTypeInfo</classname></member>
+    <member><classname>DOMStringExtend</classname></member>
+   </simplelist>
+  </para>
+  <para>
+   Los métodos no implementados de la extensión DOM que no tenían comportamiento han sido eliminados:
+  </para>
+  <para>
+   <simplelist>
+    <member><methodname>DOMNamedNodeMap::setNamedItem</methodname></member>
+    <member><methodname>DOMNamedNodeMap::removeNamedItem</methodname></member>
+    <member><methodname>DOMNamedNodeMap::setNamedItemNS</methodname></member>
+    <member><methodname>DOMNamedNodeMap::removeNamedItemNS</methodname></member>
+    <member><methodname>DOMText::replaceWholeText</methodname></member>
+    <member><methodname>DOMNode::compareDocumentPosition</methodname></member>
+    <member><methodname>DOMNode::isEqualNode</methodname></member>
+    <member><methodname>DOMNode::getFeature</methodname></member>
+    <member><methodname>DOMNode::setUserData</methodname></member>
+    <member><methodname>DOMNode::getUserData</methodname></member>
+    <member><methodname>DOMDocument::renameNode</methodname></member>
    </simplelist>
   </para>
  </sect2>
@@ -1604,19 +1634,19 @@ echo file_get_contents('http://example.org', false, $ctx);
   <itemizedlist>
    <listitem>
     <para>
-     Los tokens <literal>T_COMMENT</literal> ya no incluirán un salto de línea al final. El salto
-     de línea será parte del siguiente token <literal>T_WHITESPACE</literal>. Cabe señalar que
-     <literal>T_COMMENT</literal> no siempre va seguido de un espacio en blanco, también puede ir
-     seguido de <literal>T_CLOSE_TAG</literal> o del final del archivo.
+     Los tokens <constant>T_COMMENT</constant> ya no incluirán un salto de línea al final. El salto
+     de línea será parte del siguiente token <constant>T_WHITESPACE</constant>. Cabe señalar que
+     <constant>T_COMMENT</constant> no siempre va seguido de un espacio en blanco, también puede ir
+     seguido de <constant>T_CLOSE_TAG</constant> o del final del archivo.
     </para>
    </listitem>
    <listitem>
     <para>
      Los nombres con espacio de nombres ahora se representan utilizando los tokens
-     <literal>T_NAME_QUALIFIED</literal> (<code>Foo\Bar</code>),
-     <literal>T_NAME_FULLY_QUALIFIED</literal> (<code>\Foo\Bar</code>) y
-     <literal>T_NAME_RELATIVE</literal> (<code>namespace\Foo\Bar</code>).
-     <literal>T_NS_SEPARATOR</literal> solo se usa para separadores de espacio de nombres
+     <constant>T_NAME_QUALIFIED</constant> (<code>Foo\Bar</code>),
+     <constant>T_NAME_FULLY_QUALIFIED</constant> (<code>\Foo\Bar</code>) y
+     <constant>T_NAME_RELATIVE</constant> (<code>namespace\Foo\Bar</code>).
+     <constant>T_NS_SEPARATOR</constant> solo se usa para separadores de espacio de nombres
      independientes, y solo es sintácticamente válido en conjunto con declaraciones de uso de grupo.
      <!-- RFC: https://wiki.php.net/rfc/namespaced_names_as_token -->
     </para>

--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -71,8 +71,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      <!-- we cannot use <classname>WeakMap</classname> because that would link to the wrong class -->
-      Se ha añadido la clase <literal>WeakMap</literal>.
+      Se ha añadido la clase <link linkend="class.weakmap">WeakMap</link>.
       <!-- RFC: https://wiki.php.net/rfc/weak_maps -->
      </para>
     </listitem>
@@ -233,6 +232,11 @@ class ChildClass extends ParentClass {
       <code>(int) $resource</code>. Proporciona la misma funcionalidad con una API más clara.
      </para>
     </listitem>
+    <listitem>
+     <para>
+      Se ha añadido <classname>InternalIterator</classname>.
+     </para>
+    </listitem>
    </itemizedlist>
   </sect3>
  </sect2>
@@ -339,7 +343,7 @@ class ChildClass extends ParentClass {
   <para>
    Se ha añadido soporte para Cryptographic Message Syntax (CMS) (<link xlink:href="&url.rfc;5652">RFC 5652</link>)
    compuesto por funciones para cifrado, descifrado, firma, verificación y lectura. La API
-   es similar a la API de las funciones PKCS #7 con la adición de nuevas constantes de codificación:
+   es similar a la API de las funciones <acronym>PKCS</acronym> #7 con la adición de nuevas constantes de codificación:
    <constant>OPENSSL_ENCODING_DER</constant>, <constant>OPENSSL_ENCODING_SMIME</constant>
    y <constant>OPENSSL_ENCODING_PEM</constant>:
    <simplelist>
@@ -352,7 +356,7 @@ class ChildClass extends ParentClass {
      los resultados al archivo proporcionado.
     </member>
     <member>
-     <function>openssl_cms_read</function> exporta el archivo CMS a un array de certificados PEM.
+     <function>openssl_cms_read</function> exporta el archivo CMS a un array de certificados <acronym>PEM</acronym>.
     </member>
     <member>
      <function>openssl_cms_sign</function> firma el mensaje MIME en el archivo con un certificado y una clave

--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -38,6 +38,17 @@
    </para>
   </sect3>
 
+  <sect3 xml:id="migration80.other-changes.functions.standard">
+   <title>Standard</title>
+
+   <para>
+    Las funciones matemáticas <function>abs</function>, <function>ceil</function>,
+    <function>floor</function> y <function>round</function> ahora respetan correctamente
+    <link linkend="language.types.declarations.strict">la directiva <literal>strict_types</literal></link>.
+    Anteriormente, coercionaban el primer argumento incluso en modo de tipo estricto.
+   </para>
+  </sect3>
+
   <sect3 xml:id="migration80.other-changes.functions.zip">
    <title>Zip</title>
 
@@ -63,7 +74,7 @@
       <methodname>ZipArchive::addEmptyDir</methodname>, <methodname>ZipArchive::addFile</methodname>
       and <methodname>ZipArchive::addFromString</methodname>
       methods have a new <parameter>flags</parameter> argument. This allows managing name encoding
-      (<constant>ZipArchive::FL_ENC_*</constant>) and entry replacement
+      (<constant>ZipArchive::FL_ENC_<replaceable>*</replaceable></constant>) and entry replacement
       (<constant>ZipArchive::FL_OVERWRITE</constant>).
      </para>
     </listitem>

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -147,22 +147,22 @@
   </itemizedlist>
  </sect2>
 
- <sect2 xml:id="migration81.constants.tokenizer">
-  <title>Tokenizer</title>
-
-  <itemizedlist>
-   <listitem>
-    <simpara><constant>T_READONLY</constant></simpara>
-   </listitem>
-  </itemizedlist>
- </sect2>
-
  <sect2 xml:id="migration81.constants.standard">
   <title>Standard</title>
 
   <itemizedlist>
    <listitem>
     <simpara><constant>IMAGETYPE_AVIF</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.constants.tokenizer">
+  <title>Tokenizer</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>T_READONLY</constant></simpara>
    </listitem>
   </itemizedlist>
  </sect2>

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -96,7 +96,7 @@ function &test(): void {}
      </programlisting>
     </informalexample>
     Tal función es contradictoria, y ya emite el
-    <literal>E_NOTICE</literal> siguiente cuando se llama:
+    <constant>E_NOTICE</constant> siguiente cuando se llama:
     <literal>Only variable references should be returned by reference</literal>.
    </para>
   </sect3>

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -29,7 +29,7 @@
    </title>
 
    <para>
-    Cuando un método que utiliza variables <modifier>static</modifier> es heredado
+    Cuando un método que utiliza variables static es heredado
     (pero no sobrescrito), el método heredado compartirá ahora las variables.
     <informalexample>
      <programlisting role="php">

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -16,7 +16,7 @@
   </para>
 
   <para>
-   Los símbolos numéricos en los <link linkend="datetime.formats.relative">formatos relativos</link>
+   Los símbolos <literal>number</literal> en los <link linkend="datetime.formats.relative">formatos relativos</link>
    ya no aceptan signos múltiples, por ejemplo <literal>+-2</literal>.
   </para>
  </sect2>

--- a/appendices/migration83.xml
+++ b/appendices/migration83.xml
@@ -7,7 +7,7 @@
  <para>
   Esta nueva versión menor aporta un cierto número de
   <link linkend="migration83.new-features">nuevas funcionalidades</link> y
-  <link linkend="migration82.incompatible">algunas incompatibilidades</link>
+  <link linkend="migration83.incompatible">algunas incompatibilidades</link>
   que deberían ser probadas antes de cambiar de versión de PHP en entornos de producción.
  </para>
 

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<sect1 xml:id="migration83.deprecated" xmlns:xlink="http://www.w3.org/1999/xlink">
+<sect1 xml:id="migration83.deprecated">
  <title>Funcionalidades obsoletas</title>
 
  <sect2 xml:id="migration83.deprecated.core">
@@ -116,7 +116,7 @@
   <para>
    Llamar a <methodname>ReflectionProperty::setValue</methodname> con solo un
    parámetro está depreciado.
-   Para definir propiedades estáticas, pasar <literal>null</literal> como primer parámetro.
+   Para definir propiedades estáticas, pasar &null; como primer parámetro.
   </para>
  </sect2>
 

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -7,42 +7,130 @@
  <sect2 xml:id="migration83.incompatible.core">
   <title>Núcleo de PHP</title>
 
-  <sect3 xml:id="migration83.incompatible.core.saner-inc-dec-operators">
-   <title>Operadores de incremento/decremento más seguros</title>
+  <sect3 xml:id="migration83.incompatible.core.overflowing-call-stack">
 
+   <title>Programas que estaban muy cerca de desbordar la pila de llamadas</title>
    <para>
-    El uso del operador de <link linkend="language.operators.increment">incremento</link>
-    (<literal>++</literal>) en cadenas vacías, no numéricas
-    o no alfanuméricas está ahora depreciado.
-    Además, la incrementación de cadenas no numéricas está fuertemente depreciada.
-    Esto significa que ningún diagnóstico <constant>E_DEPRECATED</constant> se emite,
-    pero esta funcionalidad no debe usarse para producir nuevo código.
-    La nueva función <function>str_increment</function> debe usarse en su lugar.
+    Los programas que estaban muy cerca de desbordar la pila de llamadas ahora pueden lanzar
+    un <classname>Error</classname> cuando usan más de
+    <!-- link linkend="zend.max_allowed_stack_size-zend.reserved_stack_size" -->zend.max_allowed_stack_size-zend.reserved_stack_size<!-- </link>--> bytes de pila
+    (<!-- link linkend="fiber.stack_size-zend.reserved_stack_size" -->fiber.stack_size-zend.reserved_stack_size<!-- </link>--> para fibras).
    </para>
-
-   <para>
-    El uso del operador de <link linkend="language.operators.increment">decremento</link>
-    (<literal>--</literal>) en cadenas vacías o no numéricas está ahora depreciado.
-   </para>
-   <!-- RFC: https://wiki.php.net/rfc/saner-inc-dec-operators -->
   </sect3>
 
-  <sect3 xml:id="migration83.incompatible.core.get-class">
-   <title>get_class()/get_parent_class() llamadas sin argumentos</title>
-
+  <sect3 xml:id="migration83.incompatible.core.proc-get-status-multiple-times">
+   <title>Ejecución de proc_get_status() varias veces</title>
    <para>
-    Llamar a <function>get_class</function> y <function>get_parent_class</function>
-    sin argumentos está ahora depreciado.
+    Ejecutar <function>proc_get_status</function> varias veces ahora siempre
+    devolverá el valor correcto en sistemas POSIX. Anteriormente, sólo la primera llamada
+    de la función devolvía el valor correcto. Ejecutar
+    <function>proc_close</function> después de <function>proc_get_status</function>
+    ahora también devolverá el código de salida correcto. Anteriormente esto devolvía
+    <literal>-1</literal>.
+    Internamente, esto funciona almacenando en caché el resultado en sistemas POSIX.
+    Si se requiere el comportamiento anterior, es posible verificar la
+    clave <literal>"cached"</literal> en el array devuelto por
+    <function>proc_get_status</function> para verificar si el resultado fue almacenado en caché.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.incompatible.core.zend-max-execution-timers">
+   <title>Temporizadores de ejecución máxima de Zend</title>
+   <para>
+    Los temporizadores de ejecución máxima de Zend ahora están habilitados por defecto para compilaciones ZTS en
+    Linux.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.incompatible.core.traits-with-static-properties">
+   <title>Uso de traits con propiedades estáticas</title>
+   <para>
+    El uso de traits con propiedades estáticas ahora redeclarará las propiedades estáticas
+    heredadas de la clase padre. Esto creará un almacenamiento de propiedades estáticas separado
+    para la clase actual. Esto es análogo a agregar la propiedad estática a la clase directamente sin traits.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.incompatible.core.negative-index-to-empty-array">
+   <title>Asignación de un índice negativo a un array vacío</title>
+   <para>
+    Asignar un índice negativo <varname>$n</varname> a un array vacío ahora garantizará que el
+    siguiente índice sea <code>$n+1</code> en lugar de <literal>0</literal>.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.incompatible.core.class-constant-visibility-check">
+   <title>Verificación de varianza de visibilidad de constantes de clase</title>
+   <para>
+    La varianza de visibilidad de constantes de clase ahora se verifica correctamente cuando se hereda
+    de interfaces.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration83.incompatible.core.weakmap-entries-maps-to-itself">
+   <title>Entradas de WeakMap cuya clave se mapea a sí misma</title>
+   <para>
+    Las entradas de <classname>WeakMap</classname> cuya clave se mapea a sí misma (posiblemente
+    de forma transitiva) ahora pueden ser eliminadas durante la recolección de ciclos si la clave no
+    es alcanzable excepto iterando sobre el WeakMap (la alcanzabilidad mediante iteración se
+    considera débil).
+    Anteriormente, dichas entradas nunca se eliminaban automáticamente.
    </para>
   </sect3>
  </sect2>
 
- <sect2 xml:id="migration83.incompatible.core.dba">
-  <title>DBA</title>
+ <sect2 xml:id="migration83.incompatible.date">
+  <title>Date</title>
 
   <para>
-   Llamar a <function>dba_fetch</function> con <parameter>$dba</parameter> como
-   tercer argumento está ahora depreciado.
+   La extensión DateTime ha introducido excepciones y errores específicos de la extensión Date
+   bajo las jerarquías <classname>DateError</classname> y
+   <classname>DateException</classname>, en lugar de advertencias y excepciones genéricas.
+   Esto mejora el manejo de errores, a expensas de tener que verificar errores y excepciones.
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration83.incompatible.dom">
+  <title>DOM</title>
+
+  <para>
+   Llamar a <methodname>DOMChildNode::after</methodname>,
+   <methodname>DOMChildNode::before</methodname>,
+   <methodname>DOMChildNode::replaceWith</methodname>
+   en un nodo que no tiene padre ahora es una operación sin efecto en lugar de una excepción de jerarquía,
+   que es el comportamiento requerido por la especificación DOM.
+  </para>
+
+  <para>
+   Usar los métodos de <classname>DOMParentNode</classname>
+   y <classname>DOMChildNode</classname> sin un documento ahora
+   funciona en lugar de lanzar un <constant>DOM_HIERARCHY_REQUEST_ERR</constant>
+   <classname>DOMException</classname>.
+   Esto está en línea con el comportamiento requerido por la especificación DOM.
+  </para>
+
+  <para>
+   Llamar a <methodname>DOMDocument::createAttributeNS</methodname> sin especificar
+   un prefijo incorrectamente creaba un espacio de nombres predeterminado, colocando el elemento
+   dentro del espacio de nombres en lugar del atributo. Este error ahora está corregido.
+  </para>
+
+  <para>
+   <methodname>DOMDocument::createAttributeNS</methodname> anteriormente
+   lanzaba incorrectamente un <constant>DOM_NAMESPACE_ERRNAMESPACE_ERR</constant>
+   <classname>DOMException</classname> cuando el prefijo ya se usaba para una
+   URI diferente. Ahora elige correctamente un prefijo diferente cuando hay un
+   conflicto de nombre de prefijo.
+  </para>
+
+  <para>
+   Se añadieron nuevos métodos y propiedades a algunas clases DOM.
+   Si una clase de espacio de usuario hereda de estas clases y declara un método o propiedad
+   con el mismo nombre, las declaraciones deben ser compatibles. De lo contrario, se lanzará un
+   error de compilación típico sobre declaraciones incompatibles.
+   Ver la <link linkend="migration83.new-features.dom">lista de nuevas funcionalidades</link>
+   y las <link linkend="migration83.new-functions.dom">nuevas funciones</link> para
+   una lista de los métodos y propiedades recién implementados.
   </para>
  </sect2>
 
@@ -50,42 +138,23 @@
   <title>FFI</title>
 
   <para>
-   Llamar a <methodname>FFI::cast</methodname>, <methodname>FFI::new</methodname>,
-   y <methodname>FFI::type</methodname> de manera estática está ahora depreciado.
+   Las funciones C que tienen un tipo de retorno <type>void</type> ahora devuelven &null; en lugar de
+   devolver el siguiente objeto <literal>object(FFI\CData:void) { }</literal>
   </para>
  </sect2>
 
- <sect2 xml:id="migration83.incompatible.intl">
-  <title>Intl</title>
+ <sect2 xml:id="migration83.incompatible.opcache">
+  <title>Opcache</title>
 
   <para>
-   Las constantes <constant>U_MULTIPLE_SEPARATOR_SEPARATORS</constant>
-   han sido depreciadas, se recomienda usar la constante
-   <constant>U_MULTIPLE_SEPARATOR_SEPARATORS</constant>
-   en su lugar.
-  </para>
-  <para>
-   La constante <constant>NumberFormatter::TYPE_CURRENCY</constant> ha sido depreciada.
-  </para>
- </sect2>
-
- <sect2 xml:id="migration83.incompatible.ldap">
-  <title>LDAP</title>
-
-  <para>
-   Llamar a <function>ldap_connect</function> con
-   <parameter>$hostname</parameter> y <parameter>$port</parameter> separados está
-   depreciado.
-   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
-  </para>
- </sect2>
-
- <sect2 xml:id="migration83.incompatible.mbstring">
-  <title>MBString</title>
-
-  <para>
-   Pasar un <parameter>$width</parameter> negativo a
-   <function>mb_strimwidth</function> está ahora depreciado.
+   La directiva INI <link linkend="ini.opcache.consistency-checks">opcache.consistency_checks</link>
+   fue eliminada. Esta funcionalidad estaba rota con el JIT de rastreo,
+   así como con la caché de herencia, y ha estado deshabilitada sin forma de
+   habilitarla desde PHP 8.1.18 y PHP 8.2.5.
+   Tanto el JIT de rastreo como la caché de herencia pueden modificar la shm después de que el script
+   haya sido persistido al invalidar su suma de verificación. El intento de corrección omitía
+   los punteros modificables pero fue rechazado debido a la complejidad. Por esta
+   razón, se decidió eliminar la funcionalidad.
   </para>
  </sect2>
 
@@ -93,29 +162,7 @@
   <title>Phar</title>
 
   <para>
-   Llamar a <methodname>Phar::setStub</methodname> con un
-   <type>resource</type> y un <parameter>$length</parameter>
-   está ahora depreciado. Estas llamadas deben ser reemplazadas por:
-   <code>$phar->setStub(stream_get_contents($resource));</code>
-  </para>
- </sect2>
-
- <sect2 xml:id="migration83.incompatible.random">
-  <title>Random</title>
-
-  <para>
-   La variante MT19937 <constant>MT_RAND_PHP</constant> está depreciada.
-   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#mt_rand_php -->
-  </para>
- </sect2>
-
- <sect2 xml:id="migration83.incompatible.reflection">
-  <title>Reflection</title>
-
-  <para>
-   Llamar a <methodname>ReflectionProperty::setValue</methodname> con solo un
-   parámetro está depreciado.
-   Para definir propiedades estáticas, pasar <literal>null</literal> como primer parámetro.
+   Los tipos de las constantes de la clase <classname>Phar</classname> ahora están declarados.
   </para>
  </sect2>
 
@@ -123,38 +170,68 @@
   <title>Standard</title>
 
   <para>
-   La función <function>assert_options</function> está ahora depreciada.
-  </para>
-  <para>
-   Las constantes <constant>ASSERT_ACTIVE</constant>, <constant>ASSERT_BAIL</constant>,
-   <constant>ASSERT_CALLBACK</constant>, <constant>ASSERT_EXCEPTION</constant>,
-   y <constant>ASSERT_WARNING</constant> están ahora depreciadas.
+   La función <function>range</function> ha tenido varios cambios:
+   <simplelist>
+    <member>Ahora se lanza un <classname>TypeError</classname> cuando se pasan <type>object</type>s,
+    <type>resource</type>s, o <type>array</type>s como entradas de límite.</member>
+    <member>Se lanza un <classname>ValueError</classname> más descriptivo cuando
+    se pasa <literal>0</literal> para <parameter>$step</parameter>.</member>
+    <member>Ahora se lanza un <classname>ValueError</classname> cuando se usa un
+    <parameter>$step</parameter> negativo para rangos crecientes.</member>
+    <member>Si <parameter>$step</parameter> es un float que puede interpretarse
+    como un int, ahora se hace así.</member>
+    <member>Ahora se lanza un <classname>ValueError</classname> si cualquier argumento
+    es infinito o NAN.</member>
+    <member>Ahora se emite un <constant>E_WARNING</constant> si
+    <parameter>$start</parameter> o <parameter>$end</parameter> es la cadena vacía.
+    El valor continúa siendo convertido al valor <literal>0</literal>.</member>
+    <member>Ahora se emite un <constant>E_WARNING</constant> si
+    <parameter>$start</parameter> o <parameter>$end</parameter> tiene más de
+    un byte, solo si es una cadena no numérica.</member>
+    <member>Ahora se emite un <constant>E_WARNING</constant> si
+    <parameter>$start</parameter> o <parameter>$end</parameter> se convierte a un
+    entero porque la otra entrada de límite es un número.
+    (p.ej. <code>range(5, 'z');</code>).</member>
+    <member>Ahora se emite un <constant>E_WARNING</constant> si
+    <parameter>$step</parameter> es un float al intentar generar un rango de
+    caracteres, excepto si ambas entradas de límite son cadenas numéricas (p.ej.
+    <code>range('5', '9', 0.5);</code> no produce una advertencia).</member>
+    <member><function>range</function> ahora produce una lista de caracteres si una
+    de las entradas de límite es un dígito de cadena en lugar de convertir la otra entrada
+    a int (p.ej. <code>range('9', 'A');</code>).</member>
+   </simplelist>
+
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+range('9', 'A');  // ["9", ":", ";", "<", "=", ">", "?", "@", "A"], a partir de PHP 8.3.0
+range('9', 'A');  // [9, 8, 7, 6, 5, 4, 3, 2, 1, 0], antes de PHP 8.3.0
+?>
+]]>
+    </programlisting>
+   </informalexample>
   </para>
 
   <para>
-   Las directivas INI <literal>assert.*</literal> han sido depreciadas.
-   Ver la página
-   <link linkend="migration83.other-changes.ini">Cambios en la gestión del fichero INI</link>
-   para más detalles.
+   <function>number_format</function> ahora maneja valores negativos de
+   <parameter>$decimals</parameter> redondeando
+   <parameter>$num</parameter> a <code>abs($decimals)</code> dígitos antes del
+   punto decimal. Anteriormente, los valores negativos de <parameter>$decimals</parameter>
+   eran ignorados.
   </para>
-  <!-- RFC: https://wiki.php.net/rfc/assert-string-eval-cleanup -->
+
+  <para>
+   La verificación de errores de flags de <function>file</function> ahora captura todos los flags inválidos.
+   Notablemente, <constant>FILE_APPEND</constant> era anteriormente aceptado silenciosamente.
+  </para>
  </sect2>
 
- <sect2 xml:id="migration83.incompatible.sqlite3">
-  <title>SQLite3</title>
+ <sect2 xml:id="migration83.incompatible.SNMP">
+  <title>SNMP</title>
 
   <para>
-   El uso de excepciones está ahora desaconsejado, y las advertencias serán eliminadas en el futuro.
-   Llamar a <code>SQLite3::enableExceptions(false)</code> suprimirá una advertencia de depreciación en esta versión.
-  </para>
- </sect2>
-
- <sect2 xml:id="migration83.incompatible.zip">
-  <title>Zip</title>
-
-  <para>
-   La constante <constant>ZipArchive::FL_RECOMPRESS</constant> está depreciada
-   y será eliminada en una versión futura de libzip.
+   Los tipos de las constantes de la clase <classname>SNMP</classname> ahora están declarados.
   </para>
  </sect2>
 

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -305,7 +305,7 @@
 
    <para>
     <function>pg_insert</function> ahora lanza una <classname>ValueError</classname>
-    en lugar de una <classname>Exception</classname> cuando la tabla especificada es inválida.
+    en lugar de una <constant>E_WARNING</constant> cuando la tabla especificada es inválida.
    </para>
 
    <para>
@@ -374,8 +374,8 @@
    <para>
     <function>password_hash</function> ahora encadena la excepción subyacente
     <classname>Random\RandomException</classname>
-    en la <parameter>$previous</parameter> <classname>Exception</classname>
-    de <constant>ValueError</constant> cuando falla la generación de sal.
+    como <classname>ValueError</classname>'s <parameter>$previous</parameter>
+    <classname>Exception</classname> cuando falla la generación de sal.
    </para>
 
    <para>

--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -124,7 +124,7 @@ class _ {}
 
    <note>
     <para>
-     Las clases cuyo nombre comienza con un guion bajo no están
+     Las clases cuyo nombre comienza con un guion bajo <emphasis>no</emphasis> están
      desaprobadas:
      <informalexample>
       <programlisting role="php">
@@ -253,7 +253,7 @@ class _MyClass {}
    Llamar a <function>intlgregcal_create_instance</function> o
    <methodname>IntlGregorianCalendar::__construct</methodname>
    con más de dos argumentos ahora está desaprobado.
-   Usar <function>intlgregcal_create_instance</function> o
+   Usar <methodname>IntlGregorianCalendar::createFromDate</methodname> o
    <methodname>IntlGregorianCalendar::createFromDateTime</methodname> en su lugar.
   </simpara>
  </sect2>

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -6,9 +6,9 @@
 
  <simpara>
   Salvo mención contraria en esta sección,
-  cada nueva <link xlink:href="migration84.new-functions">función</link>,
-  <link xlink:href="migration84.new-classes">clase, interfaz, enumeración</link>,
-  o <link xlink:href="migration84.constants">constante</link>
+  cada nueva <link linkend="migration84.new-functions">función</link>,
+  <link linkend="migration84.new-classes">clase, interfaz, enumeración</link>,
+  o <link linkend="migration84.constants">constante</link>
   puede provocar el lanzamiento de una excepción de redeclaración <exceptionname>Error</exceptionname>.
  </simpara>
 
@@ -51,7 +51,7 @@
 
    <!-- TODO Link to clone magic method, and explain this better as UPGRADING is... -->
    <simpara>
-    La modificación indirecta de propiedades de solo lectura en <function>__clone()</function>
+    La modificación indirecta de propiedades de solo lectura en <code>__clone()</code>
     ya no está permitida, por ejemplo, <code>$ref = &amp;$this->readonly</code>.
     Ya estaba prohibido para la inicialización de solo lectura, y era un
     descuido en la implementación de la "reinicialización de solo lectura al clonar".
@@ -244,7 +244,7 @@
 
    <para>
     <function>resourcebundle_get</function>,
-    <function>ResourceBundle::get</function>, y el acceso a índices en un
+    <methodname>ResourceBundle::get</methodname>, y el acceso a índices en un
     <classname>ResourceBundle</classname> ahora lanzan:
     <simplelist>
      <member>
@@ -356,6 +356,16 @@
      </member>
     </simplelist>
    </para>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.session">
+   <title>Sesión</title>
+
+   <simpara>
+    Establecer un valor no positivo para <link linkend="ini.session.gc-divisor">session.gc_divisor</link>
+    o un valor negativo para <link linkend="ini.session.gc-probability">session.gc_probability</link>
+    emite ahora una advertencia.
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.simplexml">
@@ -675,16 +685,6 @@
   </simpara>
  </sect2>
 
- <sect2 xml:id="migration84.incompatible.new-warnings-exceptions.session">
-  <title>Sesión</title>
-
-  <simpara>
-   Establecer un valor no positivo para <link linkend="ini.session.gc-divisor">session.gc_divisor</link>
-   o un valor negativo para <link linkend="ini.session.gc-probability">session.gc_probability</link>
-   emite ahora una advertencia.
-  </simpara>
- </sect2>
-
  <sect2 xml:id="migration84.incompatible.simplexml">
   <title>SimpleXML</title>
 
@@ -694,7 +694,7 @@
    Antes de PHP 8.4.0, algunos de sus métodos (por ejemplo,
    <methodname>SimpleXMLElement::asXML</methodname> o
    <methodname>SimpleXMLElement::getName</methodname>) y la conversión de tales
-   instancias a <type>string</type> reinicializaban implícitamente el iterador.
+   instancias a &string; reinicializaban implícitamente el iterador.
   </simpara>
   <para>
    Esto podía provocar bucles infinitos no intencionados porque el iterador se reinicializaba.

--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -485,7 +485,7 @@
     </simpara>
 
     <simpara>
-     Se corrigió un error causado por el "preredondeo" de la función round().
+     Se corrigió un error causado por el "preredondeo" de la función <function>round</function>.
      Anteriormente, usando "preredondeo" para manejar un valor como <literal>0.285</literal>
      (en realidad <literal>0.28499999999999998</literal>) como un número decimal y redondearlo a <literal>0.29</literal>.
      Sin embargo, el "preredondeo" redondeaba incorrectamente algunos números,

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -439,7 +439,7 @@
 
   <simpara>
    <function>session_start</function> es más estricta con respecto al argumento
-   <parameter>options</parameter>. Ahora lanza una <exceptionname>ValueError</exceptionname> si
+   del array. Ahora lanza una <exceptionname>ValueError</exceptionname> si
    el array no es un mapa hash, o una <exceptionname>TypeError</exceptionname>
    si el valor de read_and_close no es de un tipo válido compatible con int.
   </simpara>
@@ -539,8 +539,7 @@
   </simpara>
 
   <simpara>
-   El parámetro <parameter>$length</parameter> de
-   <methodname>SplFileObject::fwrite</methodname> ahora admite valores nulos.
+   El parámetro <methodname>SplFileObject::fwrite</methodname> <parameter>$length</parameter> ahora admite valores nulos.
    El valor predeterminado cambió de <literal>0</literal> a &null;.
   </simpara>
 

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -583,7 +583,6 @@
 
    <simpara>
     Mejorado el rendimiento de <function>pack</function>.
-    Improved <function>pack</function> performance.
    </simpara>
 
    <simpara>

--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -276,7 +276,7 @@
    </term>
    <listitem>
     <simpara>
-     El número de punto flotante positivo más pequeño x, de modo que x + 1.0 != 1.0. Disponible desde PHP 7.2.0.
+     El número de punto flotante positivo más pequeño x, de modo que <literal>x + 1.0 != 1.0</literal>. Disponible desde PHP 7.2.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -287,7 +287,7 @@
    </term>
    <listitem>
     <simpara>
-     El número de punto flotante positivo más pequeño. Si necesita la representación negativa más pequeña de un número de punto flotante, use <literal>- PHP_FLOAT_MAX</literal>. Disponible desde PHP 7.2.0.
+     El número de punto flotante <emphasis>positivo</emphasis> más pequeño. Si necesita la representación <emphasis>negativa</emphasis> más pequeña de un número de punto flotante, use <literal>- PHP_FLOAT_MAX</literal>. Disponible desde PHP 7.2.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -390,7 +390,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.php-man-dir">
+  <varlistentry xml:id="constant.php-mandir">
    <term>
     <constant>PHP_MANDIR</constant>
     (<type>string</type>)

--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -218,10 +218,10 @@
      </row>
      <row>
       <entry>
-       <function>require</function>
+       <link linkend="language.oop5.properties.readonly-properties">readonly</link> (disponible a partir de PHP 8.1.0) *
       </entry>
       <entry>
-       <link linkend="language.oop5.properties.readonly-properties">readonly</link> (disponible a partir de PHP 8.1.0) *
+       <function>require</function>
       </entry>
       <entry>
        <function>require_once</function>

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -115,7 +115,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry>||</entry>
      <entry><link linkend="language.operators.logical">operadores lógicos</link></entry>
     </row>
-    <row xml:id="constant.t-boolean-cast">
+    <row xml:id="constant.t-bool-cast">
      <entry><constant>T_BOOL_CAST</constant></entry>
      <entry>(bool) o (boolean)</entry>
      <entry><link linkend="language.types.typecasting">conversión de tipos</link></entry>

--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -77,7 +77,7 @@ echo "Hola, soy un script PHP!";
  </section>
 
  <section xml:id="intro-whatcando" annotations="chunk:false">
-  <title>¿Qué puede hacer PHP?</title>
+  <info><title>¿Qué puede hacer PHP?</title></info>
   <para>
    Todo. PHP está principalmente concebido para servir como
    lenguaje de script del lado del servidor, por lo que puede hacer todo lo que cualquier otro programa CGI puede hacer, como
@@ -109,7 +109,7 @@ echo "Hola, soy un script PHP!";
       sin la ayuda del servidor web y de un navegador. Solo se necesita
       el ejecutable PHP. Este uso es ideal para los scripts que se ejecutan regularmente
       con un <command>cron</command> en Unix o Linux o
-      un <literal>gestor de tareas</literal> (en Windows). Estos scripts
+      un gestor de tareas (en Windows). Estos scripts
       también pueden ser utilizados para realizar operaciones en ficheros de texto. Vea la sección sobre el uso de PHP en
       <link linkend="features.commandline">línea de comandos</link>
       para más información.

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 876557ae38f6ca5035618f7cea48ca627118b437 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <chapter xml:id="tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Una introducción a PHP</title>
+  <info><title>Una introducción a PHP</title></info>
 
   <para>
    En esta sección, se pretende ilustrar los principios básicos
@@ -19,7 +19,7 @@
   </para>
 
   <section xml:id="tutorial.firstpage">
-   <title>Su primera página PHP</title>
+   <info><title>Su primera página PHP</title></info>
    <simpara>
     Este tutorial presupone que PHP ya está instalado.
     Las instrucciones de instalación se pueden encontrar en la
@@ -31,7 +31,7 @@
    </para>
    <para>
     <example>
-     <title>Nuestro primer script PHP : <filename>hola.php</filename></title>
+     <info><title>Nuestro primer script PHP : <filename>hola.php</filename></title></info>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -117,7 +117,7 @@ php -S localhost:8000
    </para>
 
    <note>
-    <title>Una nota sobre los retornos de línea</title>
+    <info><title>Una nota sobre los retornos de línea</title></info>
     <para>
      Los retornos de línea tienen un significado mínimo en HTML, sin embargo,
      siempre es una buena idea hacer que su HTML sea lo más bonito y cercano
@@ -130,7 +130,7 @@ php -S localhost:8000
    </note>
 
    <note>
-    <title>Una nota sobre los editores de texto</title>
+    <info><title>Una nota sobre los editores de texto</title></info>
     <para>
      Existen muchos editores de texto y entornos de
      desarrollo (IDE) que se pueden utilizar para crear, editar
@@ -144,7 +144,7 @@ php -S localhost:8000
    </note>
 
    <note>
-    <title>Una nota sobre los procesadores de texto</title>
+    <info><title>Una nota sobre los procesadores de texto</title></info>
     <para>
      Los procesadores de texto como StarOffice Writer, Microsoft Word y
      Abiword son muy malas opciones para editar scripts PHP.
@@ -167,7 +167,7 @@ php -S localhost:8000
    </para>
    <para>
     <example>
-     <title>Recuperación de la información del sistema desde PHP</title>
+     <info><title>Recuperación de la información del sistema desde PHP</title></info>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -182,7 +182,7 @@ phpinfo();
   </section>
 
   <section xml:id="tutorial.useful">
-   <title>Trucos prácticos</title>
+   <info><title>Trucos prácticos</title></info>
    <para>
     Realicemos ahora algo más potente. Vamos
     a verificar el tipo de navegador que el visitante de nuestro sitio utiliza.
@@ -208,7 +208,7 @@ phpinfo();
    </para>
    <para>
     <example>
-    <title>Mostrar el contenido de una variable (elemento de array)</title>
+    <info><title>Mostrar el contenido de una variable (elemento de array)</title></info>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -250,9 +250,9 @@ Mozilla/5.0 (Linux) Firefox/112.0
    </para>
    <para>
     <example>
-     <title>Ejemplo utilizando las
+     <info><title>Ejemplo utilizando las
      <link linkend="language.control-structures">estructuras de control</link> y
-     las <link linkend="language.functions">funciones</link></title>
+     las <link linkend="language.functions">funciones</link></title></info>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -308,7 +308,7 @@ Está utilizando Firefox.
    </para>
    <para>
     <example>
-     <title>Pasar del modo PHP al modo HTML y viceversa</title>
+     <info><title>Pasar del modo PHP al modo HTML y viceversa</title></info>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -348,7 +348,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
   </section>
 
   <section xml:id="tutorial.forms">
-   <title>Utilizar un formulario</title>
+   <info><title>Utilizar un formulario</title></info>
    <para>
     Uno de los puntos fuertes de PHP es su capacidad para manejar formularios.
     El concepto básico que es importante entender es que todos los
@@ -360,7 +360,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
    </para>
    <para>
     <example>
-     <title>Un formulario HTML simple</title>
+     <info><title>Un formulario HTML simple</title></info>
      <programlisting role="html">
 <![CDATA[
 <form action="action.php" method="post">
@@ -384,7 +384,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
    </para>
    <para>
     <example>
-     <title>Mostrar datos de un formulario</title>
+     <info><title>Mostrar datos de un formulario</title></info>
      <programlisting role="php">
 <![CDATA[
 Hola, <?php echo htmlspecialchars($_POST['nombre']); ?>.
@@ -429,7 +429,7 @@ Tienes 29 años.
   </section>
 
   <section xml:id="tutorial.whatsnext">
-   <title>¿Y después?</title>
+   <info><title>¿Y después?</title></info>
    <para>
     Con lo que sabe, ahora es capaz de comprender
     lo esencial de la documentación PHP, y los diferentes scripts de ejemplo

--- a/faq/installation.xml
+++ b/faq/installation.xml
@@ -468,34 +468,7 @@ cgi error:
     <para>
      Hay varias formas de hacerlo. Si está usando Apache, lea
      las instrucciones específicas de instalación, o de lo contrario,
-     debe configurar la variable de entorno <varname>PHPRC</varname>:
-    </para>
-    <para>
-     En Windows:
-     <itemizedlist>
-      <listitem><para>
-       Vaya a Panel de Control y abra el icono Sistema (Inicio → Configuración
-       → Panel de Control → Sistema, o directamente Inicio → Panel de Control
-       → Sistema)
-       </para></listitem>
-      <listitem><para>
-       Vaya a la pestaña Avanzado
-       </para></listitem>
-      <listitem><para>
-       Haga clic en el botón 'Variables de Entorno'
-       </para></listitem>
-      <listitem><para>
-       Revise el panel de 'Variables de Sistema'
-       </para></listitem>
-      <listitem><para>
-       Haga clic en 'Nuevo' e ingrese 'PHPRC' como nombre de variable, y el
-       directorio donde se encuentra &php.ini; como el valor de la variable
-       (p.ej., <literal>C:\php</literal>)
-       </para></listitem>
-      <listitem><para>
-       Presione OK y reinicie la máquina
-       </para></listitem>
-     </itemizedlist>
+     debe configurar la variable de entorno <varname>PHPRC</varname>.
     </para>
    </answer>
   </qandaentry>

--- a/faq/passwords.xml
+++ b/faq/passwords.xml
@@ -6,20 +6,20 @@
  <title>Hash de contraseñas seguro</title>
  <titleabbrev>Hash de Contraseñas</titleabbrev>
 
- <para>
+ <simpara>
   Esta sección explica las razones que justifican el uso de funciones hash
   para proteger las contraseñas. También se explica cómo hacerlo de un modo efectivo.
- </para>
+ </simpara>
 
  <qandaset>
   <qandaentry xml:id="faq.passwords.hashing">
    <question>
-    <para>
+    <simpara>
      ¿Por qué debo usar hash en las contraseñas de los usuarios de mi aplicación?
-    </para>
+    </simpara>
    </question>
    <answer>
-    <para>
+    <simpara>
      El hash de contraseñas es una de las consideraciones de seguridad más elementales
      que se deben llevar a la práctica al diseñar una aplicación que acepte contraseñas
      de los usuarios. Sin hashing, cualquier contraseña que se almacene en la
@@ -27,152 +27,148 @@
      lo que inmediatamente no sólo estaría comprometida la aplicación, sino también
      las cuentas de otros servicios de nuestros usuarios, siempre y cuando no utilicen
      contraseñas distintas.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Si aplicamos un algoritmo hash a las contraseñas antes de almacenarlas
      en la base de datos, dificultamos al atacante el determinar la contraseña
      original, pese a que en un futuro podrá comparar el hash resultante con
      la contraseña original.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Sin embargo, es importante tener en cuenta que el hecho de aplicar hash a las contraseñas sólo
      protege de que se vean comprometidas las contraseñas almacenadas, pero no las protege
      necesariamente de ser interceptadas por un código malicioso inyectado en la
      propia aplicación.
-    </para>
+    </simpara>
    </answer>
   </qandaentry>
   <qandaentry xml:id="faq.passwords.fasthash">
    <question>
-    <para>
+    <simpara>
      ¿Por qué las funciones hash más comunes como <function>md5</function> y
      <function>sha1</function> no son adecuadas para las contraseñas?
-    </para>
+    </simpara>
    </question>
    <answer>
-    <para>
+    <simpara>
      Los algoritmos hash como MD5, SHA1 o SHA256 están diseñados para
      ser muy rápidos y eficientes. Con las técnicas y equipos modernos,
-     es algo trivial extraer por fuerza bruta la salida de estos algoritmos,
+     es algo trivial <quote>extraer por fuerza bruta</quote> la salida de estos algoritmos,
      para determinar los datos de entrada originales.
-    </para>
-    <para>
-     Dada la velocidad con que los ordenadores actuales pueden "invertir" estos algoritmos
+    </simpara>
+    <simpara>
+     Dada la velocidad con que los ordenadores actuales pueden <quote>invertir</quote> estos algoritmos
      hash, muchos profesionales de la seguridad recomiendan encarecidamente no
      utilizarlas como funciones hash para contraseñas.
-    </para>
+    </simpara>
    </answer>
   </qandaentry>
   <qandaentry xml:id="faq.passwords.bestpractice">
    <question>
-    <para>
+    <simpara>
      ¿Qué hash debo aplicar a mis contraseñas, si las funciones hash más comunes
      no son adecuadas?
-    </para>
+    </simpara>
    </question>
    <answer>
-    <para>
+    <simpara>
      Al aplicar un algoritmo hash, los dos factores más importantes son
      el coste computacional y la sal. Cuanto más cueste aplicar un algoritmo
      hash, más costará analizar su salida por fuerza bruta.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      PHP proporciona una
      <link linkend="book.password">API de hash de contraseñas nativa</link> que
      maneja cuidadosamente <link linkend="function.password-hash">el empleo de hash</link>
      y la <link linkend="function.password-verify">verificación de contraseñas</link>
      de una manera segura.
-     </para>
-     <para>
-      Otra opción es la función <function>crypt</function>, la cual tiene
-      soporte para varios algoritmos hash. Al emplear
-      esta función, se garantiza que el algoritmo que se seleccione esté
-      disponible, debido a que PHP contiene implementaciones nativas de cada algoritomo
-      soportado, en caso de que el sistema no tenga soporte para uno o más de estos algoritmos.
-     </para>
-     <para>
-      El algoritmo recomendado para el empleo de contraseñas con hash es Blowfish, que
-      es también el predeterminado de la API de hash de contraseñas, que, aunque
-      es significativamente más caro computacionalmente que MD5 o SHA1, sigue
-      siendo escalable.
-     </para>
-     <para>
-      Observar que si se emplea <function>crypt</function> para verificar una
-      contraseña, será necesario tomar precauciones para evitar ataques de temporización
-      utilizando una comparación de string de tiempo constantes. Ni los
-      <link linkend="language.operators.comparison">operadores == y ===</link> de PHP
-      ni <function>strcmp</function> llevan a cabo una comparación de string de tiempo
-      constante. Debido a que <function>password_verify</function> hará esto de forma
-      automática, se recomienda el empleo de la
-      <link linkend="book.password">API de hash de contraseñas nativa</link>
-      siempre que sea posible.
-     </para>
-    </answer>
-   </qandaentry>
-   <qandaentry xml:id="faq.passwords.salt">
-    <question>
-     <para>
-      ¿Qué es una sal (salt)?
-     </para>
-    </question>
-    <answer>
-     <para>
-      Una sal criptográfica es un dato que se utiliza durante el proceso de hash
-      para eliminar la posibilidad de que el resultado pueda buscarse a partir de
-      una lista de pares precalculados de hash y sus entradas originales, conocidas
-      como tablas rainbow.
-     </para>
-     <para>
-      Es decir, una sal es un pequeño dato añadido que hace que los hash
-      sean significantemente más difíciles de crackear. Existe un gran número de
-      servicios online que ofrecen grandes listas de códigos hash precalculados,
-      junto con sus datos de entrada originales. El uso de una sal hace muy difícil o
-      imposible encontrar el hash resultante en cualquiera de estas listas.
-     </para>
-     <para>
-      <function>password_hash</function> creará una sal aleatoria si no se
-      proporciona una, siendo esta generalmente la estrategia más sencilla y
-      segura.
-     </para>
-    </answer>
-   </qandaentry>
-   <qandaentry xml:id="faq.password.storing-salts">
-    <question>
-     <para>
-      ¿Cómo almaceno mis sales?
-     </para>
-    </question>
-    <answer>
-     <para>
-      Al utilizar <function>password_hash</function> o
-      <function>crypt</function>, el valor devuelto incluye la sal como parte
-      del hash generado. Este valor debería almacenarse tal cual en la
-      base de datos, ya que incluye información sobre la función hash que se
-      empleó y así proporcionarla directamente a
-      <function>password_verify</function> o <function>crypt</function> al
-      verificar contraseñas.
-     </para>
-     <para>
-      El siguiente diagrama muestra el formato de un valor devuelto por
-      <function>crypt</function> o <function>password_hash</function>. Como se
-      puede observar, son autocontenidos, con toda la información del
-      algoritmo y la sal requerida para futuras verificaciones de contraseñas.
-     </para>
-     <para>
-      <mediaobject>
-       <alt>
-        Los componentes del valor devuelto por password_hash y crypt: en
-        orden, el algoritmo elegido, las opciones del algoritmo, la sal utilizada,
-        y la contraseña con hash.
-       </alt>
-       <imageobject>
-        <imagedata fileref="en/faq/figures/crypt-text-rendered.svg" width="690" depth="192" format="SVG" />
-       </imageobject>
-      </mediaobject>
-     </para>
-    </answer>
-   </qandaentry>
-  </qandaset>
+    </simpara>
+    <simpara>
+     El algoritmo recomendado para el empleo de contraseñas con hash es Blowfish, que
+     es también el predeterminado de la API de hash de contraseñas, que, aunque
+     es significativamente más caro computacionalmente que MD5 o SHA1, sigue
+     siendo escalable.
+    </simpara>
+    <simpara>
+     La función <function>crypt</function> también está disponible para el hash de
+     contraseñas, pero solo se recomienda para la interoperabilidad con otros
+     sistemas. En su lugar, se recomienda encarecidamente el uso de la
+     <link linkend="book.password">API de hash de contraseñas nativa</link>
+     siempre que sea posible.
+    </simpara>
+   </answer>
+  </qandaentry>
+  <qandaentry xml:id="faq.passwords.salt">
+   <question>
+    <simpara>
+     ¿Qué es una sal (salt)?
+    </simpara>
+   </question>
+   <answer>
+    <simpara>
+     Una sal criptográfica es un dato que se utiliza durante el proceso de hash
+     para eliminar la posibilidad de que el resultado pueda buscarse a partir de
+     una lista de pares precalculados de hash y sus entradas originales, conocidas
+     como tablas rainbow.
+    </simpara>
+    <simpara>
+     Es decir, una sal es un pequeño dato añadido que hace que los hash
+     sean significantemente más difíciles de crackear. Existe un gran número de
+     servicios online que ofrecen grandes listas de códigos hash precalculados,
+     junto con sus datos de entrada originales. El uso de una sal hace muy difícil o
+     imposible encontrar el hash resultante en cualquiera de estas listas.
+    </simpara>
+    <simpara>
+     <function>password_hash</function> creará una sal aleatoria si no se
+     proporciona una, siendo esta generalmente la estrategia más sencilla y
+     segura.
+    </simpara>
+   </answer>
+  </qandaentry>
+  <qandaentry xml:id="faq.password.storing-salts">
+   <question>
+    <simpara>
+     ¿Cómo almaceno mis sales?
+    </simpara>
+   </question>
+   <answer>
+    <simpara>
+     Al utilizar <function>password_hash</function> o
+     <function>crypt</function>, el valor devuelto incluye la sal como parte
+     del hash generado. Este valor debería almacenarse tal cual en la
+     base de datos, ya que incluye información sobre la función hash que se
+     empleó y así proporcionarla directamente a
+     <function>password_verify</function> al
+     verificar contraseñas.
+    </simpara>
+    <warning>
+     <simpara>
+      Siempre debería utilizarse <function>password_verify</function> en lugar de
+      volver a aplicar hash y comparar el resultado con un hash almacenado, a fin de
+      evitar ataques de temporización.
+     </simpara>
+    </warning>
+    <simpara>
+     El siguiente diagrama muestra el formato de un valor devuelto por
+     <function>crypt</function> o <function>password_hash</function>. Como se
+     puede observar, son autocontenidos, con toda la información del
+     algoritmo y la sal requerida para futuras verificaciones de contraseñas.
+    </simpara>
+    <para>
+     <mediaobject>
+      <alt>
+       Los componentes del valor devuelto por password_hash y crypt: en
+       orden, el algoritmo elegido, las opciones del algoritmo, la sal utilizada,
+       y la contraseña con hash.
+      </alt>
+      <imageobject>
+       <imagedata fileref="en/faq/figures/crypt-text-rendered.svg" width="690" depth="192" format="SVG" />
+      </imageobject>
+     </mediaobject>
+    </para>
+   </answer>
+  </qandaentry>
+ </qandaset>
 
 </chapter>
 

--- a/features/file-upload.xml
+++ b/features/file-upload.xml
@@ -314,25 +314,23 @@ foreach ($_FILES["pictures"]["error"] as $key => $error) {
   <title>Carga por método PUT</title>
   <para>
    PHP soporta el método HTTP PUT utilizado por los navegadores para almacenar ficheros en un servidor. Las solicitudes de tipo PUT son mucho más simples que las cargas de ficheros utilizando el tipo POST, y se parecen a:
-   <example>
-    <title>Método PUT para las cargas de ficheros</title>
+   <informalexample>
     <programlisting role="HTTP">
 <![CDATA[
 PUT /path/filename.html HTTP/1.1
 ]]>
     </programlisting>
-   </example>
+   </informalexample>
   </para>
   <para>
    Normalmente, esto significa que el servidor remoto guardará los datos que siguen en el fichero: <filename>/path/filename.html</filename> de su disco. Esto no es, por supuesto, muy seguro permitir que Apache o PHP sobrescriban cualquier fichero de la arborescencia. Para evitar esto, primero se debe indicar al servidor que se desea que un script PHP dado gestione la solicitud. Con Apache, hay una directiva para ello: <emphasis>Script</emphasis>. Puede ser colocada en cualquier lugar del fichero de configuración de Apache. En general, los webmasters la colocan en el bloque <literal>&lt;Directory&gt;</literal>, o tal vez en el bloque <literal>&lt;VirtualHost&gt;</literal>. La siguiente línea hará muy bien el trabajo:
-   <example>
-    <title>Directiva Apache para la carga por método PUT</title>
+   <informalexample>
     <programlisting>
 <![CDATA[
 Script PUT /put.php
 ]]>
     </programlisting>
-   </example>
+   </informalexample>
   </para>
   <simpara>
    Indica a Apache que debe enviar las solicitudes de carga por método PUT al script <filename>put.php</filename>. Por supuesto, esto presupone que se ha activado PHP para que maneje los ficheros de tipo <filename class="extension">.php</filename>, y que PHP está activo. El recurso de destino para todas las solicitudes PUT de este script debe ser el script mismo, y no el nombre del fichero que el fichero cargado debe tener.

--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -115,14 +115,15 @@ make install
    <para>
     Ahora, configure y compile PHP. Será en este momento
     cuando se podrá personalizar PHP con las diversas opciones disponibles,
-    como la lista de extensiones a activar. En nuestro ejemplo, realizaremos
+    como la lista de extensiones a activar. Ejecute
+    <command>./configure --help</command> para obtener la lista de opciones disponibles. En nuestro ejemplo, realizaremos
     una configuración simple, con Apache 2 y soporte MySQL.
    </para>
 
    <para>
     Si se ha construido Apache desde las fuentes, tal como se describe anteriormente,
-    el siguiente ejemplo debería ser correcto en cuanto a las rutas hacia los apxs, pero si
-    se ha instalado Apache de otra manera, se deberán tener en cuenta las especificidades y ajustar las rutas apxs en consecuencia. Tenga en cuenta que, según las distribuciones, podría ser necesario renombrar apxs a apxs2.
+    el siguiente ejemplo debería ser correcto en cuanto a las rutas hacia <command>apxs</command>, pero si
+    se ha instalado Apache de otra manera, se deberán tener en cuenta las especificidades y ajustar las rutas <command>apxs</command> en consecuencia. Tenga en cuenta que, según las distribuciones, podría ser necesario renombrar <command>apxs</command> a <command>apxs2</command>.
    </para>
    <informalexample>
     <screen>
@@ -137,14 +138,16 @@ make install
 
    <para>
     Si se decide modificar las opciones de configuración después de la instalación,
-    se deberán ejecutar nuevamente las etapas "configure", "make" y "make install".
+    se deberán ejecutar nuevamente las etapas <command>configure</command>, <command>make</command>
+    y <command>make install</command>.
     Entonces solo se necesitará reiniciar Apache para que el nuevo módulo surta efecto.
     Una recompilación de Apache no es necesaria.
    </para>
 
    <para>
-    Tenga en cuenta que, salvo indicaciones contrarias, la etapa "make install" también instalará
-    PEAR, así como diversas herramientas PHP como phpsize, PHP CLI y
+    Tenga en cuenta que, salvo indicaciones contrarias, <command>make install</command> también instalará
+    <link xlink:href="&url.php.pear;">PEAR</link>, así como diversas herramientas PHP como
+    <link linkend="install.pecl.phpize">phpize</link>, PHP CLI y
     mucho más.
    </para>
 
@@ -152,7 +155,7 @@ make install
 
   <listitem>
    <para>
-    Configurar el archivo php.ini
+    Configurar el archivo <filename>php.ini</filename>
    </para>
 
    <informalexample>
@@ -164,13 +167,13 @@ cp php.ini-development /usr/local/lib/php.ini
    </informalexample>
 
    <para>
-    Se debe editar el archivo .ini para definir las opciones PHP.
-    Si se prefiere colocar este archivo en otro directorio, utilice
+    Se debe editar el archivo <literal>.ini</literal> para definir las opciones PHP.
+    Si se prefiere colocar <filename>php.ini</filename> en otro directorio, utilice
     la opción <literal>--with-config-file-path=/some/path</literal> en la etapa 5.
    </para>
 
    <para>
-    Si se elige el archivo php.ini-production, asegúrese de leer la lista
+    Si se elige el archivo <filename>php.ini-production</filename>, asegúrese de leer la lista
     de modificaciones correspondiente ya que puede afectar considerablemente la forma
     en que PHP funcionará.
    </para>
@@ -182,7 +185,7 @@ cp php.ini-development /usr/local/lib/php.ini
    <para>
     Edite el archivo <filename>httpd.conf</filename> para cargar el módulo PHP. La ruta especificada
     a la derecha de la cadena LoadModule, debe corresponder a la ruta del sistema del módulo
-    PHP. La etapa "make install" anterior debería haber realizado esta operación
+    PHP. <command>make install</command> anterior debería haber realizado esta operación
     por usted, pero una simple verificación permitirá asegurarse.
    </para>
 
@@ -324,7 +327,7 @@ service httpd restart
  <para>
   Apache puede ser compilado en modo multithread, seleccionando
   el MPM <filename>worker</filename>, en lugar del estándar
-  MPM <filename>prefork</filename>. Esto se hace añadiendo la siguiente opción al argumento de la comando "./configure", en la etapa 3 anterior :
+  MPM <filename>prefork</filename>. Esto se hace añadiendo la siguiente opción al argumento de <command>./configure</command>, en la etapa 3 anterior:
  </para>
  <informalexample>
   <screen>

--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -258,8 +258,7 @@ Pero nueva línea ahora
    Se debe tener cuidado con los comentarios estilo 'C' anidados en grandes bloques cuando se comentan.
   </simpara>
   <para>
-   <example>
-    <title>Los comentarios de tipo C</title>
+   <informalexample>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -269,7 +268,7 @@ Pero nueva línea ahora
 ?>
 ]]>
     </programlisting>
-   </example>
+   </informalexample>
   </para>
  </sect1>
 </chapter>

--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -23,7 +23,7 @@
     <varlistentry xml:id="context.http.method">
      <term>
       <parameter>method</parameter>
-      <type>&string;</type>
+      &string;
      </term>
      <listitem>
       <para>
@@ -63,12 +63,12 @@
     <varlistentry xml:id="context.http.user-agent">
      <term>
       <parameter>user_agent</parameter>
-      <type>&string;</type>
+      &string;
      </term>
      <listitem>
       <para>
        Valor a enviar con el encabezado <literal>User-Agent:</literal>. Este valor
-       solo debe ser utilizado si el agente de usuario no está
+       solo debe ser utilizado si el agente de usuario <emphasis>no</emphasis> está
        especificado en la opción de contexto <literal>header</literal> anterior.
       </para>
       <para>
@@ -81,7 +81,7 @@
     <varlistentry xml:id="context.http.content">
      <term>
       <parameter>content</parameter>
-      <type>&string;</type>
+      &string;
      </term>
      <listitem>
       <para>
@@ -93,7 +93,7 @@
     <varlistentry xml:id="context.http.proxy">
      <term>
       <parameter>proxy</parameter>
-      <type>&string;</type>
+      &string;
      </term>
      <listitem>
       <para>
@@ -105,7 +105,7 @@
     <varlistentry xml:id="context.http.request-fulluri">
      <term>
       <parameter>request_fulluri</parameter>
-      <type>&boolean;</type>
+      &boolean;
      </term>
      <listitem>
       <para>
@@ -153,7 +153,7 @@
     <varlistentry xml:id="context.http.protocol-version">
      <term>
       <parameter>protocol_version</parameter>
-      <type>&float;</type>
+      &float;
      </term>
      <listitem>
       <para>
@@ -168,7 +168,7 @@
     <varlistentry xml:id="context.http.timeout">
      <term>
       <parameter>timeout</parameter>
-      <type>&float;</type>
+      &float;
      </term>
      <listitem>
       <para>
@@ -185,7 +185,7 @@
     <varlistentry xml:id="context.http.ignore-errors">
      <term>
       <parameter>ignore_errors</parameter>
-      <type>&boolean;</type>
+      &boolean;
      </term>
      <listitem>
       <para>

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -36,7 +36,7 @@
     <varlistentry xml:id="context.ssl.verify-peer">
      <term>
       <parameter>verify_peer</parameter>
-      <type>&boolean;</type>
+      &boolean;
      </term>
      <listitem>
       <para>
@@ -64,7 +64,7 @@
     <varlistentry xml:id="context.ssl.allow-self-signed">
      <term>
       <parameter>allow_self_signed</parameter>
-      <type>&boolean;</type>
+      &boolean;
      </term>
      <listitem>
       <para>

--- a/language/control-structures/continue.xml
+++ b/language/control-structures/continue.xml
@@ -14,7 +14,7 @@
  <note>
   <simpara>
    En PHP, la estructura
-   <link linkend="control-structures.switch"><literal>switch</literal></link>
+   <link linkend="control-structures.switch">switch</link>
    se considera un bucle por <literal>continue</literal>.
    <literal>continue</literal> se comporta como <literal>break</literal>
    (cuando no se pasa ningún argumento) pero emitirá una advertencia, ya que es probable que esto sea un error. Si un <literal>switch</literal> se encuentra dentro de un bucle, <literal>continue 2</literal> continuará en la siguiente iteración del bucle externo.

--- a/language/control-structures/declare.xml
+++ b/language/control-structures/declare.xml
@@ -84,8 +84,8 @@ declare(ticks=1);
    Un tick es un evento que interviene cada <varname>N</varname>
    comandos de bajo nivel tickables, ejecutados por el analizador en el bloque de
    <literal>declare</literal>. El valor de <varname>N</varname> es especificado
-   por la sintaxis <code>ticks=<varname>N</varname></code> en el bloque de
-   directiva <literal>declare</literal>.
+   por la sintaxis <code>ticks=<varname>N</varname></code> en la sección
+   <literal>directive</literal> del bloque <literal>declare</literal>.
   </para>
   <para>
    No todos los comandos son tickables. Típicamente,

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -10,7 +10,7 @@
   de <literal>if</literal> y de <literal>else</literal>. Como la expresión
   <literal>else</literal>, permite ejecutar una instrucción
   después de un <literal>if</literal> en el caso de que el "primer"
-  if sea evaluado como &false;. Sin embargo,
+  <literal>if</literal> sea evaluado como &false;. Sin embargo,
   a diferencia de la expresión <literal>else</literal>,
   solo ejecutará la instrucción si la expresión condicional
   <literal>elseif</literal> es evaluada como

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -8,7 +8,7 @@
  <?phpdoc print-version-for="for"?>
  <para>
   Las bucles <literal>for</literal> son las más complejas en PHP.
-  Funcionan como las bucles <literal>for</literal> del lenguaje C(C++).
+  Funcionan como las bucles for del lenguaje C(C++).
   La sintaxis de las bucles <literal>for</literal> es la siguiente :
   <informalexample>
    <programlisting>
@@ -47,7 +47,8 @@ for (expr1; expr2; expr3)
   (PHP considera implícitamente que vale &true;,
   como en C). Esto no es realmente muy útil, a menos que se desee terminar la bucle con la
   instrucción condicional
-  <link linkend="control-structures.break"><literal>break</literal></link>.
+  <link linkend="control-structures.break"><literal>break</literal></link>
+  en lugar de la expresión <literal>for</literal>.
  </simpara>
  <para>
   Considérese los siguientes ejemplos. Todos muestran los números enteros de

--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -86,7 +86,7 @@ j hit 17
  </para>
  <para>
   <example>
-   <title>Este <literal>goto</literal> no funciona</title>
+   <title>Esto no funcionará</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -32,7 +32,7 @@
  <simpara>
   Si se define una ruta, absoluta (comenzando con una letra de unidad seguida
   de <literal>\</literal> para Windows, o <literal>/</literal> para Unix/Linux)
-  o relativa (comenzando con . o ..), el <link linkend="ini.include-path">include_path</link>
+  o relativa (comenzando con <literal>.</literal> o <literal>..</literal>), el <link linkend="ini.include-path">include_path</link>
   será ignorado. Por ejemplo, si un nombre de fichero comienza con <literal>../</literal>,
   PHP buscará en el directorio padre para encontrar el fichero especificado.
  </simpara>
@@ -113,8 +113,7 @@ echo "Una $fruit $couleur"; // Una  verte
   </example>
  </para>
  <simpara>
-  Es importante señalar que cuando un fichero es
-  <function>include</function> o <function>require</function>,
+  Es importante señalar que cuando un fichero es incluido,
   los errores de análisis aparecerán en HTML al
   principio del fichero, y el análisis del fichero
   padre no será interrumpido. Por esta razón, el código
@@ -182,7 +181,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
   <function>file</function> para información relacionada.
  </para>
  <simpara>
-  Manejo del retorno: <literal>include</literal> devuelve &false; en caso
+  Manejo del retorno: <literal>include</literal> devuelve <literal>FALSE</literal> en caso
   de error y emite un aviso. Las inclusiones exitosas, incluyendo si
   son sobrescritas por el fichero incluido, devuelven
   <literal>1</literal>. Es posible ejecutar la estructura de lenguaje

--- a/language/control-structures/return.xml
+++ b/language/control-structures/return.xml
@@ -22,13 +22,13 @@
   entonces el control se devuelve al script llamante. Además, si el fichero
   del script actual ha sido incluido a través de la instrucción
   <function>include</function>,
-  entonces el valor devuelto será utilizado como resultado de la instrucción
+  entonces el valor dado a <literal>return</literal> será devuelto como resultado de la llamada
   <function>include</function>.
   Si <literal>return</literal> es llamada desde el script principal,
   entonces la ejecución del script se detiene. Si el script actual es
-  <link linkend="ini.auto-prepend-file"><option>auto_prepend_file</option></link>
+  <link linkend="ini.auto-prepend-file">auto_prepend_file</link>
   o
-  <link linkend="ini.auto-append-file"><option>auto_append_file</option></link>
+  <link linkend="ini.auto-append-file">auto_append_file</link>
   en el fichero &php.ini;, entonces la ejecución del script se detiene.
  </simpara>
  <simpara>

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -215,7 +215,7 @@ switch ($target) {
   </informalexample>
  </para>
  <para>
-  Para comparaciones más complejas, el valor &true; puede ser utilizado como valor de <literal>switch</literal>.
+  Para comparaciones más complejas, el valor &true; puede ser utilizado como valor de switch.
   O, alternativamente, bloques <literal>if</literal>-<literal>else</literal> en lugar de <literal>switch</literal>.
   <informalexample>
    <programlisting role="php">

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -12,15 +12,15 @@
    </simpara>
    <simpara>
     Las formas más básicas de expresiones son las constantes y las variables.
-    Cuando se escribe "<varname>$a</varname> = 5", se está asignando '5' a
-    <varname>$a</varname>. '5', obviamente,
-    tiene el valor 5, o en otras palabras, '5' es una expresión con el
-    valor de 5 (en este caso, '5' es una constante entera).
+    Cuando se escribe <code>$a = 5</code>, se está asignando <code>5</code> a
+    <varname>$a</varname>. <code>5</code>, obviamente,
+    tiene el valor 5, o en otras palabras <code>5</code> es una expresión con el
+    valor de 5 (en este caso, <code>5</code> es una constante entera).
    </simpara>
    <simpara>
     Después de esta asignación, se espera que el valor de <varname>$a</varname> sea 5
-    también, por lo que si se escribe <varname>$b</varname> = <varname>$a</varname>, se espera que esto
-    se comporte tal como si se escribiera <varname>$b</varname> = 5. En otras palabras,
+    también, por lo que si se escribe <code>$b = $a</code>, se espera que esto
+    se comporte tal como si se escribiera <code>$b = 5</code>. En otras palabras,
     <varname>$a</varname> es también una expresión con el valor 5. Si todo funciona bien,
     esto es exactamente lo que sucederá.
    </simpara>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -265,7 +265,7 @@ function takes_many_args(
    </simpara>
    <para>
     Si se desea que un argumento sea siempre pasado
-    por referencia, se puede añadir un '<literal>&amp;</literal>'
+    por referencia, se puede añadir un '&amp;'
     delante del parámetro en la declaración de la función:
    </para>
    <para>
@@ -329,7 +329,7 @@ Servir un espresso.
    </para>
    <para>
     Los valores por defecto de parámetros pueden ser valores escalares,
-    &array;s, el tipo especial &null;, y a partir de PHP 8.1.0,
+    <type>array</type>s, el tipo especial &null;, y a partir de PHP 8.1.0,
     objetos utilizando la sintaxis <link linkend="language.oop5.basic.new">new ClassName()</link>.
    </para>
    <para>
@@ -564,7 +564,7 @@ echo sum(1, 2, 3, 4);
 
    <para>
     <literal>...</literal> también puede ser utilizado durante las llamadas de
-    funciones para extraer el &array; o la variable
+    funciones para extraer el <type>array</type> o la variable
     <classname>Traversable</classname> o el literal en la lista de argumentos:
 
     <example>
@@ -1028,8 +1028,7 @@ $func(); // Muestra "bar"
   <para>
    PHP dispone de numerosas funciones y estructuras estándar. También
    hay funciones que requieren extensiones específicas de PHP, sin
-   las cuales se obtendrá el error fatal
-   <literal>undefined function</literal>. Por ejemplo, para utilizar las
+   las cuales se obtendrán errores fatales "undefined function". Por ejemplo, para utilizar las
    funciones <link linkend="ref.image">de imágenes</link>,
    tales como <function>imagecreatetruecolor</function>, se necesitará el
    soporte de <productname>GD</productname> en PHP. O bien, para utilizar
@@ -1062,7 +1061,7 @@ $func(); // Muestra "bar"
   </para>
   <note>
    <simpara>
-    Si los parámetros dados a una función no son correctos, como pasar un &array; cuando se espera un &string;, el valor devuelto
+    Si los parámetros dados a una función no son correctos, como pasar un <type>array</type> cuando se espera un <type>string</type>, el valor devuelto
     de la función es indefinido. En este caso, la función devolverá la mayoría de las veces un valor &null; pero esto es solo una convención y
     no puede ser considerado como una certeza.
     A partir de PHP 8.0.0, normalmente se lanza una excepción <classname>TypeError</classname>
@@ -1116,7 +1115,7 @@ var_dump(str_contains("foobar", null));
  <sect1 xml:id="functions.anonymous">
   <title>Funciones anónimas</title>
   <simpara>
-   Las funciones anónimas, también llamadas closures o <literal>closures</literal>
+   Las funciones anónimas, también conocidas como <literal>closures</literal>,
    permiten la creación de funciones sin especificar su nombre.
    Son particularmente útiles como funciones de devolución de llamada <type>callable</type>,
    pero su utilización no se limita a este único uso.

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -255,12 +255,12 @@ foreach (input_parser($input) as $id => $fields) {
     <title>Producción de valores nulos</title>
 
     <para>
-     Yield puede ser llamado sin argumento para proporcionar un valor nulo
+     Yield puede ser llamado sin argumento para proporcionar un valor &null;
      con una clave automática.
     </para>
 
     <example>
-     <title>Producción de valores nulos</title>
+     <title>Producción de valores &null;</title>
      <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -54,7 +54,6 @@
   </simpara>
   <example>
    <title>Ejemplo de sintaxis de espacios de nombres</title>
-   <titleabbrev>Espacios de nombres</titleabbrev>
    <programlisting role="php">
    <![CDATA[
 <?php
@@ -94,6 +93,7 @@ echo constant($d); // Ver "Espacios de nombres y características dinámicas"
 
  <sect1 xml:id="language.namespaces.definition">
   <title>Definición de espacios de nombres</title>
+  <titleabbrev>Espacios de nombres</titleabbrev>
   <?phpdoc print-version-for="namespaces"?>
   <para>
    Aunque el código PHP válido puede contenerse en un espacio de nombres,
@@ -270,7 +270,7 @@ echo MonProjet\Connexion::start();
   </para>
   <para>
    No puede existir ningún código PHP fuera de las llaves del espacio de nombres,
-   excepto para abrir una nueva instrucción <literal>declare</literal>.
+   excepto para abrir una nueva instrucción declare.
    <example>
     <title>Declaración de varios espacios de nombres con un espacio sin nombre (2)</title>
     <programlisting role="php">
@@ -1453,10 +1453,10 @@ $a = new MaClasse; // instancia la clase "untruc" del espacio de nombres another
    <para>
     No hay conflicto de nombres, incluso si la clase <literal>MaClasse</literal> existe
     en el espacio de nombres <literal>mes\trucs</literal>, ya que la definición de
-    <literal>MaClasse</literal> está en un archivo separado. Sin embargo, el siguiente
+    MaClasse está en un archivo separado. Sin embargo, el siguiente
     ejemplo produce un error fatal debido a un conflicto de nombres, ya que
-    <literal>MaClasse</literal> se define en el mismo archivo que la instrucción
-    <literal>use</literal>.
+    MaClasse se define en el mismo archivo que la instrucción
+    use.
     <informalexample>
      <programlisting role="php">
      <![CDATA[

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -173,8 +173,8 @@
      <row>
       <entry>7.0.0</entry>
       <entry>
-       Incompatibilidad: Iterar sobre un &object; no-
-       <classname>Traversable</classname> tendrá ahora el mismo comportamiento
+       Incompatibilidad: Iterar sobre un no-<classname>Traversable</classname>
+       &object; tendrá ahora el mismo comportamiento
        que iterar sobre los &array;s por referencia.
       </entry>
      </row>

--- a/language/oop5/cloning.xml
+++ b/language/oop5/cloning.xml
@@ -21,11 +21,9 @@
   </para>
 
   <informalexample>
-   <programlisting role="php">
+   <programlisting>
 <![CDATA[
-<?php
 $copy_of_object = clone $object;
-?>
 ]]>
    </programlisting>
   </informalexample>

--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -123,13 +123,13 @@ bar
 Fatal error: Uncaught Error: Cannot access private const Foo::BAZ in …
 ]]>
   </screen>
-  <note>
-   <para>
-    A partir de PHP 7.1.0, los modificadores de visibilidad son permitidos
-    en las constantes de clase.
-   </para>
-  </note>
  </example>
+ <note>
+  <para>
+   A partir de PHP 7.1.0, los modificadores de visibilidad son permitidos
+   en las constantes de clase.
+  </para>
+ </note>
  <example>
   <title>Verificación de varianza de visibilidad de las constantes de clase, a partir de PHP 8.3.0</title>
   <programlisting role="php">

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -22,7 +22,7 @@
      Los constructores padres no son llamados implícitamente
      si la clase hija define un constructor. Si se
      desea utilizar un constructor padre, será necesario hacer
-     llamada a <literal>parent::__construct()</literal> desde el constructor hijo.
+     llamada a <function>parent::__construct</function> desde el constructor hijo.
      Si el hijo no define un constructor entonces, puede ser heredado
      de la clase padre, exactamente de la misma forma que una método lo sería
      (si no ha sido declarado como privado).
@@ -326,7 +326,7 @@ var_dump($p1, $p2, $p3);
    </methodsynopsis>
    <para>
     PHP posee un concepto de destructor similar al de otros lenguajes
-    orientados a objeto, como el <literal>C++</literal>. El método destructor es llamado
+    orientados a objeto, como el C++. El método destructor es llamado
     tan pronto como ya no hay referencias a un objeto dado, o en cualquier orden durante la secuencia de parada.
    </para>
    <example>
@@ -355,7 +355,7 @@ $obj = new MyDestructableClass();
     Al igual que el constructor, el destructor padre no será llamado
     implícitamente por el motor. Para ejecutar el destructor padre, se
     debe llamar explícitamente a la función
-    <literal>parent::__destruct</literal> en el cuerpo del destructor.
+    <function>parent::__destruct</function> en el cuerpo del destructor.
     Al igual que los constructores, una clase hija puede heredar el
     destructor del padre si no lo implementa ella misma.
    </para>

--- a/language/oop5/final.xml
+++ b/language/oop5/final.xml
@@ -4,7 +4,7 @@
 <sect1 xml:id="language.oop5.final" xmlns="http://docbook.org/ns/docbook">
  <title>Palabra clave "final"</title>
  <para>
-  La palabra clave <literal>final</literal> impide que las clases hijas redefinan
+  La palabra clave final impide que las clases hijas redefinan
   un método, una propiedad o constante prefijando la definición con
   <literal>final</literal>. Si la clase misma es
   definida como final, no podrá ser extendida.

--- a/language/oop5/late-static-bindings.xml
+++ b/language/oop5/late-static-bindings.xml
@@ -6,7 +6,7 @@
   <title>Late Static Bindings (Resolución estática en tiempo de ejecución)</title>
   <para>
    PHP implementa una funcionalidad llamada
-   <literal>late static binding</literal>, en español la resolución
+   late static binding, en español la resolución
    estática en tiempo de ejecución, que puede ser utilizada para referenciar la clase llamada
    en un contexto de herencia estática.
   </para>
@@ -29,8 +29,8 @@
   </para>
 
   <para>
-   Esta funcionalidad ha sido bautizada como <literal>"late static bindings"</literal>,
-   con un punto de vista interno. <literal>"Late binding"</literal>, literalmente
+   Esta funcionalidad ha sido bautizada como "late static bindings",
+   con un punto de vista interno. "Late binding", literalmente
    resolución tardía, proviene del hecho de que los elementos <literal>static::</literal>
    no serán resueltos utilizando la clase donde el método ha sido definido, sino
    que será calculada utilizando la información en tiempo de ejecución.

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -83,7 +83,7 @@
     <function>serialize</function> verifica si la clase tiene un método con el
     nombre mágico <link linkend="object.serialize">__serialize()</link>.
     Si es así, este método será ejecutado antes de cualquier serialización.
-    Debe construir y devolver un &array; asociativo de pares clave/valor
+    Debe construir y devolver un array asociativo de pares clave/valor
     que represente la forma serializada del objeto. Si no se devuelve ningún array, se lanzará una <classname>TypeError</classname>.
    </para>
    <note>
@@ -291,18 +291,18 @@ class Connection
    </para>
    <warning>
     <para>
-     Un objeto <interfacename>Stringable</interfacename>
-     <emphasis>no</emphasis> será aceptado por una declaración de tipo <type>string</type> si la
-     <link linkend="language.types.declarations.strict">declaración de tipo estricta</link> está activada.
-     Si se desea tal comportamiento, la declaración de tipo debe aceptar
-     tanto <interfacename>Stringable</interfacename> como <type>string</type> a través de un tipo de unión.
-    </para>
-    <para>
      A partir de PHP 8.0.0, el valor de retorno sigue las semánticas estándar
      de PHP, lo que significa que el valor será convertido en una <type>string</type>
      si es posible y si el
      <link linkend="language.types.declarations.strict">typing stricte</link>
      está desactivado.
+    </para>
+    <para>
+     Un objeto <interfacename>Stringable</interfacename>
+     <emphasis>no</emphasis> será aceptado por una declaración de tipo <type>string</type> si la
+     <link linkend="language.types.declarations.strict">declaración de tipo estricta</link> está activada.
+     Si se desea tal comportamiento, la declaración de tipo debe aceptar
+     tanto <interfacename>Stringable</interfacename> como <type>string</type> a través de un tipo de unión.
     </para>
     <para>
      A partir de PHP 8.0.0, cualquier clase que contenga un método

--- a/language/oop5/overloading.xml
+++ b/language/oop5/overloading.xml
@@ -5,7 +5,7 @@
   <title>Sobrecarga mágica</title>
 
   <para>
-   La sobrecarga mágica en PHP permite "crear" dinámicamente propiedades y métodos. Estas entidades dinámicas son
+   La sobrecarga mágica en PHP permite <quote>crear</quote> dinámicamente propiedades y métodos. Estas entidades dinámicas son
    tratadas a través de métodos mágicos establecidos que se pueden posicionar
    en una clase para diversos tipos de acciones.
   </para>
@@ -87,7 +87,7 @@
 
    <para>
     El argumento <varname>$name</varname> es el nombre de la propiedad con la que se interactúa.
-    El argumento <varname>$value</varname> del método <link linkend="object.set">__set()</link>
+    El argumento del método <link linkend="object.set">__set()</link> <varname>$value</varname>
     especifica el valor al que la propiedad <varname>$name</varname> debería ser definida.
    </para>
 
@@ -96,7 +96,7 @@
     Estos métodos mágicos no serán lanzados en contexto estático.
     Por consiguiente, estos métodos no deberían ser declarados como
     <link linkend="language.oop5.static">estáticos</link>.
-    Se lanza un aviso si alguno de los métodos mágicos es declarado como estático.
+    Se lanza un aviso si alguno de los métodos mágicos es declarado como <literal>static</literal>.
    </para>
 
    <note>

--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -31,7 +31,7 @@
  <para>
   Paamayim Nekudotayim podría parecer al principio una elección extraña
   para nombrar un doble dos puntos.
-  Sin embargo, en el momento de la escritura del <literal>Zend Engine 0.5</literal>
+  Sin embargo, en el momento de la escritura del Zend Engine 0.5
   (que hacía funcionar PHP 3), fue el nombre elegido por el equipo Zend.
   De hecho, esto significa un doble dos puntos... ¡en hebreo!
  </para>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -93,7 +93,7 @@ EOD;
   <para>
    A partir de PHP 7.4.0, las definiciones de propiedades pueden incluir una
    <xref linkend="language.types.declarations" />,
-   con la excepción del tipo <literal>callable</literal>.
+   con la excepción del tipo <type>callable</type>.
    <example>
     <title>Ejemplo de propiedades tipadas</title>
     <programlisting role="php" annotations="non-interactive">

--- a/language/oop5/serialization.xml
+++ b/language/oop5/serialization.xml
@@ -11,7 +11,7 @@
   <function>serialize</function> devuelve un string que contiene
   una representación lineal de cualquier valor que
   puede ser almacenado en PHP. <function>unserialize</function> puede utilizar este
-  string para recrear el valor original de la variable a partir de su representación lineal. Utilizar <function>serialize</function>
+  string para recrear el valor original de la variable a partir de su representación lineal. Utilizar serialize
   para guardar un objeto conservará todas sus variables. Sus métodos no serán conservados, solo el nombre de la clase lo será.
  </para>
 

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -48,8 +48,8 @@
   <title>Covarianza</title>
 
   <para>
-   Para ilustrar el funcionamiento de la covarianza, se crea una simple clase padre abstracta, <varname>Animal</varname>
-   que será extendida por clases hijas,
+   Para ilustrar el funcionamiento de la covarianza, se crea una simple clase padre abstracta, <varname>Animal</varname>.
+   <varname>Animal</varname> será extendida por clases hijas,
   <varname>Cat</varname> y <varname>Dog</varname>.
   </para>
 

--- a/language/oop5/visibility.xml
+++ b/language/oop5/visibility.xml
@@ -248,8 +248,7 @@ class SpecialBook extends Book
       o protegidos. Los métodos declarados sin utilizar explícitamente una
       palabra clave de visibilidad serán automáticamente definidos como públicos.
     </para>
-    <para>
-      <example>
+    <example>
         <title>Declaración de métodos</title>
         <programlisting role="php" annotations="non-interactive">
 <![CDATA[
@@ -338,7 +337,6 @@ $myFoo->test(); // Bar::testPrivate
 ]]>
         </programlisting>
       </example>
-    </para>
   </sect2>
 
   <sect2 xml:id="language.oop5.visiblity-constants">

--- a/language/operators/arithmetic.xml
+++ b/language/operators/arithmetic.xml
@@ -77,7 +77,6 @@
   que se convierten en <type>int</type>) y que el numerador sea un múltiplo
   del divisor, en cuyo caso se devolverá un valor entero.
   Para la división entera, ver <function>intdiv</function>.
-  <function>intdiv</function>.
  </simpara>
  <simpara>
   Los operandos del módulo se convierten en <type>int</type> antes de la ejecución.

--- a/language/operators/array.xml
+++ b/language/operators/array.xml
@@ -3,9 +3,9 @@
 <!-- Reviewed: no -->
 <sect1 xml:id="language.operators.array">
  <title>Operadores de arrays</title>
+ <titleabbrev>Arrays</titleabbrev>
  <table>
   <title>Operadores de arrays</title>
-  <titleabbrev>Arrays</titleabbrev>
   <tgroup cols="3">
    <thead>
     <row>

--- a/language/operators/bitwise.xml
+++ b/language/operators/bitwise.xml
@@ -129,8 +129,6 @@
      <computeroutput>00000000000000000111011111110111</computeroutput>
     </literallayout>
    </para>
-   <para>
-   </para>
   </informalexample>
  </para>
  <para>

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -262,7 +262,7 @@ echo $a <=> $b, ' '; // 1
     <row>
      <entry><type>object</type></entry>
      <entry>Cualquier cosa</entry>
-     <entry>El <type>objeto</type> es siempre mayor</entry>
+     <entry>El <type>object</type> es siempre mayor</entry>
     </row>
     <row>
      <entry><type>array</type></entry>
@@ -326,7 +326,7 @@ function standard_array_compare($op1, $op2)
   <title>Comparación de números de punto flotante</title>
 
   <para>
-   Debido a la forma en que los números de punto flotante son representados
+   Debido a la forma en que los <type>float</type>s son representados
    internamente, no se debe probar la igualdad entre dos números de tipo
    <type>float</type>.
   </para>

--- a/language/operators/errorcontrol.xml
+++ b/language/operators/errorcontrol.xml
@@ -55,7 +55,7 @@ $mon_fichier = @file ('non_persistent_file') or
    El operador <literal>@</literal> solo funciona con las <link linkend="language.expressions">expresiones</link>.
    La regla general es: si es posible tomar el valor de algo, entonces se puede preponer el operador <literal>@</literal> a este.
    Por ejemplo, puede ser prepuesto a variables, llamadas de funciones, ciertas llamadas a construcciones de lenguaje (por ejemplo, <function>include</function>), etc.
-   No puede ser prepuesto a definiciones de funciones o clases o estructuras condicionales como <literal>if</literal> y <literal>foreach</literal>, etc.
+   No puede ser prepuesto a definiciones de funciones o clases o estructuras condicionales como <literal>if</literal> y &foreach;, etc.
   </simpara>
  </note>
  <warning>

--- a/language/operators/increment.xml
+++ b/language/operators/increment.xml
@@ -110,7 +110,8 @@ int(4)
     ya que esto convertirá implícitamente el valor en <type>int</type> en el futuro.
    </para>
    <para>
-    El operador de decremento no tiene ningún efecto sobre los strings no numéricos.
+    El operador de decremento no tiene ningún efecto sobre los strings no-
+    <link linkend="language.types.numeric-strings">numéricos</link>.
     Un <constant>E_WARNING</constant> es emitido a partir de PHP 8.3.0,
     ya que una <classname>TypeError</classname> será levantada en el futuro.
    </para>

--- a/language/predefined/iterator/rewind.xml
+++ b/language/predefined/iterator/rewind.xml
@@ -22,6 +22,15 @@
     &foreach; bucle. <emphasis>No</emphasis> va a ser
     ejecutado <emphasis>despues</emphasis> &foreach; bucle.
    </para>
+   <simpara>
+    Como &foreach; siempre llama a <methodname>rewind</methodname> antes de iniciar
+    la iteración, avanzar manualmente la posición del iterador (por ejemplo mediante
+    <methodname>SplFileObject::seek</methodname>) será reiniciado.
+   </simpara>
+   <simpara>
+    Para iterar sin rebobinar el iterador, envuélvalo en un
+    <classname>NoRewindIterator</classname>.
+   </simpara>
   </note>
  </refsect1>
 

--- a/language/predefined/php-incomplete-class.xml
+++ b/language/predefined/php-incomplete-class.xml
@@ -14,7 +14,7 @@
     Creada por <function>unserialize</function>
     al intentar deserializar una clase no definida
     o una clase que no está incluida en el <literal>allowed_classes</literal>
-    del array <parameter>options</parameter> de <function>unserialize</function>.
+    de <function>unserialize</function> en el array <parameter>options</parameter>.
    </para>
 
    <para>

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -44,7 +44,7 @@
   </section>
 
   <section xml:id="stringable.examples">
-   &reftitle.examples;
+   <title>Ejemplos de Stringable</title>
    <para>
     <example xml:id="stringable.basic-example">
      <title>Ejemplo simple</title>

--- a/language/predefined/stringable/tostring.xml
+++ b/language/predefined/stringable/tostring.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve la representación de un objeto en forma de string.
+   Devuelve la representación &string; del objeto.
   </para>
  </refsect1>
 

--- a/language/predefined/variables/globals.xml
+++ b/language/predefined/variables/globals.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>
-   Un array asociativo que contiene referencias a todas las variables
+   Un <type>array</type> asociativo que contiene referencias a todas las variables
    globales actualmente definidas en el contexto de ejecución global del
    script. Los nombres de las variables son los índices del array.
   </para>

--- a/language/predefined/variables/httpresponseheader.xml
+++ b/language/predefined/variables/httpresponseheader.xml
@@ -19,7 +19,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>
-   El array <varname>$http_response_header</varname> es similar a la función
+   El <varname>$http_response_header</varname> <type>array</type> es similar a la función
    <function>get_headers</function>. Al utilizar el
    <link linkend="wrappers.http">gestor HTTP</link>,
    <varname>$http_response_header</varname> será rellenado con las cabeceras

--- a/language/predefined/variables/request.xml
+++ b/language/predefined/variables/request.xml
@@ -28,8 +28,8 @@
     </link>, <emphasis>no</emphasis> se incluirán las entradas
     <link linkend="reserved.variables.argv">argv</link> y
     <link linkend="reserved.variables.argc">argc</link>; ya que están
-    presentes en el <type>array</type>
-    <varname>$_SERVER</varname>
+    presentes en el <varname>$_SERVER</varname>
+    <type>array</type>.
    </para>
   </note>
   <note>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1471,7 +1471,7 @@ print_r($files);
 
   <para>
    Debido a que el valor de un <type>array</type> puede ser cualquier cosa, también puede ser
-   otro <type>array</type>. Esto permite la creación de arrays recursivos y
+   otro <type>array</type>. Esto permite la creación de <type>array</type>s recursivos y
    multidimensionales.
   </para>
 

--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -11,7 +11,7 @@
  <sect2 xml:id="language.types.boolean.syntax">
   <title>Sintaxis</title>
   <para>
-   Para especificar un &boolean; literal, utilice la constante &true; o &false;. Ambas son insensibles a mayúsculas y minúsculas.
+   Para especificar un <type>bool</type> literal, utilice la constante &true; o &false;. Ambas son insensibles a mayúsculas y minúsculas.
   </para>
 
   <informalexample>
@@ -25,7 +25,7 @@ $foo = true; // asigna el valor TRUE a $foo
   </informalexample>
 
   <para>
-   Típicamente, el resultado de un <link linkend="language.operators">operador</link> que devuelve un &boolean;, pasado luego a una <link linkend="language.control-structures">estructura de control</link>.
+   Típicamente, el resultado de un <link linkend="language.operators">operador</link> que devuelve un <type>bool</type>, pasado luego a una <link linkend="language.control-structures">estructura de control</link>.
   </para>
 
   <informalexample>
@@ -64,7 +64,7 @@ if ($show_separators) {
   </simpara>
 
   <para>
-   Al convertir en &boolean;, los siguientes valores son considerados como &false;:
+   Al convertir en <type>bool</type>, los siguientes valores son considerados como &false;:
   </para>
 
   <itemizedlist>

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -281,7 +281,7 @@ Stack trace:
    <warning>
     <simpara>
      No es posible combinar los dos tipos de singleton
-     <literal>false</literal> y <literal>true</literal> juntos en una
+     <type>false</type> y <type>true</type> juntos en una
      unión de tipo.
      Utilice en su lugar <type>bool</type>.
     </simpara>
@@ -292,8 +292,8 @@ Stack trace:
      Anterior a PHP 8.2.0, como <type>false</type> y <type>null</type> no
      podían ser utilizados como tipos autónomos, una unión de tipo
      compuesta únicamente de estos tipos no estaba permitida. Esto incluye los
-     tipos siguientes: <type>false</type>, <type>false|null</type>
-     y <type>?false</type>.
+     tipos siguientes: <type>false</type>, <literal>false|null</literal>
+     y <literal>?false</literal>.
     </simpara>
    </caution>
 

--- a/language/types/float.xml
+++ b/language/types/float.xml
@@ -7,8 +7,8 @@
  <title>Números de punto flotante</title>
 
  <para>
-  Los números de punto flotante (también conocidos como <literal>"floats"</literal>,
-  <literal>"doubles"</literal>, o  <literal>"números reales"</literal>)
+  Los números de punto flotante (también conocidos como "floats",
+  "doubles" o "números reales")
   pueden ser especificados utilizando las siguientes sintaxis:
  </para>
 
@@ -122,14 +122,14 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
 
   <para>
    Para probar la igualdad de valores de números de punto flotante, se utiliza un límite superior del error relativo al redondeo. Este valor es conocido
-   como el epsilon de la máquina, o el <literal>unit roundoff</literal>,
+   como el epsilon de la máquina, o unit roundoff,
    y es la diferencia más pequeña aceptable en los cálculos.
   </para>
 
-  <simpara>
+  <para>
    <varname>$a</varname> y <varname>$b</varname> son iguales en 5 números
    después de la coma.
-  </simpara>
+  </para>
 
   <example>
    <title>Comparación de números de punto flotante</title>

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -60,7 +60,7 @@ $a = 1_234_567; // un número decimal (a partir de PHP 7.4.0)
   </example>
 
   <para>
-   Formalmente, la estructura de un <type>entero</type> literal es a partir de PHP 8.1.0
+   Formalmente, la estructura de un <type>int</type> literal es a partir de PHP 8.1.0
    (anteriormente, los prefijos octales <literal>0o</literal> o <literal>0O</literal>
    no estaban permitidos, y antes de PHP 7.4.0, los underscores no estaban permitidos.
   </para>

--- a/language/types/iterable.xml
+++ b/language/types/iterable.xml
@@ -11,7 +11,7 @@
   Desde su introducción en PHP 7.1.0 y antes de PHP 8.2.0,
   <type>iterable</type> era un pseudo-tipo integrado que actuaba como
   el alias de tipo mencionado anteriormente y puede ser utilizado como una declaración de tipo.
-  <type>iterable</type> puede ser utilizado en un ciclo &foreach; y con
+  Un tipo iterable puede ser utilizado en un ciclo &foreach; y con
   <command>yield from</command> en un <link linkend="language.generators">generador</link>.
  </para>
 

--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -9,7 +9,7 @@
   <title>Inicialización de los objetos</title>
 
   <para>
-   Para crear un nuevo objeto, utilice la palabra clave <literal>new</literal>
+   Para crear un nuevo <type>object</type>, utilice la palabra clave <literal>new</literal>
    para instanciar una clase:
   </para>
 
@@ -43,8 +43,8 @@ $bar->do_foo();
  <sect2 xml:id="language.types.object.casting">
   <title>Conversión en un objeto</title>
   <para>
-   Si un objeto es convertido en un objeto, no será modificado.
-   Si un valor de cualquier tipo es convertido en un objeto,
+   Si un <type>object</type> es convertido en un <type>object</type>, no será modificado.
+   Si un valor de cualquier otro tipo es convertido en un <type>object</type>,
    se creará una nueva instancia de la clase interna <classname>stdClass</classname>.
    Si el valor es &null;, la nueva instancia estará vacía.
    Un <type>array</type> se convierte en <type>object</type> con las propiedades

--- a/language/types/resource.xml
+++ b/language/types/resource.xml
@@ -34,8 +34,8 @@
 
   <para>
    Gracias al sistema de conteo de referencias introducido con el Motor
-   Zend, un recurso que ya no es referenciado es detectado
-   automáticamente, y es liberado por el recolector de basura.  Por esta
+   Zend, un valor de tipo <type>resource</type> sin más referencias es detectado
+   automáticamente, y es liberado por el recolector de basura. Por esta
    razón, rara vez se necesita liberar la memoria manualmente.
   </para>
 
@@ -43,8 +43,7 @@
    <simpara>
     Los enlaces persistentes con bases de datos son una excepción a esta
     regla. Ellos <emphasis>no</emphasis> son destruidos por el recolector de
-    basura. Vea también la sección sobre <link
-    linkend="features.persistent-connections">conexiones persistentes</link>
+    basura. Vea también la sección sobre <link linkend="features.persistent-connections">conexiones persistentes</link>
     para más información.
    </simpara>
   </note>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -70,7 +70,7 @@
      A diferencia de las <link linkend="language.types.string.syntax.double">comillas dobles</link>
      y <link linkend="language.types.string.syntax.heredoc">sintaxis heredoc</link>,
      las <link linkend="language.variables">variables</link> y las secuencias de escape
-     para caracteres especiales <emphasis>no</emphasis> serán <emphasis>extendidas</emphasis>
+     para caracteres especiales <emphasis>no</emphasis> serán extendidas
      cuando se encuentren en <type>strings</type> entre comillas simples.
     </simpara>
    </note>
@@ -689,7 +689,8 @@ EOT;
     <simpara>
      Si un signo de dólar (<literal>$</literal>) es encontrado, los caracteres que lo siguen y que pueden ser utilizados en un nombre de variable serán interpretados como tales y sustituidos.
     </simpara>
-    <informalexample>
+    <example>
+     <title>Interpolación de strings</title>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -706,13 +707,12 @@ echo "Él bebió un poco de $juice jugo." . PHP_EOL;
 Él bebió un poco de manzana jugo.
 ]]>
      </screen>
-    </informalexample>
+    </example>
 
     <simpara>
      Formalmente, la estructura para la sintaxis de sustitución de variable básica es la siguiente:
     </simpara>
-    <example>
-     <title>Interpolación de strings</title>
+    <informalexample>
      <programlisting>
 <![CDATA[
 string-variable::
@@ -739,7 +739,7 @@ name::
 
 ]]>
      </programlisting>
-    </example>
+    </informalexample>
 
     <warning>
      <para>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -243,8 +243,8 @@
     <para>
      Los tipos que no forman parte de la lista de preferencias anterior no
      son objetivos admisibles para la coerción implícita. En particular,
-     ninguna restricción implícita a los tipos <literal>null</literal> y
-     <literal>false</literal> se produce.
+     ninguna restricción implícita a los tipos <type>null</type>, <type>false</type> y
+     <type>true</type> se produce.
     </para>
    </note>
 

--- a/language/types/type-system.xml
+++ b/language/types/type-system.xml
@@ -69,28 +69,28 @@
        <type>self</type>, <type>parent</type>, y <type>static</type>
        </simpara>
       </listitem>
-     </itemizedlist>
-    </listitem>
-    <listitem>
-     <simpara>
-      <link linkend="language.types.singleton">Tipos singleton</link>
-     </simpara>
-     <itemizedlist>
       <listitem>
-       <simpara><type>false</type></simpara>
+       <simpara>
+        <link linkend="language.types.singleton">Tipos singleton</link>
+       </simpara>
+       <itemizedlist>
+        <listitem>
+         <simpara><type>false</type></simpara>
+        </listitem>
+        <listitem>
+         <simpara><type>true</type></simpara>
+        </listitem>
+       </itemizedlist>
       </listitem>
       <listitem>
-       <simpara><type>true</type></simpara>
-      </listitem>
-     </itemizedlist>
-    </listitem>
-    <listitem>
-     <simpara>
-      Tipos unitarios
-     </simpara>
-     <itemizedlist>
-      <listitem>
-       <simpara><type>null</type></simpara>
+       <simpara>
+        Tipos unitarios
+       </simpara>
+       <itemizedlist>
+        <listitem>
+         <simpara><type>null</type></simpara>
+        </listitem>
+       </itemizedlist>
       </listitem>
      </itemizedlist>
     </listitem>

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -420,10 +420,10 @@ function test_superglobal()
     </example>
    </para>
    <note>
-    <para>
+    <simpara>
      Utilizar una clave <literal>global</literal> fuera de una función no es un
      error. Esta puede ser utilizada aún si el fichero está incluido desde el interior de una función.
-    </para>
+    </simpara>
    </note>
   </sect2>
 
@@ -808,7 +808,7 @@ echo "$a $hola";
    resolver un problema de ambigüedad. Si se escribe
    <varname>$$a[1]</varname>, el intérprete necesita saber si nos
    referimos a utilizar <varname>$a[1]</varname> como una variable, o si
-   se pretendía utilizar <varname>$$a</varname> como variable y el índice [1]
+   se pretendía utilizar <varname>$$a</varname> como variable y el índice <literal>[1]</literal>
    como índice de dicha variable. La sintaxis para resolver esta ambigüedad
    es: <varname>${$a[1]}</varname> para el primer caso y
    <varname>${$a}[1]</varname> para el segundo.

--- a/language/wrappers/audio.xml
+++ b/language/wrappers/audio.xml
@@ -32,7 +32,7 @@
    <simpara>
     Para usar la envoltura <filename>ogg://</filename> es necesario instalar
     la extensión <link xlink:href="&url.pecl.package;oggvorbis">OGG/Vorbis</link>
-    disponible en <link xlink:href="&url.pecl;">PECL</link>.
+    disponible en &link.pecl;.
    </simpara>
   </note>
  </refsect1><!-- }}} -->

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -21,7 +21,7 @@
    <simpara>
     Para poder usar la envoltura <filename>expect://</filename> se debe instalar
     la extensión <link xlink:href="&url.pecl.package;expect">Expect</link>
-    disponible en <link xlink:href="&url.pecl;">PECL</link>.
+    disponible en &link.pecl;.
    </simpara>
   </note>
   <simpara><filename>expect://</filename> (PECL) </simpara>

--- a/language/wrappers/file.xml
+++ b/language/wrappers/file.xml
@@ -23,7 +23,7 @@
   </para>
   <simpara>
    Con ciertas funciones como <function>fopen</function> y
-   <function>file_get_contents</function>, <function>include_path</function>
+   <function>file_get_contents</function>, <literal>include_path</literal>
    puede eventualmente ser analizada para encontrar los ficheros, si se proporciona una ruta relativa.
   </simpara>
  </refsect1><!-- }}} -->

--- a/language/wrappers/rar.xml
+++ b/language/wrappers/rar.xml
@@ -32,7 +32,7 @@
    Esta visualización es diferente de los directorios regulares en el sentido de que el flujo resultante
    no contendrá información como la fecha y hora de modificación, ya que la raíz del directorio no se
    almacena como una entrada individual en el archivo. El uso de esta envoltura con
-   <type>RecursiveDirectoryIterator</type> requiere la presencia del signo de número en la URL al acceder
+   <classname>RecursiveDirectoryIterator</classname> requiere la presencia del signo de número en la URL al acceder
    a la raíz, para construir correctamente las URLs de los hijos.
   </simpara>
   <note>

--- a/security/cgi-bin.xml
+++ b/security/cgi-bin.xml
@@ -144,7 +144,7 @@ AddHandler php-script .php
     <simpara>
      También si el método para asegurar las peticiones no es
      redirigido, como se describió en la sección anterior, no está
-     disponible, es necesario configurar un script doc_root que sea
+     disponible, es necesario configurar un script <link linkend="ini.doc-root">doc_root</link> que sea
      diferente de la raíz del documento web.
     </simpara>
     <simpara>
@@ -161,13 +161,14 @@ AddHandler php-script .php
     </simpara>
     <simpara>
      Otra opción utilizable es esta <link
-     linkend="ini.user-dir">user_dir</link>. Cuando user_dir no está configurado,
-     lo único que controla el fichero abierto es <parameter>doc_root</parameter>.
+     linkend="ini.user-dir">user_dir</link>. Cuando <parameter>user_dir</parameter> no está configurado,
+     lo único que controla el fichero abierto es
+     <parameter>doc_root</parameter>.
      Al abrir una URL como <filename
      role="url">http://mi.servidor/~usuario/documento.php</filename> no resulta
      en la apertura de un fichero bajo el directorio personal de los usuarios, pero si
      un fichero llamado <filename role="uri">~usuario/documento.php</filename> debajo de
-     doc_root (si, un nombre de directorio que inicia con una a tilde [<literal>~</literal>]).
+     <parameter>doc_root</parameter> (si, un nombre de directorio que inicia con una a tilde [<literal>~</literal>]).
     </simpara>
     <simpara>
      Si <parameter>user_dir</parameter> es configurado, por ejemplo <filename


### PR DESCRIPTION
## Summary

- Fix inline tag types (`<literal>` → `<constant>`, `<type>`, `<emphasis>`)
- Fix entity references
- Fix indentation and nesting
- Add missing markup elements to match doc-en
- Covers: `language/`, `appendices/`, `install/`, `faq/`, `security/`, `features/`, `chapters/`