### PR TITLE
Sync EN: Add curly brace escaping example in strings

### DIFF
--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f90b26b377a61c76c0f64028e47553e550411d08 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fee54c7c435a1664a7a8b0e7b7de7cec4a084c45 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.boolean">
  <title>Booleano</title>
@@ -100,7 +100,7 @@ if ($show_separators) {
    </listitem>
    <listitem>
     <simpara>
-     los objetos internos que sobrecargan su comportamiento de casting en booleano. Por ejemplo: los <link linkend="ref.simplexml">objetos SimpleXML</link> creados a partir de elementos vacíos sin atributos.
+     los objetos internos que sobrecargan su comportamiento de casting en booleano. Por ejemplo: los <link linkend="ref.simplexml">objetos SimpleXML</link> creados a partir de elementos vacíos sin atributos, o los objetos <classname>GMP</classname> que representan el valor <literal>0</literal>.
     </simpara>
    </listitem>
   </itemizedlist>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2832df2e1bd7daa1ec29ffb167dce1c9feb8cc6b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ddc2a2d0966f746b67292b6c0987ef288747e409 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: girgias -->
 <sect1 xml:id="language.types.string">
  <title>Cadenas</title>
@@ -921,10 +921,13 @@ $arr = [
 ];
 
 // No funcionará, mostrará: Esto es { fantástico}
-echo "Esto es { $great}";
+echo "Esto es { $great}" . PHP_EOL;
 
 // Funciona, mostrará: Esto es fantástico
-echo "Esto es {$great}";
+echo "Esto es {$great}" . PHP_EOL;
+
+// Para mostrar llaves en la salida:
+echo "Esto es {{$great}}" . PHP_EOL;
 
 class Square {
     public $width;
@@ -935,29 +938,29 @@ class Square {
 $square = new Square(5);
 
 // Funciona
-echo "Este cuadrado mide {$square->width}00 centímetros de ancho.";
+echo "Este cuadrado mide {$square->width}00 centímetros de ancho." . PHP_EOL;
 
 // Funciona, las claves entre comillas solo funcionan con la sintaxis de llaves
-echo "Esto funciona: {$arr['key']}";
+echo "Esto funciona: {$arr['key']}" . PHP_EOL;
 
 // Funciona
-echo "Esto funciona: {$arr[3][2]}";
+echo "Esto funciona: {$arr[3][2]}" . PHP_EOL;
 
-echo "Esto funciona: {$arr[DATA_KEY]}";
+echo "Esto funciona: {$arr[DATA_KEY]}" . PHP_EOL;
 
 // Al utilizar arrays multidimensionales, siempre use llaves alrededor de los arrays
 // cuando estén dentro de strings
-echo "Esto funciona: {$arr['foo'][2]}";
+echo "Esto funciona: {$arr['foo'][2]}" . PHP_EOL;
 
-echo "Esto funciona: {$obj->values[3]->name}";
+echo "Esto funciona: {$obj->values[3]->name}" . PHP_EOL;
 
-echo "Esto funciona: {$obj->$staticProp}";
+echo "Esto funciona: {$obj->$staticProp}" . PHP_EOL;
 
 // No funcionará, mostrará: C:\directory\{fantástico}.txt
-echo "C:\directory\{$great}.txt";
+echo "C:\directory\{$great}.txt" . PHP_EOL;
 
 // Funciona, mostrará: C:\directory\fantástico.txt
-echo "C:\\directory\\{$great}.txt";
+echo "C:\\directory\\{$great}.txt" . PHP_EOL;
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
## Summary

- Add `. PHP_EOL` to echo statements in curly brace syntax example
- Add new escaping example showing `{{$var}}` syntax

Fixes #463