### PR TITLE
Sync EN: Add inherited class example to AllowDynamicProperties

### DIFF
--- a/language/predefined/attributes/allowdynamicproperties.xml
+++ b/language/predefined/attributes/allowdynamicproperties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: be3574f52a050f3dd9aa6ca9dffc19b0484c250a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos-->
 <reference xml:id="class.allowdynamicproperties" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>El atributo AllowDynamicProperties</title>
@@ -9,10 +9,19 @@
 
   <section xml:id="allowdynamicproperties.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Este atributo se utiliza para marcar clases que permiten
     <link linkend="language.oop5.properties.dynamic-properties">propiedades dinámicas</link>.
-   </para>
+   </simpara>
+   <note>
+    <simpara>
+     Aunque los atributos en sí no se heredan, el efecto del atributo
+     <literal>AllowDynamicProperties</literal> <emphasis>sí</emphasis>
+     se hereda. Las clases hijas de una clase marcada con este atributo también
+     permitirán propiedades dinámicas, incluso si no declaran el atributo
+     explícitamente.
+    </simpara>
+   </note>
   </section>
 
   <section xml:id="allowdynamicproperties.synopsis">
@@ -35,12 +44,13 @@
 
   <section>
    &reftitle.examples;
-   <para>
+   <simpara>
     Las propiedades dinámicas están deprecadas a partir de PHP 8.2.0,
     por lo que usarlas sin marcar la clase con este atributo emitirá
     un aviso de deprecación.
-   </para>
-   <informalexample>
+   </simpara>
+   <example>
+    <title>AllowDynamicProperties con propiedad inexistente</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -63,12 +73,39 @@ $o2->nonExistingProp = true;
 Deprecated: Creation of dynamic property DefaultBehaviour::$nonExistingProp is deprecated in file on line 10
 ]]>
     </screen>
-   </informalexample>
+   </example>
+   <example>
+    <title>AllowDynamicProperties con propiedad inexistente en clase heredada</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+class DefaultBehaviour { }
+
+#[\AllowDynamicProperties]
+class ClassAllowsDynamicProperties { }
+
+class InheritedClassAllowsDynamicProperties extends ClassAllowsDynamicProperties { }
+
+$o1 = new DefaultBehaviour();
+$o2 = new InheritedClassAllowsDynamicProperties();
+
+$o1->nonExistingProp = true;
+$o2->nonExistingProp = true;
+?>
+]]>
+    </programlisting>
+    &example.outputs.82;
+    <screen>
+     <![CDATA[
+Deprecated: Creation of dynamic property DefaultBehaviour::$nonExistingProp is deprecated in file on line 12
+]]>
+    </screen>
+   </example>
   </section>
 
   <section xml:id="allowdynamicproperties.seealso">
    &reftitle.seealso;
-   <para><link linkend="language.attributes">Visión general de los atributos</link></para>
+   <simpara><link linkend="language.attributes">Visión general de los atributos</link></simpara>
   </section>
 
  </partintro>

--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f90b26b377a61c76c0f64028e47553e550411d08 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fee54c7c435a1664a7a8b0e7b7de7cec4a084c45 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.boolean">
  <title>Booleano</title>
@@ -100,7 +100,7 @@ if ($show_separators) {
    </listitem>
    <listitem>
     <simpara>
-     los objetos internos que sobrecargan su comportamiento de casting en booleano. Por ejemplo: los <link linkend="ref.simplexml">objetos SimpleXML</link> creados a partir de elementos vacíos sin atributos.
+     los objetos internos que sobrecargan su comportamiento de casting en booleano. Por ejemplo: los <link linkend="ref.simplexml">objetos SimpleXML</link> creados a partir de elementos vacíos sin atributos, o los objetos <classname>GMP</classname> que representan el valor <literal>0</literal>.
     </simpara>
    </listitem>
   </itemizedlist>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2832df2e1bd7daa1ec29ffb167dce1c9feb8cc6b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ddc2a2d0966f746b67292b6c0987ef288747e409 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: girgias -->
 <sect1 xml:id="language.types.string">
  <title>Cadenas</title>
@@ -921,10 +921,13 @@ $arr = [
 ];
 
 // No funcionará, mostrará: Esto es { fantástico}
-echo "Esto es { $great}";
+echo "Esto es { $great}" . PHP_EOL;
 
 // Funciona, mostrará: Esto es fantástico
-echo "Esto es {$great}";
+echo "Esto es {$great}" . PHP_EOL;
+
+// Para mostrar llaves en la salida:
+echo "Esto es {{$great}}" . PHP_EOL;
 
 class Square {
     public $width;
@@ -935,29 +938,29 @@ class Square {
 $square = new Square(5);
 
 // Funciona
-echo "Este cuadrado mide {$square->width}00 centímetros de ancho.";
+echo "Este cuadrado mide {$square->width}00 centímetros de ancho." . PHP_EOL;
 
 // Funciona, las claves entre comillas solo funcionan con la sintaxis de llaves
-echo "Esto funciona: {$arr['key']}";
+echo "Esto funciona: {$arr['key']}" . PHP_EOL;
 
 // Funciona
-echo "Esto funciona: {$arr[3][2]}";
+echo "Esto funciona: {$arr[3][2]}" . PHP_EOL;
 
-echo "Esto funciona: {$arr[DATA_KEY]}";
+echo "Esto funciona: {$arr[DATA_KEY]}" . PHP_EOL;
 
 // Al utilizar arrays multidimensionales, siempre use llaves alrededor de los arrays
 // cuando estén dentro de strings
-echo "Esto funciona: {$arr['foo'][2]}";
+echo "Esto funciona: {$arr['foo'][2]}" . PHP_EOL;
 
-echo "Esto funciona: {$obj->values[3]->name}";
+echo "Esto funciona: {$obj->values[3]->name}" . PHP_EOL;
 
-echo "Esto funciona: {$obj->$staticProp}";
+echo "Esto funciona: {$obj->$staticProp}" . PHP_EOL;
 
 // No funcionará, mostrará: C:\directory\{fantástico}.txt
-echo "C:\directory\{$great}.txt";
+echo "C:\directory\{$great}.txt" . PHP_EOL;
 
 // Funciona, mostrará: C:\directory\fantástico.txt
-echo "C:\\directory\\{$great}.txt";
+echo "C:\\directory\\{$great}.txt" . PHP_EOL;
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
## Summary

- Change `<para>` to `<simpara>` to match doc-en
- Add note about attribute inheritance
- Change `<informalexample>` to `<example>` with title
- Add new example showing inherited class behavior

Fixes #464