### PR TITLE
Sync EN: Add GMP as example of internal object overloading bool cast

### DIFF
--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f90b26b377a61c76c0f64028e47553e550411d08 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fee54c7c435a1664a7a8b0e7b7de7cec4a084c45 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.boolean">
  <title>Booleano</title>
@@ -100,7 +100,7 @@ if ($show_separators) {
    </listitem>
    <listitem>
     <simpara>
-     los objetos internos que sobrecargan su comportamiento de casting en booleano. Por ejemplo: los <link linkend="ref.simplexml">objetos SimpleXML</link> creados a partir de elementos vacíos sin atributos.
+     los objetos internos que sobrecargan su comportamiento de casting en booleano. Por ejemplo: los <link linkend="ref.simplexml">objetos SimpleXML</link> creados a partir de elementos vacíos sin atributos, o los objetos <classname>GMP</classname> que representan el valor <literal>0</literal>.
     </simpara>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
## Summary

- Add GMP objects representing value 0 as example of internal objects that cast to false

Fixes #465