### PR TITLE
Translate ext/uri documentation to Spanish

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4864,6 +4864,19 @@ Las fuentes de aleatoriedad por orden de prioridad son las siguientes:
  </listitem>
 '>
 
+ <!-- URI snippets -->
+ <!ENTITY uri.errors.invalidUriException '
+  <simpara>
+   Si la URI resultante es inválida, se lanza una excepción <exceptionname>Uri\InvalidUriException</exceptionname>.
+  </simpara>
+ '>
+
+ <!ENTITY uri.errors.invalidUrlException '
+  <simpara>
+   Si la URL resultante es inválida, se lanza una excepción <exceptionname>Uri\WhatWg\InvalidUrlException</exceptionname>.
+  </simpara>
+ '>
+
  <!-- UOPZ snippets -->
 
  <!ENTITY uopz.warn.removed.function-5-0-0 '<warning

--- a/reference/uri/book.xml
+++ b/reference/uri/book.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4f62b60b56562114d9d816e2e5f13b40a5614c26 Maintainer: lacatoire Status: ready -->
+<book xml:id="book.uri" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
+ <?phpdoc extension-membership="core" ?>
+ <title>URI</title>
+ <titleabbrev>URI</titleabbrev>
+
+ <preface xml:id="intro.uri">
+  &reftitle.intro;
+  <simpara>
+   Este capítulo describe las funciones que permiten trabajar con
+   Identificadores de Recursos Uniformes (URIs). Una URI es una cadena de
+   caracteres utilizada para identificar un recurso. Las URIs se utilizan en
+   las tecnologías web para identificar recursos en Internet.
+  </simpara>
+  <simpara>
+   Esta extensión implementa funcionalidades que siguen las especificaciones
+   <link xlink:href="&url.url.rfc3986;">RFC 3986,
+   Uniform Resource Identifier (URI): Generic Syntax</link> y
+   <link xlink:href="&url.url.whatwg-url;">WHATWG URL Standard</link>.
+  </simpara>
+ </preface>
+
+ &reference.uri.uri.rfc3986.uri;
+
+ &reference.uri.uri.whatwg.url;
+
+ &reference.uri.uri.uricomparisonmode;
+
+ &reference.uri.uri.uriexception;
+ &reference.uri.uri.urierror;
+ &reference.uri.uri.invaliduriexception;
+ &reference.uri.uri.whatwg.invalidurlexception;
+ &reference.uri.uri.whatwg.urlvalidationerror;
+ &reference.uri.uri.whatwg.urlvalidationerrortype;
+</book>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.invaliduriexception.xml
+++ b/reference/uri/uri.invaliduriexception.xml
@@ -8,7 +8,7 @@
   <section xml:id="uri-invaliduriexception.intro">
    &reftitle.intro;
    <simpara>
-    Indica que una URI dada es inv&aacute;lida o que una operaci&oacute;n resultar&iacute;a en una URI inv&aacute;lida.
+    Indica que una URI dada es inválida o que una operación resultaría en una URI inválida.
    </simpara>
   </section>
 

--- a/reference/uri/uri.invaliduriexception.xml
+++ b/reference/uri/uri.invaliduriexception.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-invaliduriexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La clase Uri\InvalidUriException</title>
+ <titleabbrev>Uri\InvalidUriException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-invaliduriexception.intro">
+   &reftitle.intro;
+   <simpara>
+    Indica que una URI dada es inv&aacute;lida o que una operaci&oacute;n resultar&iacute;a en una URI inv&aacute;lida.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-invaliduriexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>InvalidUriException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Uri\UriException</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.rfc3986.uri.xml
+++ b/reference/uri/uri.rfc3986.uri.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e4aca6ce959c13feaaf1a1c880defd94cb2d8b06 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-rfc3986-uri" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La clase Uri\Rfc3986\Uri</title>
+ <titleabbrev>Uri\Rfc3986\Uri</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-rfc3986-uri.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="uri-rfc3986-uri.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\Rfc3986</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>Uri</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\Rfc3986\\Uri'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\Rfc3986\\Uri'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.rfc3986.entities.uri;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.uricomparisonmode.xml
+++ b/reference/uri/uri.uricomparisonmode.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<reference xml:id="enum.uri-uricomparisonmode" role="enum" xmlns="http://docbook.org/ns/docbook">
+ <title>La enumeraci&oacute;n Uri\UriComparisonMode</title>
+ <titleabbrev>Uri\UriComparisonMode</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.uri-uricomparisonmode.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="enum.uri-uricomparisonmode.synopsis">
+   &reftitle.enumsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <enumsynopsis>
+     <enumname>UriComparisonMode</enumname>
+
+     <enumitem>
+      <enumidentifier>IncludeFragment</enumidentifier>
+      <enumitemdescription>El componente <literal>fragment</literal> se incluye en la comparaci&oacute;n.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>ExcludeFragment</enumidentifier>
+      <enumitemdescription>El componente <literal>fragment</literal> se excluye de la comparaci&oacute;n.</enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.uricomparisonmode.xml
+++ b/reference/uri/uri.uricomparisonmode.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
 <reference xml:id="enum.uri-uricomparisonmode" role="enum" xmlns="http://docbook.org/ns/docbook">
- <title>La enumeraci&oacute;n Uri\UriComparisonMode</title>
+ <title>La enumeración Uri\UriComparisonMode</title>
  <titleabbrev>Uri\UriComparisonMode</titleabbrev>
 
  <partintro>
@@ -22,12 +22,12 @@
 
      <enumitem>
       <enumidentifier>IncludeFragment</enumidentifier>
-      <enumitemdescription>El componente <literal>fragment</literal> se incluye en la comparaci&oacute;n.</enumitemdescription>
+      <enumitemdescription>El componente <literal>fragment</literal> se incluye en la comparación.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>ExcludeFragment</enumidentifier>
-      <enumitemdescription>El componente <literal>fragment</literal> se excluye de la comparaci&oacute;n.</enumitemdescription>
+      <enumitemdescription>El componente <literal>fragment</literal> se excluye de la comparación.</enumitemdescription>
      </enumitem>
     </enumsynopsis>
    </packagesynopsis>

--- a/reference/uri/uri.urierror.xml
+++ b/reference/uri/uri.urierror.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-urierror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La clase Uri\UriError</title>
+ <titleabbrev>Uri\UriError</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-urierror.intro">
+   &reftitle.intro;
+   <simpara>
+    La clase base para los errores (<type>Error</type>) que ocurren durante el procesamiento de URIs.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-urierror.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>UriError</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Error</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.uriexception.xml
+++ b/reference/uri/uri.uriexception.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-uriexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La clase Uri\UriException</title>
+ <titleabbrev>Uri\UriException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-uriexception.intro">
+   &reftitle.intro;
+   <simpara>
+    La clase base para las excepciones (<type>Exception</type>) que ocurren durante el procesamiento de URIs.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-uriexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>UriException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Exception</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.invalidurlexception.xml
+++ b/reference/uri/uri.whatwg.invalidurlexception.xml
@@ -8,9 +8,9 @@
   <section xml:id="uri-whatwg-invalidurlexception.intro">
    &reftitle.intro;
    <simpara>
-    Indica que una URL dada es inv&aacute;lida o que una operaci&oacute;n
-    resultar&iacute;a en una URL inv&aacute;lida seg&uacute;n el
-    <link xlink:href="&url.url.whatwg-url;">est&aacute;ndar WHATWG URL</link>.
+    Indica que una URL dada es inválida o que una operación
+    resultaría en una URL inválida según el
+    <link xlink:href="&url.url.whatwg-url;">estándar WHATWG URL</link>.
    </simpara>
   </section>
 

--- a/reference/uri/uri.whatwg.invalidurlexception.xml
+++ b/reference/uri/uri.whatwg.invalidurlexception.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-whatwg-invalidurlexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La clase Uri\WhatWg\InvalidUrlException</title>
+ <titleabbrev>Uri\WhatWg\InvalidUrlException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-invalidurlexception.intro">
+   &reftitle.intro;
+   <simpara>
+    Indica que una URL dada es inv&aacute;lida o que una operaci&oacute;n
+    resultar&iacute;a en una URL inv&aacute;lida seg&uacute;n el
+    <link xlink:href="&url.url.whatwg-url;">est&aacute;ndar WHATWG URL</link>.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-invalidurlexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>InvalidUrlException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Uri\InvalidUriException</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>readonly</modifier>
+      <type>array</type>
+      <varname linkend="uri-whatwg-invalidurlexception.props.errors">errors</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-invalidurlexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\InvalidUrlException'])">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+
+  <section xml:id="uri-whatwg-invalidurlexception.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="uri-whatwg-invalidurlexception.props.errors">
+     <term><varname>errors</varname></term>
+     <listitem>
+      <simpara>
+       Un &array; de objetos <classname>Uri\WhatWg\UrlValidationError</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.invalidurlexception;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.url.xml
+++ b/reference/uri/uri.whatwg.url.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e4aca6ce959c13feaaf1a1c880defd94cb2d8b06 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-whatwg-url" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La clase Uri\WhatWg\Url</title>
+ <titleabbrev>Uri\WhatWg\Url</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-url.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-url.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>Url</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\Url'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\WhatWg\\Url'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.url;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.urlvalidationerror.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerror.xml
@@ -58,7 +58,7 @@
      <term><varname>context</varname></term>
      <listitem>
       <simpara>
-       La URL de entrada en el punto donde se detect&oacute; el error.
+       La URL de entrada en el punto donde se detectó el error.
       </simpara>
      </listitem>
     </varlistentry>
@@ -74,8 +74,8 @@
      <term><varname>failure</varname></term>
      <listitem>
       <simpara>
-       Si es &true;, el error provoc&oacute; que la URL fuera rechazada como inv&aacute;lida. Si es &false;,
-       el error es un error leve que fue corregido autom&aacute;ticamente durante el an&aacute;lisis.
+       Si es &true;, el error provocó que la URL fuera rechazada como inválida. Si es &false;,
+       el error es un error leve que fue corregido automáticamente durante el análisis.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/uri/uri.whatwg.urlvalidationerror.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerror.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b6e9565ba267f4c9a463104ffb0ea45e1a6753b0 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.uri-whatwg-urlvalidationerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La clase Uri\WhatWg\UrlValidationError</title>
+ <titleabbrev>Uri\WhatWg\UrlValidationError</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-urlvalidationerror.intro">
+   &reftitle.intro;
+   <simpara>
+    Proporciona detalles sobre los errores detectados al analizar una URL con
+    <classname>Uri\WhatWg\Url</classname>.
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-urlvalidationerror.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>UrlValidationError</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>string</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.context">context</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>Uri\WhatWg\UrlValidationErrorType</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.type">type</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>bool</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.failure">failure</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-urlvalidationerror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\UrlValidationError'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+
+  <section xml:id="uri-whatwg-urlvalidationerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.context">
+     <term><varname>context</varname></term>
+     <listitem>
+      <simpara>
+       La URL de entrada en el punto donde se detect&oacute; el error.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.type">
+     <term><varname>type</varname></term>
+     <listitem>
+      <simpara>
+       El tipo de error.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.failure">
+     <term><varname>failure</varname></term>
+     <listitem>
+      <simpara>
+       Si es &true;, el error provoc&oacute; que la URL fuera rechazada como inv&aacute;lida. Si es &false;,
+       el error es un error leve que fue corregido autom&aacute;ticamente durante el an&aacute;lisis.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.urlvalidationerror;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.urlvalidationerrortype.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerrortype.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
 <reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns="http://docbook.org/ns/docbook">
- <title>La enumeraci&oacute;n Uri\WhatWg\UrlValidationErrorType</title>
+ <title>La enumeración Uri\WhatWg\UrlValidationErrorType</title>
  <titleabbrev>Uri\WhatWg\UrlValidationErrorType</titleabbrev>
 
  <partintro>
@@ -22,116 +22,116 @@
 
      <enumitem>
       <enumidentifier>DomainToAscii</enumidentifier>
-      <enumitemdescription>Error durante el proceso de conversi&oacute;n del nombre de dominio a una cadena ASCII.</enumitemdescription>
+      <enumitemdescription>Error durante el proceso de conversión del nombre de dominio a una cadena ASCII.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>DomainToUnicode</enumidentifier>
-      <enumitemdescription>Error durante el proceso de conversi&oacute;n del nombre de dominio a una cadena Unicode.</enumitemdescription>
+      <enumitemdescription>Error durante el proceso de conversión del nombre de dominio a una cadena Unicode.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>DomainInvalidCodePoint</enumidentifier>
-      <enumitemdescription>El host de la entrada contiene un punto de c&oacute;digo de dominio prohibido.</enumitemdescription>
+      <enumitemdescription>El host de la entrada contiene un punto de código de dominio prohibido.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>HostInvalidCodePoint</enumidentifier>
-      <enumitemdescription>Un host opaco (en una URL que no es especial) contiene un punto de c&oacute;digo de host prohibido.</enumitemdescription>
+      <enumitemdescription>Un host opaco (en una URL que no es especial) contiene un punto de código de host prohibido.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4EmptyPart</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv4 termina con un <literal>U+002E</literal> (<literal>.</literal>).</enumitemdescription>
+      <enumitemdescription>Una dirección IPv4 termina con un <literal>U+002E</literal> (<literal>.</literal>).</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4TooManyParts</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv4 no consta exactamente de 4 partes.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv4 no consta exactamente de 4 partes.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4NonNumericPart</enumidentifier>
-      <enumitemdescription>Una parte de la direcci&oacute;n IPv4 no es num&eacute;rica.</enumitemdescription>
+      <enumitemdescription>Una parte de la dirección IPv4 no es numérica.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4NonDecimalPart</enumidentifier>
-      <enumitemdescription>La direcci&oacute;n IPv4 contiene n&uacute;meros expresados con d&iacute;gitos hexadecimales u octales.</enumitemdescription>
+      <enumitemdescription>La dirección IPv4 contiene números expresados con dígitos hexadecimales u octales.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4OutOfRangePart</enumidentifier>
-      <enumitemdescription>Una parte de la direcci&oacute;n IPv4 supera <literal>255</literal>.</enumitemdescription>
+      <enumitemdescription>Una parte de la dirección IPv4 supera <literal>255</literal>.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv6Unclosed</enumidentifier>
-      <enumitemdescription>A una direcci&oacute;n IPv6 le falta el cierre <literal>U+005D</literal> (<literal>]</literal>).</enumitemdescription>
+      <enumitemdescription>A una dirección IPv6 le falta el cierre <literal>U+005D</literal> (<literal>]</literal>).</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv6InvalidCompression</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv6 comienza con una compresi&oacute;n incorrecta.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv6 comienza con una compresión incorrecta.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv6TooManyPieces</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv6 contiene m&aacute;s de 8 piezas.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv6 contiene más de 8 piezas.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv6MultipleCompression</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv6 est&aacute; comprimida en m&aacute;s de un lugar.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv6 está comprimida en más de un lugar.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv6InvalidCodePoint</enumidentifier>
       <enumitemdescription>
-       Una direcci&oacute;n IPv6 contiene un punto de c&oacute;digo que no es ni un d&iacute;gito hexadecimal ASCII
+       Una dirección IPv6 contiene un punto de código que no es ni un dígito hexadecimal ASCII
        ni un <literal>U+003A</literal> (<literal>:</literal>). O termina de forma inesperada.
       </enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv6TooFewPieces</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv6 sin compresi&oacute;n contiene menos de 8 piezas.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv6 sin compresión contiene menos de 8 piezas.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4InIpv6TooManyPieces</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv6 con sintaxis de direcci&oacute;n IPv4: la direcci&oacute;n IPv6 tiene m&aacute;s de 6 piezas.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv6 con sintaxis de dirección IPv4: la dirección IPv6 tiene más de 6 piezas.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4InIpv6InvalidCodePoint</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv6 con sintaxis de direcci&oacute;n IPv4.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv6 con sintaxis de dirección IPv4.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4InIpv6OutOfRangePart</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv6 con sintaxis de direcci&oacute;n IPv4: una parte IPv4 supera <literal>255</literal>.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv6 con sintaxis de dirección IPv4: una parte IPv4 supera <literal>255</literal>.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>Ipv4InIpv6TooFewParts</enumidentifier>
-      <enumitemdescription>Una direcci&oacute;n IPv6 con sintaxis de direcci&oacute;n IPv4: una direcci&oacute;n IPv4 contiene muy pocas partes.</enumitemdescription>
+      <enumitemdescription>Una dirección IPv6 con sintaxis de dirección IPv4: una dirección IPv4 contiene muy pocas partes.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>InvalidUrlUnit</enumidentifier>
-      <enumitemdescription>Se encontr&oacute; un punto de c&oacute;digo que no es una unidad de URL.</enumitemdescription>
+      <enumitemdescription>Se encontró un punto de código que no es una unidad de URL.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>SpecialSchemeMissingFollowingSolidus</enumidentifier>
-      <enumitemdescription>El esquema de la entrada no est&aacute; seguido de <literal>//</literal>.</enumitemdescription>
+      <enumitemdescription>El esquema de la entrada no está seguido de <literal>//</literal>.</enumitemdescription>
      </enumitem>
 
      <enumitem>
       <enumidentifier>MissingSchemeNonRelativeUrl</enumidentifier>
       <enumitemdescription>
-       La entrada carece de un esquema, porque no comienza con un car&aacute;cter alfab&eacute;tico ASCII, y no se proporcion&oacute;
+       La entrada carece de un esquema, porque no comienza con un carácter alfabético ASCII, y no se proporcionó
        una URL base o la URL base no puede utilizarse como URL base porque tiene una ruta opaca.
       </enumitemdescription>
      </enumitem>
@@ -159,7 +159,7 @@
 
      <enumitem>
       <enumidentifier>PortInvalid</enumidentifier>
-      <enumitemdescription>El puerto de la entrada es inv&aacute;lido.</enumitemdescription>
+      <enumitemdescription>El puerto de la entrada es inválido.</enumitemdescription>
      </enumitem>
 
      <enumitem>

--- a/reference/uri/uri.whatwg.urlvalidationerrortype.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerrortype.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns="http://docbook.org/ns/docbook">
+ <title>La enumeraci&oacute;n Uri\WhatWg\UrlValidationErrorType</title>
+ <titleabbrev>Uri\WhatWg\UrlValidationErrorType</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.uri-whatwg-urlvalidationerrortype.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="enum.uri-whatwg-urlvalidationerrortype.synopsis">
+   &reftitle.enumsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <enumsynopsis>
+     <enumname>UrlValidationErrorType</enumname>
+
+     <enumitem>
+      <enumidentifier>DomainToAscii</enumidentifier>
+      <enumitemdescription>Error durante el proceso de conversi&oacute;n del nombre de dominio a una cadena ASCII.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>DomainToUnicode</enumidentifier>
+      <enumitemdescription>Error durante el proceso de conversi&oacute;n del nombre de dominio a una cadena Unicode.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>DomainInvalidCodePoint</enumidentifier>
+      <enumitemdescription>El host de la entrada contiene un punto de c&oacute;digo de dominio prohibido.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>HostInvalidCodePoint</enumidentifier>
+      <enumitemdescription>Un host opaco (en una URL que no es especial) contiene un punto de c&oacute;digo de host prohibido.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4EmptyPart</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv4 termina con un <literal>U+002E</literal> (<literal>.</literal>).</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4TooManyParts</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv4 no consta exactamente de 4 partes.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4NonNumericPart</enumidentifier>
+      <enumitemdescription>Una parte de la direcci&oacute;n IPv4 no es num&eacute;rica.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4NonDecimalPart</enumidentifier>
+      <enumitemdescription>La direcci&oacute;n IPv4 contiene n&uacute;meros expresados con d&iacute;gitos hexadecimales u octales.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4OutOfRangePart</enumidentifier>
+      <enumitemdescription>Una parte de la direcci&oacute;n IPv4 supera <literal>255</literal>.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6Unclosed</enumidentifier>
+      <enumitemdescription>A una direcci&oacute;n IPv6 le falta el cierre <literal>U+005D</literal> (<literal>]</literal>).</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6InvalidCompression</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv6 comienza con una compresi&oacute;n incorrecta.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6TooManyPieces</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv6 contiene m&aacute;s de 8 piezas.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6MultipleCompression</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv6 est&aacute; comprimida en m&aacute;s de un lugar.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6InvalidCodePoint</enumidentifier>
+      <enumitemdescription>
+       Una direcci&oacute;n IPv6 contiene un punto de c&oacute;digo que no es ni un d&iacute;gito hexadecimal ASCII
+       ni un <literal>U+003A</literal> (<literal>:</literal>). O termina de forma inesperada.
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6TooFewPieces</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv6 sin compresi&oacute;n contiene menos de 8 piezas.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6TooManyPieces</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv6 con sintaxis de direcci&oacute;n IPv4: la direcci&oacute;n IPv6 tiene m&aacute;s de 6 piezas.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6InvalidCodePoint</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv6 con sintaxis de direcci&oacute;n IPv4.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6OutOfRangePart</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv6 con sintaxis de direcci&oacute;n IPv4: una parte IPv4 supera <literal>255</literal>.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6TooFewParts</enumidentifier>
+      <enumitemdescription>Una direcci&oacute;n IPv6 con sintaxis de direcci&oacute;n IPv4: una direcci&oacute;n IPv4 contiene muy pocas partes.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidUrlUnit</enumidentifier>
+      <enumitemdescription>Se encontr&oacute; un punto de c&oacute;digo que no es una unidad de URL.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>SpecialSchemeMissingFollowingSolidus</enumidentifier>
+      <enumitemdescription>El esquema de la entrada no est&aacute; seguido de <literal>//</literal>.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>MissingSchemeNonRelativeUrl</enumidentifier>
+      <enumitemdescription>
+       La entrada carece de un esquema, porque no comienza con un car&aacute;cter alfab&eacute;tico ASCII, y no se proporcion&oacute;
+       una URL base o la URL base no puede utilizarse como URL base porque tiene una ruta opaca.
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidReverseSoldius</enumidentifier>
+      <enumitemdescription>La URL tiene un esquema especial y utiliza <literal>U+005C</literal> (<literal>\</literal>)
+       en lugar de <literal>U+002F</literal> (<literal>/</literal>).</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidCredentials</enumidentifier>
+      <enumitemdescription>La entrada incluye credenciales.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>HostMissing</enumidentifier>
+      <enumitemdescription>La entrada tiene un esquema especial, pero no contiene un host.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>PortOutOfRange</enumidentifier>
+      <enumitemdescription>El puerto de la entrada es demasiado grande.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>PortInvalid</enumidentifier>
+      <enumitemdescription>El puerto de la entrada es inv&aacute;lido.</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>FileInvalidWindowsDriveLetter</enumidentifier>
+      <enumitemdescription>
+       La entrada es una cadena de URL relativa que comienza con una letra de unidad Windows y
+       el esquema de la URL base es <literal>file</literal>.
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>FileInvalidWindowsDriveLetterHost</enumidentifier>
+      <enumitemdescription>El host de una URL <literal>file:</literal> es una letra de unidad Windows.</enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/construct.xml
+++ b/reference/uri/uri/rfc3986/uri/construct.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__construct</refname>
+  <refpurpose>Construye el objeto Uri</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <methodname>Uri\Rfc3986\Uri::__construct</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\Rfc3986\Uri</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Construye el objeto <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      URI a analizar.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      Cuando se pasa un &string;, <parameter>uri</parameter> se aplica sobre
+      <parameter>baseUrl</parameter>, si <parameter>uri</parameter> es una referencia relativa.
+      Si se pasa &null;, o <parameter>uri</parameter> no es una referencia relativa,
+      <parameter>baseUrl</parameter> no tiene ningún efecto.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/debuginfo.xml
+++ b/reference/uri/uri/rfc3986/uri/debuginfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__debugInfo</refname>
+  <refpurpose>Devuelve el estado interno de la URI</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\Rfc3986\Uri::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Devuelve el estado interno de la URI.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el estado interno de la URI como un &array;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__debugInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/equals.xml
+++ b/reference/uri/uri/rfc3986/uri/equals.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.equals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::equals</refname>
+  <refpurpose>Verifica si dos URIs son equivalentes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>bool</type><methodname>Uri\Rfc3986\Uri::equals</methodname>
+   <methodparam><type>Uri\Rfc3986\Uri</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type>Uri\UriComparisonMode</type><parameter>comparisonMode</parameter><initializer><constant>Uri\UriComparisonMode::ExcludeFragment</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Verifica si dos URIs son equivalentes.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      URI con la que comparar la URI actual.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>comparisonMode</parameter></term>
+    <listitem>
+     <simpara>
+      Indica si el componente de fragmento se tiene en cuenta en la comparación
+      (<literal>Uri\UriComparisonMode::IncludeFragment</literal>) o no
+      (<literal>Uri\UriComparisonMode::ExcludeFragment</literal>). Por defecto, el fragmento se excluye.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve &true; si las dos URIs son equivalentes, o &false; en caso contrario.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.equals.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::equals</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri1 = new \Uri\Rfc3986\Uri("https://example.com");
+$uri2 = new \Uri\Rfc3986\Uri("HTTPS://example.com");
+
+var_dump($uri1->equals($uri2));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::equals</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/getfragment.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getFragment</refname>
+  <refpurpose>Recupera el componente de fragmento normalizado</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de fragmento normalizado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de fragmento normalizado como un &string; si el componente de fragmento existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getfragment.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getFragment</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com#foo=bar");
+
+echo $uri->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/gethost.xml
+++ b/reference/uri/uri/rfc3986/uri/gethost.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getHost</refname>
+  <refpurpose>Recupera el componente de host normalizado</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de host normalizado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de host normalizado como un &string; si el componente de host existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.gethost.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getHost</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getpassword.xml
+++ b/reference/uri/uri/rfc3986/uri/getpassword.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPassword</refname>
+  <refpurpose>Recupera la contraseña normalizada</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera la parte de contraseña normalizada (el texto después del primer carácter <literal>:</literal>)
+   del componente userinfo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la contraseña normalizada como un &string; si el componente userinfo contiene un carácter <literal>:</literal>.
+   Se devuelve una cadena vacía cuando el componente userinfo no contiene un carácter <literal>:</literal>.
+   Se devuelve &null; cuando el componente userinfo no existe.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getpassword.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getPassword</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getpath.xml
+++ b/reference/uri/uri/rfc3986/uri/getpath.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPath</refname>
+  <refpurpose>Recupera el componente de ruta normalizado</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::getPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de ruta normalizado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de ruta normalizado como un &string;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getpath.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getPath</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+
+echo $uri->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getport.xml
+++ b/reference/uri/uri/rfc3986/uri/getport.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPort</refname>
+  <refpurpose>Recupera el componente de puerto normalizado</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getPort</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de puerto normalizado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de puerto normalizado como un &integer; si el componente de puerto existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getport.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getPort</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com:443");
+
+echo $uri->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::withPort</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getquery.xml
+++ b/reference/uri/uri/rfc3986/uri/getquery.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getQuery</refname>
+  <refpurpose>Recupera el componente de consulta normalizado</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de consulta normalizado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de consulta normalizado como un &string; si el componente de consulta existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getquery.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getQuery</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+
+echo $uri->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawfragment.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawFragment</refname>
+  <refpurpose>Recupera el componente de fragmento sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de fragmento sin procesar (no normalizado).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de fragmento sin procesar como un &string; si el componente de fragmento existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawfragment.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com#foo=bar");
+
+echo $uri->getRawFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawhost.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawhost.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawHost</refname>
+  <refpurpose>Recupera el componente de host sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de host sin procesar (no normalizado).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de host sin procesar como un &string; si el componente de host existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawhost.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getRawHost</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getRawHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawpassword.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawpassword.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawPassword</refname>
+  <refpurpose>Recupera la contraseña sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera la parte de contraseña sin procesar (no normalizada) (el texto después del primer carácter <literal>:</literal>)
+   del componente userinfo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la contraseña sin procesar (no normalizada) como un &string; si el componente userinfo contiene un carácter <literal>:</literal>.
+   Se devuelve una cadena vacía cuando el componente userinfo no contiene un carácter <literal>:</literal>.
+   Se devuelve &null; cuando el componente userinfo no existe.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawpassword.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawpath.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawpath.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawPath</refname>
+  <refpurpose>Recupera el componente de ruta sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::getRawPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de ruta sin procesar (no normalizado).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de ruta sin procesar como un &string;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawpath.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getRawPath</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+
+echo $uri->getRawPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawquery.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawquery.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawQuery</refname>
+  <refpurpose>Recupera el componente de consulta sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de consulta sin procesar (no normalizado).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de consulta sin procesar como un &string; si el componente de consulta existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawquery.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+
+echo $uri->getRawQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawscheme.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawScheme</refname>
+  <refpurpose>Recupera el componente de esquema sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de esquema sin procesar (no normalizado).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de esquema sin procesar como un &string; si el componente de esquema existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawscheme.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getRawScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawUserInfo</refname>
+  <refpurpose>Recupera el componente userinfo sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente userinfo sin procesar (no normalizado).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente userinfo sin procesar como un &string; si el componente userinfo existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawuserinfo.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user:password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawusername.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getrawusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawUsername</refname>
+  <refpurpose>Recupera el nombre de usuario sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera la parte del nombre de usuario sin procesar (no normalizado) (el texto antes del primer carácter <literal>:</literal>)
+   del componente userinfo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el nombre de usuario sin procesar (no normalizado) como un &string; si el componente userinfo existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawusername.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/getscheme.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getScheme</refname>
+  <refpurpose>Recupera el componente de esquema normalizado</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de esquema normalizado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de esquema normalizado como un &string; si el componente de esquema existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getscheme.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getScheme</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getuserinfo.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getUserInfo</refname>
+  <refpurpose>Recupera el componente userinfo normalizado</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente userinfo normalizado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente userinfo normalizado como un &string; si el componente userinfo existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getuserinfo.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user:password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getusername.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getUsername</refname>
+  <refpurpose>Recupera el nombre de usuario normalizado</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera la parte del nombre de usuario normalizado (el texto antes del primer carácter <literal>:</literal>)
+   del componente userinfo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el nombre de usuario normalizado como un &string; si el componente userinfo existe; de lo contrario, se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getusername.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::getUsername</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/parse.xml
+++ b/reference/uri/uri/rfc3986/uri/parse.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::parse</refname>
+  <refpurpose>Analiza una URI</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>static</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::parse</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\Rfc3986\Uri</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Analiza una URI.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      URI a analizar.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      Cuando se pasa un &string;, <parameter>uri</parameter> se aplica sobre
+      <parameter>baseUrl</parameter>, si <parameter>uri</parameter> es una referencia relativa.
+      Si se pasa &null;, o <parameter>uri</parameter> no es una referencia relativa,
+      <parameter>baseUrl</parameter> no tiene ningún efecto.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve una instancia de <classname>Uri\Rfc3986\Uri</classname> en caso de éxito, o &null; en caso de error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.parse.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::parse</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = \Uri\Rfc3986\Uri::parse("https://example.com");
+
+if ($uri !== null) {
+    echo "Valid URI: " . $uri->toString();
+} else {
+    echo "Invalid URI"
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Valid URI: https://example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/resolve.xml
+++ b/reference/uri/uri/rfc3986/uri/resolve.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.resolve" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::resolve</refname>
+  <refpurpose>Resuelve una URI con el objeto actual como URL base</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::resolve</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Resuelve una URI - que puede ser potencialmente una referencia relativa - con el objeto actual como URL base.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      Una URI a aplicar sobre el objeto actual.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Una nueva instancia de <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.resolve.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::resolve</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->resolve("/foo");
+
+echo $uri->toRawString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/serialize.xml
+++ b/reference/uri/uri/rfc3986/uri/serialize.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__serialize</refname>
+  <refpurpose>Serializa el objeto Uri</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\Rfc3986\Uri::__serialize</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Serializa el objeto <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la URI serializada como un &string;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__unserialize</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__serialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/torawstring.xml
+++ b/reference/uri/uri/rfc3986/uri/torawstring.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.torawstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::toRawString</refname>
+  <refpurpose>Recompone la URI sin procesar</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::toRawString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recompone la URI sin procesar (no normalizada) en un &string;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la URI recompuesta sin procesar (no normalizada) como un &string;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.torawstring.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::toRawString</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar?baz");
+
+echo $uri->toRawString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/tostring.xml
+++ b/reference/uri/uri/rfc3986/uri/tostring.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::toString</refname>
+  <refpurpose>Recompone la URI normalizada</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::toString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recompone la URI normalizada en un &string;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la URI recompuesta normalizada como un &string;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.tostring.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::toString</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar?baz");
+
+echo $uri->toString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/unserialize.xml
+++ b/reference/uri/uri/rfc3986/uri/unserialize.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__unserialize</refname>
+  <refpurpose>Deserializa el parámetro data en un objeto Uri</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>void</type><methodname>Uri\Rfc3986\Uri::__unserialize</methodname>
+   <methodparam><type>array</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Deserializa un parámetro data en un objeto <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+      Los datos serializados como un <type>array</type>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si el método <methodname>__unserialize</methodname> se llama sobre una URI ya existente,
+   se lanza un <exceptionname>Error</exceptionname>.
+  </simpara>
+
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__serialize</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__unserialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/withfragment.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withFragment</refname>
+  <refpurpose>Modifica el componente de fragmento</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withFragment</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>fragment</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URI y modifica su componente de fragmento.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fragment</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de fragmento.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia modificada de <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withfragment.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::withFragment</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+$uri = new \Uri\Rfc3986\Uri("https://example.com/#foo");
+$uri = $uri->withFragment("bar");
+
+echo $uri->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withhost.xml
+++ b/reference/uri/uri/rfc3986/uri/withhost.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withHost</refname>
+  <refpurpose>Modifica el componente de host</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withHost</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URI y modifica su componente de host.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de host.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia modificada de <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withhost.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::withHost</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->withHost("example.net");
+
+echo $uri->getHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.net
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withpath.xml
+++ b/reference/uri/uri/rfc3986/uri/withpath.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withPath</refname>
+  <refpurpose>Modifica el componente de ruta</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withPath</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URI y modifica su componente de ruta.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de ruta.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia modificada de <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withpath.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::withPath</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+$uri = $uri->withPath("/baz");
+
+echo $uri->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withport.xml
+++ b/reference/uri/uri/rfc3986/uri/withport.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withPort</refname>
+  <refpurpose>Modifica el componente de puerto</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withPort</methodname>
+   <methodparam><type class="union"><type>int</type><type>null</type></type><parameter>port</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URI y modifica su componente de puerto.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>port</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de puerto.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia modificada de <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withport.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::withPort</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com:8080");
+$uri = $uri->withPort(443);
+
+echo $uri->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPort</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withquery.xml
+++ b/reference/uri/uri/rfc3986/uri/withquery.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withQuery</refname>
+  <refpurpose>Modifica el componente de consulta</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withQuery</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>query</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URI y modifica su componente de consulta.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>query</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de consulta.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia modificada de <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withquery.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::withQuery</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+$uri = $uri->withQuery("foo=baz");
+
+echo $uri->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/withscheme.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withScheme</refname>
+  <refpurpose>Modifica el componente de esquema</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withScheme</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>scheme</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URI y modifica su componente de esquema.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>scheme</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de esquema.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia modificada de <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withscheme.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::withScheme</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->withScheme("http");
+
+echo $uri->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+http
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/withuserinfo.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withUserInfo</refname>
+  <refpurpose>Modifica el componente de información de usuario</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>userinfo</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URI y modifica su componente de información de usuario.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>userinfo</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de información de usuario.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia modificada de <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withuserinfo.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+$uri = $uri->withUserInfo("userinfo");
+
+echo $uri->getUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+userinfo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/invalidurlexception/construct.xml
+++ b/reference/uri/uri/whatwg/invalidurlexception/construct.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-invalidurlexception.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\InvalidUrlException::__construct</refname>
+  <refpurpose>Construye un objeto InvalidUrlException</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\WhatWg\\InvalidUrlException">
+   <modifier>public</modifier> <methodname>Uri\WhatWg\InvalidUrlException::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>message</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>errors</parameter><initializer>[]</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>code</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Throwable</type><type>null</type></type><parameter>previous</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Construye un objeto <classname>Uri\WhatWg\InvalidUrlException</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <simpara>
+      Mensaje de la excepción.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>errors</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; de objetos <classname>Uri\WhatWg\UrlValidationError</classname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>code</parameter></term>
+    <listitem>
+     <simpara>
+      Código de la excepción.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>previous</parameter></term>
+    <listitem>
+     <simpara>
+      La excepción anterior utilizada para el encadenamiento de excepciones.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/construct.xml
+++ b/reference/uri/uri/whatwg/url/construct.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__construct</refname>
+  <refpurpose>Construye el objeto Url</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <methodname>Uri\WhatWg\Url::__construct</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\WhatWg\Url</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">softErrors</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Construye el objeto <classname>Uri\Rfc3986\Uri</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      Una cadena de URL válida a analizar (por ejemplo, <literal>/foo</literal> o <literal>https://example.com/foo</literal>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      Cuando se pasa un &string;, <parameter>uri</parameter> se aplica sobre
+      <parameter>baseUrl</parameter>, si <parameter>uri</parameter> es una cadena de URL relativa.
+      Si se pasa &null;, o <parameter>uri</parameter> no es una cadena de URL relativa,
+      <parameter>baseUrl</parameter> no tiene ningún efecto.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>softErrors</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; para pasar por referencia una lista de instancias de <classname>Uri\WhatWg\UrlValidationError</classname>
+      que proporciona información extendida sobre los errores generados durante el análisis.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/debuginfo.xml
+++ b/reference/uri/uri/whatwg/url/debuginfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__debugInfo</refname>
+  <refpurpose>Devuelve el estado interno de la URL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\WhatWg\Url::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Devuelve el estado interno de la URL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el estado interno de la URL como un &array;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__debugInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/equals.xml
+++ b/reference/uri/uri/whatwg/url/equals.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.equals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::equals</refname>
+  <refpurpose>Verifica si dos URLs son equivalentes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>bool</type><methodname>Uri\WhatWg\Url::equals</methodname>
+   <methodparam><type>Uri\WhatWg\Url</type><parameter>url</parameter></methodparam>
+   <methodparam choice="opt"><type>Uri\UriComparisonMode</type><parameter>comparisonMode</parameter><initializer><constant>Uri\UriComparisonMode::ExcludeFragment</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Verifica si dos URLs son equivalentes.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>url</parameter></term>
+    <listitem>
+     <simpara>
+      URL con la que comparar la URL actual.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>comparisonMode</parameter></term>
+    <listitem>
+     <simpara>
+      Indica si el componente de fragmento se tiene en cuenta en la comparación
+      (<literal>Uri\UriComparisonMode::IncludeFragment</literal>) o no
+      (<literal>Uri\UriComparisonMode::ExcludeFragment</literal>). Por defecto, el fragmento se excluye.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve &true; si las dos URLs son equivalentes, o &false; en caso contrario.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.equals.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::equals</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url1 = new \Uri\WhatWg\Url("https://example.com");
+$url2 = new \Uri\WhatWg\Url("HTTPS://example.com");
+
+var_dump($url1->equals($url2));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::equals</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getasciihost.xml
+++ b/reference/uri/uri/whatwg/url/getasciihost.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="uri-whatwg-url.getasciihost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::getAsciiHost</refname>
-  <refpurpose>Recupera el componente de host como una cadena ASCII</refpurpose>
+  <refpurpose>Recupera el componente de host como un &string; ASCII</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/uri/uri/whatwg/url/getasciihost.xml
+++ b/reference/uri/uri/whatwg/url/getasciihost.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getasciihost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getAsciiHost</refname>
+  <refpurpose>Recupera el componente de host como una cadena ASCII</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getAsciiHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de host como un &string; utilizando la transcripción punycode en lugar de caracteres Unicode.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de host como un &string; ASCII si el componente de host existe, en caso contrario se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getasciihost.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getAsciiHost</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getAsciiHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getfragment.xml
+++ b/reference/uri/uri/whatwg/url/getfragment.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getFragment</refname>
+  <refpurpose>Recupera el componente de fragmento</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de fragmento.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de fragmento como un &string; si el componente de fragmento existe, en caso contrario se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getfragment.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getFragment</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com#foo");
+
+echo $url->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getpassword.xml
+++ b/reference/uri/uri/whatwg/url/getpassword.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPassword</refname>
+  <refpurpose>Recupera el componente de contraseña</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de contraseña.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de contraseña como un &string; si el componente de contraseña existe, en caso contrario se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getpassword.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getPassword</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+
+echo $url->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getpath.xml
+++ b/reference/uri/uri/whatwg/url/getpath.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPath</refname>
+  <refpurpose>Recupera el componente de ruta</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::getPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de ruta.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de ruta como un &string;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getpath.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getPath</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar");
+
+echo $url->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getport.xml
+++ b/reference/uri/uri/whatwg/url/getport.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: a00f03a6131b0b74c851b06879c528fc9537da8c Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPort</refname>
+  <refpurpose>Recupera el componente de puerto</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>Uri\WhatWg\Url::getPort</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de puerto.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de puerto como un &integer; si el componente de puerto existe, en caso contrario se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getport.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getPort</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com:443");
+
+echo $url->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPort</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getquery.xml
+++ b/reference/uri/uri/whatwg/url/getquery.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getQuery</refname>
+  <refpurpose>Recupera el componente de consulta</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de consulta.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de consulta como un &string; si el componente de consulta existe, en caso contrario se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getquery.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getQuery</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com?foo/bar");
+
+echo $url->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getscheme.xml
+++ b/reference/uri/uri/whatwg/url/getscheme.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getScheme</refname>
+  <refpurpose>Recupera el componente de esquema</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::getScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de esquema.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de esquema como un &string; si el componente de esquema existe, en caso contrario se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getscheme.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getScheme</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getunicodehost.xml
+++ b/reference/uri/uri/whatwg/url/getunicodehost.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getunicodehost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getUnicodeHost</refname>
+  <refpurpose>Recupera el componente de host como una cadena Unicode</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de host como un &string;, que puede contener caracteres Unicode.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de host como un &string; Unicode si el componente de host existe, en caso contrario se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getunicodehost.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getUnicodeHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getusername.xml
+++ b/reference/uri/uri/whatwg/url/getusername.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.getusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getUsername</refname>
+  <refpurpose>Recupera el componente de nombre de usuario</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recupera el componente de nombre de usuario.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el componente de nombre de usuario como un &string; si el componente de nombre de usuario existe, en caso contrario se devuelve &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getusername.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::getUsername</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://username:password@example.com");
+
+echo $url->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+username
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::parse</refname>
+  <refpurpose>Analiza una URL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>static</type><type>null</type></type><methodname>Uri\WhatWg\Url::parse</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\WhatWg\Url</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">errors</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Analiza una URL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      Una cadena de URL válida a analizar (p.ej. <literal>/foo</literal> o (p.ej. <literal>https://example.com/foo</literal>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      Cuando se pasa un &string;, <parameter>uri</parameter> se aplica sobre
+      <parameter>baseUrl</parameter>, si <parameter>uri</parameter> es una cadena de URL relativa.
+      Si se pasa &null;, o <parameter>uri</parameter> no es una cadena de URL relativa,
+      <parameter>baseUrl</parameter> no tiene ningún efecto.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>errors</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; para pasar por referencia una lista de instancias de
+      <classname>Uri\WhatWg\UrlValidationError</classname> que proporcionan
+      información extendida sobre los errores generados durante el análisis.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve una instancia de <classname>Uri\WhatWg\Url</classname> en caso de éxito, o &null; en caso de error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.parse.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::parse</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = \Uri\WhatWg\Url::parse("https://example.com");
+
+if ($url !== null) {
+    echo "Valid URL: " . $url->toAsciiString();
+} else {
+    echo "Invalid URL"
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Valid URL: https://example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/resolve.xml
+++ b/reference/uri/uri/whatwg/url/resolve.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.resolve" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::resolve</refname>
+  <refpurpose>Resuelve una URL con el objeto actual como URL base</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::resolve</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">softErrors</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Resuelve una cadena de URL válida, que potencialmente puede ser una cadena de URL relativa, con el objeto actual como URL base.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      Una cadena de URL válida (p.ej. <literal>/foo</literal> o (p.ej. <literal>https://example.com/foo</literal>) a aplicar sobre
+      el objeto actual.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>softErrors</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; para pasar por referencia una lista de instancias de
+      <classname>Uri\WhatWg\UrlValidationError</classname> que proporcionan
+      información extendida sobre los errores leves generados durante la resolución de referencia.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Una nueva instancia de <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.resolve.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::resolve</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->resolve("/foo");
+
+echo $url->toAsciiString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/serialize.xml
+++ b/reference/uri/uri/whatwg/url/serialize.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__serialize</refname>
+  <refpurpose>Serializa el objeto Url</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\WhatWg\Url::__serialize</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Serializa el objeto <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la URL serializada como un &array;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__unserialize</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__serialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/toasciistring.xml
+++ b/reference/uri/uri/whatwg/url/toasciistring.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.toasciistring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::toAsciiString</refname>
+  <refpurpose>Recompone la URL como un &string; ASCII</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::toAsciiString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recompone la URL como un &string; ASCII, utilizando la transcripción punycode en lugar de caracteres Unicode en el
+   componente del host.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la URL recompuesta como un &string; ASCII.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.toasciistring.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::toAsciiString</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar?baz");
+
+echo $url->toAsciiString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/tounicodestring.xml
+++ b/reference/uri/uri/whatwg/url/tounicodestring.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.tounicodestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::toUnicodeString</refname>
+  <refpurpose>Recompone la URL como un &string; Unicode</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::toUnicodeString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Recompone la URL como un &string;, donde el componente del host puede contener caracteres Unicode.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la URL recompuesta como un &string; Unicode.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.tounicodestring.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::toUnicodeString</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar?baz");
+
+echo $url->toUnicodeString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/unserialize.xml
+++ b/reference/uri/uri/whatwg/url/unserialize.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__unserialize</refname>
+  <refpurpose>Deserializa el parámetro data en un objeto Url</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>void</type><methodname>Uri\WhatWg\Url::__unserialize</methodname>
+   <methodparam><type>array</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Deserializa un parámetro data en un objeto <classname>Uri\WhatWg\Url</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+      Los datos serializados como un <type>array</type>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si el método <methodname>__unserialize</methodname> se invoca sobre una URL ya existente, se lanza una excepción
+   <exceptionname>Error</exceptionname>.
+  </simpara>
+
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__serialize</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__unserialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withfragment.xml
+++ b/reference/uri/uri/whatwg/url/withfragment.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withFragment</refname>
+  <refpurpose>Modifica el componente de fragmento</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withFragment</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>fragment</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URL y modifica su componente de fragmento.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fragment</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de fragmento.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia de <classname>Uri\WhatWg\Url</classname> modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withfragment.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::withFragment</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/#foo");
+$url = $url->withFragment("bar");
+
+echo $url->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withhost.xml
+++ b/reference/uri/uri/whatwg/url/withhost.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withHost</refname>
+  <refpurpose>Modifica el componente de host</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withHost</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URL y modifica su componente de host.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de host.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia de <classname>Uri\WhatWg\Url</classname> modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withhost.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::withHost</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->withHost("example.net");
+
+echo $url->getAsciiHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.net
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withpassword.xml
+++ b/reference/uri/uri/whatwg/url/withpassword.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPassword</refname>
+  <refpurpose>Modifica el componente de contraseña</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPassword</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URL y modifica su componente de contraseña.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de contraseña.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia de <classname>Uri\WhatWg\Url</classname> modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withpassword.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::withPassword</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+$url = $url->withPassword("pass");
+
+echo $url->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+pass
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withpath.xml
+++ b/reference/uri/uri/whatwg/url/withpath.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPath</refname>
+  <refpurpose>Modifica el componente de ruta</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPath</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URL y modifica su componente de ruta.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de ruta.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia de <classname>Uri\WhatWg\Url</classname> modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withpath.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::withPath</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar");
+$url = $url->withPath("/baz");
+
+echo $url->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withport.xml
+++ b/reference/uri/uri/whatwg/url/withport.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPort</refname>
+  <refpurpose>Modifica el componente de puerto</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPort</methodname>
+   <methodparam><type class="union"><type>int</type><type>null</type></type><parameter>port</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URL y modifica su componente de puerto.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>port</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de puerto.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia de <classname>Uri\WhatWg\Url</classname> modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withport.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::withPort</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com:8080");
+$url = $url->withPort(443);
+
+echo $url->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPort</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withquery.xml
+++ b/reference/uri/uri/whatwg/url/withquery.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withQuery</refname>
+  <refpurpose>Modifica el componente de consulta</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withQuery</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>query</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URL y modifica su componente de consulta.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>query</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de consulta.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia de <classname>Uri\WhatWg\Url</classname> modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withquery.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::withQuery</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com?foo=bar");
+$url = $url->withQuery("foo=baz");
+
+echo $url->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withscheme.xml
+++ b/reference/uri/uri/whatwg/url/withscheme.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withScheme</refname>
+  <refpurpose>Modifica el componente de esquema</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withScheme</methodname>
+   <methodparam><type>string</type><parameter>scheme</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URL y modifica su componente de esquema.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>scheme</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de esquema.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia de <classname>Uri\WhatWg\Url</classname> modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withscheme.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::withScheme</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->withScheme("http");
+
+echo $url->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+http
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withusername.xml
+++ b/reference/uri/uri/whatwg/url/withusername.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-url.withusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withUsername</refname>
+  <refpurpose>Modifica el componente de nombre de usuario</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withUsername</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>username</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Crea una nueva URL y modifica su componente de nombre de usuario.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>username</parameter></term>
+    <listitem>
+     <simpara>
+      Nuevo componente de nombre de usuario.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La instancia de <classname>Uri\WhatWg\Url</classname> modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withusername.example.basic">
+   <title>Ejemplo básico de <methodname>Uri\WhatWg\Url::withUsername</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+$url = $url->withUsername("usr");
+
+echo $url->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+usr
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/urlvalidationerror/construct.xml
+++ b/reference/uri/uri/whatwg/urlvalidationerror/construct.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ab4cf5ea8b49c1dac6b09fe6b6fee31eb12c3adc Maintainer: lacatoire Status: ready -->
+<refentry xml:id="uri-whatwg-urlvalidationerror.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\UrlValidationError::__construct</refname>
+  <refpurpose>Construye un objeto UrlValidationError</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\WhatWg\\UrlValidationError">
+   <modifier>public</modifier> <methodname>Uri\WhatWg\UrlValidationError::__construct</methodname>
+   <methodparam><type>string</type><parameter>context</parameter></methodparam>
+   <methodparam><type>Uri\WhatWg\UrlValidationErrorType</type><parameter>type</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>failure</parameter></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Construye un objeto <classname>Uri\WhatWg\UrlValidationError</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>context</parameter></term>
+    <listitem>
+     <simpara>
+      La URL de entrada en el punto donde se detectó el error.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <simpara>
+      El tipo de error.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>failure</parameter></term>
+    <listitem>
+     <simpara>
+      Si es &true;, el error ha causado que la URL sea rechazada como inválida. Si es &false;,
+      el error es un error leve que fue corregido automáticamente durante el análisis.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/versions.xml
+++ b/reference/uri/versions.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do NOT translate this file -->
+<versions>
+ <!-- Classes and Methods -->
+
+ <!-- Uri\InvalidUrlException class -->
+ <function name='uri\invaliduriexception' from='PHP 8 &gt;= 8.5.0'/>
+
+ <!-- Uri\UriComparisonMode class -->
+ <function name='uri\uricomparisonmode' from='PHP 8 &gt;= 8.5.0'/>
+
+ <!-- Uri\UriError class -->
+ <function name='uri\urierror' from='PHP 8 &gt;= 8.5.0'/>
+
+ <!-- Uri\UriException class -->
+ <function name='uri\uriexception' from='PHP 8 &gt;= 8.5.0'/>
+
+ <!-- Uri\Rfc3986\Uri class -->
+ <function name='uri\rfc3986\uri' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::__construct' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::__debuginfo' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::__serialize' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::__unserialize' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::equals' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getfragment' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::gethost' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getpassword' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getpath' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getport' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getquery' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getrawfragment' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getrawhost' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getrawpassword' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getrawpath' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getrawquery' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getrawscheme' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getrawuserinfo' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getrawusername' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getscheme' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getuserinfo' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::getusername' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::parse' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::resolve' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::torawstring' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::tostring' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::withfragment' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::withhost' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::withpath' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::withport' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::withquery' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::withscheme' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\rfc3986\uri::withuserinfo' from='PHP 8 &gt;= 8.5.0'/>
+
+ <!-- Uri\WhatWg\InvalidUrlException class -->
+ <function name='uri\whatwg\invalidurlexception' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\invalidurlexception::__construct' from='PHP 8 &gt;= 8.5.0'/>
+
+ <!-- Uri\WhatWg\Url class -->
+ <function name='uri\whatwg\url' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::__construct' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::__debuginfo' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::__serialize' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::__unserialize' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::equals' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getasciihost' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getfragment' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getpassword' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getpath' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getport' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getquery' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getscheme' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getunicodehost' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::getusername' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::parse' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::resolve' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::toasciistring' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::tounicodestring' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::withfragment' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::withhost' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::withpassword' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::withpath' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::withport' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::withquery' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::withscheme' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\url::withusername' from='PHP 8 &gt;= 8.5.0'/>
+
+ <!-- Uri\WhatWg\UrlValidationError class -->
+ <function name='uri\whatwg\urlvalidationerror' from='PHP 8 &gt;= 8.5.0'/>
+ <function name='uri\whatwg\urlvalidationerror::__construct' from='PHP 8 &gt;= 8.5.0'/>
+
+ <!-- Uri\WhatWg\UrlValidationErrorType class -->
+ <function name='uri\whatwg\urlvalidationerrortype' from='PHP 8 &gt;= 8.5.0'/>
+</versions>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translate the ext/uri extension documentation to Spanish.

Includes all classes (Rfc3986\Uri, WhatWg\Url, exceptions, enums)
and all methods (getters, setters, parse, resolve, serialize, etc.)

Fixes #489
Fixes #488
Fixes #487
Fixes #486
Fixes #485
Fixes #484
Fixes #483
Fixes #482
Fixes #481
Fixes #479
Fixes #478