### PR TITLE
Expand caution note in parse_url and reference ext/uri

### DIFF
--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4266e03897e77751a6cf7d15f9556c92124d8df3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b3194d54645b22d5f229fcac3b4baf0d7b85ac8d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.parse-url" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -26,14 +26,29 @@
    <function>parse_url</function> hará todo lo posible para analizarlas correctamente.
   </para>
   <caution>
-   <para>
-    Esta función puede no proporcionar resultados correctos para URL relativas o inválidas y los resultados pueden no coincidir con
-    el comportamiento estándar de los clientes HTTP.
-    Si se deben analizar URL provenientes de la entrada del usuario,
-    se requieren verificaciones adicionales, por ejemplo utilizando
-    <function>filter_var</function> con el filtro
-    <constant>FILTER_VALIDATE_URL</constant>.
-   </para>
+   <simpara>
+    Esta función no sigue ningún estándar URI o URL establecido.
+    Devolverá resultados incorrectos o sin sentido para URL relativas o
+    malformadas. Incluso para URL válidas, el resultado puede diferir del de
+    otro analizador de URL, ya que existen múltiples estándares diferentes
+    relacionados con las URL que se dirigen a diferentes casos de uso y que
+    difieren en sus requisitos.
+   </simpara>
+   <simpara>
+    El procesamiento de una URL con analizadores que siguen diferentes estándares
+    de URL es una fuente común de vulnerabilidades de seguridad. Por ejemplo,
+    la validación de una URL contra una lista de nombres de host permitidos con
+    el analizador A podría ser ineficaz cuando la recuperación real del recurso
+    utiliza el analizador B que extrae los nombres de host de manera diferente.
+   </simpara>
+   <simpara>
+    Las clases <classname>Uri\Rfc3986\Uri</classname> y <classname>Uri\WhatWg\Url</classname>
+    siguen estrictamente los estándares RFC 3986 y WHATWG URL respectivamente.
+    Se recomienda encarecidamente utilizar estas clases para todo el código nuevo
+    y migrar los usos existentes de la función <function>parse_url</function>
+    a estas clases, a menos que el comportamiento de <function>parse_url</function>
+    deba preservarse por razones de compatibilidad.
+   </simpara>
   </caution>
  </refsect1>
 


### PR DESCRIPTION
Expand the caution note in `parse_url` to better explain the limitations of
the function and reference the new `Uri\Rfc3986\Uri` and `Uri\WhatWg\Url`
classes as recommended alternatives.

Fixes #477