### PR TITLE
Sync EN: fix ImagickDraw::getTextInterlineSpacing description typo

### DIFF
--- a/reference/imagick/imagickdraw/gettextinterlinespacing.xml
+++ b/reference/imagick/imagickdraw/gettextinterlinespacing.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 13cc59c9fe01418faf015ace0c88ae7b52f9d0a1 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="imagickdraw.gettextinterlinespacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
Update EN-Revision hash for `reference/imagick/imagickdraw/gettextinterlinespacing.xml`.

The Spanish translation was already correct ("espacio entre líneas"), only the EN source had a typo (interword instead of interline).

Fixes #491