### PR TITLE
[Sync EN] singleton: actualizar hash de revisión

### DIFF
--- a/language/types/singleton.xml
+++ b/language/types/singleton.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f908fff129bcd8ec1605658e06457cb04e5b2b51 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 828980b619bb4300e196924598b6a5d398f630e4 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.singleton">
  <title>Tipo singleton</title>


### PR DESCRIPTION
El cambio EN (php/doc-en#5487) elimina solo el artículo "an" antes de "enumerations" por una corrección gramatical. La traducción al español usa "una enumeración" (femenino), que sigue siendo correcta sin cambios. Solo se actualiza el hash de revisión.

Refs #494.