### PR TITLE
Sync EN: add xlink namespace and intro description to UrlValidationErrorType

### DIFF
--- a/reference/uri/uri.whatwg.urlvalidationerrortype.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerrortype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
-<reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns="http://docbook.org/ns/docbook">
+<!-- EN-Revision: 8352249a84d0b91b38c741ff1c256061127dbfbb Maintainer: lacatoire Status: ready -->
+<reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook">
  <title>La enumeración Uri\WhatWg\UrlValidationErrorType</title>
  <titleabbrev>Uri\WhatWg\UrlValidationErrorType</titleabbrev>
 
@@ -8,6 +8,7 @@
   <section xml:id="enum.uri-whatwg-urlvalidationerrortype.intro">
    &reftitle.intro;
    <simpara>
+    Los posibles errores de validación definidos en el <link xlink:href="&url.url.whatwg-url;">estándar WHATWG URL</link>.
    </simpara>
   </section>
 


### PR DESCRIPTION
Sincroniza `reference/uri/uri.whatwg.urlvalidationerrortype.xml` con php/doc-en hasta `8352249a`:

- php/doc-en#5474 (`66d06b9c`): traducción del `<simpara>` de introducción
- php/doc-en#5481 (`8352249a`): declaración del espacio de nombres `xmlns:xlink` en `<reference>`

Closes #496