### PR TITLE
Sync EN: wrap CURLOPT_CONNECTTIMEOUT zero in literal tag

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c9888ac6e5c75d00d50f9c2fd741ae3a82a479ec Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d7d6dd60085409b295916649e4bd7107742659a2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <variablelist role="constant_list">
  <title><function>curl_setopt</function></title>
@@ -244,7 +244,7 @@
   </term>
   <listitem>
    <para>
-    El número de segundos a esperar al intentar conectarse. Use 0 para
+    El número de segundos a esperar al intentar conectarse. Use <literal>0</literal> para
     esperar indefinidamente.
     Esta opción acepta cualquier valor que pueda ser convertido en un <type>int</type> válido.
     Por omisión, el valor es <literal>300</literal>.


### PR DESCRIPTION
Sincroniza `reference/curl/constants_curl_setopt.xml` con php/doc-en hasta `d7d6dd60` (php/doc-en#5498).

Closes #497