### PR TITLE
[Sync EN] pdo: Fix the call sequence in FETCH_INTO example

### DIFF
--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86d3fb841e0206e2588896ad3c21432333535848 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 581589d2c4d3183f1c0e67214a65cbd181a5edac Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <section xmlns="http://docbook.org/ns/docbook" xml:id="pdo.constants.fetch-modes">
  <title>Modos de recuperación</title>
@@ -1063,6 +1063,7 @@ while ($stmt->fetch(\PDO::FETCH_BOUND)) {
    <programlisting role="php">
 <![CDATA[
 <?php
+
 class TestEntity
 {
     public $userid;
@@ -1075,10 +1076,12 @@ class TestEntity
 }
 
 $obj = new TestEntity();
-$stmt->setFetchMode(\PDO::FETCH_INTO, $obj);
 
 $stmt = $db->query("SELECT userid, name, country, referred_by_userid FROM users");
+
+$stmt->setFetchMode(\PDO::FETCH_INTO, $obj);
 $result = $stmt->fetch();
+
 var_dump($result);
 ]]>
    </programlisting>


### PR DESCRIPTION
Sync con doc-en#5361: setFetchMode() debe llamarse después de query() en el ejemplo de PDO::FETCH_INTO.

Fixes #502