### PR TITLE
[Sync EN] Document Locale::isRightToLeft (PHP 8.5)

### DIFF
--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ac2b471bbca22b1b77140cf7c67c979d18a0caec Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="locale.isrighttoleft"
+          xmlns="http://docbook.org/ns/docbook"
+          xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <refnamediv>
+  <refname>Locale::isRightToLeft</refname>
+  <refpurpose>Comprueba si una configuración regional usa un sistema de escritura de derecha a izquierda</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>bool</type>
+   <methodname>Locale::isRightToLeft</methodname>
+   <methodparam choice="opt">
+    <type>string</type><parameter>locale</parameter>
+    <initializer>""</initializer>
+   </methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Determina si una configuración regional usa un sistema de escritura de derecha a izquierda.
+  </simpara>
+
+  <simpara>
+   Este método se basa en la biblioteca ICU y evalúa el script dominante asociado
+   a la configuración regional.
+  </simpara>
+
+  <simpara>
+   Si se proporciona una cadena vacía, se usa la configuración regional predeterminada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      El identificador de configuración regional. Si está vacío, se usa la configuración
+      regional predeterminada.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve &true; si la configuración regional usa un sistema de escritura de derecha
+   a izquierda, o &false; en caso contrario.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Se ha añadido <methodname>Locale::isRightToLeft</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Comprobar la dirección del texto para una configuración regional</title>
+   <programlisting>
+<![CDATA[
+var_dump(Locale::isRightToLeft('en-US'));
+var_dump(Locale::isRightToLeft('ar'));
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>


### PR DESCRIPTION
Sync con doc-en#5055: traducción del nuevo método Locale::isRightToLeft (PHP 8.5).

Fixes #506