### PR TITLE
[Sync EN] Add reserved words restrictions for class_alias in PHP 8.5

### DIFF
--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 170b6cda37f29c39b9e08375344c5eb9523b2de3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ff9181ea03ac348b2c7ff4ad07896f277cddcb1d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <appendix xml:id="reserved" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Palabras reservadas en PHP</title>
@@ -570,6 +570,12 @@
        </entry>
        <entry>
         never (disponible a partir de PHP 8.1)
+       </entry>
+       <entry>
+        array (disponible a partir de PHP 8.5)
+       </entry>
+       <entry>
+        callable (disponible a partir de PHP 8.5)
        </entry>
       </row>
      </tbody>

--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f5a677b8fdc3f7f72f2225f906cac0e466d4558d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ff9181ea03ac348b2c7ff4ad07896f277cddcb1d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: pmartin -->
 <refentry xml:id="function.class-alias" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,6 +21,9 @@
    por el usuario. El alias es en todos los puntos
    similar a la clase original.
   </para>
+  <simpara>
+   El alias de clase no puede ser ninguna de las <link linkend="reserved.other-reserved-words">palabras reservadas</link> de PHP.
+  </simpara>
   <note>
    <simpara>
     A partir de PHP 8.3.0, <function>class_alias</function> también soporta


### PR DESCRIPTION
Sync con doc-en#5059: añade array y callable a las palabras reservadas (PHP 8.5) y precisa que class_alias no puede usar una de estas palabras como alias.

Fixes #507