### PR TITLE
[Sync EN] request_parse_body: Clarify behavior when body already consumed

### DIFF
--- a/reference/network/functions/request-parse-body.xml
+++ b/reference/network/functions/request-parse-body.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4bf789e981af0836c41daa16e57ef86c21497faa Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c78af136d0497e16230218083ce43448f1864272 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.request-parse-body" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -39,8 +39,12 @@
 
   <caution>
    <simpara>
+    El cuerpo de la petición solo puede consumirse una vez.
     <function>request_parse_body</function> consume el cuerpo de la petición sin
     almacenarlo en el búfer en el flujo <literal>php://input</literal>.
+    Inversamente, si el cuerpo ya ha sido leído (por ejemplo a través de
+    <literal>php://input</literal>), <function>request_parse_body</function>
+    devolverá datos vacíos.
    </simpara>
   </caution>
  </refsect1>


### PR DESCRIPTION
Sync con doc-en#5504: precisa que el cuerpo de la petición solo puede consumirse una vez y que request_parse_body() devuelve datos vacíos si el cuerpo ya ha sido leído.

Fixes #508