### PR TITLE
[Sync EN] Clarify persistent connections reuse scope per child process

### DIFF
--- a/features/persistent-connections.xml
+++ b/features/persistent-connections.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cd8b964b8566801265f0d287db6eb651f93be950 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: ee5ee84013f11aaaf01b09484bc9aa3225379748 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="features.persistent-connections" xmlns="http://docbook.org/ns/docbook">
  <title>Conexiones persistentes a bases de datos</title>
@@ -60,9 +60,9 @@
    un cliente, esta es cedida a uno de los hijos que no esté ya
    sirviendo a otro cliente. Esto significa que cuando el mismo cliente
    hace una segunda solicitud al servidor, esta podría ser servida por un
-   proceso hijo diferente a la primera vez. Cuando se abre una conexión
-   persistente, cada página que solicite servicios SQL puede reusar
-   la misma conexión establecida al servidor SQL.
+   proceso hijo diferente a la primera vez. Una vez que se ha abierto una conexión
+   persistente, cualquier solicitud posterior servida por el mismo proceso hijo
+   puede reusar la conexión ya establecida al servidor SQL.
   </simpara>
   <note>
    <para>


### PR DESCRIPTION
Sync con doc-en#5502: precisa que la reutilización de una conexión persistente está limitada al mismo proceso hijo.

La versión ES ya usaba expresiones impersonales, no se modifica el tono.

Fixes #509