### PR TITLE
Clarifica el comportamiento de intval() con cadenas numéricas en notación científica

### DIFF
--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6197a68b1e9bc777323fa0df01adbed4d0c743f4 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.intval" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -101,6 +101,32 @@
    <link linkend="language.types.integer.casting">moldeado de enteros</link>
    se aplica.
   </para>
+  <note>
+   <simpara>
+    Las cadenas numéricas que utilizan notación científica (que contienen la
+    letra <literal>e</literal> o <literal>E</literal>) se analizan primero
+    como números antes de ser convertidas a entero.
+   </simpara>
+   <simpara>
+    Dado que la parte numérica de la cadena se analiza en su totalidad, el
+    resultado no es simplemente la parte entera inicial. Además, los
+    exponentes grandes pueden desbordarse hasta
+    <constant>PHP_INT_MAX</constant>:
+   </simpara>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo intval('42.42e42'); // 9223372036854775807 en sistemas de 64 bits
+?>
+]]>
+    </programlisting>
+   </informalexample>
+   <simpara>
+    Véase <link linkend="language.types.numeric-strings">Cadenas numéricas</link>
+    para obtener detalles sobre cómo se interpretan estas cadenas.
+   </simpara>
+  </note>
  </refsect1>
  <refsect1 role="changelog">
   &reftitle.changelog;


### PR DESCRIPTION
Sync EN de [#5098](https://github.com/php/doc-en/pull/5098).

Fixes #518