### PR TITLE
DATE_RFC7231 obsoleta en PHP 8.5 (sync EN #5505)

### DIFF
--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a69d8c2c891e70c03c33cbe251a208dd7d185af9 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: e1e7f1f922033c50c2fd2d33fc5e0512f4e76844 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 
 <reference xml:id="class.datetimeinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -370,6 +370,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Las constantes <constant>DATE_RFC7231</constant> y
+        <constant>DateTimeInterface::RFC7231</constant> han sido obsoletas.
+       </entry>
+      </row>
       <row>
        <entry>8.4.0</entry>
        <entry>Las constantes de clase ahora están tipadas.</entry>


### PR DESCRIPTION
Sync EN de [#5505](https://github.com/php/doc-en/pull/5505).

Fixes #516