### PR TITLE
sync-en: clarifica enable_post_data_reading y corrige typo

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ef757b033ba1df823b1ac5176ada439effe4cab4 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: Marqitos -->
+<!-- EN-Revision: 185dda85976e5ed392664db011abda0110726c0d Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
 
 <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Descripción de las directivas internas del &php.ini;</title>
@@ -714,7 +714,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
       </term>
       <listitem>
        <simpara>
-        Si se desactiva esta opción, las variables <varname>$_POST</varname> y <varname>$_FILES</varname> no se <emphasis>poblarán</emphasis>. La única forma de leer los datos transmitidos será usando el manejador de flujo <link linkend="wrappers.php">php://input</link>. Esto puede ser interesante para las solicitudes a través de un proxy o para analizar los datos transmitidos directamente en la memoria.
+        Si se desactiva esta opción, las variables <varname>$_POST</varname> y <varname>$_FILES</varname> no se <emphasis>poblarán</emphasis>. El cuerpo de la petición permanece sin consumir en <link linkend="wrappers.php">php://input</link> y puede leerse manualmente o analizarse mediante <function>request_parse_body</function>. Esto puede ser interesante para las solicitudes a través de un proxy o para analizar los datos transmitidos directamente en la memoria.
        </simpara>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
Sincroniza `appendices/ini.core.xml` con doc-en hasta `185dda8597` (PRs #5511 y #5513). Anade la mencion a `request_parse_body()` como forma alternativa de consumir el cuerpo de la peticion cuando `enable_post_data_reading=0`, con la etiqueta `<function>` correcta.

Fixes #526
Fixes #527