### PR TITLE
[Sync EN] Replace <para> with <simpara> in extensions.ent

### DIFF
--- a/extensions.ent
+++ b/extensions.ent
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e2d8231b5d8a3795b365c6770fab288e59e6249 Maintainer: yago Status: ready -->
+<!-- EN-Revision: 067e27db0a6f790ee0faaf99aa1f321f88f82cc9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: julionc -->
 
 <!--
@@ -9,8 +9,8 @@
 -->
 
 <!ENTITY extcat.intro '<title xmlns="http://docbook.org/ns/docbook">Categorización de
-Extensiones</title><para xmlns="http://docbook.org/ns/docbook">Este apéndice categoriza más de 150 extensiones
-documentadas en el manual de PHP de acuerdo a varios criterios.</para>'>
+Extensiones</title><simpara xmlns="http://docbook.org/ns/docbook">Este apéndice categoriza más de 150 extensiones
+documentadas en el manual de PHP de acuerdo a varios criterios.</simpara>'>
 
 <!ENTITY extcat.alphabetical '<title xmlns="http://docbook.org/ns/docbook">Alfabética</title>'>
 
@@ -67,26 +67,26 @@ codificación de caracteres</title>'>
 
 <!ENTITY extcat.membership '<title xmlns="http://docbook.org/ns/docbook">Incorporación</title>'>
 
-<!ENTITY extcat.membership.core '<title xmlns="http://docbook.org/ns/docbook">Extensiones del núcleo</title><para xmlns="http://docbook.org/ns/docbook">No son extensiones realmente. Son parte del núcleo de PHP y no pueden omitirse en un binario de PHP con opciones de
-compilación.</para>'>
+<!ENTITY extcat.membership.core '<title xmlns="http://docbook.org/ns/docbook">Extensiones del núcleo</title><simpara xmlns="http://docbook.org/ns/docbook">No son extensiones realmente. Son parte del núcleo de PHP y no pueden omitirse en un binario de PHP con opciones de
+compilación.</simpara>'>
 
 <!ENTITY extcat.membership.bundled '<title xmlns="http://docbook.org/ns/docbook">Bundled
-</title><para xmlns="http://docbook.org/ns/docbook">Extensiones incorporadas en PHP.</para>'>
+</title><simpara xmlns="http://docbook.org/ns/docbook">Extensiones incorporadas en PHP.</simpara>'>
 
-<!ENTITY extcat.membership.external '<title xmlns="http://docbook.org/ns/docbook">Extensiones externas</title><para xmlns="http://docbook.org/ns/docbook">Estas extensiones vienen con PHP, pero para poder compilarlas, se requieren bibliotecas externas.</para>'>
+<!ENTITY extcat.membership.external '<title xmlns="http://docbook.org/ns/docbook">Extensiones externas</title><simpara xmlns="http://docbook.org/ns/docbook">Estas extensiones vienen con PHP, pero para poder compilarlas, se requieren bibliotecas externas.</simpara>'>
 
 <!ENTITY extcat.membership.pecl '<title xmlns="http://docbook.org/ns/docbook">
 Extensiones PECL</title>
-<para xmlns="http://docbook.org/ns/docbook">Estas extensiones están disponibles desde
+<simpara xmlns="http://docbook.org/ns/docbook">Estas extensiones están disponibles desde
 &link.pecl;. Pueden requerir bibliotecas externas. Existen más extensiones PECL pero
-todavía no están documentadas en el manual de PHP.</para>'>
+todavía no están documentadas en el manual de PHP.</simpara>'>
 
 <!-- ======================================================================= -->
 
-<!ENTITY extcat.state '<title xmlns="http://docbook.org/ns/docbook">Estado</title><para xmlns="http://docbook.org/ns/docbook">Esta sección lista las extensiones que no son recomendables para su uso en producción - son demasiado "viejas" (obsoletas) o "nuevas" (experimentales).</para>'>
+<!ENTITY extcat.state '<title xmlns="http://docbook.org/ns/docbook">Estado</title><simpara xmlns="http://docbook.org/ns/docbook">Esta sección lista las extensiones que no son recomendables para su uso en producción - son demasiado "viejas" (obsoletas) o "nuevas" (experimentales).</simpara>'>
 
-<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Extensiones obsoletas</title><para xmlns="http://docbook.org/ns/docbook">Estas extensiones han sido marcadas como obsoletas, por lo general han sido reemplazadas por otras extensiones.</para>'>
+<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Extensiones obsoletas</title><simpara xmlns="http://docbook.org/ns/docbook">Estas extensiones han sido marcadas como obsoletas, por lo general han sido reemplazadas por otras extensiones.</simpara>'>
 
-<!ENTITY extcat.state.experimental '<title xmlns="http://docbook.org/ns/docbook">Extensiones experimentales</title><para xmlns="http://docbook.org/ns/docbook">El comportamiento de estas extensiones - incluyendo los nombres de sus funciones y cualquier otra cosa documentada
+<!ENTITY extcat.state.experimental '<title xmlns="http://docbook.org/ns/docbook">Extensiones experimentales</title><simpara xmlns="http://docbook.org/ns/docbook">El comportamiento de estas extensiones - incluyendo los nombres de sus funciones y cualquier otra cosa documentada
 sobre estas extensiones - puede cambiar sin previo aviso en una futura
-versión de PHP. Use estas extensiones bajo su propio riesgo.</para>'>
+versión de PHP. Use estas extensiones bajo su propio riesgo.</simpara>'>


### PR DESCRIPTION
Sync with php/doc-en#5523: replaces ``<para>`` with ``<simpara>`` in ``extensions.ent`` and bumps the EN-Revision hash.

Fixes #536