### PR TITLE
[Sync EN] Document warning emitted by openssl_x509_read

### DIFF
--- a/reference/openssl/functions/openssl-x509-read.xml
+++ b/reference/openssl/functions/openssl-x509-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d1e3ea622e5d4f542cd36eca59a9f22aa0142633 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 47881dcf54038053a6aa70d901e61c14e2c01a06 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-x509-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -43,6 +43,13 @@
   <para>
    Devuelve un <classname>OpenSSLCertificate</classname> en caso de éxito&return.falseforfailure;.
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Se emite un <constant>E_WARNING</constant> si no se puede recuperar el certificado X.509.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Sync with php/doc-en#5494: añade la sección ``errors`` documentando el ``E_WARNING`` emitido por ``openssl_x509_read`` cuando el certificado X.509 no se puede recuperar. Bumpea también el hash ``EN-Revision``.

Fixes #537