### PR TITLE
[Sync EN] isrighttoleft.xml Add the <?php tag

### DIFF
--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ac2b471bbca22b1b77140cf7c67c979d18a0caec Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: facf6996ca5a6057f7092761079e4aa00c5b7713 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="locale.isrighttoleft"
           xmlns="http://docbook.org/ns/docbook"
@@ -86,8 +86,10 @@
   &reftitle.examples;
   <example>
    <title>Comprobar la dirección del texto para una configuración regional</title>
-   <programlisting>
+   <programlisting role="php">
 <![CDATA[
+<?php
+
 var_dump(Locale::isRightToLeft('en-US'));
 var_dump(Locale::isRightToLeft('ar'));
 ]]>


### PR DESCRIPTION
Sync con php/doc-en#5514: añade ``role="php"`` al ``<programlisting>`` y la apertura ``<?php`` al ejemplo de ``Locale::isRightToLeft``. Bumpea el hash ``EN-Revision``.

Fixes #538