### PR TITLE
[Sync EN] Fix exception name in createFromDateString documentation

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -64,7 +64,7 @@
   &reftitle.errors;
   <para>
    Solo en la API Orientada a Objetos: Si se pasa una cadena de fecha/hora inválida,
-   se lanza <exceptionname>DateMalformedStringException</exceptionname>.
+   se lanza <exceptionname>DateMalformedIntervalStringException</exceptionname>.
   </para>
  </refsect1>
 
@@ -83,7 +83,7 @@
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> ahora lanza
-       <exceptionname>DateMalformedStringException</exceptionname> si se pasa
+       <exceptionname>DateMalformedIntervalStringException</exceptionname> si se pasa
        una cadena inválida. Anteriormente, devolvía <literal>false</literal>,
        y emitía una advertencia.
        <function>date_interval_create_from_date_string</function> no ha


### PR DESCRIPTION
Sync con php/doc-en#5521: corrige el nombre de la excepción lanzada por ``DateInterval::createFromDateString`` (``DateMalformedStringException`` &rarr; ``DateMalformedIntervalStringException``) en las secciones ``errors`` y ``changelog``. Bumpea el hash ``EN-Revision``.

Fixes #539