### PR TITLE
[Sync EN] MongoDB: document readonly properties and IWM URI options

### DIFF
--- a/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwriteexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e3c3525f7f288bc3a455a9619215fa759c2a9f5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-exception-bulkwriteexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -44,7 +44,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>protected</modifier>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>MongoDB\Driver\WriteResult</type>
      <varname linkend="mongodb-driver-exception-bulkwriteexception.props.writeresult">writeResult</varname>
     </fieldsynopsis>
@@ -97,6 +98,13 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         La propiedad <varname>writeResult</varname> ahora es
+         <modifier>public</modifier> <modifier>readonly</modifier>.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 2.0.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/exception/commandexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/commandexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-exception-commandexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Exception\CommandException</title>
@@ -41,7 +41,8 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
-     <modifier>protected</modifier>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
      <type>object</type>
      <varname linkend="mongodb-driver-exception-commandexception.props.resultdocument">resultDocument</varname>
     </fieldsynopsis>
@@ -81,6 +82,29 @@
    </variablelist>
   </section>
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        La propiedad <varname>resultDocument</varname> ahora es
+        <modifier>public</modifier> <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7ba4efc7524c06343c6e9f1fc2b10f91cfdfd945 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-manager.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -207,6 +207,16 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
           </entry>
          </row>
          <row>
+          <entry>enableOverloadRetargeting</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <simpara>
+            Cuando se establece a &true;, fuerza la selección del servidor tras un
+            <literal>SystemOverloadedError</literal>. Por omisión, &false;.
+           </simpara>
+          </entry>
+         </row>
+         <row>
           <entry>heartbeatFrequencyMS</entry>
           <entry><type>int</type></entry>
           <entry>
@@ -257,6 +267,17 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
             múltiples instancias MongoDB apropiadas al resolver una preferencia de lectura.
             Por omisión, 15 milisegundos.
            </para>
+          </entry>
+         </row>
+         <row>
+          <entry>maxAdaptiveRetries</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <simpara>
+            Esta opción puede ser utilizada para cambiar el número máximo de reintentos
+            cuando se produce un <literal>SystemOverloadedError</literal>. Debe ser un
+            entero positivo; por omisión, <literal>2</literal>.
+           </simpara>
           </entry>
          </row>
          <row>

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-monitoring-commandfailedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -36,11 +36,197 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Exception</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.error">error</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.reply">reply</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandfailedevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandfailedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandFailedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandfailedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El nombre del host del servidor que ejecutó el comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor que ejecutó el comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <simpara>El nombre del comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <simpara>El nombre de la base de datos.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <simpara>
+       La duración del comando en microsegundos. La duración es un
+       valor calculado que incluye el tiempo necesario para enviar el
+       mensaje y recibir la respuesta del servidor.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.error">
+     <term><varname>error</varname></term>
+     <listitem>
+      <simpara>La excepción lanzada cuando el comando falló.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <simpara>El documento de respuesta de error devuelto por el servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de operación. Puede usarse para vincular eventos
+       entre sí, como en escrituras en bloque, que pueden despachar
+       varios comandos.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de la petición. Puede usarse para asociar este
+       <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname>
+       con un
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>
+       correspondiente.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de servicio, o &null; si el servidor no lo
+       soporta (es decir, cuando no se utiliza el modo de balanceo de carga).
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandfailedevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de la conexión al servidor, o &null; si no está
+       disponible.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>. La
+        propiedad <varname>duration</varname> reemplaza al método
+        <methodname>getDurationMicros</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-monitoring-commandstartedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -36,11 +36,166 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.command">command</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandstartedevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandstartedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandStartedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandstartedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El nombre del host del servidor que ejecutó el comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor que ejecutó el comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <simpara>El nombre del comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <simpara>El nombre de la base de datos.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.command">
+     <term><varname>command</varname></term>
+     <listitem>
+      <simpara>El documento del comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de operación. Puede usarse para vincular eventos
+       entre sí, como en escrituras en bloque, que pueden despachar
+       varios comandos.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de la petición. Puede usarse para asociar este
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>
+       con un
+       <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>
+       o
+       <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname>
+       correspondiente.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de servicio, o &null; si el servidor no lo
+       soporta (es decir, cuando no se utiliza el modo de balanceo de carga).
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandstartedevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <simpara>El identificador de la conexión al servidor, o &null; si no está disponible.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-commandsucceededevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\CommandSucceededEvent</title>
@@ -33,11 +33,182 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.commandname">commandName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.databasename">databaseName</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.reply">reply</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.operationid">operationId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.requestid">requestId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.serviceid">serviceId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-monitoring-commandsucceededevent.props.serverconnectionid">serverConnectionId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-commandsucceededevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\CommandSucceededEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-commandsucceededevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El nombre del host del servidor que ejecutó el comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor que ejecutó el comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.commandname">
+     <term><varname>commandName</varname></term>
+     <listitem>
+      <simpara>El nombre del comando.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.databasename">
+     <term><varname>databaseName</varname></term>
+     <listitem>
+      <simpara>El nombre de la base de datos.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <simpara>
+       La duración del comando en microsegundos. La duración es un
+       valor calculado que incluye el tiempo necesario para enviar el
+       mensaje y recibir la respuesta del servidor.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <simpara>El documento de respuesta devuelto por el servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.operationid">
+     <term><varname>operationId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de operación. Puede usarse para vincular eventos
+       entre sí, como en escrituras en bloque, que pueden despachar
+       varios comandos.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.requestid">
+     <term><varname>requestId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de la petición. Puede usarse para asociar este
+       <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>
+       con un
+       <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>
+       correspondiente.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.serviceid">
+     <term><varname>serviceId</varname></term>
+     <listitem>
+      <simpara>
+       El identificador de servicio, o &null; si el servidor no lo
+       soporta (es decir, cuando no se utiliza el modo de balanceo de carga).
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-commandsucceededevent.props.serverconnectionid">
+     <term><varname>serverConnectionId</varname></term>
+     <listitem>
+      <simpara>El identificador de la conexión al servidor, o &null; si no está disponible.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>. La
+        propiedad <varname>duration</varname> reemplaza al método
+        <methodname>getDurationMicros</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-serverchangedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\ServerChangedEvent</title>
@@ -35,11 +35,103 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\ServerDescription</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.newdescription">newDescription</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\ServerDescription</type>
+     <varname linkend="mongodb-driver-monitoring-serverchangedevent.props.previousdescription">previousDescription</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverchangedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerChangedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverchangedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El nombre de host del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>El identificador de la topología.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.newdescription">
+     <term><varname>newDescription</varname></term>
+     <listitem>
+      <simpara>La nueva descripción del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverchangedevent.props.previousdescription">
+     <term><varname>previousDescription</varname></term>
+     <listitem>
+      <simpara>La descripción previa del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-serverclosedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\ServerClosedEvent</title>
@@ -34,11 +34,79 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serverclosedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverclosedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerClosedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverclosedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El nombre de host del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverclosedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>El identificador de la topología.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatfailedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent</title>
@@ -36,11 +36,113 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Exception</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatfailedevent.props.error">error</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatfailedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El nombre de host del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <simpara>
+       Indica si el latido utilizó un protocolo de streaming. La extensión no
+       utiliza el protocolo de streaming para la monitorización, por lo que
+       este método siempre devolverá &false;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <simpara>
+       La duración del latido en microsegundos. La duración es un valor
+       calculado que incluye el tiempo de envío del mensaje y de recepción
+       de la respuesta del servidor.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.props.error">
+     <term><varname>error</varname></term>
+     <listitem>
+      <simpara>La excepción lanzada cuando el latido falló.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>. La
+        propiedad <varname>duration</varname> reemplaza al método
+        <methodname>getDurationMicros</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatstartedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent</title>
@@ -36,11 +36,83 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatstartedevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatstartedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El host del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <simpara>
+       Indica si el latido utilizó un protocolo de transmisión continua. La extensión no
+       utiliza el protocolo de transmisión continua para la supervisión, por lo que este método siempre
+       devolverá &false;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades public <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
@@ -107,7 +107,7 @@
       <row>
        <entry>PECL mongodb 2.3.0</entry>
        <entry>
-        Se añadieron propiedades public <modifier>readonly</modifier>.
+        Se añadieron propiedades públicas <modifier>readonly</modifier>.
        </entry>
       </row>
      </tbody>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatsucceededevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent</title>
@@ -36,11 +36,113 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.awaited">awaited</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.duration">duration</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>object</type>
+     <varname linkend="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.reply">reply</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serverheartbeatsucceededevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El host del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.awaited">
+     <term><varname>awaited</varname></term>
+     <listitem>
+      <simpara>
+       Indica si el latido utilizó un protocolo de transmisión continua. La extensión no
+       utiliza el protocolo de transmisión continua para la supervisión, por lo que este método siempre
+       devolverá &false;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.duration">
+     <term><varname>duration</varname></term>
+     <listitem>
+      <simpara>
+       La duración del latido en microsegundos. La duración es un
+       valor calculado que incluye el tiempo necesario para enviar el mensaje y
+       recibir la respuesta del servidor.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.props.reply">
+     <term><varname>reply</varname></term>
+     <listitem>
+      <simpara>El documento de respuesta devuelto por el servidor.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades public <modifier>readonly</modifier>. La
+        propiedad <varname>duration</varname> reemplaza al método
+        <methodname>getDurationMicros</methodname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
@@ -135,7 +135,7 @@
       <row>
        <entry>PECL mongodb 2.3.0</entry>
        <entry>
-        Se añadieron propiedades public <modifier>readonly</modifier>. La
+        Se añadieron propiedades públicas <modifier>readonly</modifier>. La
         propiedad <varname>duration</varname> reemplaza al método
         <methodname>getDurationMicros</methodname>.
        </entry>

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-serveropeningevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\ServerOpeningEvent</title>
@@ -34,11 +34,79 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.host">host</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.port">port</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-serveropeningevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-serveropeningevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\ServerOpeningEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-serveropeningevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.host">
+     <term><varname>host</varname></term>
+     <listitem>
+      <simpara>El host del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.port">
+     <term><varname>port</varname></term>
+     <listitem>
+      <simpara>El puerto del servidor.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-serveropeningevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>El identificador de la topología.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades public <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
@@ -101,7 +101,7 @@
       <row>
        <entry>PECL mongodb 2.3.0</entry>
        <entry>
-        Se añadieron propiedades public <modifier>readonly</modifier>.
+        Se añadieron propiedades públicas <modifier>readonly</modifier>.
        </entry>
       </row>
      </tbody>

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-topologychangedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\TopologyChangedEvent</title>
@@ -35,11 +35,79 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\TopologyDescription</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.newdescription">newDescription</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\TopologyDescription</type>
+     <varname linkend="mongodb-driver-monitoring-topologychangedevent.props.previousdescription">previousDescription</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologychangedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyChangedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologychangedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>El identificador de la topología.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.newdescription">
+     <term><varname>newDescription</varname></term>
+     <listitem>
+      <simpara>La nueva descripción de la topología.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologychangedevent.props.previousdescription">
+     <term><varname>previousDescription</varname></term>
+     <listitem>
+      <simpara>La descripción previa de la topología.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-topologyclosedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\TopologyClosedEvent</title>
@@ -42,11 +42,55 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologyclosedevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologyclosedevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyClosedEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologyclosedevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologyclosedevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>El identificador de la topología.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-topologyopeningevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Monitoring\TopologyOpeningEvent</title>
@@ -42,11 +42,55 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\BSON\ObjectId</type>
+     <varname linkend="mongodb-driver-monitoring-topologyopeningevent.props.topologyid">topologyId</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-monitoring-topologyopeningevent')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\Monitoring\TopologyOpeningEvent properties -->
+  <section xml:id="mongodb-driver-monitoring-topologyopeningevent.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-monitoring-topologyopeningevent.props.topologyid">
+     <term><varname>topologyId</varname></term>
+     <listitem>
+      <simpara>El identificador de la topología.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Se añadieron propiedades públicas <modifier>readonly</modifier>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/readconcern.xml
+++ b/reference/mongodb/mongodb/driver/readconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-readconcern" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\ReadConcern</title>
@@ -41,6 +41,14 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readconcern.props.level">level</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
@@ -79,6 +87,22 @@
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\ReadConcern properties -->
+  <section xml:id="mongodb-driver-readconcern.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-readconcern.props.level">
+     <term><varname>level</varname></term>
+     <listitem>
+      <simpara>
+       El nivel del read concern. &null; si no se especificó ningún nivel.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\ReadConcern constants -->
   <section xml:id="mongodb-driver-readconcern.constants">
@@ -234,6 +258,12 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Se añadieron las propiedades públicas <modifier>readonly</modifier>.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 1.11.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/readpreference.xml
+++ b/reference/mongodb/mongodb/driver/readpreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-readpreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -41,6 +41,32 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-readpreference.props.mode">mode</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>array</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readpreference.props.tags">tags</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-readpreference.props.maxstaleness">maxStalenessSeconds</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-readpreference.props.hedge">hedge</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
@@ -91,6 +117,57 @@
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\ReadPreference properties -->
+  <section xml:id="mongodb-driver-readpreference.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.mode">
+     <term><varname>mode</varname></term>
+     <listitem>
+      <simpara>
+       El modo de preferencia de lectura como cadena (por ejemplo
+       <literal>"primary"</literal>, <literal>"secondary"</literal>).
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.tags">
+     <term><varname>tags</varname></term>
+     <listitem>
+      <simpara>
+       La lista de conjuntos de tags utilizada por la preferencia de lectura, o &null; si no
+       se especificó ningún conjunto de tags.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.maxstaleness">
+     <term><varname>maxStalenessSeconds</varname></term>
+     <listitem>
+      <simpara>
+       La duración máxima de obsolescencia en segundos para las lecturas, o
+       <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>
+       si no se especificó ninguna duración máxima de obsolescencia.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-readpreference.props.hedge">
+     <term><varname>hedge</varname></term>
+     <listitem>
+      <simpara>
+       Un documento que especifica las opciones de hedge para la preferencia de lectura, o
+       &null; si no se especificó ninguna opción de hedge.
+      </simpara>
+      <warning>
+       <simpara>
+        Esta propiedad está obsoleta ya que las lecturas con hedge están obsoletas en
+        MongoDB 8.0.
+       </simpara>
+      </warning>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\ReadPreference constants -->
   <section xml:id="mongodb-driver-readpreference.constants">
@@ -189,6 +266,12 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Se añadieron las propiedades públicas <modifier>readonly</modifier>.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 2.0.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/writeconcern.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-writeconcern" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -55,12 +55,68 @@
      <initializer>"majority"</initializer>
     </fieldsynopsis>
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcern.props.w">w</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>bool</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcern.props.j">j</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeconcern.props.wtimeout">wtimeout</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeconcern')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ MongoDB\Driver\WriteConcern properties -->
+  <section xml:id="mongodb-driver-writeconcern.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.w">
+     <term><varname>w</varname></term>
+     <listitem>
+      <simpara>
+       El número de réplicas necesarias (entero correspondiente al número de nodos, la cadena
+       <literal>"majority"</literal>, o el nombre de un tag de write concern personalizado),
+       o &null; si no está definido.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.j">
+     <term><varname>j</varname></term>
+     <listitem>
+      <simpara>
+       Indica si el journal es requerido, es decir, si las operaciones de escritura deben
+       ser confirmadas en el journal antes de ser reconocidas, o &null; si no se especificó.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcern.props.wtimeout">
+     <term><varname>wtimeout</varname></term>
+     <listitem>
+      <simpara>
+       El timeout de espera en milisegundos para el reconocimiento del write concern.
+       Un valor de <literal>0</literal> significa esperar indefinidamente.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
 
 <!-- {{{ MongoDB\Driver\WriteConcern constants -->
   <section xml:id="mongodb-driver-writeconcern.constants">
@@ -94,6 +150,12 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>PECL mongodb 2.3.0</entry>
+        <entry>
+         Se añadieron las propiedades públicas <modifier>readonly</modifier>.
+        </entry>
+       </row>
        <row>
         <entry>PECL mongodb 1.7.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/writeconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-writeconcernerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -37,11 +37,81 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.message">message</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.code">code</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeconcernerror.props.info">info</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeconcernerror')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteConcernError properties -->
+  <section xml:id="mongodb-driver-writeconcernerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.message">
+     <term><varname>message</varname></term>
+     <listitem>
+      <simpara>El mensaje de error.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.code">
+     <term><varname>code</varname></term>
+     <listitem>
+      <simpara>El código de error.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeconcernerror.props.info">
+     <term><varname>info</varname></term>
+     <listitem>
+      <simpara>
+       El documento de información adicional sobre el error, o &null; si no está disponible.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Las propiedades <modifier>public</modifier> <modifier>readonly</modifier> han sido añadidas.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeerror.xml
+++ b/reference/mongodb/mongodb/driver/writeerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-writeerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -37,11 +37,96 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-writeerror.props.message">message</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeerror.props.code">code</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-writeerror.props.index">index</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>object</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeerror.props.info">info</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeerror')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteError properties -->
+  <section xml:id="mongodb-driver-writeerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.message">
+     <term><varname>message</varname></term>
+     <listitem>
+      <simpara>El mensaje de error.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.code">
+     <term><varname>code</varname></term>
+     <listitem>
+      <simpara>El código de error.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.index">
+     <term><varname>index</varname></term>
+     <listitem>
+      <simpara>
+       El índice de la operación de escritura dentro del
+       <classname>MongoDB\Driver\BulkWrite</classname> que ha provocado el error.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeerror.props.info">
+     <term><varname>info</varname></term>
+     <listitem>
+      <simpara>
+       El documento de información adicional sobre el error, o &null; si no está disponible.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Las propiedades <modifier>public</modifier> <modifier>readonly</modifier> han sido añadidas.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeresult.xml
+++ b/reference/mongodb/mongodb/driver/writeresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-writeresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -39,11 +39,208 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.insertedcount">insertedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.matchedcount">matchedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.modifiedcount">modifiedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.deletedcount">deletedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>int</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.upsertedcount">upsertedCount</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>MongoDB\Driver\Server</type>
+     <varname linkend="mongodb-driver-writeresult.props.server">server</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.upsertedids">upsertedIds</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.writeerrors">writeErrors</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\Driver\WriteConcernError</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.writeconcernerror">writeConcernError</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>MongoDB\Driver\WriteConcern</type><type>null</type></type>
+     <varname linkend="mongodb-driver-writeresult.props.writeconcern">writeConcern</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>array</type>
+     <varname linkend="mongodb-driver-writeresult.props.errorreplies">errorReplies</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-writeresult')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+<!-- {{{ MongoDB\Driver\WriteResult properties -->
+  <section xml:id="mongodb-driver-writeresult.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.insertedcount">
+     <term><varname>insertedCount</varname></term>
+     <listitem>
+      <simpara>
+       El número de documentos insertados (excluyendo los upserts), o &null; si
+       el write concern no ha solicitado acuse de recibo.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.matchedcount">
+     <term><varname>matchedCount</varname></term>
+     <listitem>
+      <simpara>
+       El número de documentos coincidentes con las operaciones de actualización y reemplazo, o
+       &null; si el write concern no ha solicitado acuse de recibo.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.modifiedcount">
+     <term><varname>modifiedCount</varname></term>
+     <listitem>
+      <simpara>
+       El número de documentos modificados por las operaciones de actualización y reemplazo, o
+       &null; si el write concern no ha solicitado acuse de recibo o si el
+       servidor no ha proporcionado esta información.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.deletedcount">
+     <term><varname>deletedCount</varname></term>
+     <listitem>
+      <simpara>
+       El número de documentos eliminados, o &null; si el write concern
+       no ha solicitado acuse de recibo.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.upsertedcount">
+     <term><varname>upsertedCount</varname></term>
+     <listitem>
+      <simpara>
+       El número de documentos upserted, o &null; si el write concern
+       no ha solicitado acuse de recibo.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.server">
+     <term><varname>server</varname></term>
+     <listitem>
+      <simpara>
+       El servidor que ha ejecutado el bulk write.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.upsertedids">
+     <term><varname>upsertedIds</varname></term>
+     <listitem>
+      <simpara>
+       Un array de valores <literal>_id</literal> para los documentos upserted.
+       Las claves del array corresponden al índice de la operación de escritura de
+       <classname>MongoDB\Driver\BulkWrite</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeerrors">
+     <term><varname>writeErrors</varname></term>
+     <listitem>
+      <simpara>
+       Un array de <classname>MongoDB\Driver\WriteError</classname> para
+       los errores de escritura producidos durante la ejecución.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeconcernerror">
+     <term><varname>writeConcernError</varname></term>
+     <listitem>
+      <simpara>
+       El <classname>MongoDB\Driver\WriteConcernError</classname> que
+       ha ocurrido, o &null; si no ha ocurrido ningún error de write concern.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.writeconcern">
+     <term><varname>writeConcern</varname></term>
+     <listitem>
+      <simpara>
+       El <classname>MongoDB\Driver\WriteConcern</classname> utilizado para
+       el bulk write, o &null; si no está disponible.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="mongodb-driver-writeresult.props.errorreplies">
+     <term><varname>errorReplies</varname></term>
+     <listitem>
+      <simpara>
+       Un array de documentos de respuesta de error procedentes del servidor.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Las propiedades <modifier>public</modifier> <modifier>readonly</modifier> han sido añadidas.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>


### PR DESCRIPTION
Sync con php/doc-en#5496: documenta las propiedades ``public readonly`` añadidas en ext-mongodb 2.3.0 (clases ``Driver\Manager``, eventos de monitoring, ``ReadConcern``, ``ReadPreference``, ``WriteConcern``, ``WriteConcernError``, ``WriteError``, ``WriteResult`` y excepciones ``BulkWriteException``/``CommandException``) y añade las nuevas opciones URI ``enableOverloadRetargeting`` y ``maxAdaptiveRetries`` para Intelligent Workload Management. 21 archivos, hash ``EN-Revision`` actualizado.

Fixes #535