### PR TITLE
Sync EN: gc_collect_cycles changelog PHP 8.5 (#5528)

### DIFF
--- a/reference/info/functions/gc-collect-cycles.xml
+++ b/reference/info/functions/gc-collect-cycles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3dee475a90f49a8b755b741e892723eb68e68993 Maintainer: jorgeolaya Status: ready -->
+<!-- EN-Revision: eec7af8395621ed03c2f4ffe8e7d784da6641739 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <refentry xml:id="function.gc-collect-cycles" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -41,29 +41,28 @@
 </refsect1>
  -->
 
- <!-- Use when a CHANGELOG exists
  <refsect1 role="changelog">
- &reftitle.changelog;
- <para>
- <informaltable>
- <tgroup cols="2">
- <thead>
- <row>
- <entry>&Version;</entry>
- <entry>&Description;</entry>
-</row>
-</thead>
- <tbody>
- <row>
- <entry>Enter the PHP version of change here</entry>
- <entry>Description of change</entry>
-</row>
-</tbody>
-</tgroup>
-</informaltable>
-</para>
-</refsect1>
- -->
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       El valor de retorno ya no incluye las cadenas y los recursos que
+       fueron recolectados indirectamente a través de los ciclos.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
  <!-- Use when examples exist
  <refsect1 role="examples">


### PR DESCRIPTION
Sync desde https://github.com/php/doc-en/pull/5528 : añade la entrada del changelog de PHP 8.5 indicando que el valor de retorno de \`gc_collect_cycles()\` ya no incluye las cadenas y recursos recolectados indirectamente a través de los ciclos.

Fixes #546