### PR TITLE
Sync EN: SNMP changelog PHP 8.5 ValueError validation (#5533)

### DIFF
--- a/reference/snmp/functions/snmp2-get.xml
+++ b/reference/snmp/functions/snmp2-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-get">
  <refnamediv>
@@ -76,6 +76,31 @@
    Devuelve el valor del objeto <acronym>SNMP</acronym>
    en caso de éxito, o &false; si ocurre un error.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ahora lanza un <exceptionname>ValueError</exceptionname> cuando la
+       longitud del nombre de host es igual o mayor a 128 bytes, cuando el
+       puerto es negativo o mayor que 65535, o cuando los valores de
+       timeout o reintentos son menores a -1 o demasiado grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmp2-set.xml
+++ b/reference/snmp/functions/snmp2-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-set">
  <refnamediv>
@@ -101,6 +101,31 @@
    Si se especifica un OID desconocido o inválido, la alerta emitida contendrá
    probablemente esto: "Could not add variable".
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ahora lanza un <exceptionname>ValueError</exceptionname> cuando la
+       longitud del nombre de host es igual o mayor a 128 bytes, cuando el
+       puerto es negativo o mayor que 65535, o cuando los valores de
+       timeout o reintentos son menores a -1 o demasiado grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-get">
  <refnamediv>
@@ -135,6 +135,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ahora lanza un <exceptionname>ValueError</exceptionname> cuando la
+       longitud del nombre de host es igual o mayor a 128 bytes, cuando el
+       puerto es negativo o mayor que 65535, o cuando los valores de
+       timeout o reintentos son menores a -1 o demasiado grandes.
+      </entry>
+     </row>
      <row>
       <entry>8.1.0</entry>
       <entry>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-set">
  <refnamediv>
@@ -150,6 +150,31 @@
    Si se especifica un OID desconocido o inválido, la alerta será probablemente
    "Could not add variable".
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ahora lanza un <exceptionname>ValueError</exceptionname> cuando la
+       longitud del nombre de host es igual o mayor a 128 bytes, cuando el
+       puerto es negativo o mayor que 65535, o cuando los valores de
+       timeout o reintentos son menores a -1 o demasiado grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmpget.xml
+++ b/reference/snmp/functions/snmpget.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpget">
  <refnamediv>
@@ -74,6 +74,31 @@
   <simpara>
    Devuelve el valor del objeto <acronym>SNMP</acronym> en caso de éxito, &false; si ocurre un error.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ahora lanza un <exceptionname>ValueError</exceptionname> cuando la
+       longitud del nombre de host es igual o mayor a 128 bytes, cuando el
+       puerto es negativo o mayor que 65535, o cuando los valores de
+       timeout o reintentos son menores a -1 o demasiado grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmpset.xml
+++ b/reference/snmp/functions/snmpset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpset">
  <refnamediv>
@@ -102,6 +102,31 @@
    wrong type or length." Si se especifica un OID desconocido o inválido, el contenido de la alerta será
    probablemente "Could not add variable".
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ahora lanza un <exceptionname>ValueError</exceptionname> cuando la
+       longitud del nombre de host es igual o mayor a 128 bytes, cuando el
+       puerto es negativo o mayor que 65535, o cuando los valores de
+       timeout o reintentos son menores a -1 o demasiado grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Sync desde https://github.com/php/doc-en/pull/5533 : añade la entrada del changelog de PHP 8.5 a las funciones SNMP (snmpget, snmpset, snmp2_get, snmp2_set, snmp3_get, snmp3_set) que ahora lanzan un \`ValueError\` ante un nombre de host, puerto, timeout o reintentos inválidos.

Fixes #545