### PR TITLE
[Sync EN] ext/zip: Change <para> to <simpara> (#5536)

### DIFF
--- a/reference/zip/book.xml
+++ b/reference/zip/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: aebf045bfb7f4f2350db5e1e908cf290be334075 Maintainer: chuso Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 
 <book xml:id="book.zip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -10,10 +10,10 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.zip">
   &reftitle.intro;
-  <para>
+  <simpara>
    Esta extensión permite leer o escribir de forma transparente archivos
    comprimidos ZIP y los ficheros que hay dentro.
-  </para>
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -1,47 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7747acdc55fe497b9e920d6edcbe70c71e03ea30 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <section xml:id="zip.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
   <section xml:id="zip.installation.linux">
     <title>Sistemas Linux</title>
-    <para>
+    <simpara>
      Para usar estas funciones, PHP debe compilarse con soporte ZIP
      utilizando la opción de configuración <option role="configure">--with-zip</option>.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Antes de PHP 7.4.0, libzip estaba incluida con PHP,
      y para compilar la extensión se necesitaba usar la opción de configuración
      <option role="configure">--enable-zip</option>.
      Compilar contra la libzip incluida estaba desaconsejado a partir de PHP 7.3.0,
      pero aún era posible usando la opción de configuración
      <option role="configure">--without-libzip</option>.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      Se ha añadido una opción de configuración <option role="configure">--with-libzip=DIR</option>
      para usar una instalación de libzip del sistema. Se requiere la versión 0.11 de libzip,
      recomendándose la 0.11.2 o superior.
-    </para>
+    </simpara>
   </section>
 
   <section xml:id="zip.installation.new.windows">
     <title>Windows</title>
-    <para>
+    <simpara>
      A partir de PHP 8.2.0, el archivo <filename>php_zip.dll</filename> DLL debe ser
      <link linkend="install.pecl.windows.loading">habilitado</link> en
      &php.ini;.
      Anteriormente, esta extensión estaba integrada.
-    </para>
+    </simpara>
   </section>
 
  <section xml:id="zip.installation.pecl">
   <title>Instalación mediante PECL</title>
-  <para>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;zip">&url.pecl.package;zip</link>.
-  </para>
+  </simpara>
  </section>
 
 </section>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8afee82662753fe5ed0c3b8003b14118f00547ef Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="zip.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
 
- <para>
+ <simpara>
   <classname>ZipArchive</classname> usa constantes de clase.
   Existen varios tipos de constantes, los principales son:
   Flags (prefijadas con <literal>FL_</literal>),
   Flags globales (prefijadas con <literal>AFL_</literal>),
   errores (prefijados con <literal>ER_</literal>) y
   modos (sin prefijo).
- </para>
+ </simpara>
 
  <variablelist xml:id="ziparchive.constants.mode">
   <title>Modos de apertura de archivos</title>

--- a/reference/zip/examples.xml
+++ b/reference/zip/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bac24fafb415f56925732ef41ec7b2326ded3d8e Maintainer: yago Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="zip.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -80,13 +80,13 @@ print_r($odt_meta);
 ]]>
   </programlisting>
  </example>
- <para>
+ <simpara>
   Este ejemplo utiliza la antigua API (PHP 4), abre un fichero ZIP,
   lee cada fichero del archivo y imprime
   su contenido. El archivo<filename>test2.zip</filename> usado en este
   ejmplo es uno de los archivos de prueba la fuente de distribución
   de ZZIPlib.
- </para>
+ </simpara>
  <example>
   <title>Ejemplo del uso de Zip</title>
   <programlisting role="php">

--- a/reference/zip/functions/zip-close.xml
+++ b/reference/zip/functions/zip-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,9 +19,9 @@
    <type>void</type><methodname>zip_close</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_close</function> cierra el archivo ZIP dado.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,9 +30,9 @@
     <varlistentry>
      <term><parameter>zip</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un archivo ZIP previamente abierto con la función <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,9 +40,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-close.xml
+++ b/reference/zip/functions/zip-entry-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,9 +19,9 @@
    <type>bool</type><methodname>zip_entry_close</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_close</function> cierra un directorio de archivo dado.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,10 +30,10 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un directorio de archivo previamente abierto con la función
        <function>zip_entry_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-compressedsize.xml
+++ b/reference/zip/functions/zip-entry-compressedsize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-compressedsize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_compressedsize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_compressedsize</function> devuelve el tamaño comprimido
    de un directorio de archivo dado.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,10 +31,10 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un directorio de archivo devuelto por la función
        <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El tamaño comprimido, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-compressionmethod.xml
+++ b/reference/zip/functions/zip-entry-compressionmethod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-compressionmethod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_compressionmethod</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_compressionmethod</function> devuelve el método de compresión
    usado en el directorio de archivo especificado por <parameter>zip_entry</parameter>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,9 +31,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un directorio de archivo devuelto por la función <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El método de compresión, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-filesize.xml
+++ b/reference/zip/functions/zip-entry-filesize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-filesize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_filesize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_filesize</function> devuelve el tamaño descomprimido
    de un directorio de archivo dado.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,10 +31,10 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un directorio de archivo devuelto por la función
        <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El tamaño descomprimido del directorio de archivo, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-name.xml
+++ b/reference/zip/functions/zip-entry-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-name" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_name</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_name</function> devuelve el nombre de un
    directorio de archivo dado.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,9 +31,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un directorio de archivo devuelto por la función <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El nombre del directorio de archivo, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-open.xml
+++ b/reference/zip/functions/zip-entry-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,10 +21,10 @@
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>mode</parameter><initializer>"rb"</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_open</function> abre un directorio en un archivo ZIP
    para lectura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -33,34 +33,34 @@
     <varlistentry>
      <term><parameter>zip_dp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un recurso válido devuelto por la función
        <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un directorio de archivo devuelto por la función
        <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>mode</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Todos los métodos especificados en la documentación
        de la función <function>fopen</function>.
-      </para>
+      </simpara>
       <note>
-       <para>
+       <simpara>
         Actualmente, <parameter>mode</parameter> es ignorado y siempre vale
         <literal>"rb"</literal>. Esto se debe a que el soporte ZIP
         de PHP es solo de lectura.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -69,16 +69,16 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     A diferencia de <function>fopen</function> y otras funciones
     de archivos, el valor devuelto por <function>zip_entry_open</function>
     solo indica el resultado de la operación y no es necesario
     para la lectura o el cierre del archivo del directorio de archivo.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,9 +20,9 @@
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>1024</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_read</function> lee en un directorio de archivo abierto.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,22 +31,22 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un directorio de archivo devuelto por la función
        <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El número de bytes a devolver.
-      </para>
+      </simpara>
       <note>
-       <para>
+       <simpara>
         Esto debe ser el tamaño descomprimido que desea leer.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -55,10 +55,10 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve los datos leídos, una cadena vacía si se está al
    final del archivo, o &false; si ocurre un error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-open.xml
+++ b/reference/zip/functions/zip-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,9 +19,9 @@
    <type class="union"><type>resource</type><type>int</type><type>false</type></type><methodname>zip_open</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_open</function> abre un nuevo archivo ZIP para lectura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,9 +30,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nombre del archivo ZIP a abrir.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,13 +40,13 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un recurso a utilizar
    más tarde con las funciones <function>zip_read</function> y
    <function>zip_close</function>, o bien devuelve &false; o
    el número de error si el parámetro <parameter>filename</parameter>
    no existe o en caso de otro error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-read.xml
+++ b/reference/zip/functions/zip-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>resource</type><type>false</type></type><methodname>zip_read</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_read</function> lee la siguiente entrada en un archivo
    ZIP.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,10 +32,10 @@
     <varlistentry>
      <term><parameter>zip</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un archivo ZIP previamente abierto con la función
        <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,11 +43,11 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un recurso de entrada de directorio para usar más tarde con las
    funciones <literal>zip_entry_...</literal>, o &false; si no hay más entradas
    para leer, o un código de error si ocurre un error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/setup.xml
+++ b/reference/zip/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 765b2d6eec7dfbaeed900b32aa91a1360d73df42 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="zip.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -8,12 +8,12 @@
  <!-- {{{ Requirements -->
  <section xml:id="zip.requirements">
   &reftitle.required;
-  <para>
+  <simpara>
    Esta extensión requiere <link xlink:href="&url.libzip;">libzip</link>. La versión 1.1.2 estaba incluida en PHP hasta la versión 7.3.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    La versión mínima soportada es 0.11, pero se recomienda encarecidamente una versión superior.
-  </para>
+  </simpara>
   <para>
    <simplelist>
     <member>Versión 1.2 requerida para soporte de encriptación, ver <methodname>ZipArchive::setEncryptionIndex</methodname></member>
@@ -31,11 +31,11 @@
  <!-- {{{ Resources -->
  <section xml:id="zip.resources">
   &reftitle.resources;
-  <para>
+  <simpara>
    Existen dos tipos de recursos usados en el módulo Zip. El primero es
    el directorio Zip para el fichero Zip, el segundo la entrada Zip
    para la entrada de archivos.
-  </para>
+  </simpara>
  </section>
  <!-- }}} -->
 

--- a/reference/zip/ziparchive.xml
+++ b/reference/zip/ziparchive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c0e48705eb88453af785e0e4a6cbd526085dfe3a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.ziparchive" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase <classname>ZipArchive</classname></title>
@@ -10,9 +10,9 @@
   <!-- {{{ ZipArchive intro -->
   <section xml:id="ziparchive.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Un fichero, comprimido con Zip.
-   </para>
+   </simpara>
   </section>
   <!-- }}} -->
 
@@ -746,46 +746,46 @@
     <varlistentry xml:id="ziparchive.props.lastid">
      <term><varname>lastId</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Valor de índice de la última entrada añadida (archivo o directorio).
        Disponible para archivo cerrado, a partir de PHP 8.0.0 y PECL zip 1.18.0.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.status">
      <term><varname>status</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Estado del archivo Zip.
        Disponible para archivo cerrado, a partir de PHP 8.0.0 y PECL zip 1.18.0.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.statussys">
      <term><varname>statusSys</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Estado del sistema del archivo Zip.
        Disponible para archivo cerrado, a partir de PHP 8.0.0 y PECL zip 1.18.0.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.numfiles">
      <term><varname>numFiles</varname></term>
      <listitem>
-      <para>Número de ficheros en el archivo</para>
+      <simpara>Número de ficheros en el archivo</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.filename">
      <term><varname>filename</varname></term>
      <listitem>
-      <para>Nombre del archivo en le sistema de archivos</para>
+      <simpara>Nombre del archivo en le sistema de archivos</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.comment">
      <term><varname>comment</varname></term>
      <listitem>
-      <para>Comentario para el archivo</para>
+      <simpara>Comentario para el archivo</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/zip/ziparchive/addemptydir.xml
+++ b/reference/zip/ziparchive/addemptydir.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0545e305cf06937b14b3f0694d6e716c9881ffd7 Maintainer: yago Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.addemptydir" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>dirname</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Añade un directoro vacío en el archivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,22 +25,22 @@
     <varlistentry>
      <term><parameter>dirname</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El directorio a añadir.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Máscara de bits compuesta por
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
        <constant>ZipArchive::FL_ENC_CP437</constant>.
        El comportamiento de estas constantes se describe en
        la página de <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -49,9 +49,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="ziparchive.addfile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,9 +16,9 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>ZipArchive::LENGTH_TO_END</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ZipArchive::FL_OVERWRITE</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Añade un fichero al archivo ZIP par la ruta dada.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -28,42 +28,42 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La ruta del fichero a añadir.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>entryname</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si corresponde, este es el nombre local dentro del archivo ZIP que reemplazará el <parameter>filepath</parameter>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>start</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Para la copia parcial, posición de inicio.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Para copia parcial, longitud a copiar,
        si <constant>ZipArchive::LENGTH_TO_END</constant> (0) se usa el tamaño del archivo,
        si <constant>ZipArchive::LENGTH_UNCHECKED</constant> se usa todo el archivo
        (comenzando desde <parameter>start</parameter>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Máscara de bits compuesta por
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -72,7 +72,7 @@
        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        El comportamiento de estas constantes se describe en
        la página de <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -81,9 +81,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -124,12 +124,12 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Este ejemplo abre un archivo ZIP
      <filename>test.zip</filename> y añade
      el fichero <filename>/path/to/index.txt</filename>.
      como <filename>newname.txt</filename>.
-    </para>
+    </simpara>
     <example>
      <title>Abrir y extraer</title>
      <programlisting role="php">
@@ -152,14 +152,14 @@ if ($zip->open('test.zip') === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cuando un fichero es añadido al archivo, PHP bloqueará el fichero. El
     bloqueo se desbloqueará cuando el objeto <classname>ZipArchive</classname> finalice,
     ya sea a través de <methodname>ZipArchive::close</methodname> o el
     objeto <classname>ZipArchive</classname> sea destruido. Esto puede impedir
     que se pueda eliminar el archivo que se está añadiendo hasta después de que el
     bloqueo haya sido liberado.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yago Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="ziparchive.addfromstring" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>string</type><parameter>content</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ZipArchive::FL_OVERWRITE</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Añade un fichero al archivo ZIP usando su contenido.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -26,24 +26,24 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada a crear.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>content</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El contenido a usar para crear la entrada. Es usado en modo
        binary safe.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Máscara de bits compuesta por
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -51,7 +51,7 @@
        <constant>ZipArchive::FL_ENC_CP437</constant>.
        El comportamiento de estas constantes se describe en
        la página de <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,9 +59,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.addglob" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Añade ficheros de un directorio que corresponde con el patrón global <parameter>pattern</parameter>.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
 
@@ -27,17 +27,17 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un patrón <function>glob</function>contra el cual se hará la correspondencia con los ficheros.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>flags</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Una máscara de un bit de marcas <literal>glob()</literal>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -47,36 +47,36 @@
       Un array asociativo de opciones. Las opciones disponibles son:
       <itemizedlist>
        <listitem>
-        <para>
+        <simpara>
          <literal>"add_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Prefijo a indicar cuando se traduce la ruta de acceso del fichero dentro
          del archivo. Esta traducción se aplica después de cualquier operación de eliminación definida por las opciones
          <literal>"remove_path"</literal> o <literal>"remove_all_path"</literal>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"remove_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Prefijo para eliminar la ruta de acceso de los ficheros antes de añadirlos al archivo.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"remove_all_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          &true; para utilizar únicamente el nombre del fichero y añadirlo a la raíz del archivo.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"flags"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Máscara de bits compuesta por
          <constant>ZipArchive::FL_OVERWRITE</constant>,
          <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -85,41 +85,41 @@
          <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
          El comportamiento de estas constantes se describe en
          la página de <link linkend="zip.constants">constantes ZIP</link>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"comp_method"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Método de compresión, una de las constantes <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>,
          ver la página de <link linkend="zip.constants">constantes ZIP</link>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"comp_flags"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Nivel de compresión.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"enc_method"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Método de cifrado, una de las constantes <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>,
          ver la página de <link linkend="zip.constants">constantes ZIP</link>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"enc_password"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Contraseña utilizada para el cifrado.
-        </para>
+        </simpara>
        </listitem>
       </itemizedlist>
      </para>
@@ -130,9 +130,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un <type>array</type> de archivos añadidos en caso de éxito &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -177,9 +177,9 @@
   &reftitle.examples;
   <example xml:id="ziparchive.addglob.example.basic">
    <title>Ejemplo con <methodname>ZipArchive::addGlob</methodname></title>
-   <para>
+   <simpara>
      Añadir todos los ficheros de scripts y texto php del directorio de trabajo actual
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/addpattern.xml
+++ b/reference/zip/ziparchive/addpattern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: regiemix Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.addpattern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam choice="opt"><type>string</type><parameter>path</parameter><initializer>"."</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Añade ficheros de un directorio que coinciden con la expresión regular  <parameter>pattern</parameter>.
    La operación no es recursiva. Únicamente se hará la correspondencia del patrón con el nombre del fichero.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,25 +27,25 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un patrón <link linkend="book.pcre">PCRE</link> contra el cual se realizará la correspondencia.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>path</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       El directorio que será escaneado. Por defecto es el directorio de trabajo actual.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un array asociativo de opciones aceptadas por <methodname>ZipArchive::addGlob</methodname>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -53,18 +53,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un <type>array</type> de archivos añadidos en caso de éxito &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="ziparchive.addpattern.example.basic">
    <title>Ejemplo con <methodname>ZipArchive::addPattern</methodname></title>
-   <para>
+   <simpara>
      Añadir todos los scripts y ficheros de texto php del directorio actual
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/clearerror.xml
+++ b/reference/zip/ziparchive/clearerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.clearerror" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>void</type><methodname>ZipArchive::clearError</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Borra el mensaje de error, los mensajes del sistema y/o zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,15 +12,15 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::close</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cierra fichero abierto o creado y guarda los cambios. Este método es
    automáticamente llamado al finalizar el script.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si el archivo no contiene ningún fichero, el fichero es completamente eliminado por defecto
    (no se escribe ningún archivo vacío) según el valor de la
    bandera global <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zip/ziparchive/count.xml
+++ b/reference/zip/ziparchive/count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el número de ficheros en el archivo.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/zip/ziparchive/deleteindex.xml
+++ b/reference/zip/ziparchive/deleteindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yago Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.deleteindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::deleteIndex</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Elimina una entrada en su archivo usando su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada a eliminar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/deletename.xml
+++ b/reference/zip/ziparchive/deletename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yago Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.deletename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::deleteName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Elimina una entrada en el archivo por su nombre
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada a eliminar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b61758269e3619194047cb5d6d4962734372c0a6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.extractto" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,23 +13,23 @@
    <methodparam><type>string</type><parameter>pathto</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>string</type><type>null</type></type><parameter>files</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Extrae el archivo completo o los ficheros dados en la ruta
    que se especifique.
-  </para>
+  </simpara>
   <warning>
-   <para>
+   <simpara>
     Los permisos por omisión para los archivos y directorios
     extraídos dan el más amplio acceso posible. Esto se puede restringir
     estableciendo la umask actual, que se puede cambiar usando
     <function>umask</function>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Por razones de seguridad, los permisos originales no se restauran.
     Para ver un ejemplo de cómo restaurarlos, consulte el
     <link linkend="ziparchive.getexternalattributesindex.examples.perms">ejemplo de código</link>
     en la página de <methodname>ZipArchive::getExternalAttributesIndex</methodname>.
-   </para>
+   </simpara>
   </warning>
  </refsect1>
  <refsect1 role="parameters">
@@ -39,18 +39,18 @@
     <varlistentry>
      <term><parameter>pathto</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Destino en donde extraer los ficheros.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>files</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Las entradas a extraer. Acepta tanto un solo nombre o un array
        de nombres.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -58,9 +58,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getarchivecomment.xml
+++ b/reference/zip/ziparchive/getarchivecomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: agarzon Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: agarzon -->
 <refentry xml:id="ziparchive.getarchivecomment" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>ZipArchive::getArchiveComment</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el comentario del archivo ZIP.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,10 +24,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si las flags se establecen en <constant>ZipArchive::FL_UNCHANGED</constant>, el
        comentario original se devuelve sin cambios.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el comentario del archivo Zip&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bb6e8c9fb1f4cc4c83a67a2c3e031ac3c8c28ccc Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.getarchiveflag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>flag</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el valor de una bandera global del archivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,24 +29,24 @@
        La bandera global a recuperar, entre las constantes <literal>AFL_*</literal>:
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_RDONLY</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_IS_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -55,10 +55,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si <parameter>flags</parameter> se define como <constant>ZipArchive::FL_UNCHANGED</constant>,
        la bandera original no se modifica y se devuelve.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -67,9 +67,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve 1 si la bandera está definida para el archivo, 0 si no lo está, y -1 si ocurre un error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getcommentindex.xml
+++ b/reference/zip/ziparchive/getcommentindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yago Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: yago -->
 <refentry xml:id="ziparchive.getcommentindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el comentario de una entrada usando la entrada índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si flags <constant>ZipArchive::FL_UNCHANGED</constant>, se devolverá
        el comentario original no cambiado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Con éxito devuelve el comentario&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getcommentname.xml
+++ b/reference/zip/ziparchive/getcommentname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yago Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: yago -->
 <refentry xml:id="ziparchive.getcommentname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el comentario de una entrada usando el nombre de la entrada.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si flags está defindo a <constant>ZipArchive::FL_UNCHANGED</constant>, se devuelve el
        comentario original no cambiado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el comentario si se ejecutó con éxito&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getexternalattributesindex.xml
+++ b/reference/zip/ziparchive/getexternalattributesindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b61758269e3619194047cb5d6d4962734372c0a6 Maintainer: lduran Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.getexternalattributesindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Recuperar los atributos externos de una entrada definida por su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,34 +26,34 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El índice de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        En caso de éxito, recibe el código del sistema operativo definido por una de las constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        En caso de éxito, recibe los atributos externos. El valor dependerá del sistema operativo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si flags se establece a <constant>ZipArchive::FL_UNCHANGED</constant>, se devuelven los atributos
        originales sin cambios.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -61,17 +61,17 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
+  <simpara>
    Este ejemplo extrae todas las entradas de un archivo
    ZIP <filename>test.zip</filename> y
    asigna los permisos Unix tomados de los atributos externos.
-  </para>
+  </simpara>
   <example xml:id="ziparchive.getexternalattributesindex.examples.perms">
    <title>Extraer todas las entradas con permisos Unix</title>
    <programlisting role="php">

--- a/reference/zip/ziparchive/getexternalattributesname.xml
+++ b/reference/zip/ziparchive/getexternalattributesname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: lduran Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.getexternalattributesname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Obtener los atributos externos de una entrada definida por su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,34 +26,34 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nombre de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        En caso de éxito, recibe el código del sistema operativo definido por una de las constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        En caso de éxito, recibe los atributos externos. El valor depende del sistema operativo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si flags se establece a <constant>ZipArchive::FL_UNCHANGED</constant>, se devuelven los atributos
        originales sin cambios.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -61,9 +61,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/getfromindex.xml
+++ b/reference/zip/ziparchive/getfromindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: agarzon Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: agarzon -->
 <refentry xml:id="ziparchive.getfromindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el contenido de la entrada usando su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El índice de la entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La longitud  que se see desde la entrada. Si es <literal>0</literal>, entonces
        toda la entrada se lee.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -47,14 +47,14 @@
        pueden ser Ored.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_COMPRESSED</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -65,9 +65,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el contenido de la entrada si se ejecutó con éxito&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getfromname.xml
+++ b/reference/zip/ziparchive/getfromname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.getfromname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el contenido de la entrada utilizando su nombre
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La longitud a ser leída desde la entrada. Si es <literal>0</literal>, entonces
        toda la entrada es leída.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -47,19 +47,19 @@
        ser escritos juntos con un OR lógico en él.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_COMPRESSED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -70,9 +70,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el contenido de la entrada en caso de tener éxito,&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getnameindex.xml
+++ b/reference/zip/ziparchive/getnameindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: agarzon Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: agarzon -->
 <refentry xml:id="ziparchive.getnameindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el nombre de una entrada utilizando su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El índice de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si las flags se establecen en <constant>ZipArchive::FL_UNCHANGED</constant>, el nombre original es
        devuelto sin cambios.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre en caso de tener éxito, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstatusstring.xml
+++ b/reference/zip/ziparchive/getstatusstring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0545e305cf06937b14b3f0694d6e716c9881ffd7 Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.getstatusstring" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>string</type><methodname>ZipArchive::getStatusString</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve mensajes de: estado de error, de sistema y/o mensajes de zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un <type>string</type> con el mensaje de estado.
-  </para>
+  </simpara>
  </refsect1>
 
 <refsect1 role="changelog">

--- a/reference/zip/ziparchive/getstream.xml
+++ b/reference/zip/ziparchive/getstream.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: agarzon Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.getstream" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,10 +12,10 @@
    <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>ZipArchive::getStream</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Obtener un manejador de fichero para la entrada definido por su nombre. Por ahora, éste solamente
    soporta operaciones de lectura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nombre de la entrada a utilizar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -34,9 +34,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un puntero de fichero (un recurso) en caso de tener éxito,&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstreamindex.xml
+++ b/reference/zip/ziparchive/getstreamindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.getstreamindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Recupera un manejador de archivo para la entrada definida por su índice. Actualmente,
    esta función solo soporta operaciones de lectura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada a utilizar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si <parameter>flags</parameter> se define como <constant>ZipArchive::FL_UNCHANGED</constant>, el flujo original
        es devuelto.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un puntero de archivo (recurso) en caso de éxito, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstreamname.xml
+++ b/reference/zip/ziparchive/getstreamname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.getstreamname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Recupera un manejador de archivo para la entrada definida por su nombre. Actualmente,
    esta función solo soporta operaciones de lectura.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nombre de la entrada a utilizar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si <parameter>flags</parameter> se define como <constant>ZipArchive::FL_UNCHANGED</constant>, el flujo original
        es devuelto.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un puntero de archivo (recurso) en caso de éxito, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/iscompressionmethoddupported.xml
+++ b/reference/zip/ziparchive/iscompressionmethoddupported.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.iscompressionmethoddupported" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Verifica si un método de compresión es soportado por libzip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,19 +26,19 @@
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El método de compresión, una de las constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>enc</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si es &true;, verifica la compresión; si es &false;, verifica la
        descompresión.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -47,18 +47,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta función está disponible solo si la compilación
     se realizó con ≥ 1.7.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/isencryptionmethoddupported.xml
+++ b/reference/zip/ziparchive/isencryptionmethoddupported.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.isencryptionmethoddupported" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Verifica si un método de cifrado es soportado por libzip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,19 +26,19 @@
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El método de cifrado, una de las constantes
        <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>enc</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si es &true;, verifica el cifrado; si es &false;, verifica el
        descifrado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -47,18 +47,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta función está disponible solo si la extensión ha sido compilada con
     libzip ≥ 1.7.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/locatename.xml
+++ b/reference/zip/ziparchive/locatename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.locatename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Localiza una entrada utilizando su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nombre de la entrada a buscar
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -36,14 +36,14 @@
        Los indicadores son especificados agregándoles OR a los siguientes valores, ó 0 para ninguno de ellos.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NODIR</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -54,9 +54,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el índice de la entrada en caso de tener éxito,&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.open" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Abre un archivo zip nuevo o existente para leer, escribir o modificar.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Desde libzip 1.6.0, un archivo vacío ya no es un archivo válido.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -27,9 +27,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nombre del fichero del archivo ZIP para ser abierto.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -39,29 +39,29 @@
        El modo a utilizar para abrir el archivo.
       <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::OVERWRITE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::CREATE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::RDONLY</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::EXCL</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::CHECKCONS</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>

--- a/reference/zip/ziparchive/registercancelcallback.xml
+++ b/reference/zip/ziparchive/registercancelcallback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.registercancelcallback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::registerCancelCallback</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Registrar una función <parameter>callback</parameter> para permitir la cancelación durante el cierre del archivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si esta función vuelve a 0, la operación continuará, otro valor será cancelado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -36,18 +36,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
+  <simpara>
    Este ejemplo crea un archivo ZIP
    <filename>php.zip</filename> y cancela
    la operación en alguna condición de operación.
-  </para>
+  </simpara>
   <example>
    <title>Archive a file</title>
    <programlisting role="php">
@@ -69,9 +69,9 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta función sólo está disponible si se construye con libzip ≥ 1.6.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/registerprogresscallback.xml
+++ b/reference/zip/ziparchive/registerprogresscallback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.registerprogresscallback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>float</type><parameter>rate</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Registra una función <parameter>callback</parameter> para proporcionar actualizaciones durante el cierre del archivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,17 +25,17 @@
     <varlistentry>
      <term><parameter>rate</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Cambiar entre cada llamada de la devolución de llamada (de 0.0 a 1.0).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Esta función recibirá el actual <parameter>state</parameter> como un <type>float</type> (de 0.0 a 1.0).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,18 +44,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
+  <simpara>
    Este ejemplo crea un archivo ZIP
    <filename>php.zip</filename> y muestra
    la progresión.
-  </para>
+  </simpara>
   <example>
    <title>Archive a file</title>
    <programlisting role="php">
@@ -76,9 +76,9 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta función sólo está disponible si se construye con libzip ≥ 1.3.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/renameindex.xml
+++ b/reference/zip/ziparchive/renameindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.renameindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>string</type><parameter>new_name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renombra una entrada definida por su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,17 +24,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada a renombrar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>new_name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre nuevo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/renamename.xml
+++ b/reference/zip/ziparchive/renamename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.renamename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>new_name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renombra una entrada definida por su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,17 +24,17 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada a renombrar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>new_name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre nuevo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="ziparchive.replacefile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,9 +16,9 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>ZipArchive::LENGTH_TO_END</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Reemplaza fichero en el archivo ZIP con una ruta determinada.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -28,42 +28,42 @@
     <varlistentry>
      <term><parameter>filepath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La ruta del archivo a añadir.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El índice del archivo a reemplazar, su nombre no ha cambiado.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>start</parameter></term>
      <listitem>
-      <para>
+      <simpara>
         Para la copia parcial, posición de inicio.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Para copia parcial, longitud a copiar,
        si <constant>ZipArchive::LENGTH_TO_END</constant> (0) se usa el tamaño del archivo,
        si <constant>ZipArchive::LENGTH_UNCHECKED</constant> se usa todo el archivo
        (comenzando desde <parameter>start</parameter>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Máscara de bits compuesta por
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
@@ -71,7 +71,7 @@
        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        El comportamiento de estas constantes se describe en
        la página de <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -80,9 +80,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -117,11 +117,11 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
+  <simpara>
    Este ejemplo abre un archivo ZIP
    <filename>test.zip</filename> y sustituye la entrada del índice 1
    con <filename>/path/to/index.txt</filename>.
-  </para>
+  </simpara>
   <example>
    <title>Abrir y reemplazar</title>
    <programlisting role="php">

--- a/reference/zip/ziparchive/setarchivecomment.xml
+++ b/reference/zip/ziparchive/setarchivecomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.setarchivecomment" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setArchiveComment</methodname>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece el comentario de un archivo ZIP.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Los contenidos del comentario.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setarchiveflag.xml
+++ b/reference/zip/ziparchive/setarchiveflag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setarchiveflag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>flag</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Define una bandera global de un archivo ZIP.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -28,14 +28,14 @@
        La bandera global a cambiar, entre las constantes <literal>AFL_*</literal>.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -44,9 +44,9 @@
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nuevo valor de la bandera.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -55,9 +55,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/setcommentindex.xml
+++ b/reference/zip/ziparchive/setcommentindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.setcommentindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece el comentario de una entrada definido por su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,17 +24,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Los contenidos del comentario.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcommentname.xml
+++ b/reference/zip/ziparchive/setcommentname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.setcommentname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece el comentario de una entrada definido por su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,17 +24,17 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Los contenidos del comentario.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcompressionindex.xml
+++ b/reference/zip/ziparchive/setcompressionindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.setcompressionindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>compflags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establecer el método de compresión de una entrada definida por su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,26 +25,26 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El índice de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El método de compresión, una de las constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compflags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nivel de compresión.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,9 +52,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcompressionname.xml
+++ b/reference/zip/ziparchive/setcompressionname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.setcompressionname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>compflags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establecer el método de compresión de una entrada definida por su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,26 +25,26 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nombre de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El método de compresión. Una de las constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compflags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nivel de compresión.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,9 +52,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setencryptionindex.xml
+++ b/reference/zip/ziparchive/setencryptionindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setencryptionindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece el método de cifrado de una entrada definida por su índice.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,25 +27,25 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El método de cifrado definido por una de las constantes ZipArchive::EM_ constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>password</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Contraseña opcional, se utiliza por defecto cuando falta.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -54,9 +54,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -84,9 +84,9 @@
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta función sólo está disponible si se construye con libzip ≥ 1.2.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setencryptionname.xml
+++ b/reference/zip/ziparchive/setencryptionname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setencryptionname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece el método de cifrado de una entrada definida por su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,25 +25,25 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El método de encriptación definido por una de las constantes ZipArchive::EM_constants.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>password</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Contraseña opcional, se utiliza por defecto cuando falta.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,9 +51,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -80,12 +80,12 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
+  <simpara>
    Este ejemplo crea un archivo ZIP
    <filename>test.zip</filename> y añade
    al archivo <filename>test.txt</filename>
    encriptado usando el método AES 256.
-  </para>
+  </simpara>
   <example>
    <title>Archivar y encriptar un archivo</title>
    <programlisting role="php">
@@ -110,9 +110,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta función sólo está disponible si se construye con libzip ≥ 1.2.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setexternalattributesindex.xml
+++ b/reference/zip/ziparchive/setexternalattributesindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: lduran Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setexternalattributesindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece los atributos externos de una entrada definida por su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,33 +26,33 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El índice de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El código del sistema operativo definido por una de las constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Los atributos externos. El valor depende del sistema operativo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Banderas opcionales. Actualmente no se utiliza.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,9 +60,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/setexternalattributesname.xml
+++ b/reference/zip/ziparchive/setexternalattributesname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: lduran Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.setexternalattributesname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece los atributos externos de una entrada definida por su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,33 +26,33 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El nombre de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El código del sistema operativo definido por una de las constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Los atributos externos. El valor depende del sistema operativo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Banderas opcionales. Actualmente no se utiliza.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,18 +60,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
+  <simpara>
    Este ejemplo abre un archivo comprimido ZIP
    <filename>test.zip</filename> y añade
    el fichero <filename>test.txt</filename>
    con sus permisos Unix como atributos externos.
-  </para>
+  </simpara>
   <example>
    <title>Archivar un fichero, con sus permisos Unix</title>
    <programlisting role="php">

--- a/reference/zip/ziparchive/setmtimeindex.xml
+++ b/reference/zip/ziparchive/setmtimeindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setmtimeindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece el tiempo de modificación de una entrada definido por su índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,25 +25,25 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>timestamp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La hora de modificación (unix timestamp) del archivo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Flags opcionales, sin usar por ahora.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,19 +51,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
+  <simpara>
    Este ejemplo crea un archivo ZIP
    <filename>test.zip</filename> y añade
    al archivo <filename>test.txt</filename>
    con su fecha de modificación.
-  </para>
+  </simpara>
   <example>
    <title>Archivar un fichero</title>
    <programlisting role="php">
@@ -87,9 +87,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta función sólo está disponible si se construye con libzip ≥ 1.0.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setmtimename.xml
+++ b/reference/zip/ziparchive/setmtimename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setmtimename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece la hora de modificación de una entrada definida por su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,25 +25,25 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>timestamp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La hora de modificación (unix timestamp) del archivo.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Flags opcionales, sin usar por ahora.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,19 +51,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
+  <simpara>
    Este ejemplo crea un archivo ZIP
    <filename>test.zip</filename> y añade
    al archivo <filename>test.txt</filename>
    con su fecha de modificación.
-  </para>
+  </simpara>
   <example>
    <title>Archivar un fichero</title>
    <programlisting role="php">
@@ -87,9 +87,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Esta función sólo está disponible si se construye con libzip ≥ 1.0.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setpassword.xml
+++ b/reference/zip/ziparchive/setpassword.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.setpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setPassword</methodname>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Establece la contraseña para el archivo activo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
    <varlistentry>
     <term><parameter>password</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       La contraseña a emplear para el archivo.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -34,22 +34,22 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     A partir de PHP 7.2.0 y libzip 1.2.0 la contraseña se utiliza para descomprimir el archivo,
     y también es la contraseña por omisión para <methodname>ZipArchive::setEncryptionName</methodname>
     y <methodname>ZipArchive::setEncryptionIndex</methodname>.
     Anteriormente, esta función sólo establecía la contraseña que se usaría para descomprimir el archivo;
     No se convirtió en un no protegido con contraseña <classname>ZipArchive</classname>
     en un protegido con contraseña <classname>ZipArchive</classname>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/statindex.xml
+++ b/reference/zip/ziparchive/statindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.statindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     La función obtiene información acerca de la entrada definida por su
     índice.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,19 +25,19 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        <constant>ZipArchive::FL_UNCHANGED</constant> podría ser puesto con otros OR lógicos en él para pedir
        información  acerca del fichero original en el archivo,
        ignorando cualquiera de los cambios hechos.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -45,9 +45,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve una matríz conteniendo los detalles de la entrada,&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/statname.xml
+++ b/reference/zip/ziparchive/statname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.statname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     La función obtiene información acerca de la entrada definida por su nombre.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -39,19 +39,19 @@
        ignorando cualquier cambio realizado.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NODIR</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -62,9 +62,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve una matríz que contenie detalles de la entrada&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/unchangeall.xml
+++ b/reference/zip/ziparchive/unchangeall.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.unchangeall" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeAll</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Deshacer todos los cambios hechos en el archivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangearchive.xml
+++ b/reference/zip/ziparchive/unchangearchive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.unchangearchive" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,10 +12,10 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeArchive</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Revertir todos los cambios globales en el archivo. Por ahora, esto
    solamente revierte los cambios de los comentarios del archivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangeindex.xml
+++ b/reference/zip/ziparchive/unchangeindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: edwincartagenah Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: edwincartagenah -->
 <refentry xml:id="ziparchive.unchangeindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeIndex</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Revertir todos los cambios hechos a una entrada en el índice dado.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Índice de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangename.xml
+++ b/reference/zip/ziparchive/unchangename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yago Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: yago -->
 <refentry xml:id="ziparchive.unchangename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Deshacer todos los cambios hechos a una entrada.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la entrada.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Espejo tag-por-tag de php/doc-en#5536 sobre la extensión zip: `<para>` se convierte en `<simpara>` cuando el contenido es puramente inline. Sin cambios de traducción.

Fixes #554