### PR TITLE
[Sync EN] WASM: enable runnable examples for language sections (#5456)

### DIFF
--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
- <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Constantes</title>
 
   <simpara>
@@ -38,7 +38,7 @@
 <!-- TODO Move into syntax section? -->
    <example>
     <title>Nombres de constantes válidos e inválidos</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -54,8 +54,6 @@ define("2FOO",    "something");
 // PHP podría algún día proporcionar una constante mágica
 // que rompa el script
 define("__FOO__", "something");
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -181,7 +179,6 @@ define("CONSTANT", "Hello world.");
 echo CONSTANT; // muestra "Hello world."
 echo Constant; // Lanza un Error: Undefined constant "Constant"
                // Antes de PHP 8.0.0, muestra "Constant" y emite una advertencia.
-?>
 ]]>
      </programlisting>
     </example>
@@ -196,23 +193,22 @@ echo Constant; // Lanza un Error: Undefined constant "Constant"
 // Valor escalar simple
 const CONSTANT = 'Hello World';
 
-echo CONSTANT;
+echo CONSTANT . "\n";
 
 // Expresión escalar
-const ANOTHER_CONST = CONSTANT.'; Goodbye World';
-echo ANOTHER_CONST;
+const ANOTHER_CONST = CONSTANT . '; Goodbye World';
+echo ANOTHER_CONST . "\n";
 
 const ANIMALS = array('dog', 'cat', 'bird');
-echo ANIMALS[1]; // muestra "cat"
+echo ANIMALS[1] . "\n"; // muestra "cat"
 
 // Arrays constantes
-define('ANIMALS', array(
+define('ANIMALS_DEF', array(
     'dog',
     'cat',
     'bird'
 ));
-echo ANIMALS[1]; // muestra "cat"
-?>
+echo ANIMALS_DEF[1] . "\n"; // muestra "cat"
 ]]>
      </programlisting>
     </example>

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c81a48e58fc530a74827316027fae74668d17a1d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
-<chapter xml:id="language.exceptions">
+<chapter xml:id="language.exceptions" annotations="interactive">
  <!-- we use our own DTD instead of xmlns="http://docbook.org/ns/docbook" so that we can use
  <sect1 annotations="chunk:false"> -->
  <title>Las excepciones</title>
+ <note>
+  <simpara>Vea también la clase <exceptionname>Exception</exceptionname></simpara>
+ </note>
  <para>
   PHP tiene un manejo de excepciones similar al que ofrecen otros
   lenguajes de programación.
@@ -125,7 +128,7 @@
     </para>
     <example>
      <title>Convertir el error reporting en excepciones</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function exceptions_error_handler($severity, $message, $filename, $lineno) {
@@ -133,7 +136,6 @@ function exceptions_error_handler($severity, $message, $filename, $lineno) {
 }
 
 set_error_handler('exceptions_error_handler');
-?>
 ]]>
      </programlisting>
     </example>
@@ -170,7 +172,6 @@ try {
 
 // Continuar la ejecución
 echo "¡Hola mundo!\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -212,7 +213,6 @@ try {
 
 // Continuar la ejecución
 echo "¡Hola mundo!\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -243,7 +243,6 @@ function test() {
 }
 
 echo test();
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -278,8 +277,6 @@ class Test {
 
 $foo = new Test;
 $foo->testing();
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -311,8 +308,6 @@ class Test {
 
 $foo = new Test;
 $foo->testing();
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -338,7 +333,6 @@ try {
 } catch (SpecificException) {
     print "Se lanzó una SpecificException, pero no nos importa con los detalles.";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -370,7 +364,6 @@ try {
 } catch (Exception $e) {
     print $e->getMessage();
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -418,13 +411,13 @@ string(6) "Fourth"
   <title>Extender las Excepciones</title>
   <para>
    Una clase de excepción definida por el usuario puede ser definida extendiendo
-   la clase Exception integrada. Los miembros y las propiedades a continuación muestran
+   la clase <exceptionname>Exception</exceptionname> integrada. Los miembros y las propiedades a continuación muestran
    lo que está accesible en la clase hija que deriva de la clase Exception
    integrada.
   </para>
   <example>
    <title>La clase de excepción integrada</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 class Exception implements Throwable
@@ -452,12 +445,11 @@ class Exception implements Throwable
     // Puede ser redefinido
     public function __toString();               // string formateado para la visualización
 }
-?>
 ]]>
    </programlisting>
   </example>
   <para>
-   Si una clase extiende la clase Exception integrada y redefine el <link
+   Si una clase extiende la clase <exceptionname>Exception</exceptionname> integrada y redefine el <link
    linkend="language.oop5.decon">constructor</link>, se recomienda fuertemente
    que también llame a <link
    linkend="language.oop5.paamayim-nekudotayim">parent::__construct()</link>
@@ -533,7 +525,7 @@ class TestException
     }
 }
 
-// Ejemplo 1
+echo "# Ejemplo 1\n";
 try {
     $o = new TestException(TestException::THROW_CUSTOM);
 } catch (MyException $e) {      // Será capturada
@@ -545,9 +537,9 @@ try {
 
 // Continuar la ejecución
 var_dump($o); // Null
-echo "\n\n";
 
-// Ejemplo 2
+
+echo "\n\n# Ejemplo 2\n";
 try {
     $o = new TestException(TestException::THROW_DEFAULT);
 } catch (MyException $e) {      // No coincide con este tipo
@@ -559,9 +551,9 @@ try {
 
 // Continuar la ejecución
 var_dump($o); // Null
-echo "\n\n";
 
-// Ejemplo 3
+
+echo "\n\n# Ejemplo 3\n";
 try {
     $o = new TestException(TestException::THROW_CUSTOM);
 } catch (Exception $e) {        // Será capturada
@@ -570,9 +562,9 @@ try {
 
 // Continuar la ejecución
 var_dump($o); // Null
-echo "\n\n";
 
-// Ejemplo 4
+
+echo "\n\n# Ejemplo 4\n";
 try {
     $o = new TestException();
 } catch (Exception $e) {        // Saltado, ninguna excepción
@@ -581,8 +573,6 @@ try {
 
 // Continuar la ejecución
 var_dump($o); // TestException
-echo "\n\n";
-?>
 ]]>
    </programlisting>
   </example>

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
- <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
    <title>Expresiones</title>
    <simpara>
     La expresiones son los bloques de construcción más importantes de PHP. En PHP
@@ -28,7 +28,7 @@
     Un ejemplo de expresiones algo más complejo son las funciones. Por
     ejemplo, considere la siguiente función:
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -139,7 +139,7 @@ function foo ()
    </para>
    <para>
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $primero ? $segundo : $tercero
@@ -165,24 +165,33 @@ $primero ? $segundo : $tercero
 <?php
 function double($i)
 {
-    return $i*2;
+    return $i * 2;
 }
+
 $b = $a = 5;        /* asignar el valor cinco a la variable $a y $b */
 $c = $a++;          /* post-incremento, asignar el valor original de $a
                        (5) a $c */
+print "a = {$a}; b = {$b}; c = {$c}" . PHP_EOL;
+
 $e = $d = ++$b;     /* pre-incremento, asignar el valor incrementado de
                        $b (6) a $d y $e */
+print "b = {$b}; d = {$d}; e = {$e}" . PHP_EOL;
 
 /* en este punto, $d y $e son iguales a 6 */
 
 $f = double($d++);  /* asignar el doble del valor de $d antes
                        del incremento, 2*6 = 12, a $f */
+print "d = {$d}; f = {$f}" . PHP_EOL;
+
 $g = double(++$e);  /* asignar el doble del valor de $e después
                        del incremento, 2*7 = 14, a $g */
+print "e = {$e}; g = {$g}" . PHP_EOL;
+
 $h = $g += 10;      /* primero, $g es incrementado en 10 y finaliza con el
                        valor 24. El valor de la asignación (24) es
                        asignado después a $h, y $h finaliza también con el
                        valor 24. */
+print "g = {$g}; h = {$h}" . PHP_EOL;
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
Espejo de php/doc-en#5456: anotaciones `interactive`/`non-interactive` y reescritura de ejemplos en `language/{constants,exceptions,expressions}.xml` para el sandbox WASM de php.net.

Fixes #549