### PR TITLE
[Sync EN] WASM: enable runnable examples for Predefined Interfaces & Classes (#5485)

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -82,7 +82,6 @@ $obj[] = 'Añadido 1';
 $obj[] = 'Añadido 2';
 $obj[] = 'Añadido 3';
 print_r($obj);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -92,9 +91,9 @@ bool(true)
 int(2)
 bool(false)
 string(9) "Un valor"
-obj Object
+Obj Object
 (
-    [container:obj:private] => Array
+    [container] => Array
         (
             [uno] => 1
             [tres] => 3

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
-<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>La clase Fiber</title>
  <titleabbrev>Fiber</titleabbrev>
 

--- a/language/predefined/fibererror.xml
+++ b/language/predefined/fibererror.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
-<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>FiberError</title>
  <titleabbrev>FiberError</titleabbrev>
 

--- a/language/predefined/interfaces.xml
+++ b/language/predefined/interfaces.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 267a3d4e60d8a6da941e72d195386b5841052cca Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 
-<part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+ annotations="interactive">
  <title>Interfaces y clases predefinidas</title>
 
  <partintro>

--- a/language/predefined/iteratoraggregate.xml
+++ b/language/predefined/iteratoraggregate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.iteratoraggregate" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -50,19 +50,13 @@
 
 class myData implements IteratorAggregate
 {
-    public $property1 = "Propiedad pública número uno";
-    public $property2 = "Propiedad pública número dos";
-    public $property3 = "Propiedad pública número tres";
-    public $property4 = "";
-
-    public function __construct()
-    {
-        $this->property4 = "última propiedad";
-    }
-
     public function getIterator(): Traversable
     {
-        return new ArrayIterator($this);
+        return new ArrayIterator([
+            "clave uno" => "elemento uno",
+            "clave dos" => "elemento dos",
+            "clave tres" => "elemento tres"
+        ]);
     }
 }
 
@@ -72,24 +66,19 @@ foreach($obj as $key => $value) {
     var_dump($key, $value);
     echo "\n";
 }
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
-string(9) "property1"
-string(27) "Propiedad pública número uno"
+string(9) "clave uno"
+string(12) "elemento uno"
 
-string(9) "property2"
-string(27) "Propiedad pública número dos"
+string(9) "clave dos"
+string(12) "elemento dos"
 
-string(9) "property3"
-string(29) "Propiedad pública número tres"
-
-string(9) "property4"
-string(17) "última propiedad"
+string(10) "clave tres"
+string(13) "elemento tres"
 
 ]]>
     </screen>

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -94,6 +94,7 @@ var_dump($newobj->getData());
     &example.outputs.similar;
     <screen>
 <![CDATA[
+Deprecated: obj implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in script on line 2
 string(38) "C:3:"obj":23:{s:19:"Mis datos privados";}"
 string(19) "Mis datos privados"
 ]]>

--- a/language/predefined/unitenum/cases.xml
+++ b/language/predefined/unitenum/cases.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 787d71d9c02bc0329da579ec3ac83729a3d71e3f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="unitenum.cases" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -50,21 +50,20 @@ enum Suit
 }
 
 var_dump(Suit::cases());
-?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
 array(4) {
-    [0]=>
-    enum(Suit::Hearts)
-    [1]=>
-    enum(Suit::Diamonds)
-    [2]=>
-    enum(Suit::Clubs)
-    [3]=>
-    enum(Suit::Spades)
+  [0]=>
+  enum(Suit::Hearts)
+  [1]=>
+  enum(Suit::Diamonds)
+  [2]=>
+  enum(Suit::Clubs)
+  [3]=>
+  enum(Suit::Spades)
 }
 ]]>
    </screen>


### PR DESCRIPTION
Espejo de php/doc-en#5485: anotaciones `interactive`/`non-interactive` y reescritura de ejemplos en los 7 archivos `language/predefined/` para el sandbox WASM de php.net.

Fixes #550