### PR TITLE
[Sync EN] yar: call.xml add missing parameters, CS (#5492)

### DIFF
--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: seros Status: ready -->
+<!-- EN-Revision: c50df321d2cccb1044219a98d4c5c7677d4b29cf Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -22,7 +22,7 @@
   </methodsynopsis>
   <para>
    Registra una llamada RPC, aunque no la envía inmediatamente. Se enviará al
-   llamar a <methodname>Yar_Concurrent_Client::loop</methodname>
+   llamar a <methodname>Yar_Concurrent_Client::loop</methodname>.
   </para>
  </refsect1>
 
@@ -33,7 +33,7 @@
     <term><parameter>uri</parameter></term>
     <listitem>
      <para>
-       El URI del servidor de RPC (http, tcp)
+       El URI del servidor de RPC (HTTP, TCP).
      </para>
     </listitem>
    </varlistentry>
@@ -41,7 +41,7 @@
     <term><parameter>method</parameter></term>
     <listitem>
      <para>
-      El nombre del servicio (es decir, el nombre del método)
+      El nombre del servicio (es decir, el nombre del método).
      </para>
     </listitem>
    </varlistentry>
@@ -49,7 +49,7 @@
     <term><parameter>parameters</parameter></term>
     <listitem>
      <para>
-      Parámetros
+      Parámetros.
      </para>
     </listitem>
    </varlistentry>
@@ -61,41 +61,62 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry>
+    <term><parameter>error_callback</parameter></term>
+    <listitem>
+     <simpara>
+      Si se establece esta retrollamada, Yar la invocará cuando ocurra un error.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; de opciones.
+      Ver la lista de <link linkend="yar.constants">constantes</link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un ID único que se puede utilizar para identificar la llamada que es.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example>
-   <title>Ejemplo de <function>Yar_Concurrent_Client::call</function></title>
+  <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
-function callback($retval, $callinfo) {
-     var_dump($retval);
+
+function callback($retval, $callinfo)
+{
+    var_dump($retval);
 }
 
-function error_callback($type, $error, $callinfo) {
+function error_callback($type, $error, $callinfo)
+{
     error_log($error);
 }
 
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));   // si no se especifica la retrollamada,
-                                                                               // se usará la retrollamada en bucle
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
-                                                                               //este servidor acepta empaquetadores json
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
-                                                                               //tiempo de espera personalizado
 
-//Las peticiones aún no se han enviado
-?>
+// Si no se especifica la retrollamada, se usará la retrollamada en bucle
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+
+// Este servidor acepta empaquetador JSON
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+
+// Tiempo de espera personalizado
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1));
+
+// Las peticiones aún no se han enviado
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -103,9 +124,8 @@ Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters
 <![CDATA[
 ]]>
    </screen>
-  </example>
+  </informalexample>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;


### PR DESCRIPTION
Espejo de php/doc-en#5492: añade los parámetros `error_callback` y `options` en `Yar_Concurrent_Client::call`, y limpieza de coding style.

Fixes #551