### PR TITLE
[Sync EN] debug_backtrace: use constants for int mask combinations (#5537)

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a124543dd3f6b1e5567b07420d23899e582514dc Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1e31c8f3a81d8fbfc79c0a6b033f0750cff48581 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.debug-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -58,7 +58,7 @@
            <tbody>
             <row>
              <entry><code>debug_backtrace()</code></entry>
-             <entry morerows="2" valign="middle">
+             <entry morerows="1" valign="middle">
               Rellena los dos índices
              </entry>
             </row>
@@ -66,13 +66,13 @@
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(1)</code></entry>
+             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
+             <entry morerows="1" valign="middle">
+              Omite el índice <literal>"object"</literal> y rellena el índice <literal>"args"</literal>.
+             </entry>
             </row>
             <row>
              <entry><code>debug_backtrace(0)</code></entry>
-             <entry valign="middle">
-              Omite el índice <literal>"object"</literal> y rellena el índice <literal>"args"</literal>.
-             </entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
@@ -81,16 +81,13 @@
              </entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(2)</code></entry>
+             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
-             <entry morerows="1" valign="middle">
+             <entry valign="middle">
               Rellena el índice <literal>"object"</literal> <emphasis>y</emphasis> omite el índice <literal>"args"</literal>.
              </entry>
-            </row>
-            <row>
-             <entry><code>debug_backtrace(3)</code></entry>
             </row>
            </tbody>
           </tgroup>


### PR DESCRIPTION
Espejo de php/doc-en#5537: la tabla de opciones reemplaza las máscaras enteras literales por las constantes nombradas.

Fixes #553