### PR TITLE
[Sync EN] debug_backtrace: move emphasis to beginning of sentence (#5538)

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -77,7 +77,7 @@
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
              <entry morerows="1" valign="middle">
-              Omite el índice <literal>"object"</literal> <emphasis>y</emphasis> el índice <literal>"args"</literal>.
+              Omite <emphasis>ambos</emphasis> el índice <literal>"object"</literal> <emphasis>y</emphasis> el índice <literal>"args"</literal>.
              </entry>
             </row>
             <row>


### PR DESCRIPTION
Espejo de php/doc-en#5538: el `<emphasis>` se desplaza al principio de la frase para mantener la coherencia con los otros elementos de la lista.

Fixes #555