### PR TITLE
[Sync EN] Change <para> to <simpara> in language-snippets (#5522)

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3502ec883a7e65741ac493022d0c03ec10b11607 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 
 <!ENTITY installation.enabled.disable 'Esta extensión está activada por omisión. Puede ser desactivada utilizando la opción de configuración: '>
@@ -20,16 +20,16 @@ altamente desaconsejado.</simpara></warning>'>
 
 <!-- Cautions / Precauciones -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Esta función no genera valores criptográficamente seguros, y <emphasis>no debe</emphasis>
   ser utilizada con fines criptográficos, o con fines que requieran que los valores devueltos sean indescifrables.
- </para>
- <para>
+ </simpara>
+ <simpara>
   Si se requiere aleatoriedad criptográficamente segura, el <classname>Random\Randomizer</classname> puede ser utilizado
   con el motor <classname>Random\Engine\Secure</classname>. Para casos de uso simples, las funciones
   <function>random_int</function> y <function>random_bytes</function> proporcionan una <acronym>API</acronym>
    práctica y segura que es soportada por el <acronym>CSPRNG</acronym> del sistema operativo.
- </para>
+ </simpara>
 </caution>'>
 
 <!ENTITY caution.mt19937-global-state '<caution xmlns="http://docbook.org/ns/docbook">
@@ -46,25 +46,25 @@ altamente desaconsejado.</simpara></warning>'>
 </caution>'>
 
 <!ENTITY caution.mt19937-tiny-seed '<caution xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
    Dado que el motor Mt19937 ("Mersenne Twister") toma un solo entero de 32 bits como
    semilla, el número de secuencias aleatorias posibles está limitado a solo 2<superscript>32</superscript>
    (por ejemplo 4 294 967 296), a pesar de la enorme período de Mt19937 de 2<superscript>19937</superscript>-1.
- </para>
- <para>
+ </simpara>
+ <simpara>
    Cuando se confía en una semilla aleatoria implícita o explícita, las duplicaciones aparecerán
    mucho antes. Las semillas duplicadas son esperadas con una probabilidad del 50&#37; después de menos de
    80 000 semillas generadas aleatoriamente según el problema del cumpleaños. Una probabilidad del 10&#37;
    de una semilla duplicada ocurre después de haber generado aproximadamente 30 000 semillas de manera aleatoria.
- </para>
- <para>
+ </simpara>
+ <simpara>
   Esto hace que Mt19937 sea inadecuado para aplicaciones donde las secuencias duplicadas no deben ocurrir con
   más que una probabilidad despreciable. Si se requiere una semilla reproducible, tanto el
   motor <classname>Random\Engine\Xoshiro256StarStar</classname> como <classname>Random\Engine\PcgOneseq128XslRr64</classname>
   soportan semillas mucho más grandes que son poco propensas a colisionar aleatoriamente. Si la reproductibilidad
   no es requerida, el motor <classname>Random\Engine\Secure</classname> proporciona datos aleatorios criptográficamente
   seguros.
- </para>
+ </simpara>
 </caution>'>
 
 <!-- Notes -->
@@ -76,48 +76,48 @@ segura para sistemas binarios.</simpara></note>'>
 función se almacenan en caché. Véase la función <function>clearstatcache</function> para
 más detalles.</simpara></note>'>
 
- <!ENTITY note.context-support '<para xmlns="http://docbook.org/ns/docbook">Un <type>resource</type> de
- <link linkend="stream.contexts">contexto de flujo</link>.</para>'>
+ <!ENTITY note.context-support '<simpara xmlns="http://docbook.org/ns/docbook">Un <type>resource</type> de
+ <link linkend="stream.contexts">contexto de flujo</link>.</simpara>'>
 
- <!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><para>Si un programa es iniciado con esta función
+ <!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><simpara>Si un programa es iniciado con esta función
  y se ejecuta en segundo plano, la salida del programa debe
  ser redirigida a un archivo, o a otro flujo de salida. De lo contrario,
- PHP se bloqueará hasta el final de la ejecución del programa.</para></note>'>
+ PHP se bloqueará hasta el final de la ejecución del programa.</simpara></note>'>
 
- <!ENTITY note.exec-bypass-shell '<note xmlns="http://docbook.org/ns/docbook"><para>En Windows <function>exec</function>
+ <!ENTITY note.exec-bypass-shell '<note xmlns="http://docbook.org/ns/docbook"><simpara>En Windows <function>exec</function>
  iniciará primero cmd.exe para ejecutar el comando. Si se desea iniciar un programa externo sin ejecutar cmd.exe
- utilice <function>proc_open</function> definiendo la opción <parameter>bypass_shell</parameter>.</para></note>'>
+ utilice <function>proc_open</function> definiendo la opción <parameter>bypass_shell</parameter>.</simpara></note>'>
 
- <!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><para>Los sistemas de archivos NTFS de Windows
+ <!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los sistemas de archivos NTFS de Windows
  no soportan ciertos caracteres en los nombres de archivo, como <literal>&lt;|&gt;*?":</literal>. Los nombres de archivo con un punto
  final no son soportados. A diferencia de algunas herramientas de extracción, este método no reemplaza estos caracteres con
- un guión bajo, sino que falla al extraer tales archivos.</para></note>'>
+ un guión bajo, sino que falla al extraer tales archivos.</simpara></note>'>
 
  <!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara> En lugar de un nombre de función, un
  array que contenga una referencia de objeto y un nombre de método también
  puede ser utilizado.</simpara></note>'>
 
- <!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><para>Las devoluciónes de llamada registradas
+ <!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>Las devoluciónes de llamada registradas
  con funciones como <function>call_user_func</function> y <function>call_user_func_array</function> no serán
- llamadas si una excepción no es interceptada cuando ha sido lanzada en una función de devolución de llamada anterior.</para></note>'>
+ llamadas si una excepción no es interceptada cuando ha sido lanzada en una función de devolución de llamada anterior.</simpara></note>'>
 
- <!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><para>Si los argumentos son pasados por referencia,
+ <!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>Si los argumentos son pasados por referencia,
  todas sus modificaciones serán reflejadas en los valores devueltos por esta función. A partir de PHP 7,
- los valores actuales también serán devueltos si los argumentos son pasados por su valor.</para></note>'>
+ los valores actuales también serán devueltos si los argumentos son pasados por su valor.</simpara></note>'>
 
- <!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Dado que esta función depende del ámbito actual para determinar los detalles de los argumentos, estos no
  pueden ser utilizados como argumento de una función en versiones de PHP anteriores a 5.3.0.
  Si este valor debe ser pasado, el resultado debe ser asignado a una variable y esta variable debe ser pasada.
-</para></note>'>
+</simpara></note>'>
 
- <!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  A partir de PHP 8.0.0, la familia de funciones func_*() está diseñada para ser esencialmente
  transparente con respecto a los argumentos nombrados, tratando los argumentos como si fueran todos pasados
  de manera posicional, y los argumentos faltantes son reemplazados con sus valores por defecto.
  Esta función ignora la colección de argumentos variádicos nombrados desconocidos.
  Los argumentos nombrados que son recolectados solo son accesibles a través del parámetro variádico.
-</para></note>'>
+</simpara></note>'>
 
  <!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Si PHP no reconoce correctamente los finales de línea al leer archivos que han sido creados o leídos en
@@ -159,52 +159,52 @@ más detalles.</simpara></note>'>
  <function>srand</function> o <function>mt_srand</function>, esto se hace automáticamente.
 </simpara></note>'>
 
- <!ENTITY note.is-superglobal "<note xmlns='http://docbook.org/ns/docbook'><para>
+ <!ENTITY note.is-superglobal "<note xmlns='http://docbook.org/ns/docbook'><simpara>
  Esto es una 'superglobal', o variable global automática. Esto significa simplemente que esta variable
  está disponible en todos los contextos del script. No es necesario hacer <command>global $variable;</command>
  para acceder a ella en las funciones o los métodos.
-</para></note>">
+</simpara></note>">
 
- <!ENTITY note.uses-ob '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY note.uses-ob '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Cuando el parámetro <parameter>return</parameter> es utilizado, esta función utiliza el buffer
  interno de salida, por lo tanto no puede ser utilizado en la función de devolución de llamada de <function>ob_start</function>.
-</para></note>'>
+</simpara></note>'>
 
- <!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Cuando el parámetro <parameter>return</parameter> es utilizado, esta función
  utilizaba el buffer interno de salida anterior a PHP 7.1.0, y por lo tanto no puede ser
  utilizado en la función de devolución de llamada de <function>ob_start</function>.
-</para></note>'>
+</simpara></note>'>
 
- <!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Tenga en cuenta que la precisión temporal puede variar según el sistema de archivos utilizado.
-</para></note>'>
+</simpara></note>'>
 
- <!ENTITY note.uses-autoload '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY note.uses-autoload '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  El uso de esta función utilizará todos los <link linkend="language.oop5.autoload">autoloaders</link>
  registrados si la clase no es conocida aún.
-</para></note>'>
+</simpara></note>'>
 
  <!ENTITY note.network.header.sapi '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Los encabezados solo serán accesibles y se mostrarán cuando se utilice un SAPI que los soporte.
- </para>
+ </simpara>
 </note>
 '>
 
  <!ENTITY note.sigchild '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Si PHP ha sido compilado con la opción de configuración --enable-sigchild,
   el valor devuelto de esta función será indefinido.
- </para>
+ </simpara>
 </note>
 '>
 
  <!ENTITY note.sort-unstable '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Si dos miembros se comparan como iguales, mantienen su orden original.
   Anterior a PHP 8.0.0, su orden relativo en el array ordenado no está definido.
- </para>
+ </simpara>
 </note>
 '>
 
@@ -216,10 +216,10 @@ más detalles.</simpara></note>'>
 ">
 
  <!ENTITY note.resource-migration-8.0-dead-function '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Esta función no tiene ningún efecto. Anterior a PHP 8.0.0,
   esta función era utilizada para cerrar un recurso.
- </para>
+ </simpara>
 </note>
 '>
 
@@ -251,11 +251,11 @@ más detalles.</simpara></note>'>
 
  <!-- Warnings / Avertissement -->
 
- <!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Si los datos provenientes de los usuarios tienen permiso de ser pasados a esta función, utilice
  <function>escapeshellarg</function> o <function>escapeshellcmd</function> para asegurarse de que los usuarios
  no puedan hacer que el sistema ejecute comandos arbitrarios.
-</para></warning>'>
+</simpara></warning>'>
 
  <!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Esta extensión es <emphasis>EXPERIMENTAL</emphasis>. El comportamiento de esta extensión, los nombres de sus funciones,
@@ -518,21 +518,21 @@ xmlns="http://docbook.org/ns/docbook"><simpara>
  Nota: Yaz 2.0 y superior ya no sufre de este problema.
 </simpara></warning>'>
 
- <!ENTITY warn.install.cgi '<warning xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY warn.install.cgi '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Un servidor desplegado en modo CGI se expone a varias vulnerabilidades posibles. Por favor, lea nuestra
  <link linkend="security.cgi-bin">sección sobre la seguridad en modo CGI</link>
  para aprender cómo protegerse contra estos ataques.
-</para></warning>'>
+</simpara></warning>'>
 
  <!ENTITY warn.passwordhashing '<warning xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
  No se recomienda utilizar esta función para asegurar contraseñas, debido a la naturaleza
  rápida de este algoritmo de hash. Ver <link linkend="faq.passwords.fasthash">F.A.Q del hash de
  contraseñas</link> para más detalles y las buenas prácticas.
-</para>
+</simpara>
 </warning>'>
 
- <!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cuando SSL es utilizado, el servidor IIS de Microsoft violará el protocolo al cerrar la conexión sin
  enviar un indicador <literal>close_notify</literal>. PHP lo reportará como "SSL: Fatal Protocol Error"
  cuando se llegue al final de los datos. Para evitar esto, el nivel de la directiva
@@ -541,7 +541,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>
  el flujo utilizando <literal>https://</literal> y suprimirá el aviso.
  Al utilizar <function>fsockopen</function> para crear un socket <literal>ssl://</literal>,
  es responsabilidad del desarrollador detectar y suprimir el aviso.
-</para></warning>'>
+</simpara></warning>'>
 
  <!ENTITY warn.undocumented.class '
 <warning xmlns="http://docbook.org/ns/docbook">
@@ -564,90 +564,90 @@ xmlns="http://docbook.org/ns/docbook"><simpara>
      en/reference/regex/reference.xml for examples of these in action. -->
 
  <!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 4.1.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta función incluyen:
-</para>
+</simpara>
 '>
 
  <!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta funcionalidad incluyen:
-</para>
+</simpara>
 '>
 
  <!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta función incluyen:
-</para>
+</simpara>
 '>
 
  <!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta función incluyen:
-</para>
+</simpara>
 '>
 
  <!ENTITY warn.removed.feature.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Esta funcionalidad ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta funcionalidad incluyen:
-</para>
+</simpara>
 '>
 
  <!ENTITY warn.removed.function.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Esta función ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta función incluyen:
-</para>
+</simpara>
 '>
 
  <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.2.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta funcionalidad incluyen:
-</para>
+</simpara>
 '>
 
  <!ENTITY warn.deprecated.function.7-1-0.removed.7-2-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.2.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta función incluyen:
-</para>
+</simpara>
 '>
 
  <!ENTITY warn.deprecated.function-8-1-0.alternatives '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>Esta función
 está <emphasis>OBSOLETA</emphasis> a partir de PHP 8.1.0.
 Se recomienda evitar su uso.</simpara></warning>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta función incluyen:
-</para>
+</simpara>
 '>
 
  <!-- Misc / Divers -->
@@ -656,67 +656,67 @@ Se recomienda evitar su uso.</simpara></warning>
 
  <!ENTITY version.trunk.changelog 'Futuro'>
 
- <!ENTITY no.function.parameters '<para xmlns="http://docbook.org/ns/docbook">Esta función no contiene ningún parámetro.</para>'>
+ <!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">Esta función no contiene ningún parámetro.</simpara>'>
 
- <!ENTITY example.outputs '<para xmlns="http://docbook.org/ns/docbook">El ejemplo anterior mostrará:</para>'>
+ <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">El ejemplo anterior mostrará:</simpara>'>
 
- <!ENTITY example.outputs.5 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5:</para>'>
+ <!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5:</simpara>'>
 
- <!ENTITY example.outputs.53 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.3:</para>'>
+ <!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.3:</simpara>'>
 
- <!ENTITY example.outputs.54 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.4:</para>'>
+ <!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.4:</simpara>'>
 
- <!ENTITY example.outputs.55 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.5:</para>'>
+ <!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.5:</simpara>'>
 
- <!ENTITY example.outputs.56 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.6:</para>'>
+ <!ENTITY example.outputs.56 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.6:</simpara>'>
 
- <!ENTITY example.outputs.7 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7:</para>'>
+ <!ENTITY example.outputs.7 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7:</simpara>'>
 
- <!ENTITY example.outputs.70 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.0:</para>'>
+ <!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.0:</simpara>'>
 
- <!ENTITY example.outputs.71 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.1:</para>'>
+ <!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.1:</simpara>'>
 
- <!ENTITY example.outputs.72 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.2:</para>'>
+ <!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.2:</simpara>'>
 
- <!ENTITY example.outputs.73 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.3:</para>'>
+ <!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.3:</simpara>'>
 
- <!ENTITY example.outputs.8 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8:</para>'>
+ <!ENTITY example.outputs.8 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8:</simpara>'>
 
- <!ENTITY example.outputs.8.similar '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8 es similar a:</para>'>
+ <!ENTITY example.outputs.8.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.80 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.0:</para>'>
+ <!ENTITY example.outputs.80 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.0:</simpara>'>
 
- <!ENTITY example.outputs.81 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.1:</para>'>
+ <!ENTITY example.outputs.81 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.1:</simpara>'>
 
- <!ENTITY example.outputs.82 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.2:</para>'>
+ <!ENTITY example.outputs.82 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.2:</simpara>'>
 
- <!ENTITY example.outputs.82.similar '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.2 es similar a:</para>'>
+ <!ENTITY example.outputs.82.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.2 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.83 '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.3:</para>'>
+ <!ENTITY example.outputs.83 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.3:</simpara>'>
 
- <!ENTITY example.outputs.83.similar '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.3 es similar a:</para>'>
+ <!ENTITY example.outputs.83.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.3 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.84 '<para xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.4:</para>'>
+ <!ENTITY example.outputs.84 '<simpara xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.4:</simpara>'>
 
- <!ENTITY example.outputs.84.similar '<para xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.4 es similar a:</para>'>
+ <!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.4 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.85 '<para xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.5:</para>'>
+ <!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.5:</simpara>'>
 
- <!ENTITY example.outputs.85.similar '<para xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.5 es similar a:</para>'>
+ <!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.5 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.32bit '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 32 bits:</para>'>
+ <!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 32 bits:</simpara>'>
 
- <!ENTITY example.outputs.64bit '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 64 bits:</para>'>
+ <!ENTITY example.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 64 bits:</simpara>'>
 
- <!ENTITY example.outputs.similar '<para xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior es similar a:</para>'>
+ <!ENTITY example.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior es similar a:</simpara>'>
 
- <!ENTITY examples.outputs '<para xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán:</para>'>
+ <!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán:</simpara>'>
 
- <!ENTITY examples.outputs.32bit '<para xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 32 bits:</para>'>
+ <!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 32 bits:</simpara>'>
 
- <!ENTITY examples.outputs.64bit '<para xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 64 bits:</para>'>
+ <!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 64 bits:</simpara>'>
 
- <!ENTITY examples.outputs.similar '<para xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán algo similar a:</para>'>
+ <!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán algo similar a:</simpara>'>
 
  <!ENTITY array.resetspointer '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Esta función reinicia el puntero al inicio del array de entrada (equivalente a <function>reset</function>).
@@ -743,10 +743,10 @@ Se recomienda evitar su uso.</simpara></warning>
  <!ENTITY sort.flags.parameter '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>flags</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    El segundo parámetro opcional <parameter>flags</parameter>
    puede ser utilizado para modificar el comportamiento de ordenación utilizando estos valores:
-  </para>
+  </simpara>
   <para>
    Tipo de banderas de ordenación:
    <itemizedlist>
@@ -787,18 +787,18 @@ Se recomienda evitar su uso.</simpara></warning>
 </varlistentry>
 '>
 
- <!ENTITY sort.callback.description '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY sort.callback.description '<simpara xmlns="http://docbook.org/ns/docbook">
 &return.callbacksort;
-</para>
+</simpara>
 &callback.cmp;
 <caution xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
 Retornar valores <emphasis>no-entero</emphasis> desde la función
 de comparación, tales como <type>float</type>, resultará en una conversión interna
 del valor de retorno del callback a <type>int</type>. Así, valores tales como
 <literal>0.99</literal> y <literal>0.1</literal> serán convertidos ambos a un
 valor entero de <literal>0</literal>, lo que comparará tales valores como iguales.
-</para>
+</simpara>
 </caution>'>
 
  <!ENTITY sort.callback.description.presort '<caution xmlns="http://docbook.org/ns/docbook">
@@ -926,7 +926,7 @@ que 0 si el primer argumento es considerado, respectivamente, menor que, igual a
 '>
 
  <!-- FileInfo -->
- <!ENTITY fileinfo.parameters.finfo '<para xmlns="http://docbook.org/ns/docbook">Una instancia <classname>finfo</classname>, retornada por <function>finfo_open</function>.</para>'>
+ <!ENTITY fileinfo.parameters.finfo '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>finfo</classname>, retornada por <function>finfo_open</function>.</simpara>'>
  <!ENTITY fileinfo.changelog.finfo-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
@@ -939,28 +939,28 @@ que 0 si el primer argumento es considerado, respectivamente, menor que, igual a
  <!ENTITY openssl.param.x509 '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>x509</parameter></term>
 <listitem>
-    <para>
+    <simpara>
         Ver los <link linkend="openssl.certparams">parámetros clave/Certificados</link>
         para una lista de valores válidos.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>'>
 
  <!ENTITY openssl.param.csr '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>csr</parameter></term>
 <listitem>
-    <para>
+    <simpara>
         Ver los <link linkend="openssl.certparams">parámetros CSR</link> para obtener una lista de los valores válidos.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>'>
 
  <!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>key</parameter></term>
 <listitem>
-    <para>
+    <simpara>
         Ver los <link linkend="openssl.certparams">parámetros clave pública/privada</link> para obtener una lista de los valores válidos.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>'>
 
@@ -973,23 +973,23 @@ que 0 si el primer argumento es considerado, respectivamente, menor que, igual a
     si PHP es compilado con soporte Freetype (<option role="configure">--with-freetype-dir=DIR</option>)
 </simpara></note>'>
 
- <!ENTITY note.gd.notrequired '<note xmlns="http://docbook.org/ns/docbook"><para>Esta función no requiere la biblioteca GD.</para></note>'>
+ <!ENTITY note.gd.notrequired '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función no requiere la biblioteca GD.</simpara></note>'>
 
- <!ENTITY note.gd.interpolation '<note xmlns="http://docbook.org/ns/docbook"><para>Esta función es afectada por
-    el método de interpolación, definido por la función <function>imagesetinterpolation</function>.</para></note>'>
+ <!ENTITY note.gd.interpolation '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función es afectada por
+    el método de interpolación, definido por la función <function>imagesetinterpolation</function>.</simpara></note>'>
 
  <!ENTITY gd.image.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>image</parameter></term><listitem><para>
+<term><parameter>image</parameter></term><listitem><simpara>
  Un objeto <classname>GdImage</classname>, retornado por una de las funciones de
  creación de imágenes, como <function>imagecreatetruecolor</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
  <!ENTITY gd.font.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>font</parameter></term><listitem><para>
+<term><parameter>font</parameter></term><listitem><simpara>
  Puede ser 1, 2, 3, 4, 5 para las fuentes internas de codificación Latin2
  (donde los números más grandes corresponden a fuentes anchas) o una instancia
  de <classname>GdFont</classname> retornado por <function>imageloadfont</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
  <!ENTITY gd.changelog.gdfont-instance '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
@@ -1151,33 +1151,33 @@ pruebas.</simpara></warning>'>
 <!-- DBM notes -->
 
 <!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>dbm_identifier</parameter></term><listitem><para>El identificador de enlace DBM,
-devuelto por <function>dbmopen</function>.</para></listitem></varlistentry>'>
+<parameter>dbm_identifier</parameter></term><listitem><simpara>El identificador de enlace DBM,
+devuelto por <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
 <!ENTITY json.implementation.superset '
  <note xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <para>
+  <simpara>
    PHP implementa un superconjunto de JSON tal como se especifica en el
    <link xlink:href="&url.rfc;7159">RFC 7159</link> original.
-  </para>
+  </simpara>
  </note>
 '>
 
 <!-- cURL notes -->
 
 <!ENTITY curl.ch.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>handle</parameter>
-</term><listitem><para>Un gestor cURL devuelto por
-<function>curl_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>Un gestor cURL devuelto por
+<function>curl_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.mh.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>multi_handle</parameter>
-</term><listitem><para>Un gestor múltiple cURL devuelto por
-<function>curl_multi_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>Un gestor múltiple cURL devuelto por
+<function>curl_multi_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.sh.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>share_handle</parameter>
-</term><listitem><para>Un gestor compartido cURL devuelto por
-<function>curl_share_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>Un gestor compartido cURL devuelto por
+<function>curl_share_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.changelog.handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -1249,19 +1249,19 @@ devuelto por <function>dbmopen</function>.</para></listitem></varlistentry>'>
 <!ENTITY enchant.param.broker '<varlistentry xmlns="http://docbook.org/ns/docbook">
      <term><parameter>broker</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un broker Enchant devuelto por <function>enchant_broker_init</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>'>
 
 <!ENTITY enchant.param.dictionary '<varlistentry xmlns="http://docbook.org/ns/docbook">
      <term><parameter>dictionary</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un diccionario Enchant devuelto por <function>enchant_broker_request_dict</function>
        o <function>enchant_broker_request_pwl_dict</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>'>
 
@@ -1292,15 +1292,15 @@ devuelto por <function>dbmopen</function>.</para></listitem></varlistentry>'>
 </row>'>
 
 <!ENTITY imap.imap-parameter.imap '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><para>Una instancia de <classname>IMAP\Connection</classname>.</para></listitem></varlistentry>'>
+<parameter>imap</parameter></term><listitem><simpara>Una instancia de <classname>IMAP\Connection</classname>.</simpara></listitem></varlistentry>'>
 
 <!-- Deprecated -->
 <!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><para>Un flujo IMAP devuelto por
-<function>imap_open</function>.</para></listitem></varlistentry>'>
+<parameter>imap</parameter></term><listitem><simpara>Un flujo IMAP devuelto por
+<function>imap_open</function>.</simpara></listitem></varlistentry>'>
 
-<!ENTITY imap.pattern '<para xmlns="http://docbook.org/ns/docbook">Especifica en qué parte de la jerarquía del buzón
-comenzar la búsqueda.</para><para xmlns="http://docbook.org/ns/docbook">Hay dos caracteres especiales que se pueden
+<!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Especifica en qué parte de la jerarquía del buzón
+comenzar la búsqueda.</simpara><simpara xmlns="http://docbook.org/ns/docbook">Hay dos caracteres especiales que se pueden
 pasar como parte del <parameter>pattern</parameter>:
 &apos;<literal>*</literal>&apos; y &apos;<literal>&#37;</literal>&apos;.
 &apos;<literal>*</literal>&apos; significa devolver todos los buzones. Si se pasa
@@ -1310,7 +1310,7 @@ obtendrá una lista de toda la jerarquía del buzón.
 significa devolver solo el nivel actual.
 &apos;<literal>&#37;</literal>&apos; como parámetro <parameter>pattern</parameter>
 devolverá solo los buzones de nivel superior;
-&apos;<literal>~/mail/&#37;</literal>&apos; en <literal>UW_IMAPD</literal> devolverá cada buzón en el directorio <filename>~/mail</filename>, pero ninguno en las subcarpetas de ese directorio.</para>'>
+&apos;<literal>~/mail/&#37;</literal>&apos; en <literal>UW_IMAPD</literal> devolverá cada buzón en el directorio <filename>~/mail</filename>, pero ninguno en las subcarpetas de ese directorio.</simpara>'>
 
 <!ENTITY imap.mailboxname.insecure '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
 Pasar datos no confiables a este parámetro es <emphasis>inseguro</emphasis>, a menos que
@@ -1319,19 +1319,19 @@ Pasar datos no confiables a este parámetro es <emphasis>inseguro</emphasis>, a 
 
 <!-- intl notes -->
 
-<!ENTITY intl.parameter.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>IntlCalendar</classname>.</para>'>
+<!ENTITY intl.parameter.intl-calendar '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>IntlCalendar</classname>.</simpara>'>
 
-<!ENTITY intl.error.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">En caso de fallo, también se devuelve &false;. Para detectar condiciones de error, utilice <function>intl_get_error_code</function>, o configure Intl para lanzar <link linkend="ini.intl.use-exceptions">excepciones</link>.</para>'>
+<!ENTITY intl.error.intl-calendar '<simpara xmlns="http://docbook.org/ns/docbook">En caso de fallo, también se devuelve &false;. Para detectar condiciones de error, utilice <function>intl_get_error_code</function>, o configure Intl para lanzar <link linkend="ini.intl.use-exceptions">excepciones</link>.</simpara>'>
 
-<!ENTITY intl.codepoint.parameter '<para xmlns="http://docbook.org/ns/docbook">El valor <type>int</type> del punto de código (por ejemplo, <literal>0x2603</literal> para <emphasis>U+2603 SNOWMAN</emphasis>), o el carácter codificado como un <type>string</type> UTF-8 (por ejemplo, <literal>"\u{2603}"</literal>)</para>'>
+<!ENTITY intl.codepoint.parameter '<simpara xmlns="http://docbook.org/ns/docbook">El valor <type>int</type> del punto de código (por ejemplo, <literal>0x2603</literal> para <emphasis>U+2603 SNOWMAN</emphasis>), o el carácter codificado como un <type>string</type> UTF-8 (por ejemplo, <literal>"\u{2603}"</literal>)</simpara>'>
 
-<!ENTITY intl.codepoint.return '<para xmlns="http://docbook.org/ns/docbook">El tipo de retorno es <type>int</type> a menos que el punto de código haya sido pasado como un <type>string</type> UTF-8, en cuyo caso se devuelve un <type>string</type>. Devuelve &null; en caso de fallo.</para>'>
+<!ENTITY intl.codepoint.return '<simpara xmlns="http://docbook.org/ns/docbook">El tipo de retorno es <type>int</type> a menos que el punto de código haya sido pasado como un <type>string</type> UTF-8, en cuyo caso se devuelve un <type>string</type>. Devuelve &null; en caso de fallo.</simpara>'>
 
 <!ENTITY intl.codepoint.example 'Probar diferentes puntos de código'>
 
-<!ENTITY intl.locale-len.return '<para xmlns="http://docbook.org/ns/docbook">Devuelve &null; cuando la longitud de <parameter>locale</parameter> excede <constant>INTL_MAX_LOCALE_LEN</constant>.</para>'>
+<!ENTITY intl.locale-len.return '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve &null; cuando la longitud de <parameter>locale</parameter> excede <constant>INTL_MAX_LOCALE_LEN</constant>.</simpara>'>
 
-<!ENTITY intl.property.parameter '<para xmlns="http://docbook.org/ns/docbook">La propiedad Unicode a buscar (véanse las constantes <literal>IntlChar::PROPERTY_*</literal>).</para>'>
+<!ENTITY intl.property.parameter '<simpara xmlns="http://docbook.org/ns/docbook">La propiedad Unicode a buscar (véanse las constantes <literal>IntlChar::PROPERTY_*</literal>).</simpara>'>
 
 <!ENTITY intl.property.example 'Probar diferentes propiedades'>
 
@@ -1410,28 +1410,28 @@ Pasar datos no confiables a este parámetro es <emphasis>inseguro</emphasis>, a 
 <!ENTITY ldap.return-result 'Devuelve una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
 <!ENTITY ldap.return-result-array 'Devuelve una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>, un array de instancias de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
 
-<!ENTITY ldap.return-result-array-info '<para xmlns="http://docbook.org/ns/docbook">También es posible realizar búsquedas en paralelo. En este caso, el primer argumento debe ser un array de
+<!ENTITY ldap.return-result-array-info '<simpara xmlns="http://docbook.org/ns/docbook">También es posible realizar búsquedas en paralelo. En este caso, el primer argumento debe ser un array de
 instancias de <classname>LDAP\Connection</classname>, en lugar de una sola.
 Si las búsquedas no deben utilizar todas el mismo DN base y filtro, se puede pasar un array de DN base y/o un array de filtros como argumentos.
 Estos arrays deben tener el mismo tamaño que el array de instancias de <classname>LDAP\Connection</classname>,
 ya que las primeras entradas de los arrays se utilizan para una búsqueda, las segundas entradas para otra, y así sucesivamente.
-Al realizar búsquedas en paralelo, se devuelve un array de instancias de <classname>LDAP\Result</classname>, excepto en caso de error, donde el valor de retorno será &false;.</para>'>
+Al realizar búsquedas en paralelo, se devuelve un array de instancias de <classname>LDAP\Result</classname>, excepto en caso de error, donde el valor de retorno será &false;.</simpara>'>
 
 <!-- mbstring notes -->
 
-<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><para>La codificación interna o la
+<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><simpara>La codificación interna o la
 codificación de caracteres especificada por <function>mb_regex_encoding</function>
-se utilizará como codificación de caracteres para esta función.</para></note>'>
+se utilizará como codificación de caracteres para esta función.</simpara></note>'>
 
-<!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><para>La
+<!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><simpara>La
 codificación de caracteres especificada por <function>mb_regex_encoding</function>
-se utilizará como codificación de caracteres para esta función de forma predeterminada.</para></note>'>
+se utilizará como codificación de caracteres para esta función de forma predeterminada.</simpara></note>'>
 
-<!ENTITY mbstring.encoding.parameter '<para xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>encoding</parameter>
+<!ENTITY mbstring.encoding.parameter '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>encoding</parameter>
 es la codificación de caracteres. Si se omite o es &null;, se utilizará el valor de la codificación
-de caracteres interna.</para>'>
+de caracteres interna.</simpara>'>
 
-<!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><para>Nunca utilice el modificador <literal>e</literal> con datos de entrada no confiables. No se realizará ningún escape automático (como se conoce de <function>preg_replace</function>). No tener esto en cuenta probablemente creará vulnerabilidades de ejecución remota de código en la aplicación.</para></warning>'>
+<!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Nunca utilice el modificador <literal>e</literal> con datos de entrada no confiables. No se realizará ningún escape automático (como se conoce de <function>preg_replace</function>). No tener esto en cuenta probablemente creará vulnerabilidades de ejecución remota de código en la aplicación.</simpara></warning>'>
 
 <!ENTITY mbstring.changelog.encoding-nullable '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -1449,19 +1449,19 @@ de caracteres interna.</para>'>
 
 <!-- mcrypt notes -->
 
-<!ENTITY mcrypt.parameter.cipher '<para xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_ciphername</constant>, o el nombre del algoritmo como cadena.</para>'>
+<!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_ciphername</constant>, o el nombre del algoritmo como cadena.</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv '<para xmlns="http://docbook.org/ns/docbook">Utilizado para la inicialización en los modos CBC, CFB, OFB, y en algunos algoritmos en modo STREAM. Si no se proporciona un IV, siendo necesario para un algoritmo, la función emite una advertencia y utiliza un IV con todos sus bytes establecidos a "<literal>\0</literal>".</para>'>
+<!ENTITY mcrypt.parameter.iv '<simpara xmlns="http://docbook.org/ns/docbook">Utilizado para la inicialización en los modos CBC, CFB, OFB, y en algunos algoritmos en modo STREAM. Si no se proporciona un IV, siendo necesario para un algoritmo, la función emite una advertencia y utiliza un IV con todos sus bytes establecidos a "<literal>\0</literal>".</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv.strict '<para xmlns="http://docbook.org/ns/docbook">Utilizado para la inicialización en los modos CBC, CFB, OFB, y en algunos algoritmos en modo STREAM. Si el tamaño del IV proporcionado no es soportado por el modo de encadenamiento o no se proporcionó un IV, pero el modo de encadenamiento requiere uno, la función emitirá una advertencia y devolverá &false;.</para>'>
+<!ENTITY mcrypt.parameter.iv.strict '<simpara xmlns="http://docbook.org/ns/docbook">Utilizado para la inicialización en los modos CBC, CFB, OFB, y en algunos algoritmos en modo STREAM. Si el tamaño del IV proporcionado no es soportado por el modo de encadenamiento o no se proporcionó un IV, pero el modo de encadenamiento requiere uno, la función emitirá una advertencia y devolverá &false;.</simpara>'>
 
-<!ENTITY mcrypt.parameter.mode '<para xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_MODE_modename</constant>, o una de las siguientes cadenas: "ecb", "cbc", "cfb", "ofb", "nofb" o "stream".</para>'>
+<!ENTITY mcrypt.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_MODE_modename</constant>, o una de las siguientes cadenas: "ecb", "cbc", "cfb", "ofb", "nofb" o "stream".</simpara>'>
 
  <!-- MCVE notes -->
 
 <!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>conn</parameter></term><listitem><para>Un recurso MCVE_CONN devuelto por
-<function>m_initengine</function>.</para></listitem></varlistentry>'>
+<parameter>conn</parameter></term><listitem><simpara>Un recurso MCVE_CONN devuelto por
+<function>m_initengine</function>.</simpara></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
@@ -1486,17 +1486,17 @@ de caracteres interna.</para>'>
 
 <!ENTITY memcached.result.getresultcode 'Utilice <methodname xmlns="http://docbook.org/ns/docbook">Memcached::getResultCode</methodname> si es necesario.'>
 
-<!ENTITY memcached.result.delete-multi '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY memcached.result.delete-multi '<simpara xmlns="http://docbook.org/ns/docbook">
    Devuelve un array indexado por <parameter>keys</parameter>. Cada elemento
    es &true; si la clave correspondiente fue eliminada, o una de las
    constantes <constant>Memcached::RES_<replaceable>*</replaceable></constant> si la eliminación correspondiente
    falló.
-   </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+   </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    <methodname>Memcached::getResultCode</methodname> devolverá
    el código de resultado de la última operación de eliminación ejecutada, es decir, la operación de eliminación
    del último elemento de <parameter>keys</parameter>.
-  </para>
+  </simpara>
 '>
 
  <!-- password notes -->
@@ -1530,9 +1530,9 @@ de contraseña</link> que representa el algoritmo a utilizar durante el hasheo d
  </entry>
 </row>'>
 
- <!ENTITY pspell.parameter.pspell-dictionary '<para xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>PSpell\Dictionary</classname>.</para>'>
+ <!ENTITY pspell.parameter.pspell-dictionary '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>PSpell\Dictionary</classname>.</simpara>'>
 
- <!ENTITY pspell.parameter.pspell-config '<para xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>PSpell\Config</classname>.</para>'>
+ <!ENTITY pspell.parameter.pspell-config '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>PSpell\Config</classname>.</simpara>'>
 
  <!-- RNP -->
 
@@ -1583,13 +1583,13 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
  <!ENTITY gearman.parameter.callback '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>callback</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    Una función o método a llamar.
    Debe retornar un valor válido <link linkend="gearman.constants">de retorno Gearman</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si no se proporciona una instrucción de retorno, el valor por omisión será <constant>GEARMAN_SUCCESS</constant>.
-  </para>
+  </simpara>
   <methodsynopsis>
    <type>int</type><methodname><replaceable>callback</replaceable></methodname>
    <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
@@ -1599,17 +1599,17 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
    <varlistentry>
     <term><parameter>task</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       La tarea para la cual se llama este callback.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>context</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Todo lo que se pasó a <methodname>GearmanClient::addTask</methodname> (o método equivalente) como <parameter>context</parameter>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -1617,10 +1617,10 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
 </varlistentry>'>
 
  <!ENTITY gearman.note.callback '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   El callback solo será disparado para las tareas que son añadidas (por ejemplo llamando a <methodname>GearmanClient::addTask</methodname>)
   después de la llamada a este método.
- </para>
+ </simpara>
 </note>'>
 
  <!-- Date and time entities -->
@@ -1664,37 +1664,37 @@ Estas abreviaturas de zonas horarias deben ser consideradas como no permanentes,
 pueden ser diferentes para cada versión de la base de datos de zonas horarias, y por lo tanto no deben ser utilizadas. Se recomienda encarecidamente evitarlas.
 </simpara>'>
 
- <!ENTITY date.timezone.errors.description '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
 Cada llamada a una función de fecha/hora generará un diagnóstico de tipo
 <constant>E_WARNING</constant> si la zona horaria no es válida.
-Ver también <function>date_default_timezone_set</function></para>'>
+Ver también <function>date_default_timezone_set</function></simpara>'>
 
- <!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><para>
+ <!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
     Emite un mensaje de tipo <constant>E_STRICT</constant> y <constant>E_NOTICE</constant>
-    durante errores de zonas horarias.</para></entry></row>'>
+    durante errores de zonas horarias.</simpara></entry></row>'>
 
  <!ENTITY date.timestamp.description '
-<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><para>
+<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
     El parámetro opcional <parameter>timestamp</parameter> es un timestamp
     Unix de tipo &integer; que por omisión es la hora actual local si
     <parameter>timestamp</parameter> es omitido o &null;. En otras
     palabras, es por omisión el valor de la función <function>time</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
  <!ENTITY date.datetime.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
-<listitem><para>Solo en estilo procedimental: un objeto <classname>DateTime</classname>
-    retornado por <function>date_create</function></para></listitem></varlistentry>'>
+<listitem><simpara>Solo en estilo procedimental: un objeto <classname>DateTime</classname>
+    retornado por <function>date_create</function></simpara></listitem></varlistentry>'>
 
  <!ENTITY date.datetime.description.modified '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
-<listitem><para>Solo en estilo procedimental: Un objeto <classname>DateTime</classname>
+<listitem><simpara>Solo en estilo procedimental: Un objeto <classname>DateTime</classname>
     retornado por la función <function>date_create</function>.
-    Esta función modifica este objeto.</para></listitem></varlistentry>'>
+    Esta función modifica este objeto.</simpara></listitem></varlistentry>'>
 
  <!ENTITY date.datetimezone.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>object</parameter></term><listitem><para>
+<term><parameter>object</parameter></term><listitem><simpara>
  Solo en estilo procedimental: un objeto <classname>DateTimeZone</classname>
  retornado por <function>timezone_open</function>
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
  <!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Retorna el objeto modificado <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> para encadenar métodos&return.falseforfailure;.'>
  <!ENTITY date.datetime.return.modifiedobject 'Retorna el objeto modificado <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> para encadenar métodos.'>
@@ -1726,15 +1726,15 @@ Ver también <function>date_default_timezone_set</function></para>'>
  <!ENTITY dom.node.inserted 'Este nodo no será mostrado en el documento,
         a menos que sea insertado con <function xmlns="http://docbook.org/ns/docbook">DOMNode::appendChild</function>.'>
 
- <!ENTITY dom.malformederror '<para xmlns="http://docbook.org/ns/docbook">Aunque el HTML mal-formado debería cargarse con éxito, esta función puede generar
+ <!ENTITY dom.malformederror '<simpara xmlns="http://docbook.org/ns/docbook">Aunque el HTML mal-formado debería cargarse con éxito, esta función puede generar
 una advertencia de tipo <constant>E_WARNING</constant> cuando encuentre una mala etiqueta.
 <link linkend="function.libxml-use-internal-errors">Las funciones de manejo de errores libxml</link>
-pueden ser utilizadas para manejar estos errores.</para>'>
+pueden ser utilizadas para manejar estos errores.</simpara>'>
 
- <!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  La extensión DOM utiliza el codificado UTF-8. Utilice <function>mb_convert_encoding</function>,
  <methodname>UConverter::transcode</methodname>, o <function>iconv</function> para manipular otros codificados.
-</para></note>'>
+</simpara></note>'>
 
  <!ENTITY dom.note.modern.utf8 '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -1743,10 +1743,10 @@ pueden ser utilizadas para manejar estos errores.</para>'>
  </simpara>
 </note>'>
 
- <!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Al utilizar <function>json_encode</function> sobre un objeto
  <classname>DOMDocument</classname> el resultado será el de codificar un objeto vacío.
-</para></note>'>
+</simpara></note>'>
  <!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Utilice <classname>Dom\HTMLDocument</classname> para analizar y tratar el HTML moderno en lugar de <classname>DOMDocument</classname>.
@@ -1799,8 +1799,8 @@ pueden ser utilizadas para manejar estos errores.</para>'>
 '>
 
  <!-- Dom Examples -->
- <!ENTITY dom.book.example '<para xmlns="http://docbook.org/ns/docbook">El siguiente ejemplo
-utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</para>
+ <!ENTITY dom.book.example '<simpara xmlns="http://docbook.org/ns/docbook">El siguiente ejemplo
+utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
 <programlisting role="xml" xmlns="http://docbook.org/ns/docbook">
 <!-- Warning: The CDATA markup here is a little tricky. Please DO NOT BREAK it! -->
 <![CDATA[
@@ -1834,10 +1834,10 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</para>
 ]]></programlisting>'>
 
  <!-- Dom entities -->
- <!ENTITY dom.parameter.options '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY dom.parameter.options '<simpara xmlns="http://docbook.org/ns/docbook">
   <link linkend="language.operators.bitwise">Operación de &apos;OR&apos; lógica</link>
   de las <link linkend="libxml.constants">constantes de opción libxml</link>.
-</para>'>
+</simpara>'>
 
  <!ENTITY dom.parameter.compliant.options '&dom.parameter.options;
  <simpara xmlns="http://docbook.org/ns/docbook">
@@ -1864,11 +1864,11 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</para>
  <!ENTITY dom.parameters.register_node_ns '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>registerNodeNS</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    Indica si se deben registrar automáticamente los prefijos de espacio de nombres en vigor del nodo de contexto en el objeto <classname>DOMXPath</classname>.
    Esto puede ser utilizado para evitar tener que llamar manualmente a <methodname>DOMXPath::registerNamespace</methodname> para cada espacio de nombres en vigor.
    En caso de conflicto de prefijos de espacio de nombres, solo se registra el prefijo de espacio de nombres descendiente más cercano.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -1883,32 +1883,32 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</para>
  <!ENTITY dom.errors.hierarchy.parent '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Se levanta si el padre es de un tipo que no permite hijos del
     tipo de uno de los <parameter>nodes</parameter> transmitidos, o si el nodo a
     insertar es uno de los ancestros de este nodo o este nodo mismo.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
  <!ENTITY dom.errors.hierarchy.self '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Se levanta si este nodo es de un tipo que no permite hijos del
     tipo de uno de los <parameter>nodes</parameter> transmitidos, o si el nodo a
     insertar es uno de los ancestros de este nodo o este nodo mismo.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
  <!ENTITY dom.errors.wrong_document '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_WRONG_DOCUMENT_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Se levanta si uno de los <parameter>nodes</parameter> transmitidos ha sido creado a partir de un documento diferente
     del que creó este nodo.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -1957,16 +1957,16 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</para>
  </listitem>'>
 
  <!-- FileSystem entities -->
- <!ENTITY fs.emits.warning.on.failure '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY fs.emits.warning.on.failure '<simpara xmlns="http://docbook.org/ns/docbook">
 En caso de fallo, se emitirá una advertencia de tipo <constant>E_WARNING</constant>.
-</para>'>
+</simpara>'>
 
- <!ENTITY fs.validfp.all '<para xmlns="http://docbook.org/ns/docbook">El puntero de archivo debe ser válido y apuntar
+ <!ENTITY fs.validfp.all '<simpara xmlns="http://docbook.org/ns/docbook">El puntero de archivo debe ser válido y apuntar
 a un archivo abierto con éxito por <function>fopen</function> o
-<function>fsockopen</function> (y no cerrado aún por <function>fclose</function>).</para>'>
+<function>fsockopen</function> (y no cerrado aún por <function>fclose</function>).</simpara>'>
 
- <!ENTITY fs.file.pointer '<para xmlns="http://docbook.org/ns/docbook">Un puntero del sistema de archivos de tipo &resource;
-que es habitualmente creado utilizando la función <function>fopen</function>.</para>'>
+ <!ENTITY fs.file.pointer '<simpara xmlns="http://docbook.org/ns/docbook">Un puntero del sistema de archivos de tipo &resource;
+que es habitualmente creado utilizando la función <function>fopen</function>.</simpara>'>
 
  <!ENTITY fs.file.32bit '<note xmlns="http://docbook.org/ns/docbook"><simpara>
     Como el tipo entero de PHP es firmado y que muchas plataformas
@@ -1975,28 +1975,28 @@ que es habitualmente creado utilizando la función <function>fopen</function>.</
     tamaño superior a 2 Go.
 </simpara></note>'>
 
- <!ENTITY ini.scanner.typed '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY ini.scanner.typed '<simpara xmlns="http://docbook.org/ns/docbook">
 A partir de PHP 5.6.1 también puede ser especificado como <constant>INI_SCANNER_TYPED</constant>.
 En este modo los booleanos, null y enteros son preservados tanto como sea posible.
 Las cadenas de caracteres <literal>"true"</literal>, <literal>"on"</literal> y <literal>"yes"</literal>
 son convertidas a &true;. <literal>"false"</literal>, <literal>"off"</literal>, <literal>"no"</literal>
 y <literal>"none"</literal> son considerados como &false;. <literal>"null"</literal> es convertido a &null; en este modo. Además todas las cadenas de caracteres numéricas son convertidas a entero si es posible.
-</para>'>
+</simpara>'>
 
  <!-- GNUPG -->
- <!ENTITY gnupg.identifier '<para xmlns="http://docbook.org/ns/docbook">El identificador gnupg, generado por una llamada
+ <!ENTITY gnupg.identifier '<simpara xmlns="http://docbook.org/ns/docbook">El identificador gnupg, generado por una llamada
 a la función <function>gnupg_init</function> o a la función
-<classname>gnupg</classname>.</para>'>
+<classname>gnupg</classname>.</simpara>'>
 
- <!ENTITY gnupg.fingerprint '<para xmlns="http://docbook.org/ns/docbook">La huella de la clave.</para>'>
+ <!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">La huella de la clave.</simpara>'>
 
  <!-- HaruDoc -->
- <!ENTITY haru.error '<para xmlns="http://docbook.org/ns/docbook">Emite una excepción <classname>HaruException</classname> en caso de error.</para>'>
+ <!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Emite una excepción <classname>HaruException</classname> en caso de error.</simpara>'>
 
  <!-- ODBC -->
- <!ENTITY odbc.connection.id '<para xmlns="http://docbook.org/ns/docbook">El objeto de conexión ODBC,
+ <!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">El objeto de conexión ODBC,
 ver la documentación de la función <function>odbc_connect</function> para más
-detalles.</para>'><!ENTITY odbc.result.object 'El objeto de resultado ODBC'>
+detalles.</simpara>'><!ENTITY odbc.result.object 'El objeto de resultado ODBC'>
 
  <!ENTITY odbc.result.object-return 'Devuelve un objeto de resultado ODBC'>
 
@@ -2083,17 +2083,17 @@ detalles.</para>'><!ENTITY odbc.result.object 'El objeto de resultado ODBC'>
  <!ENTITY oauth.changelog.error.null 'Antes de esta versión, &null; era devuelto en lugar de &false;.'>
 
  <!-- Oracle -->
- <!ENTITY oci.db "<para xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'>
+ <!ENTITY oci.db "<simpara xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'>
 Contiene la instancia <literal>Oracle</literal> a la que debemos conectarnos.
 Esto puede ser una <link xlink:href='&url.oracle.oic.connect;'>cadena de conexión
     rápida</link>, un nombre de conexión del archivo <filename>tnsnames.ora</filename>,
-o el nombre de una instancia local Oracle.</para>
-<para xmlns='http://docbook.org/ns/docbook'>Si no se especifica o es &null;, PHP utiliza variables de entorno como <constant>TWO_TASK</constant> (en Linux)
+o el nombre de una instancia local Oracle.</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>Si no se especifica o es &null;, PHP utiliza variables de entorno como <constant>TWO_TASK</constant> (en Linux)
 o <constant>LOCAL</constant> (en Windows)
 y <constant>ORACLE_SID</constant> para determinar la instancia
 <literal>Oracle</literal> a la que debemos conectarnos.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>
 Para usar el método de conexión rápida, PHP debe estar vinculado con la biblioteca
 cliente Oracle 10<emphasis>g</emphasis> o superior. La cadena de conexión rápida para Oracle
 10<emphasis>g</emphasis> o superior es de la forma:
@@ -2104,8 +2104,8 @@ cliente Oracle 10<emphasis>g</emphasis> o superior. La cadena de conexión rápi
 Los nombres de los servicios pueden ser encontrados ejecutando la utilidad
 Oracle <literal>lsnrctl status</literal> en la máquina que ejecuta
 la base de datos.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>
 El archivo <filename>tnsnames.ora</filename> puede estar en el camino
 de búsqueda de Oracle Net, que incluye
 <filename>/your/path/to/instantclient/network/admin</filename>, <filename>$ORACLE_HOME/network/admin</filename>
@@ -2114,25 +2114,25 @@ Una solución alternativa sería definir <literal>TNS_ADMIN</literal>
 para que el archivo <filename>$TNS_ADMIN/tnsnames.ora</filename> sea leído.
 Asegúrese de que el demonio que ejecuta el servidor web tenga acceso de lectura a este
 archivo.
-</para>">
+</simpara>">
 
- <!ENTITY oci.charset "<para xmlns='http://docbook.org/ns/docbook'>Determina
+ <!ENTITY oci.charset "<simpara xmlns='http://docbook.org/ns/docbook'>Determina
 el juego de caracteres utilizado por la biblioteca cliente Oracle. El juego de
 caracteres no necesita ser idéntico al utilizado por la base de datos.
 Si no coincide, Oracle hará lo mejor posible para convertir los datos
 desde el juego de caracteres de la base de datos. Dependiendo de los juegos de caracteres,
 el resultado puede no ser perfecto. Además, esta conversión
 requiere un poco de tiempo del sistema.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>Si no se especifica, la biblioteca
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>Si no se especifica, la biblioteca
 cliente Oracle determinará un juego de caracteres desde la variable de entorno
 <constant>NLS_LANG</constant>.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>Pasar este parámetro puede
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>Pasar este parámetro puede
 reducir el tiempo de conexión.
-</para>">
+</simpara>">
 
- <!ENTITY oci.sessionmode '<para xmlns="http://docbook.org/ns/docbook">Este parámetro
+ <!ENTITY oci.sessionmode '<simpara xmlns="http://docbook.org/ns/docbook">Este parámetro
 está disponible a partir de PHP 5 (PECL OCI8 1.1) y acepta los siguientes valores:
 <constant>OCI_DEFAULT</constant>, <constant>OCI_SYSOPER</constant> y
 <constant>OCI_SYSDBA</constant>.
@@ -2142,8 +2142,8 @@ una conexión privilegiada usando identidades externas. Las
 conexiones privilegiadas están desactivadas por omisión. Para activarlas, debe
 definir la opción <link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
 a <literal>On</literal>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 PHP 5.3 (PECL OCI8 1.3.4) introducen el valor de modo
 <constant>OCI_CRED_EXT</constant>. Este modo solicita a Oracle usar una
 identificación externa o bien del sistema operativo, que debe ser
@@ -2151,62 +2151,62 @@ configurada en la base de datos. El flag <constant>OCI_CRED_EXT</constant>
 solo puede ser usado con el nombre de usuario &quot;/&quot; asociado a una contraseña vacía.
 La opción <link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
 puede ser definida a <literal>On</literal> o <literal>Off</literal>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 <constant>OCI_CRED_EXT</constant> puede ser combinado con el modo
 <constant>OCI_SYSOPER</constant> o el modo
 <constant>OCI_SYSDBA</constant>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 <constant>OCI_CRED_EXT</constant> no es soportado en Windows por razones de seguridad.
-</para>'>
+</simpara>'>
 
- <!ENTITY oci.datatypes '<para xmlns="http://docbook.org/ns/docbook">Para más detalles sobre el mapeo de tipos de datos
+ <!ENTITY oci.datatypes '<simpara xmlns="http://docbook.org/ns/docbook">Para más detalles sobre el mapeo de tipos de datos
 realizado por la extensión OCI8, lea los <link linkend="oci8.datatypes">tipos de datos
-    soportados por el driver</link>.</para>'>
+    soportados por el driver</link>.</simpara>'>
 
- <!ENTITY oci.parameter.connection '<para xmlns="http://docbook.org/ns/docbook">Un identificador de conexión Oracle,
+ <!ENTITY oci.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">Un identificador de conexión Oracle,
 devuelto por la función <function>oci_connect</function>, <function>oci_pconnect</function>
-o la función <function>oci_new_connect</function>.</para>'>
+o la función <function>oci_new_connect</function>.</simpara>'>
 
  <!ENTITY oci.availability.note.10g '<note xmlns="http://docbook.org/ns/docbook"><title>Requerido por la versión Oracle</title>
-<para>Esta función está disponible si PHP está vinculado a partir de la versión 10<emphasis>g</emphasis>
-    de la biblioteca de la base de datos Oracle.</para></note>'>
+<simpara>Esta función está disponible si PHP está vinculado a partir de la versión 10<emphasis>g</emphasis>
+    de la biblioteca de la base de datos Oracle.</simpara></note>'>
 
- <!ENTITY oci.clientinfo.tip '<tip xmlns="http://docbook.org/ns/docbook"><title>Rendimiento</title><para>Con versiones antiguas de OCI8 o bases de datos Oracle antiguas, la información del cliente
+ <!ENTITY oci.clientinfo.tip '<tip xmlns="http://docbook.org/ns/docbook"><title>Rendimiento</title><simpara>Con versiones antiguas de OCI8 o bases de datos Oracle antiguas, la información del cliente
     puede ser definida usando el paquete Oracle <literal>DBMS_APPLICATION_INFO</literal>.
     Esto es menos eficiente que usar la función
-    <function>oci_set_client_info</function>.</para></tip>'>
+    <function>oci_set_client_info</function>.</simpara></tip>'>
 
  <!ENTITY oci.roundtrip.caution '<caution xmlns="http://docbook.org/ns/docbook"><title>Ida y vuelta</title>
-<para>Algunas funciones OCI8 requieren ida y vuelta con la base de datos.
+<simpara>Algunas funciones OCI8 requieren ida y vuelta con la base de datos.
     Estas ida y vuelta pueden ser evitadas al usar consultas cuyo resultado es almacenado en caché.
-</para></caution>'>
+</simpara></caution>'>
 
- <!ENTITY oci.use.setprefetch '<para xmlns="http://docbook.org/ns/docbook">Para las
+ <!ENTITY oci.use.setprefetch '<simpara xmlns="http://docbook.org/ns/docbook">Para las
 consultas que devuelven un número muy grande de líneas, el rendimiento puede
 ser muy significativamente mejorado aumentando el valor de la opción
 <link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link>
 o usando la función <function>oci_set_prefetch</function>.
-</para>'>
+</simpara>'>
 
- <!ENTITY oci.arg.statement.id "<para xmlns='http://docbook.org/ns/docbook'>Un identificador de consulta OCI8
+ <!ENTITY oci.arg.statement.id "<simpara xmlns='http://docbook.org/ns/docbook'>Un identificador de consulta OCI8
 creado por la función <function>oci_parse</function> y ejecutado por la función
 <function>oci_execute</function>, o un identificador de consulta <literal>REF
-    CURSOR</literal>.</para>">
+    CURSOR</literal>.</simpara>">
 
  <!-- PCNTL Notes -->
- <!ENTITY pcntl.parameter.status '<para xmlns="http://docbook.org/ns/docbook">El parámetro
+ <!ENTITY pcntl.parameter.status '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro
 <parameter>status</parameter> es el parámetro status pasado a una llamada
-de <function>pcntl_waitpid</function> que tuvo éxito.</para>'>
+de <function>pcntl_waitpid</function> que tuvo éxito.</simpara>'>
 
  <!-- PS Notes -->
- <!ENTITY ps.note.visible '<para xmlns="http://docbook.org/ns/docbook">La nota no será visible si el documento es impreso o
+ <!ENTITY ps.note.visible '<simpara xmlns="http://docbook.org/ns/docbook">La nota no será visible si el documento es impreso o
 mostrado, pero será visible si el documento es convertido a PDF, ya sea por
-Acrobat Distiller™, o por Ghostview.</para>'>
+Acrobat Distiller™, o por Ghostview.</simpara>'>
 
- <!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><para>Esta función es afectada por
-    la directiva de configuración <link linkend="ini.open-basedir">open_basedir</link>.</para></note>'>
+ <!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función es afectada por
+    la directiva de configuración <link linkend="ini.open-basedir">open_basedir</link>.</simpara></note>'>
 
  <!ENTITY note.language-construct '<note xmlns="http://docbook.org/ns/docbook"><simpara>Como esto es una estructura
     del lenguaje, y no una función, no es posible llamarla
@@ -2214,16 +2214,16 @@ Acrobat Distiller™, o por Ghostview.</para>'>
 </simpara></note>'>
 
  <!-- Common pieces in partintro-sections -->
- <!ENTITY no.config '<para xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna directiva de configuración.</para>'>
- <!ENTITY no.resource '<para xmlns="http://docbook.org/ns/docbook">Esta extensión no define ningún recurso.</para>'>
- <!ENTITY no.constants '<para xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna constante.</para>'>
- <!ENTITY no.requirement '<para xmlns="http://docbook.org/ns/docbook">No se requiere ninguna biblioteca externa para compilar esta extensión.</para>'>
- <!ENTITY no.install '<para xmlns="http://docbook.org/ns/docbook">No hay instalación necesaria para
-usar estas funciones, son parte del núcleo de PHP.</para>'>
+ <!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna directiva de configuración.</simpara>'>
+ <!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ningún recurso.</simpara>'>
+ <!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna constante.</simpara>'>
+ <!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">No se requiere ninguna biblioteca externa para compilar esta extensión.</simpara>'>
+ <!ENTITY no.install '<simpara xmlns="http://docbook.org/ns/docbook">No hay instalación necesaria para
+usar estas funciones, son parte del núcleo de PHP.</simpara>'>
 
  <!-- Used in every chapter that has directive descriptions -->
- <!ENTITY ini.descriptions.title '<para xmlns="http://docbook.org/ns/docbook">Aquí hay una aclaración sobre
-el uso de las directivas de configuración.</para>'>
+ <!ENTITY ini.descriptions.title '<simpara xmlns="http://docbook.org/ns/docbook">Aquí hay una aclaración sobre
+el uso de las directivas de configuración.</simpara>'>
 
  <!-- Common pieces for reference part BEGIN-->
 
@@ -2265,14 +2265,14 @@ controlador, si su código puede funcionar en múltiples controladores.</simpara
 
  <!-- PDO errors -->
 
- <!ENTITY pdo.errors '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY pdo.errors '<simpara xmlns="http://docbook.org/ns/docbook">
 Emite un error de nivel <constant>E_WARNING</constant> si el atributo <constant>PDO::ATTR_ERRMODE</constant> está definido
 a <constant>PDO::ERRMODE_WARNING</constant>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 Lanza una excepción <classname>PDOException</classname> si el atributo <constant>PDO::ATTR_ERRMODE</constant> está definido
 a <constant>PDO::ERRMODE_EXCEPTION</constant>.
-</para>'>
+</simpara>'>
 
  <!-- PECL entities -->
  <!ENTITY pecl.moved 'Esta extensión &link.pecl; no está integrada en PHP.'>
@@ -2320,7 +2320,7 @@ de extensiones PECL</link>. Otra información como notas sobre nuevas
 
  <!-- PGSQL entities -->
 
- <!ENTITY pgsql.parameter.connection '<para xmlns="http://docbook.org/ns/docbook">Una instancia <classname>PgSql\Connection</classname>.</para>'>
+ <!ENTITY pgsql.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>PgSql\Connection</classname>.</simpara>'>
 
  <!ENTITY pgsql.parameter.connection-with-unspecified-default '<para xmlns="http://docbook.org/ns/docbook">
  Una instancia <classname>PgSql\Connection</classname>.
@@ -2338,20 +2338,20 @@ de extensiones PECL</link>. Otra información como notas sobre nuevas
  <warning><simpara>Desde PHP 8.1.0, usar la conexión por defecto está obsoleto.</simpara></warning>
  </para>'>
 
- <!ENTITY pgsql.parameter.result '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY pgsql.parameter.result '<simpara xmlns="http://docbook.org/ns/docbook">
  Una instancia <classname>PgSql\Result</classname>, devuelta por <function>pg_query</function>,
  <function>pg_query_params</function>, o <function>pg_execute</function> (entre otros).
-</para>'>
+</simpara>'>
 
- <!ENTITY pgsql.parameter.lob '<para xmlns="http://docbook.org/ns/docbook">Una instancia <classname>PgSql\Lob</classname>, devuelta por <function>pg_lo_open</function>.</para>'>
+ <!ENTITY pgsql.parameter.lob '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>PgSql\Lob</classname>, devuelta por <function>pg_lo_open</function>.</simpara>'>
 
- <!ENTITY pgsql.parameter.mode '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY pgsql.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">
 Un parámetro opcional que controla cómo el <type>array</type> devuelto es indexado.
 <parameter>mode</parameter> es una constante que puede tomar los siguientes valores:
 <constant>PGSQL_ASSOC</constant>, <constant>PGSQL_NUM</constant> y <constant>PGSQL_BOTH</constant>.
 Usando <constant>PGSQL_NUM</constant>, la función devolverá un array con índices numéricos,
 usando <constant>PGSQL_ASSOC</constant>, devolverá solo índices asociativos
-mientras que <constant>PGSQL_BOTH</constant> devolverá ambos índices numéricos y asociativos.</para>'>
+mientras que <constant>PGSQL_BOTH</constant> devolverá ambos índices numéricos y asociativos.</simpara>'>
 
  <!ENTITY pgsql.changelog.connection-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
@@ -2397,16 +2397,16 @@ añadir ninguna biblioteca adicional para disponer de estas funciones.</simpara>
  <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">safe mode SQL</link>'>
 
  <!-- CTYPE Notes -->
- <!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><para>
+ <!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><simpara>
     Si se proporciona un entero en el rango -128 y 255 inclusive, será interpretado como
     el valor ASCII de un solo carácter (los valores negativos se verán añadir 256 para permitir
     caracteres en el rango ASCII extendido). Cualquier otro entero será interpretado como
-    una cadena de caracteres que contiene los dígitos decimales del entero.</para></note>'>
+    una cadena de caracteres que contiene los dígitos decimales del entero.</simpara></note>'>
 
- <!ENTITY note.ctype.parameter.non-string "<warning xmlns='http://docbook.org/ns/docbook'><para>
+ <!ENTITY note.ctype.parameter.non-string "<warning xmlns='http://docbook.org/ns/docbook'><simpara>
 Desde PHP 8.1.0, pasar un argumento diferente de una cadena está obsoleto.
 En el futuro, el argumento será interpretado como una cadena de caracteres en lugar de un punto de código ASCII.
-Según el comportamiento deseado, el argumento debe ser convertido a &string; o debe realizarse una llamada explícita a <function>chr</function>.</para></warning>">
+Según el comportamiento deseado, el argumento debe ser convertido a &string; o debe realizarse una llamada explícita a <function>chr</function>.</simpara></warning>">
 
  <!ENTITY ctype.result.empty-string 'Cuando se llama con una cadena vacía, el resultado será siempre &false;.'>
 
@@ -2418,51 +2418,51 @@ Según el comportamiento deseado, el argumento debe ser convertido a &string; o 
   <classname>FTP\Connection</classname> ; anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
- <!ENTITY ftp.parameter.ftp '<para xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>FTP\Connection</classname>.</para>'>
+ <!ENTITY ftp.parameter.ftp '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>FTP\Connection</classname>.</simpara>'>
 
  <!-- GMP Notes -->
  <!ENTITY gmp.return 'Un objeto <classname xmlns="http://docbook.org/ns/docbook">GMP</classname>.'>
- <!ENTITY gmp.parameter '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY gmp.parameter '<simpara xmlns="http://docbook.org/ns/docbook">
  Un objeto <classname>GMP</classname>, un &integer;,
  o un &string; que puede ser interpretado como un número siguiendo la misma lógica
  que si la cadena fuera usada en <function>gmp_init</function> con detección automática de la base (es decir cuando <parameter>base</parameter> es igual a 0).
-</para>'>
+</simpara>'>
 
  <!-- MySQLi Notes -->
  <!ENTITY mysqli.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>result</parameter></term><listitem><para>Solo estilo procedimental: Un objeto <classname>mysqli_result</classname>
+<parameter>result</parameter></term><listitem><simpara>Solo estilo procedimental: Un objeto <classname>mysqli_result</classname>
 devuelto por <function>mysqli_query</function>, <function>mysqli_store_result</function>,
-<function>mysqli_use_result</function> o <function>mysqli_stmt_get_result</function>.</para></listitem></varlistentry>'>
+<function>mysqli_use_result</function> o <function>mysqli_stmt_get_result</function>.</simpara></listitem></varlistentry>'>
  <!ENTITY mysqli.link.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>mysql</parameter></term><listitem><para>Solo estilo procedimental: Un objeto <classname>mysqli</classname>
+<parameter>mysql</parameter></term><listitem><simpara>Solo estilo procedimental: Un objeto <classname>mysqli</classname>
 devuelto por <function>mysqli_connect</function> o <function>mysqli_init</function>
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
  <!ENTITY mysqli.stmt.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>statement</parameter></term><listitem><para>Solo estilo procedimental: Un objeto <classname>mysqli_stmt</classname>
-devuelto por <function>mysqli_stmt_init</function>.</para></listitem></varlistentry>'>
+<parameter>statement</parameter></term><listitem><simpara>Solo estilo procedimental: Un objeto <classname>mysqli_stmt</classname>
+devuelto por <function>mysqli_stmt_init</function>.</simpara></listitem></varlistentry>'>
  <!ENTITY mysqli.available.mysqlnd 'Disponible solo con <link xmlns="http://docbook.org/ns/docbook"
 linkend="book.mysqlnd">mysqlnd</link>.'>
  <!ENTITY mysqli.charset.note '<note xmlns="http://docbook.org/ns/docbook">
-<para>MySQLnd siempre asume el juego de caracteres predeterminado del servidor. Este juego de caracteres es enviado durante el intercambio de conexión/autenticación, el cual mysqlnd utilizará.</para><para>Libmysqlclient utiliza el juego de caracteres predeterminado establecido en el
+<simpara>MySQLnd siempre asume el juego de caracteres predeterminado del servidor. Este juego de caracteres es enviado durante el intercambio de conexión/autenticación, el cual mysqlnd utilizará.</simpara><simpara>Libmysqlclient utiliza el juego de caracteres predeterminado establecido en el
 <filename>my.cnf</filename> o mediante una llamada explícita a <function>mysqli_options</function> antes de
-llamar a <function>mysqli_real_connect</function>, pero después de <function>mysqli_init</function>.</para></note>'>
+llamar a <function>mysqli_real_connect</function>, pero después de <function>mysqli_init</function>.</simpara></note>'>
  <!ENTITY mysqli.integer.overflow.as.string.note '<note xmlns="http://docbook.org/ns/docbook">
-<para>Si el número de filas es mayor que <constant>PHP_INT_MAX</constant>,
-el número será devuelto como un &string;.</para></note>'>
+<simpara>Si el número de filas es mayor que <constant>PHP_INT_MAX</constant>,
+el número será devuelto como un &string;.</simpara></note>'>
  <!ENTITY mysqli.sqlinjection.warning '<warning xmlns="http://docbook.org/ns/docbook">
-<title>Advertencia de seguridad: Inyección SQL</title><para>Si la consulta contiene alguna entrada de variable,
+<title>Advertencia de seguridad: Inyección SQL</title><simpara>Si la consulta contiene alguna entrada de variable,
 entonces se deben usar <link linkend="mysqli.quickstart.prepared-statements">sentencias preparadas
 parametrizadas</link> en su lugar. Alternativamente, los datos deben estar correctamente formateados y todas las cadenas deben ser escapadas usando
-la función <function>mysqli_real_escape_string</function>.</para></warning>'>
- <!ENTITY mysqli.conditionalexception '<para xmlns="http://docbook.org/ns/docbook">
+la función <function>mysqli_real_escape_string</function>.</simpara></warning>'>
+ <!ENTITY mysqli.conditionalexception '<simpara xmlns="http://docbook.org/ns/docbook">
 Si el informe de errores de mysqli está habilitado (<constant>MYSQLI_REPORT_ERROR</constant>) y la operación solicitada falla,
 se genera una advertencia. Si, además, el modo está configurado como <constant>MYSQLI_REPORT_STRICT</constant>,
-se lanza una <classname>mysqli_sql_exception</classname> en su lugar.</para>'>
+se lanza una <classname>mysqli_sql_exception</classname> en su lugar.</simpara>'>
 
  <!-- Notes for PCRE -->
- <!ENTITY pcre.pattern.warning '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY pcre.pattern.warning '<simpara xmlns="http://docbook.org/ns/docbook">
 Si el patrón regex pasado no se compila a una regex válida, se emite una <constant>E_WARNING</constant>.
-</para>'>
+</simpara>'>
 
  <!-- Notes for SAPI/Apache -->
  <!ENTITY apache.req.module '<simpara xmlns="http://docbook.org/ns/docbook">Esta función
@@ -2470,9 +2470,9 @@ es soportada cuando PHP está instalado como módulo de Apache.
 </simpara>'>
 
  <!-- Notes for SAPI/FPM -->
- <!ENTITY fpm.intro "<para xmlns='http://docbook.org/ns/docbook'>FPM (FastCGI Process Manager, gestor de procesos FastCGI)
+ <!ENTITY fpm.intro "<simpara xmlns='http://docbook.org/ns/docbook'>FPM (FastCGI Process Manager, gestor de procesos FastCGI)
 es una alternativa a la implementación PHP FastCGI con funcionalidades adicionales útiles para sitios muy altamente cargados.
-</para>">
+</simpara>">
 
  <!-- SimpleXML Notes -->
  <!ENTITY simplexml.iteration '<note xmlns="http://docbook.org/ns/docbook"><simpara>SimpleXML añade propiedades
@@ -2481,27 +2481,27 @@ es una alternativa a la implementación PHP FastCGI con funcionalidades adiciona
     objetos.</simpara></note>'>
 
  <!-- SQLite Notes -->
- <!ENTITY sqlite.case-fold '<para xmlns="http://docbook.org/ns/docbook">Los nombres de columnas devueltos por
+ <!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">Los nombres de columnas devueltos por
 <constant>SQLITE_ASSOC</constant> y <constant>SQLITE_BOTH</constant>
 siguen las reglas concernientes a la case definidas por la opción de configuración
-<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>.</para>'>
+<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>.</simpara>'>
 
- <!ENTITY sqlite.decode-bin '<para xmlns="http://docbook.org/ns/docbook">Cuando <parameter>decode_binary</parameter>
+ <!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">Cuando <parameter>decode_binary</parameter>
 vale &true; (por defecto), PHP va a decodificar los datos binarios, si estos han sido
 codificados con la función <function>sqlite_escape_string</function>.
 Generalmente se dejará este valor en su valor por defecto,
 a menos que se esté trabajando con bases operadas por otras
-aplicaciones.</para>'>
+aplicaciones.</simpara>'>
 
- <!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><para>Esta función no funcionará con
-    resultados no bufferizados.</para></note>'>
+ <!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función no funcionará con
+    resultados no bufferizados.</simpara></note>'>
 
  <!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Dos sintaxis alternativas son
     soportadas para asegurar la compatibilidad con otras bases de datos
     (tales como MySQL): la forma recomendada es la primera, donde el parámetro
     <parameter>dbhandle</parameter> es el primero en la función.</simpara></note>'>
 
- <!ENTITY sqlite.result-type '<para xmlns="http://docbook.org/ns/docbook">El parámetro opcional
+ <!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro opcional
 <parameter>result_type</parameter> acepta una constante y determina cómo
 el array devuelto debe ser indexado. El uso de
 <constant>SQLITE_ASSOC</constant> devolverá únicamente un array asociativo
@@ -2509,7 +2509,7 @@ el array devuelto debe ser indexado. El uso de
 array indexado numéricamente (número ordinal de los campos).
 <constant>SQLITE_BOTH</constant> devolverá índices numéricos y asociativos.
 <constant>SQLITE_BOTH</constant> es el valor por defecto para esta
-función.</para>'>
+función.</simpara>'>
 
  <!-- Database Notes -->
  <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los nombres de los campos devueltos por
@@ -2520,86 +2520,86 @@ función.</para>'>
  <!-- MySQL Notes -->
  <!-- The mysql.*.description entities are used in the parameters refsect1 -->
  <!ENTITY mysql.linkid.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>link_identifier</parameter></term><listitem><para>
+<term><parameter>link_identifier</parameter></term><listitem><simpara>
  La conexión MySQL.
  Si no se especifica, se utilizará la última conexión abierta con la función
  <function>mysql_connect</function>. Si no se encuentra una conexión de este tipo,
  la función intentará abrir una conexión, como si la función <function>mysql_connect</function> hubiera sido llamada sin argumento.
  Si no se encuentra o establece una conexión, se generará una alerta de nivel
  <constant>E_WARNING</constant>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
  <!ENTITY mysql.linkid-noreopen.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>link_identifier</parameter></term><listitem><para>
+<term><parameter>link_identifier</parameter></term><listitem><simpara>
  La conexión MySQL.
  Si el identificador del enlace no se especifica, se utilizará la última conexión
  abierta con la función <function>mysql_connect</function>.
  Si no se encuentra o establece una conexión, se generará una alerta de nivel
  <constant>E_WARNING</constant>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
  <!ENTITY mysql.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>result</parameter></term><listitem><para>
+<term><parameter>result</parameter></term><listitem><simpara>
  La &resource; de resultado que acaba de ser evaluada.
  Este resultado proviene de la llamada a la función <function>mysql_query</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
  <!ENTITY mysql.field-offset.req.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>field_offset</parameter></term><listitem><para>
+<term><parameter>field_offset</parameter></term><listitem><simpara>
  La posición numérica del campo.
  <parameter>field_offset</parameter> comienza en <literal>0</literal>.
  Si <parameter>field_offset</parameter> no existe, se generará una alerta de nivel
  <constant>E_WARNING</constant>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
- <!ENTITY mysql.alternative.note '<para xmlns="http://docbook.org/ns/docbook">Esta extensión
+ <!ENTITY mysql.alternative.note '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión
 estaba obsoleta en PHP 5.5.0, y fue eliminada en PHP 7.0.0. En su lugar, se puede
 utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también
 <link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de la guía.
-Alternativas a esta función:</para>'>
+Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note.4-3-0 '<para xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
+ <!ENTITY mysql.alternative.note.4-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
 en PHP 4.3.0, y toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0.
 En su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir
-una API</link> de la guía. Alternativas a esta función:</para>'>
+una API</link> de la guía. Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note.5-3-0 '<para xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
+ <!ENTITY mysql.alternative.note.5-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
 en PHP 5.3.0, y toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0.
 En su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir
 una API</link> de la guía.
-Alternativas a esta función:</para>'>
+Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note.5-4-0 '<para xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
+ <!ENTITY mysql.alternative.note.5-4-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
 en PHP 5.4.0, y toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0.
 En su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir
-    una API</link> de la guía. Alternativas a esta función:</para>'>
+    una API</link> de la guía. Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note.5-5-0 '<para xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
+ <!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
 en PHP 5.5.0, y toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0.
 En su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir
-    una API</link> de la guía. Alternativas a esta función:</para>'>
+    una API</link> de la guía. Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.close.connections.result.sets '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
 Las conexiones y los juegos de resultados abiertos de forma no persistente son automáticamente
 destruidos cuando un script PHP termina su ejecución. También, el hecho de cerrar una conexión
 y liberar los resultados siendo opcional, el hecho de hacerlo explícitamente es altamente
 recomendado. Esto devolverá los recursos inmediatamente a PHP y a MySQL, lo que mejorará las
 performance. Para más información, refiérase a la
-<link linkend="language.types.resource.self-destruct">liberación de recursos</link></para>'>
+<link linkend="language.types.resource.self-destruct">liberación de recursos</link></simpara>'>
 
  <!-- Xattr entities -->
- <!ENTITY xattr.namespace '<para xmlns="http://docbook.org/ns/docbook">Los atributos extendidos tienen dos espacios de nombres
+ <!ENTITY xattr.namespace '<simpara xmlns="http://docbook.org/ns/docbook">Los atributos extendidos tienen dos espacios de nombres
 diferentes: <literal>user</literal> y <literal>root</literal>. El espacio de nombres
 <literal>user</literal> está disponible para todos los usuarios mientras que el espacio de
 nombres <literal>root</literal> solo está disponible para los usuarios con privilegios
 <literal>root</literal>. xattr opera sobre el espacio de nombres <literal>user</literal> por
 defecto, pero esto puede ser cambiado utilizando el argumento
-<parameter>flags</parameter>.</para>'>
+<parameter>flags</parameter>.</simpara>'>
 
  <!-- Notes for IPv6 -->
  <!ENTITY ipv6.brackets '<note xmlns="http://docbook.org/ns/docbook"><simpara>Al especificar direcciones
@@ -2610,12 +2610,12 @@ defecto, pero esto puede ser cambiado utilizando el argumento
  <!-- Notes for tidy -->
  <!ENTITY tidy.object 'El objeto <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>'>
 
- <!ENTITY tidy.conf-enc '<para xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>config</parameter> puede
+ <!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>config</parameter> puede
 tomar la forma de un array o de una cadena de caracteres. En forma de cadena, representa el nombre del archivo de configuración y de lo contrario, es
 un array con las opciones de configuración. Lea <link xmlns:xlink="http://www.w3.org/1999/xlink"
                                                           xlink:href="&url.tidy.conf;">&url.tidy.conf;</link> para saber más sobre cada
-opción.</para>
-<para>El parámetro <parameter>encoding</parameter> especifica el juego de caracteres
+opción.</simpara>
+<simpara>El parámetro <parameter>encoding</parameter> especifica el juego de caracteres
 utilizado para los documentos de entrada y salida. Los valores posibles de
 <parameter>encoding</parameter> son:
 <literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
@@ -2623,23 +2623,23 @@ utilizado para los documentos de entrada y salida. Los valores posibles de
 <literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
 <literal>utf16</literal>, <literal>utf16le</literal>,
 <literal>utf16be</literal>, <literal>big5</literal> y
-<literal>shiftjis</literal>.</para>'>
+<literal>shiftjis</literal>.</simpara>'>
 
  <!-- Snippets for the installation section -->
- <!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><para>No se recomienda
+ <!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>No se recomienda
     el uso de PHP en un entorno thread MPM, con Apache 2.
     Utilice el modo prefork MPM, que es el MPM por defecto para Apache 2.0 y 2.2.
     Para saber por qué, lea
     la entrada de la FAQ correspondiente a la
-    <link linkend="faq.installation.apache2">utilización de Apache 2 en un entorno thread MPM</link>.</para></warning>'>
+    <link linkend="faq.installation.apache2">utilización de Apache 2 en un entorno thread MPM</link>.</simpara></warning>'>
  <!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <para>
+ <simpara>
  Las versiones provenientes de terceros son consideradas no oficiales y no
  son directamente soportadas por el proyecto PHP. Cualquier bug encontrado
  debe ser reportado al proveedor de estas versiones no oficiales, a menos que
  pueda ser reproducido utilizando las versiones provenientes de <link xlink:href="&url.php.downloads;">
  la zona de descargas oficial</link>.
- </para>
+ </simpara>
 </warning>'>
 
  <!ENTITY note.apache.slashes '<note xmlns="http://docbook.org/ns/docbook"><simpara>Recuerde que al añadir
@@ -2652,11 +2652,11 @@ utilizado para los documentos de entrada y salida. Los valores posibles de
  <!-- Snippets and titles for the contributors section -->
  <!ENTITY Credit.Authors.and.Contributors 'Autores y Contribuyentes'>
 
- <!ENTITY Credit.Introduction '<para xmlns="http://docbook.org/ns/docbook">Destacamos a las personas más activas en el prólogo del manual pero hay muchos más contribuyentes
+ <!ENTITY Credit.Introduction '<simpara xmlns="http://docbook.org/ns/docbook">Destacamos a las personas más activas en el prólogo del manual pero hay muchos más contribuyentes
 que nos ayudan actualmente en nuestro trabajo o que han proporcionado ayuda
 preciosa al proyecto en el pasado. Hay muchos desconocidos que nos han ayudado
 mediante sus notas concernientes a las páginas del manual que son
-continuamente incluidas en el manual, trabajo del cual estamos muy agradecidos. La lista proporcionada a continuación está ordenada alfabéticamente.</para>'>
+continuamente incluidas en el manual, trabajo del cual estamos muy agradecidos. La lista proporcionada a continuación está ordenada alfabéticamente.</simpara>'>
 
  <!ENTITY Credit.Authors.and.Editors 'Autores y Editores'>
 
@@ -2701,12 +2701,12 @@ continuamente incluidas en el manual, trabajo del cual estamos muy agradecidos. 
 
  <!-- XMLWriter Notes -->
  <!ENTITY xmlwriter.xmlwriter.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>writer</parameter></term><listitem><para>
+<term><parameter>writer</parameter></term><listitem><simpara>
  Únicamente para llamadas procedimentales.
  La instancia <classname>XMLWriter</classname> que es modificada.
  Este objeto proviene de una llamada a <function>xmlwriter_open_uri</function>
  o <function>xmlwriter_open_memory</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
  <!ENTITY xmlwriter.changelog.writer-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -2717,12 +2717,12 @@ continuamente incluidas en el manual, trabajo del cual estamos muy agradecidos. 
 </row>'>
 
  <!-- SOAP notes -->
- <!ENTITY soap.wsdl.mode.only "<note xmlns='http://docbook.org/ns/docbook'><para>Esta función solo está disponible en modo WSDL.</para></note>">
+ <!ENTITY soap.wsdl.mode.only "<note xmlns='http://docbook.org/ns/docbook'><simpara>Esta función solo está disponible en modo WSDL.</simpara></note>">
 
  <!-- Stomp notes -->
- <!ENTITY stomp.param.link "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>link</parameter></term><listitem><para>Estilo procedimental únicamente: El identificador stomp devuelto por la función<function>stomp_connect</function>.</para></listitem></varlistentry>">
- <!ENTITY stomp.param.headers "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>headers</parameter></term><listitem><para>Array asociativo que contiene los encabezados adicionales (ejemplo: receipt).</para></listitem></varlistentry>">
- <!ENTITY stomp.note.transaction "<note xmlns='http://docbook.org/ns/docbook'><para>Un encabezado de transacción puede ser especificado, indicando que la confirmación de los mensajes debe ser parte de la transacción.</para></note>">
+ <!ENTITY stomp.param.link "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>link</parameter></term><listitem><simpara>Estilo procedimental únicamente: El identificador stomp devuelto por la función<function>stomp_connect</function>.</simpara></listitem></varlistentry>">
+ <!ENTITY stomp.param.headers "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>headers</parameter></term><listitem><simpara>Array asociativo que contiene los encabezados adicionales (ejemplo: receipt).</simpara></listitem></varlistentry>">
+ <!ENTITY stomp.note.transaction "<note xmlns='http://docbook.org/ns/docbook'><simpara>Un encabezado de transacción puede ser especificado, indicando que la confirmación de los mensajes debe ser parte de la transacción.</simpara></note>">
  <!ENTITY stomp.note.sync "<tip xmlns='http://docbook.org/ns/docbook'><simpara>Stomp es, por naturaleza, asíncrono. Una comunicación síncrona puede ser implementada añadiendo un encabezado <literal>receipt</literal>. Esto hará que los métodos no devuelvan nada hasta que el mensaje de confirmación no haya sido recibido o hasta que el tiempo de espera no sea alcanzado.</simpara></tip>">
 
  <!-- SVN notes -->
@@ -2735,15 +2735,15 @@ continuamente incluidas en el manual, trabajo del cual estamos muy agradecidos. 
  <!ENTITY svn.referto.type 'Refiérase a las <link xmlns="http://docbook.org/ns/docbook" linkend="svn.constants.type">constantes de tipo</link> para los valores posibles.'>
 
  <!-- FANN notes -->
- <!ENTITY fann.ann.description '<para xmlns="http://docbook.org/ns/docbook">Recurso de red neuronal.</para>'>
- <!ENTITY fann.train.description '<para xmlns="http://docbook.org/ns/docbook">Recurso de datos de entrenamiento de la red neuronal.</para>'>
- <!ENTITY fann.errdat.description '<para xmlns="http://docbook.org/ns/docbook">O bien un recurso de red neuronal, o un recurso de datos de entrenamiento de una red neuronal.</para>'>
- <!ENTITY fann.return.void '<para xmlns="http://docbook.org/ns/docbook">No devuelve ningún valor.</para>'>
- <!ENTITY fann.return.bool '<para xmlns="http://docbook.org/ns/docbook">Devuelve &true; en caso de éxito, &false; de lo contrario.</para>'>
- <!ENTITY fann.return.ann '<para xmlns="http://docbook.org/ns/docbook">Devuelve un recurso de red neuronal en caso de éxito, o &false; si ocurre un error.</para>'>
- <!ENTITY fann.return.train '<para xmlns="http://docbook.org/ns/docbook">Devuelve un recurso de datos de entrenamiento en caso de éxito, o &false; si ocurre un error.</para>'>
- <!ENTITY fann.note.function.fann-2.2 '<note xmlns="http://docbook.org/ns/docbook"><para>Esta función ahora está disponible si la extensión fann ha sido compilada
-con libfann >= 2.2.</para></note>'>
+ <!ENTITY fann.ann.description '<simpara xmlns="http://docbook.org/ns/docbook">Recurso de red neuronal.</simpara>'>
+ <!ENTITY fann.train.description '<simpara xmlns="http://docbook.org/ns/docbook">Recurso de datos de entrenamiento de la red neuronal.</simpara>'>
+ <!ENTITY fann.errdat.description '<simpara xmlns="http://docbook.org/ns/docbook">O bien un recurso de red neuronal, o un recurso de datos de entrenamiento de una red neuronal.</simpara>'>
+ <!ENTITY fann.return.void '<simpara xmlns="http://docbook.org/ns/docbook">No devuelve ningún valor.</simpara>'>
+ <!ENTITY fann.return.bool '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve &true; en caso de éxito, &false; de lo contrario.</simpara>'>
+ <!ENTITY fann.return.ann '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve un recurso de red neuronal en caso de éxito, o &false; si ocurre un error.</simpara>'>
+ <!ENTITY fann.return.train '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve un recurso de datos de entrenamiento en caso de éxito, o &false; si ocurre un error.</simpara>'>
+ <!ENTITY fann.note.function.fann-2.2 '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ahora está disponible si la extensión fann ha sido compilada
+con libfann >= 2.2.</simpara></note>'>
 
  <!-- Imagick generic return types -->
  <!ENTITY imagick.return.success 'Devuelve &true; en caso de éxito.'>
@@ -2807,35 +2807,35 @@ con libfann >= 2.2.</para></note>'>
     concerniente a la instalación</link> para más información.
 </simpara>
 </note>'>
- <!ENTITY note.openssl.param-notext '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY note.openssl.param-notext '<simpara xmlns="http://docbook.org/ns/docbook">
 El parámetro opcional <parameter>notext</parameter> afecta al nivel de verbosidad del display;
 si vale &false;, se añadirán información legible por humanos en el display.
 Por omisión, el parámetro <parameter>notext</parameter> vale &true;.
-</para>'>
+</simpara>'>
 
  <!-- COM/Dotnet -->
  <!ENTITY com.variant-arith '<note xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
     Al igual que para todas las funciones aritméticas, los parámetros para esta función
     pueden ser ya sea un tipo nativo de PHP (entero, string, float, bool o &null;), o una instancia de la clase COM, VARIANT o DOTNET. Los tipos nativos de PHP
     serán convertidos a VARIANT utilizando las mismas reglas que las encontradas en el
     constructor de la clase <xref linkend="class.variant"/>. Los objetos COM y DOTNET
     tendrán el valor de su propiedad por defecto recuperado y utilizado como valor VARIANT.
-</para>
-<para>
+</simpara>
+<simpara>
     Las funciones aritméticas VARIANT están interfazadas con las funciones equivalentes de la biblioteca
     COM; para más información sobre estas funciones, consúltese la biblioteca MSDN. Las funciones PHP tienen nombres ligeramente diferentes:
     por ejemplo, <function>variant_add</function>, en PHP, corresponde a
     <literal>VarAdd()</literal> en la documentación MSDN.
-</para>
+</simpara>
 </note>
 '>
 
  <!-- phar -->
- <!ENTITY phar.write '<note xmlns="http://docbook.org/ns/docbook"><para>Este
+ <!ENTITY phar.write '<note xmlns="http://docbook.org/ns/docbook"><simpara>Este
     método requiere que la variable de configuración INI <literal>phar.readonly</literal>
     esté definida a <literal>0</literal> para funcionar con los objetos <classname>Phar</classname>.
-    De lo contrario, se lanzará una excepción <classname>PharException</classname>.</para></note>'>
+    De lo contrario, se lanzará una excepción <classname>PharException</classname>.</simpara></note>'>
 
  <!ENTITY phar.note.performance '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -2856,30 +2856,30 @@ Por omisión, el parámetro <parameter>notext</parameter> vale &true;.
 </note>'>
 
  <!-- XML -->
- <!ENTITY libxml.required '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY libxml.required '<simpara xmlns="http://docbook.org/ns/docbook">
  Esta extensión requiere la extensión PHP <link linkend="book.libxml">libxml</link>.
  Esto significa pasar la opción de configuración
  <option role="configure">--with-libxml</option>, o anterior a PHP 7.4
  la opción de configuración <option role="configure">--enable-libxml</option>,
  aunque esto se realiza implícitamente ya que libxml está activado por omisión.
-</para>'>
+</simpara>'>
 
  <!-- XMLReader -->
- <!ENTITY xmlreader.libxml20620.note '<caution xmlns="http://docbook.org/ns/docbook"><para>Esta función solo está disponible
-    si PHP es compilado utilizando la biblioteca libxml 20620 o posterior.</para></caution>'>
+ <!ENTITY xmlreader.libxml20620.note '<caution xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible
+    si PHP es compilado utilizando la biblioteca libxml 20620 o posterior.</simpara></caution>'>
 
  <!-- inotify -->
  <!ENTITY inotify.instance.description 'Recurso retornado por
 <function xmlns="http://docbook.org/ns/docbook">inotify_init</function>'>
 
  <!-- User streams -->
- <!ENTITY userstream.not.implemented.warning '<para xmlns="http://docbook.org/ns/docbook">Emite una advertencia
+ <!ENTITY userstream.not.implemented.warning '<simpara xmlns="http://docbook.org/ns/docbook">Emite una advertencia
 <constant>E_WARNING</constant> si la llamada a este método falla
-(i.e. no implementado).</para>'>
+(i.e. no implementado).</simpara>'>
 
- <!ENTITY userstream.updates.context '<note xmlns="http://docbook.org/ns/docbook"><para>La propiedad
+ <!ENTITY userstream.updates.context '<note xmlns="http://docbook.org/ns/docbook"><simpara>La propiedad
     <varname linkend="streamwrapper.props.context">streamWrapper::$context</varname>
-    es actualizada si un contexto válido es pasado a la función.</para></note>'>
+    es actualizada si un contexto válido es pasado a la función.</simpara></note>'>
 
  <!ENTITY stream.bucket.param '<parameter>bucket</parameter> ahora espera una instancia de <classname>StreamBucket</classname>; anteriormente, se esperaba una <classname>stdClass</classname>.'>
  <!ENTITY stream.bucket.return 'Esta función ahora retorna una instancia de <classname>StreamBucket</classname>; anteriormente, se retornaba una <classname>stdClass</classname>.'>
@@ -2905,27 +2905,27 @@ Por omisión, el parámetro <parameter>notext</parameter> vale &true;.
  <!ENTITY reflection.getattributes.param.name '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>name</parameter></term>
 <listitem>
- <para>
+ <simpara>
   Filtrar los resultados para incluir únicamente las instancias
   de <classname>ReflectionAttribute</classname> para los atributos correspondientes a este nombre de clase.
- </para>
+ </simpara>
 </listitem>
 </varlistentry>'>
 
  <!ENTITY reflection.getattributes.param.flags '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>flags</parameter></term>
 <listitem>
- <para>
+ <simpara>
   Flags para determinar cómo filtrar los resultados, si <parameter>name</parameter> es proporcionado.
- </para>
- <para>
+ </simpara>
+ <simpara>
   El valor por omisión es <literal>0</literal> que solo retornará los resultados
   para los atributos que son de la clase <parameter>name</parameter>.
- </para>
- <para>
+ </simpara>
+ <simpara>
   La única otra opción disponible es utilizar <constant>ReflectionAttribute::IS_INSTANCEOF</constant>,
   que utilizará <literal>instanceof</literal> para el filtrado.
- </para>
+ </simpara>
 </listitem>
 </varlistentry>'>
 
@@ -2938,10 +2938,10 @@ Por omisión, el parámetro <parameter>notext</parameter> vale &true;.
  <!ENTITY win32service.noerror.false.error 'retornaba <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> en caso de éxito&win32service.false.error;'>
 
  <!-- SNMP -->
- <!ENTITY snmp.set.type.values '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY snmp.set.type.values '<simpara xmlns="http://docbook.org/ns/docbook">
 El <acronym>MIB</acronym> define el tipo de cada identificador de objeto. Debe
 ser especificado como un carácter simple de la lista siguiente.
-</para>
+</simpara>
 <table xmlns="http://docbook.org/ns/docbook">
 <title>tipos</title>
 <tgroup cols="2">
@@ -2960,11 +2960,11 @@ ser especificado como un carácter simple de la lista siguiente.
     </tbody>
 </tgroup>
 </table>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Si la constante <constant>OPAQUE_SPECIAL_TYPES</constant> ha sido definida durante
 la compilación de la biblioteca <acronym>SNMP</acronym>, los caracteres siguientes
 también estarán disponibles:
-</para>
+</simpara>
 <table xmlns="http://docbook.org/ns/docbook">
 <title>tipos</title>
 <tgroup cols="2">
@@ -2977,22 +2977,22 @@ también estarán disponibles:
 </tgroup>
 </table>
 '>
- <!ENTITY snmp.set.type.values.asn.mapping '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY snmp.set.type.values.asn.mapping '<simpara xmlns="http://docbook.org/ns/docbook">
 La mayoría de estos valores utilizan el tipo ASN.1 correspondiente. &apos;s&apos;, &apos;x&apos;, &apos;d&apos; y &apos;b&apos;
 son todas formas diferentes de especificar el valor OCTET STRING y el tipo sin signo
 &apos;u&apos; también es utilizado para manejar los valores Gauge32.
-</para>
+</simpara>
 '>
- <!ENTITY snmp.set.type.values.equal.note '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY snmp.set.type.values.equal.note '<simpara xmlns="http://docbook.org/ns/docbook">
 Si los archivos MIB son cargados en el árbol MIB con "snmp_read_mib" o especificándolos
 en la configuración de libsnmp, &apos;=&apos; podrá ser utilizado como parámetro
 de tipo para todos los identificadores de objetos, ya que el tipo puede ser leído automáticamente desde el MIB.
-</para>
+</simpara>
 '>
- <!ENTITY snmp.set.type.values.bitset.note '<para xmlns="http://docbook.org/ns/docbook">
+ <!ENTITY snmp.set.type.values.bitset.note '<simpara xmlns="http://docbook.org/ns/docbook">
 Nota que hay 2 formas de definir una variable de tipo BITS como i.e.
 "SYNTAX    BITS {telnet(0), ftp(1), http(2), icmp(3), snmp(4), ssh(5), https(6)}":
-</para>
+</simpara>
 <itemizedlist xmlns="http://docbook.org/ns/docbook">
 <listitem>
     <simpara>
@@ -3007,13 +3007,13 @@ Nota que hay 2 formas de definir una variable de tipo BITS como i.e.
     </simpara>
 </listitem>
 </itemizedlist>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Consúltese la sección sobre ejemplos para más detalles.
-</para>
+</simpara>
 '>
  <!ENTITY snmp.methods.exceptions_enable.refsect '<refsect1 role="errors" xmlns="http://docbook.org/ns/docbook">
 &reftitle.errors;
-<para>
+<simpara>
     Este método no lanza excepciones por omisión.
     Para activar el lanzamiento de excepciones SNMPException cuando
     ocurren errores de la biblioteca,
@@ -3021,7 +3021,7 @@ Consúltese la sección sobre ejemplos para más detalles.
     debe ser definido al valor correspondiente. Ver las <link linkend="snmp.props.exceptions-enabled">
     explicaciones sobre <parameter>SNMP::$exceptions_enabled</parameter></link>
     para más detalles.
-</para>
+</simpara>
 </refsect1>
 '>
 
@@ -3035,23 +3035,23 @@ void callback(mixed $data, int $result[, resource $req]);
 <variablelist xmlns="http://docbook.org/ns/docbook">
     <varlistentry xmlns="http://docbook.org/ns/docbook">
         <term><parameter>data</parameter></term>
-        <listitem><para>representa los datos personalizados pasados a la petición.</para></listitem>
+        <listitem><simpara>representa los datos personalizados pasados a la petición.</simpara></listitem>
     </varlistentry>
     <varlistentry xmlns="http://docbook.org/ns/docbook">
         <term><parameter>result</parameter></term>
-        <listitem><para>representa el valor resultante específico de la petición; básicamente,
-            el valor retornado por la llamada al sistema correspondiente.</para></listitem>
+        <listitem><simpara>representa el valor resultante específico de la petición; básicamente,
+            el valor retornado por la llamada al sistema correspondiente.</simpara></listitem>
     </varlistentry>
     <varlistentry xmlns="http://docbook.org/ns/docbook">
         <term><parameter>req</parameter></term>
-        <listitem><para>es el recurso opcional de la petición que puede ser
-            utilizado con funciones como <function>eio_get_last_error</function>.</para></listitem>
+        <listitem><simpara>es el recurso opcional de la petición que puede ser
+            utilizado con funciones como <function>eio_get_last_error</function>.</simpara></listitem>
     </varlistentry>
 </variablelist>
 </para>
 '>
 
- <!ENTITY eio.request.pri.values '<para
+ <!ENTITY eio.request.pri.values '<simpara
 xmlns="http://docbook.org/ns/docbook">La prioridad de la petición: <constant
         xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>, <constant
         xmlns="http://docbook.org/ns/docbook">EIO_PRI_MIN</constant>, <constant
@@ -3059,7 +3059,7 @@ xmlns="http://docbook.org/ns/docbook">La prioridad de la petición: <constant
 Si &null; es pasado, el parámetro <parameter
         xmlns="http://docbook.org/ns/docbook">pri</parameter>, internamente, es definido a
 <constant xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>.
-</para>
+</simpara>
 '>
 
  <!ENTITY eio.warn.relpath '<warning
@@ -3132,10 +3132,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
     <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            <para>
+            <simpara>
                 Esta clase ya no implementa la interfaz
                 <interfacename>Serializable</interfacename>.
-            </para>
+            </simpara>
         </entry>
     </row>
 '>
@@ -3166,10 +3166,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
     <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            <para>
+            <simpara>
                 Este método ahora lanza una excepción cuando es llamado
                 para una escritura no reconocida, en lugar de retornar &null;.
-            </para>
+            </simpara>
         </entry>
     </row>
 '>
@@ -3179,15 +3179,15 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
 <entry>collation</entry>
 <entry><type class="union"><type>array</type><type>object</type></type></entry>
 <entry>
-    <para>
+    <simpara>
         <link xlink:href="&url.mongodb.docs.collation;" xmlns:xlink="http://www.w3.org/1999/xlink">Collation</link> permite a los usuarios especificar reglas específicas del lenguaje para la comparación de cadenas, por ejemplo, reglas para mayúsculas o acentos. Al especificar una collation, el campo <literal>"locale"</literal> es obligatorio; todos los demás campos de la collation son opcionales. Para la descripción de estos campos, consúltese el <link xlink:href="&url.mongodb.docs.collation;#collation-document" xmlns:xlink="http://www.w3.org/1999/xlink">documento Collation</link>.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
         Si la collation no es especificada pero la colección tiene una collation por omisión, la operación utilizará la collation especificada para la colección. Si ninguna collation es especificada para la colección o para la operación, MongoDB utilizará el binario simple de comparación utilizado en versiones anteriores para las comparaciones de cadenas.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
         Esta opción está disponible en MongoDB 3.4+ y una excepción será emitida en tiempo de ejecución si es especificada en una versión anterior.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
@@ -3197,12 +3197,12 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
   <entry>let</entry>
   <entry><type class="union"><type>array</type><type>object</type></type></entry>
   <entry>
-   <para>
+   <simpara>
     Diccionario de nombres y valores de parámetros. Los valores deben ser constantes o expresiones cerradas que no hagan referencia a campos del documento. Los parámetros pueden ser accedidos luego como variables en un contexto de expresión agregada (por ejemplo <literal>$$var</literal>).
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Esta opción está disponible en MongoDB 5.0+ y resultará en una excepción en tiempo de ejecución si es especificada para una versión anterior del servidor.
-   </para>
+   </simpara>
   </entry>
  </row>
 '>
@@ -3225,22 +3225,22 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
           <entry>kmsProviders</entry>
           <entry>&array;</entry>
           <entry>
-           <para>
+           <simpara>
             Un documento que contiene la configuración de uno o varios
             proveedores KMS, que se utilizan para cifrar las claves de datos.
             Los proveedores soportados son <literal>"aws"</literal>,
             <literal>"azure"</literal>, <literal>"gcp"</literal> y
             <literal>"local"</literal>, y al menos uno debe ser especificado.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Si se especifica un documento vacío para <literal>"aws"</literal>,
             <literal>"azure"</literal>, o <literal>"gcp"</literal>, el controlador
             intentará configurar el proveedor utilizando
             <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Automatic Credentials</link>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             El formato para <literal>"aws"</literal> es el siguiente:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 aws: {
@@ -3250,9 +3250,9 @@ aws: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             El formato para <literal>"azure"</literal> es el siguiente:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 azure: {
@@ -3264,9 +3264,9 @@ azure: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             El formato para <literal>"gcp"</literal> es el siguiente:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 gcp: {
@@ -3277,9 +3277,9 @@ gcp: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             El formato para <literal>"kmip"</literal> es el siguiente:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 kmip: {
@@ -3287,9 +3287,9 @@ kmip: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             El formato para <literal>"local"</literal> es el siguiente:
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 local: {
@@ -3449,14 +3449,14 @@ local: {
   <entry>tlsOptions</entry>
   <entry><type>array</type></entry>
   <entry>
-   <para>
+   <simpara>
     Un documento que contiene la configuración TLS de uno o varios
     proveedores KMS.
     Los proveedores soportados son <literal>"aws"</literal>,
     <literal>"azure"</literal>, <literal>"gcp"</literal> y
     <literal>"kmip"</literal>.
     Todos los proveedores soportan las siguientes opciones:
-   </para>
+   </simpara>
    <programlisting role="javascript">
 <![CDATA[
 <provider>: {
@@ -3476,14 +3476,14 @@ local: {
  <entry>maxCommitTimeMS</entry>
  <entry>integer</entry>
  <entry>
-  <para>
+  <simpara>
    El tiempo máximo en milisegundos para permitir que una sola
    comando <literal>commitTransaction</literal> se ejecute.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si se especifica, <literal>maxCommitTimeMS</literal> debe ser un entero
    32 bits con signo superior o igual a cero.
-  </para>
+  </simpara>
  </entry>
 </row>
 '>
@@ -3492,14 +3492,14 @@ local: {
 <entry>readConcern</entry>
 <entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
 <entry>
-    <para>
+    <simpara>
         Una preocupación de lectura a aplicar a la operación.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
         Esta opción está disponible en MongoDB 3.2+ y se traducirá en
         una excepción en el momento de la ejecución si se especifica para
         una versión más antigua del servidor.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
@@ -3508,10 +3508,10 @@ local: {
 <entry>readPreference</entry>
 <entry><classname>MongoDB\Driver\ReadPreference</classname></entry>
 <entry>
-    <para>
+    <simpara>
         Una preferencia de lectura a utilizar para seleccionar un servidor
         para la operación.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
@@ -3520,22 +3520,22 @@ local: {
 <entry>session</entry>
 <entry><classname>MongoDB\Driver\Session</classname></entry>
 <entry>
-    <para>
+    <simpara>
         Una sesión a asociar a la operación.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
  <!ENTITY mongodb.option.transactionReadWriteConcern '
 <warning xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
     Si se utiliza una <literal>"session"</literal> que tiene una transacción
     en curso, no se puede especificar la opción <literal>"readConcern"</literal>
     o <literal>"writeConcern"</literal>. Intentar hacer esto lanzará una excepción
     <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>.
     En su lugar, debe definir estas opciones cuando se crea la transacción con
     <methodname>MongoDB\Driver\Session::startTransaction</methodname>.
-</para>
+</simpara>
 </warning>
 '>
  <!ENTITY mongodb.option.writeConcern '
@@ -3543,9 +3543,9 @@ local: {
 <entry>writeConcern</entry>
 <entry><classname>MongoDB\Driver\WriteConcern</classname></entry>
 <entry>
-    <para>
+    <simpara>
         Una preocupación de escritura a aplicar a la operación.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
@@ -3553,9 +3553,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>namespace</parameter> (<type>string</type>)</term>
 <listitem>
-    <para>
+    <simpara>
         Un espacio de nombres completamente calificado (ej. <literal>"databaseName.collectionName"</literal>)
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3563,9 +3563,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>db</parameter> (<type>string</type>)</term>
 <listitem>
-    <para>
+    <simpara>
         El nombre de la base de datos sobre la cual se ejecutará el comando.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3573,9 +3573,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWrite</classname>)</term>
 <listitem>
-    <para>
+    <simpara>
         Escritura(s) a ejecutar.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3583,9 +3583,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWriteCommand</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       Escritura(s) a ejecutar.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3593,9 +3593,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>command</parameter> (<classname>MongoDB\Driver\Command</classname>)</term>
 <listitem>
-    <para>
+    <simpara>
         El comando a ejecutar.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3623,10 +3623,10 @@ local: {
                 <type>string</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   El algoritmo de cifrado a utilizar. Esta opción es requerida. Especifique una de las siguientes constantes de
                   <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption</link>:
-                </para>
+                </simpara>
                 <simplelist>
                   <member>
                     <constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC</constant>
@@ -3652,15 +3652,15 @@ local: {
                 <type>int</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   El factor de contención para evaluar las consultas con cargas útiles cifradas indexadas.
-                </para>
-                <para>
+                </simpara>
+                <simpara>
                   Esta opción se aplica únicamente y solo puede ser especificada cuando
                   <literal>algorithm</literal> es
                   <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant> o
                   <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-                </para>
+                </simpara>
               </entry>
             </row>
             <row>
@@ -3669,10 +3669,10 @@ local: {
                 <type>string</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   Identifica un documento de colección de cofre de claves por <literal>keyAltName</literal>. Esta opción es mutuamente exclusiva
                   con <literal>keyId</literal> y una de las dos es requerida.
-                </para>
+                </simpara>
               </entry>
             </row>
             <row>
@@ -3681,10 +3681,10 @@ local: {
                 <classname>MongoDB\BSON\Binary</classname>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   Identifica una clave de datos por <literal>_id</literal>. El valor es un UUID (subtipo binario 4). Esta opción es mutuamente
                   exclusiva con <literal>keyAltName</literal> y una de las dos es requerida.
-                </para>
+                </simpara>
               </entry>
             </row>
             <row>
@@ -3693,10 +3693,10 @@ local: {
                 <type>string</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   El tipo de consulta para evaluar las consultas con cargas útiles cifradas indexadas. Especifique una de las siguientes constantes de
                   <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption</link>:
-                </para>
+                </simpara>
                 <simplelist>
                   <member>
                     <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant>
@@ -3705,12 +3705,12 @@ local: {
                     <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant>
                   </member>
                 </simplelist>
-                <para>
+                <simpara>
                   Esta opción se aplica únicamente y solo puede ser especificada cuando
                   <literal>algorithm</literal> es
                   <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant> o
                   <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-                </para>
+                </simpara>
               </entry>
             </row>
             <row>
@@ -3719,11 +3719,11 @@ local: {
                 <type>array</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   Opciones de índice para un campo de cifrado interrogeable que soporta consultas "range". Las opciones a continuación deben coincidir
                   con los valores definidos en <literal>encryptedFields</literal> de la colección objetivo. Para los tipos de campo BSON double y decimal128,
                   <literal>min</literal>, <literal>max</literal> y <literal>precision</literal> deben ser todos definidos o todos no definidos.
-                </para>
+                </simpara>
                 <para>
                   <table>
                     <title>Opciones de índice de rango</title>
@@ -3790,9 +3790,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>query</parameter> (<classname>MongoDB\Driver\Query</classname>)</term>
 <listitem>
-    <para>
+    <simpara>
         La consulta a ejecutar.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3800,9 +3800,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>typeMap</parameter> (<type>array</type>)</term>
 <listitem>
-    <para>
+    <simpara>
         <link linkend="mongodb.persistence.typemaps">Configuración del mapa de tipos</link>.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3810,10 +3810,10 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>filter</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
 <listitem>
-    <para>
+    <simpara>
         El <link xlink:href="&url.mongodb.docs;tutorial/query-documents/" xmlns:xlink="http://www.w3.org/1999/xlink">atributo de la consulta</link>.
         Un atributo vacío hará coincidir todos los documentos de la colección.
-    </para>
+    </simpara>
     <note>
         <simpara>
             Al evaluar los criterios de consulta, MongoDB compara los tipos y los valores según sus propias <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">reglas de comparación para los tipos BSON</link>, que difieren de las reglas de <link linkend="types.comparisons">comparación</link> y de <link linkend="language.types.type-juggling">manipulación de tipos</link> de PHP. Al hacer coincidir un tipo BSON especial, los criterios de consulta deben utilizar la <link linkend="mongodb.bson">clase BSON</link> (ej.: utilizar <classname>MongoDB\BSON\ObjectId</classname> para hacer coincidir un <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
@@ -3822,9 +3822,9 @@ local: {
 </listitem>
 </varlistentry>
 '>
- <!ENTITY mongodb.returns.cursor '<para xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\Cursor</classname> en caso de éxito.</para>'>
- <!ENTITY mongodb.returns.writeresult '<para xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\WriteResult</classname> en caso de éxito.</para>'>
- <!ENTITY mongodb.returns.bulkwritecommandresult '<para xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\BulkWriteCommandResult</classname> en caso de éxito.</para>'>
+ <!ENTITY mongodb.returns.cursor '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\Cursor</classname> en caso de éxito.</simpara>'>
+ <!ENTITY mongodb.returns.writeresult '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\WriteResult</classname> en caso de éxito.</simpara>'>
+ <!ENTITY mongodb.returns.bulkwritecommandresult '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\BulkWriteCommandResult</classname> en caso de éxito.</simpara>'>
  <!ENTITY mongodb.throws.std '&mongodb.throws.argumentparsing;&mongodb.throws.connection;&mongodb.throws.authentication;'>
  <!ENTITY mongodb.throws.session-readwriteconcern '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si la opción <literal>"session"</literal> se utiliza con una transacción asociada en combinación con una opción <literal>"readConcern"</literal> o <literal>"writeConcern"</literal>.</member>'>
  <!ENTITY mongodb.throws.session-unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si la opción <literal>"session"</literal> se utiliza junto con una preocupación de escritura no reconocida.</member>'>
@@ -3929,35 +3929,35 @@ local: {
  '>
 
 <!-- Radius -->
-<!ENTITY radius.request.required '<note xmlns="http://docbook.org/ns/docbook"><para>Una petición debe ser creada mediante la función <function>radius_create_request</function> antes de que esta función pueda ser llamada.</para></note>'>
-<!ENTITY radius.parameter.attribute-type '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>type</parameter></term><listitem><para>El tipo de atributo.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.handle '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>radius_handle</parameter></term><listitem><para>El recurso RADIUS.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.options '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>options</parameter></term><listitem><para>Una máscara de opciones de atributo. Las opciones disponibles incluyen <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> y <link linkend="constant.radius-option-salt"><constant>RADIUS_OPTION_SALT</constant></link>.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.tag '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>tag</parameter></term><listitem><para>La etiqueta del atributo. Este parámetro es ignorado mientras que la opción <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> esté definida.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.vendor '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>vendor</parameter></term><listitem><para>El identificador del proveedor.</para></listitem></varlistentry>'>
+<!ENTITY radius.request.required '<note xmlns="http://docbook.org/ns/docbook"><simpara>Una petición debe ser creada mediante la función <function>radius_create_request</function> antes de que esta función pueda ser llamada.</simpara></note>'>
+<!ENTITY radius.parameter.attribute-type '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>type</parameter></term><listitem><simpara>El tipo de atributo.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.handle '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>radius_handle</parameter></term><listitem><simpara>El recurso RADIUS.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.options '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>options</parameter></term><listitem><simpara>Una máscara de opciones de atributo. Las opciones disponibles incluyen <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> y <link linkend="constant.radius-option-salt"><constant>RADIUS_OPTION_SALT</constant></link>.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.tag '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>tag</parameter></term><listitem><simpara>La etiqueta del atributo. Este parámetro es ignorado mientras que la opción <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> esté definida.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.vendor '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>vendor</parameter></term><listitem><simpara>El identificador del proveedor.</simpara></listitem></varlistentry>'>
 
 <!-- posix snippets -->
 <!ENTITY posix.parameter.fd '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>file_descriptor</parameter></term>
  <listitem>
- <para>
+ <simpara>
  El descriptor de archivo, que debe ser ya sea una recurso
  de archivo, o un entero. Un entero se asume como un descriptor
  de archivo que puede ser pasado directamente a la llamada al sistema
  subyacente.
- </para>
+ </simpara>
  </listitem>
  </varlistentry>'>
 
 <!ENTITY posix.rlimits '
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
  Cada recurso tiene un límite soft y hard asociados. El límite
  soft corresponde al valor que el núcleo fuerza para el recurso
  correspondiente. El límite hard actúa como un techo del límite soft.
  Un proceso no privilegiado solo puede definir su límite soft en un
  valor comprendido entre 0 y el límite hard, lo que solo hará bajar
  su límite hard.
- </para>
+ </simpara>
  '>
 
 <!-- strings snippets -->
@@ -4160,41 +4160,41 @@ local: {
  '>
 
 <!ENTITY strings.parameter.encoding '
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
  Un argumento opcional que define el codificado utilizado durante
  la conversión de caracteres.
- </para>
+ </simpara>
 
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
  Si se omite, el valor por omisión del parámetro <parameter>encoding</parameter>
  es el valor de la opción de configuración
  <link linkend="ini.default-charset">default_charset</link>.
- </para>
+ </simpara>
 
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
  Aunque este argumento es técnicamente opcional, se recomienda encarecidamente
  especificar el valor correcto para su código si la opción de configuración
  <link linkend="ini.default-charset">default_charset</link>
  ha sido definida incorrectamente para la entrada proporcionada.
- </para>
+ </simpara>
  '>
 
 <!ENTITY strings.parameter.format '
  <varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>format</parameter></term>
  <listitem>
- <para>
+ <simpara>
  La cadena de formato está compuesta por cero o más directivas:
  caracteres ordinarios (excepto <literal>&#37;</literal>)
  que se copian directamente al resultado y
  <emphasis>especificaciones de conversión</emphasis>,
  cada una con su propio parámetro.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
  Una especificación de conversión que sigue este prototipo:
  <literal>&#37;[argnum$][flags][width][.precision]specifier</literal>.
- </para>
+ </simpara>
 
 <formalpara>
  <title>Argnum</title>
@@ -4380,18 +4380,18 @@ local: {
     <row>
      <entry><literal>g</literal></entry>
      <entry>
-      <para>
+      <simpara>
        Formato general.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Sea P igual a la precisión si diferente de 0, 6 si la precisión
        es omitida o 1 si la precisión es cero.
        Entonces, si la conversión con el estilo E tuviera como exponente X:
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Si P > X ≥ −4, la conversión es con estilo f y precisión P − (X + 1).
        De lo contrario, la conversión es con el estilo e y precisión P - 1.
-      </para>
+      </simpara>
      </entry>
     </row>
     <row>
@@ -4455,17 +4455,17 @@ local: {
 </para>
 
 <warning>
- <para>
+ <simpara>
   El especificador de tipo <literal>c</literal> ignora el alineamiento y el tamaño.
- </para>
+ </simpara>
 </warning>
 
 <warning>
- <para>
+ <simpara>
   Intentar utilizar una combinación de una cadena
   y especificadores con juegos de caracteres que necesitan
   más de un octeto por carácter dará un resultado inesperado.
- </para>
+ </simpara>
 </warning>
 
 <para>
@@ -4555,14 +4555,14 @@ local: {
 '>
 
  <!ENTITY strings.parameter.needle.non-string '
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
   Anterior a PHP 8.0.0, si <parameter>needle</parameter> no es una cadena de caracteres,
   se convierte en un entero y se aplica como valor ordinal de un carácter.
   Este comportamiento está obsoleto a partir de PHP 7.3.0, y confiar en él
   está fuertemente desaconsejado. Dependiendo del comportamiento esperado,
   <parameter>needle</parameter> debe ser explícitamente convertido a una cadena de caracteres,
   o debe realizarse una llamada explícita a <function>chr</function>.
- </para>
+ </simpara>
 '><!ENTITY strings.changelog.needle-empty '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
@@ -4699,41 +4699,41 @@ local: {
   </informaltable>
 '>
  <!ENTITY strings.errors.sprintf '
-  <para xmlns="http://docbook.org/ns/docbook">
+  <simpara xmlns="http://docbook.org/ns/docbook">
 A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si el número de argumentos es nulo.
 Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si <literal>[width]</literal> es inferior a cero o superior a <constant>PHP_INT_MAX</constant>.
 Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si <literal>[precision]</literal> es inferior a cero o superior a <constant>PHP_INT_MAX</constant>.
 Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 A partir de PHP 8.0.0, se lanza una <classname>ArgumentCountError</classname> cuando se proporcionan menos argumentos de los requeridos.
 Anterior a PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</constant> en su lugar.
-</para>
+</simpara>
 '>
 
 <!ENTITY strings.errors.vsprintf '
-  <para xmlns="http://docbook.org/ns/docbook">
+  <simpara xmlns="http://docbook.org/ns/docbook">
    A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si el número de argumentos es cero.
    Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si <literal>[width]</literal> es menor que cero o mayor que <constant>PHP_INT_MAX</constant>.
    Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si <literal>[precision]</literal> es menor que cero o mayor que <constant>PHP_INT_MAX</constant>.
    Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-  </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> cuando se proporcionan menos argumentos de los requeridos.
    Anterior a PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</constant> en su lugar.
-  </para>
+  </simpara>
 '>
 
  <!ENTITY strings.comparison.return '
@@ -4754,73 +4754,73 @@ Anterior a PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>filter</parameter></term>
 <listitem>
-    <para>
+    <simpara>
      El filtro a aplicar.
      Puede ser un filtro de validación utilizando una de las constantes
      <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>, un filtro de
      limpieza utilizando una de las constantes
      <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant> o <constant>FILTER_UNSAFE_RAW</constant>,
      o un filtro personalizado utilizando <constant>FILTER_CALLBACK</constant>.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      El valor por omisión es <constant>FILTER_DEFAULT</constant>,
      que es un alias de <constant>FILTER_UNSAFE_RAW</constant>.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
 
  <!-- csprng snippets -->
  <!ENTITY csprng.sources '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Las fuentes de aleatoriedad por orden de prioridad son las siguientes:
-</para>
+</simpara>
 <itemizedlist xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
 <listitem>
-  <para>
+  <simpara>
    Linux: <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
 </listitem>
 <listitem>
-   <para>
+   <simpara>
    FreeBSD >= 12 (PHP >= 7.3): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    Windows (PHP >= 7.2): <link xlink:href="&url.csprng.cng-api;">CNG-API</link>
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Windows: <link xlink:href="&url.csprng.crypt-gen-random;">CryptGenRandom</link>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    macOS (PHP >= 8.2; >= 8.1.9; >= 8.0.22 si CCRandomGenerateBytes está disponible en el momento de la compilación): CCRandomGenerateBytes()
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    macOS (PHP >= 8.1; >= 8.0.2): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    NetBSD >= 7 (PHP >= 7.1; >= 7.0.1): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    OpenBSD >= 5.5 (PHP >= 7.1; >= 7.0.1): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    DragonflyBSD (PHP >= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    Solaris (PHP >= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
 </listitem>
 <listitem>
     <simpara>
@@ -4887,9 +4887,9 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
  <!ENTITY xml.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>parser</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    El analizador XML.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -4902,10 +4902,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
   </simpara>
  </warning>
 </para>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Si <parameter>handler</parameter> es un <type>callable</type>,
  el callable se define como el controlador.
-</para>
+</simpara>
 <para xmlns="http://docbook.org/ns/docbook">
  Si <parameter>handler</parameter> es una <type>string</type>,
  puede ser el nombre de un método de un objeto definido con
@@ -4963,23 +4963,23 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
 
  <!-- Migration Guide snippets -->
  <!ENTITY migration56.openssl.peer-verification '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
     Todos los flujos clientes cifrados activan ahora la verificación por pares por omisión.
     Por omisión, esto utilizará el CA OpenSSL por omisión para verificar el par
     de certificados. En la mayoría de los casos, no se necesita realizar ninguna modificación
     para comunicarse con servidores y certificados SSL válidos, sabiendo que los distribuidores
     configuran generalmente OpenSSL para utilizar los CA conocidos.
-</para>
+</simpara>
 
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
     El CA por omisión puede ser sobrescrito a nivel global utilizando las
     opciones de configuración openssl.cafile o openssl.capath, o mediante una solicitud
     básica utilizando las opciones de contexto
     <link linkend="context.ssl.cafile"><parameter>cafile</parameter></link> o
     <link linkend="context.ssl.capath"><parameter>capath</parameter></link>.
-</para>
+</simpara>
 
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
     Aunque no se recomienda en general, es posible desactivar la
     verificación de certificados por pares para una solicitud definiendo la
     opción de contexto <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>
@@ -4987,7 +4987,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
     la opción de contexto
     <link linkend="context.ssl.verify-peer-name"><parameter>verify_peer_name</parameter></link>
     a &false;.
-</para>
+</simpara>
 '>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Espejo de php/doc-en#5522: `<para>` se convierte en `<simpara>` en `language-snippets.ent` cuando el contenido es puramente inline. Sin cambios de traducción.

Fixes #557