### PR TITLE
[Sync EN] debug_backtrace: remove extra whitespaces (#5543)

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1e31c8f3a81d8fbfc79c0a6b033f0750cff48581 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 26f18bad4964592e0020daa67f0bac81ae7aeb4c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.debug-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>


### PR DESCRIPTION
Espejo de php/doc-en#5543. La traducción ya usaba un único espacio en las líneas afectadas, así que solo se actualiza el hash `EN-Revision`.

Fixes #567