### PR TITLE
[Sync EN] WASM: enable runnable examples for language.functions section (#5463)

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9c835d146d452976f21db7d9cb60dca013829d39 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
-<chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Las funciones</title>
 
  <sect1 xml:id="functions.user-defined">
@@ -15,7 +15,7 @@
   </para>
   <example>
    <title>Declaración de una nueva función llamada <literal>foo</literal></title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo($arg_1, $arg_2, /* ..., */ $arg_n)
@@ -23,7 +23,6 @@ function foo($arg_1, $arg_2, /* ..., */ $arg_n)
     echo "Ejemplo de función.\n";
     return $retval;
 }
-?>
 ]]>
    </programlisting>
   </example>
@@ -31,11 +30,10 @@ function foo($arg_1, $arg_2, /* ..., */ $arg_n)
    <para>
     A partir de PHP 8.0.0, la lista de argumentos puede tener una coma final:
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo($arg_1, $arg_2,) { }
-?>
 ]]>
      </programlisting>
     </informalexample>
@@ -71,12 +69,16 @@ function foo($arg_1, $arg_2,) { }
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $makefoo = true;
 
 /* No es posible llamar a foo() aquí,
    ya que esta función no existe.
    Pero podemos utilizar bar() */
+if (function_exists('foo')) {
+    foo();
+} else {
+    echo "La función foo no existe (todavía).\n";
+}
 
 bar();
 
@@ -96,8 +98,6 @@ function bar()
 {
   echo "Existo desde el principio del programa.\n";
 }
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -118,6 +118,9 @@ function foo()
 
 /* No es posible llamar a bar() aquí
    ya que no existe. */
+if (function_exists('bar')) {
+    bar();
+}
 
 foo();
 
@@ -126,8 +129,6 @@ foo();
    accesible. */
 
 bar();
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -173,7 +174,8 @@ function recursion($a)
         recursion($a + 1);
     }
 }
-?>
+
+recursion(17);
 ]]>
     </programlisting>
    </example>
@@ -214,14 +216,13 @@ function recursion($a)
     A partir de PHP 7.3.0, es posible tener una coma final en la lista de argumentos
     para las llamadas de función:
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $v = foo(
     $arg_1,
     $arg_2,
 );
-?>
 ]]>
       </programlisting>
      </informalexample>
@@ -236,7 +237,7 @@ $v = foo(
    </para>
    <example>
     <title>Lista de parámetros de función con una coma final</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function takes_many_args(
@@ -249,7 +250,6 @@ function takes_many_args(
 {
     // ...
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -281,7 +281,6 @@ function add_some_extra(&$string)
 $str = 'Esto es un string';
 add_some_extra($str);
 echo $str; // Muestra: 'Esto es un string, y un poco más.'
-?>
 ]]>
      </programlisting>
     </example>
@@ -314,7 +313,6 @@ function servir_cafe ($type = "cappuccino")
 echo servir_cafe();
 echo servir_cafe(null);
 echo servir_cafe("espresso");
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -345,7 +343,6 @@ function servir_cafe($types = array("cappuccino"), $coffeeMaker = NULL)
 }
 echo servir_cafe();
 echo servir_cafe(array("cappuccino", "lavazza"), "una cafetera");
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -379,7 +376,6 @@ function makecoffee($coffeeMaker = new DefaultCoffeeMaker)
 }
 echo makecoffee();
 echo makecoffee(new FancyCoffeeMaker);
-?>
 ]]>
         </programlisting>
 
@@ -414,14 +410,18 @@ function hacerunyaourt ($container = "bol", $flavour)
 }
 
 echo hacerunyaourt("framboise");   // "framboise" es $container, no $flavour
-?>
 ]]>
      </programlisting>
      &example.outputs;
      <screen>
 <![CDATA[
-Fatal error: Uncaught ArgumentCountError: Too few arguments
- to function hacerunyaourt(), 1 passed in example.php on line 42
+Deprecated: hacerunyaourt(): Optional parameter $container declared before required parameter $flavour is implicitly treated as a required parameter in script on line 2
+
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function hacerunyaourt(), 1 passed in script on line 7 and exactly 2 expected in script:2
+Stack trace:
+#0 script(7): hacerunyaourt('framboise')
+#1 {main}
+  thrown in script on line 2
 ]]>
      </screen>
     </example>
@@ -441,7 +441,6 @@ function hacerunyaourt ($flavour, $container = "bol")
 }
 
 echo hacerunyaourt ("framboise");   // "framboise" es $flavour
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -467,7 +466,6 @@ function hacerunyaourt($container = "bol", $flavour = "framboise", $style = "Gre
     return "Preparar un $container de yogur $style a la $flavour.\n";
 }
 echo hacerunyaourt(style: "natural");
-?>
 ]]>
       </programlisting>
       &example.outputs;
@@ -488,10 +486,9 @@ Preparar un bol de yogur natural a la framboise.
       explícito debe ser utilizado en su lugar.
       <example>
        <title>Declaración de parámetros opcionales después de parámetros obligatorios</title>
-        <programlisting role="php">
+        <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 function foo($a = [], $b) {}     // Valor por defecto no utilizado; desaconsejado a partir de PHP 8.0.0
 function foo($a, $b) {}          // Funcionalmente equivalente, sin advertencia de deprecación
 
@@ -500,8 +497,6 @@ function bar(A $a = null, $b) {} // A partir de PHP 8.1.0, $a es implicitamente 
                                  // pero implicitamente nullable (desaconsejado a partir de PHP 8.4.0),
                                  // ya que el valor por defecto del parámetro es null
 function bar(?A $a, $b) {}       // Recomendado
-
-?>
 ]]>
         </programlisting>
       </example>
@@ -550,7 +545,6 @@ function sum(...$numbers) {
 }
 
 echo sum(1, 2, 3, 4);
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -580,7 +574,6 @@ echo add(...[1, 2])."\n";
 
 $a = [1, 2];
 echo add(...$a);
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -626,14 +619,17 @@ echo total_intervals('d', $a, $b).' días';
 
 // Esto fallará, ya que null no es un objeto DateInterval.
 echo total_intervals('d', null);
-?>
 ]]>
      </programlisting>
      &example.outputs;
      <screen>
 <![CDATA[
 3 días
-Catchable fatal error: Argument 2 passed to total_intervals() must be an instance of DateInterval, null given, called in - on line 14 and defined in - on line 2
+Fatal error: Uncaught TypeError: total_intervals(): Argument #2 must be of type DateInterval, null given, called in script on line 15 and defined in script:2
+Stack trace:
+#0 script(15): total_intervals('d', NULL)
+#1 {main}
+  thrown in script on line 2
 ]]>
      </screen>
     </example>
@@ -669,7 +665,7 @@ Catchable fatal error: Argument 2 passed to total_intervals() must be an instanc
 
    <example>
     <title>Sintaxis de argumentos nombrados</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 myFunction(paramName: $value);
@@ -677,14 +673,13 @@ array_foobar(array: $value);
 
 // NO soportado.
 function_name($variableStoringParamName: $value);
-?>
 ]]>
     </programlisting>
    </example>
 
    <example>
     <title>Argumentos posicionales comparados con argumentos nombrados</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Utilizando argumentos posicionales:
@@ -692,7 +687,6 @@ array_fill(0, 100, 50);
 
 // Utilizando argumentos nombrados:
 array_fill(start_index: 0, count: 100, value: 50);
-?>
 ]]>
     </programlisting>
    </example>
@@ -703,11 +697,10 @@ array_fill(start_index: 0, count: 100, value: 50);
 
    <example>
     <title>Mismo ejemplo que arriba, pero con un orden de parámetro diferente</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 array_fill(value: 50, count: 100, start_index: 0);
-?>
 ]]>
     </programlisting>
    </example>
@@ -721,13 +714,12 @@ array_fill(value: 50, count: 100, start_index: 0);
 
    <example>
     <title>Combinar argumentos nombrados con argumentos posicionales</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 htmlspecialchars($string, double_encode: false);
 // Igual que
 htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8', false);
-?>
 ]]>
     </programlisting>
    </example>
@@ -739,7 +731,7 @@ htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8', fa
 
    <example>
     <title>Error lanzado cuando un argumento es pasado varias veces al mismo parámetro nombrado</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo($param) { ... }
@@ -749,8 +741,6 @@ foo(param: 1, param: 2);
 
 foo(1, param: 2);
 // Error: Named parameter $param overwrites previous argument
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -771,7 +761,6 @@ function foo($a, $b, $c = 3, $d = 4) {
 var_dump(foo(...[1, 2], d: 40)); // 46
 var_dump(foo(...['b' => 2, 'a' => 1], d: 40)); // 46
 var_dump(foo(...[1, 2], b: 20)); // Error fatal. El parámetro nombrado $b sobrescribe el argumento anterior.
-?>
 ]]>
       </programlisting>
     </example>
@@ -811,7 +800,6 @@ function cuadrado($num)
     return $num * $num;
 }
 echo cuadrado(4); // Muestra '16'
-?>
 ]]>
      </programlisting>
     </example>
@@ -833,10 +821,10 @@ function pequeño_numero()
 }
 // La descomposición de un array recolectará cada miembro del array individualmente
 [$zero, $one, $two] = pequeño_numero();
+var_dump($zero, $one, $two);
 
 // Anterior a PHP 7.1, la única alternativa equivalente es utilizando la estructura de lenguaje list()
 list ($zero, $un, $deux) = pequeño_numero();
-?>
 ]]>
      </programlisting>
     </example>
@@ -849,7 +837,7 @@ list ($zero, $un, $deux) = pequeño_numero();
    <para>
     <example>
      <title>Devolver una referencia de una función</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function &devolver_referencia()
@@ -858,7 +846,6 @@ function &devolver_referencia()
 }
 
 $newref =& devolver_referencia();
-?>
 ]]>
      </programlisting>
     </example>
@@ -896,12 +883,12 @@ $newref =& devolver_referencia();
 <![CDATA[
 <?php
 function foo() {
-    echo "en foo()<br />\n";
+    echo "en foo()\n";
 }
 
 function bar($arg = '')
 {
-    echo "En bar(); el argumento era '$arg'.<br />\n";
+    echo "En bar(); el argumento era '$arg'.\n";
 }
 
 // Esto es una función desviada de echo
@@ -918,7 +905,6 @@ $func('test');  // Llama a bar()
 
 $func = 'echoit';
 $func('test');  // Llama a echoit()
-?>
 ]]>
     </programlisting>
    </example>
@@ -948,8 +934,6 @@ class Foo
 $foo = new Foo();
 $funcname = "Variable";
 $foo->$funcname();  // Llama a $foo->Variable()
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -967,17 +951,22 @@ class Foo
     static $variable = 'propiedad estática';
     static function Variable()
     {
-        echo 'Método Variable llamado';
+        echo "Método Variable llamado\n";
     }
 }
 
-echo Foo::$variable; // Esto muestra 'propiedad estática'. Es necesario tener una $variable en el contexto.
+echo Foo::$variable ."\n"; // Esto muestra 'propiedad estática'. Es necesario tener una $variable en el contexto.
 $variable = "Variable";
 Foo::$variable();  // Esto llama a $foo->Variable(), leyendo así la $variable desde el contexto.
-
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+propiedad estática
+Método Variable llamado
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -1094,7 +1083,6 @@ var_dump(strlen(null));
 var_dump(str_contains("foobar", null));
 // "Deprecated: Passing null to parameter #2 ($needle) of type string is deprecated" a partir de PHP 8.1.0
 // bool(true)
-?>
 ]]>
      </programlisting>
     </informalexample>
@@ -1133,7 +1121,7 @@ var_dump(str_contains("foobar", null));
 echo preg_replace_callback('~-([a-z])~', function ($match) {
     return strtoupper($match[1]);
 }, 'hola-mundo');
-?>
+// muestra holaMundo
 ]]>
    </programlisting>
   </example>
@@ -1157,7 +1145,6 @@ $saludo = function($name) {
 
 $saludo('Mundo');
 $saludo('PHP');
-?>
 ]]>
    </programlisting>
   </example>
@@ -1221,7 +1208,6 @@ $example = function () use ($message): string {
     return "hola $message";
 };
 var_dump($example());
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -1307,7 +1293,6 @@ $mi_carrito->add('huevo', 6);
 // Mostrar el precio con 5.5% de IVA
 print $mi_carrito->getTotal(0.055) . "\n";
 // El resultado será 54.29
-?>
 ]]>
    </programlisting>
   </example>
@@ -1317,7 +1302,6 @@ print $mi_carrito->getTotal(0.055) . "\n";
    <programlisting role="php">
 <![CDATA[
 <?php
-
 class Test
 {
     public function testing()
@@ -1331,8 +1315,6 @@ class Test
 $object = new Test;
 $function = $object->testing();
 $function();
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -1366,7 +1348,6 @@ object(Test)#1 (0) {
      <programlisting role="php">
 <![CDATA[
 <?php
-
 class Foo
 {
     function __construct()
@@ -1378,15 +1359,17 @@ class Foo
     }
 };
 new Foo();
-
-?>
 ]]>
       </programlisting>
       &example.outputs;
       <screen>
 <![CDATA[
-Notice: Undefined variable: this in %s on line %d
-NULL
+Fatal error: Uncaught Error: Using $this when not in object context in script:7
+Stack trace:
+#0 script(9): Foo::{closure:Foo::__construct():6}()
+#1 script(12): Foo->__construct()
+#2 {main}
+  thrown in script on line 7
 ]]>
       </screen>
      </example>
@@ -1398,20 +1381,22 @@ NULL
       <programlisting role="php">
 <![CDATA[
 <?php
-
 $func = static function() {
     // cuerpo de la función
 };
 $func = $func->bindTo(new stdClass);
 $func();
-
-?>
 ]]>
       </programlisting>
       &example.outputs;
       <screen>
 <![CDATA[
-Warning: Cannot bind an instance to a static closure in %s on line %d
+Warning: Cannot bind an instance to a static closure, this will be an error in PHP 9 in script on line 5
+
+Fatal error: Uncaught Error: Value of type null is not callable in script:6
+Stack trace:
+#0 {main}
+  thrown in script on line 6
 ]]>
       </screen>
      </example>
@@ -1500,7 +1485,6 @@ Warning: Cannot bind an instance to a static closure in %s on line %d
      <programlisting role="php">
 <![CDATA[
 <?php
-
 $y = 1;
 
 $fn1 = fn($x) => $x + $y;
@@ -1510,7 +1494,6 @@ $fn2 = function ($x) use ($y) {
 };
 
 var_export($fn1(3));
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -1530,12 +1513,10 @@ var_export($fn1(3));
      <programlisting role="php">
 <![CDATA[
 <?php
-
 $z = 1;
 $fn = fn($x) => fn($y) => $x * $y + $z;
 // Muestra 51
 var_export($fn(5)(10));
-?>
 ]]>
      </programlisting>
     </example>
@@ -1550,18 +1531,15 @@ var_export($fn(5)(10));
    <para>
     <example>
      <title>Ejemplos de funciones flecha</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 fn(array $x) => $x;
 static fn($x): int => $x;
 fn($x = 42) => $x;
 fn(&$x) => $x;
 fn&($x) => $x;
 fn($x, ...$rest) => $rest;
-
-?>
 ]]>
      </programlisting>
     </example>
@@ -1584,13 +1562,10 @@ fn($x, ...$rest) => $rest;
      <programlisting role="php">
 <![CDATA[
 <?php
-
 $x = 1;
 $fn = fn() => $x++; // No tiene efecto
 $fn();
 var_export($x);  // Muestra 1
-
-?>
 ]]>
      </programlisting>
     </example>
@@ -1651,7 +1626,7 @@ var_export($x);  // Muestra 1
    llamada en la gramática de PHP:
    <example>
     <title>Sintaxis callable de primera clase básica</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 class Foo {
@@ -1673,7 +1648,6 @@ $f6 = $classStr::$staticmethodStr(...);
 $f7 = 'strlen'(...);
 $f8 = [$obj, 'method'](...);
 $f9 = [Foo::class, 'staticmethod'](...);
-?>
 ]]>
     </programlisting>
    </example>
@@ -1707,6 +1681,14 @@ $privateMethod = $foo->getPrivateMethod();
 $privateMethod();
 // Fatal error: Call to private method Foo::privateMethod() from global scope
 // Esto es porque la llamada se realiza fuera de Foo y la visibilidad será verificada desde este punto.
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 class Foo1 {
     public function getPrivateMethod() {
         // Usa el ámbito donde el callable es adquirido.
@@ -1719,12 +1701,9 @@ class Foo1 {
 $foo1 = new Foo1;
 $privateMethod = $foo1->getPrivateMethod();
 $privateMethod();  // Foo1::privateMethod
-?>
 ]]>
-    </programlisting>
-   </example>
-
-  </para>
+   </programlisting>
+  </informalexample>
 
   <note>
    <para>
@@ -1739,12 +1718,11 @@ $privateMethod();  // Foo1::privateMethod
     el <link linkend="language.oop5.basic.nullsafe">operador nullsafe</link>.
     Los dos casos siguientes resultan en un error de compilación:
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $obj?->method(...);
 $obj?->prop->method(...);
-?>
 ]]>
      </programlisting>
     </informalexample>


### PR DESCRIPTION
Espejo de php/doc-en#5463: se habilitan los ejemplos ejecutables (WASM) en `language/functions.xml`. Se conservan las traducciones de comentarios y cadenas en español, y los mensajes de error en `<screen>` se mantienen en inglés (salida real de PHP).

Fixes #568