### PR TITLE
[Sync EN] WASM: enable runnable examples for language.enumerations section (#5479)

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5744be5a4d239c18d4610581bd32b69a7d82947e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1eb67bea30f61f7d9cdfd371146911a0ba07bbd2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
-<chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Enumeraciones</title>
   <sect1 xml:id="language.enumerations.overview">
    <title>Visión general de las enumeraciones</title>
@@ -35,10 +35,9 @@
     que tiene un número fijo y limitado de valores legales posibles.
    </para>
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum Suit
 {
     case Hearts;
@@ -46,7 +45,6 @@ enum Suit
     case Clubs;
     case Spades;
 }
-?>
 ]]>
    </programlisting>
 
@@ -58,13 +56,21 @@ enum Suit
     en cuyo caso solo se pueden pasar valores de ese tipo.
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 function pick_a_card(Suit $suit)
 {
-    /* ... */
+    var_dump($suit);
 }
 
 $val = Suit::Diamonds;
@@ -77,9 +83,9 @@ pick_a_card(Suit::Clubs);
 
 // TypeError: pick_a_card(): Argument #1 ($suit) must be of type Suit, string given
 pick_a_card('Spades');
-?>
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     Una enumeración puede tener cero o más definiciones de <literal>case</literal>, sin máximo.
@@ -96,21 +102,35 @@ pick_a_card('Spades');
     no es igual a <literal>"0"</literal>. En su lugar, cada caso está respaldado por un objeto singleton de ese nombre. Eso significa que:
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 $a = Suit::Spades;
 $b = Suit::Spades;
 
-$a === $b; // true
+if ($a === $b) {
+    print "Los palos coinciden usando ===\n";
+}
 
-$a instanceof Suit;  // true
+if ($a instanceof Suit) {
+    print "Los palos coinciden usando instanceof\n";
+}
 
-$a !== 'Spades'; // true
-?>
+if ($a !== 'Spades') {
+    print "El palo no coincide con la cadena\n";
+}
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     También significa que los valores de enumeración nunca son <literal>&lt;</literal> o <literal>&gt;</literal> entre sí,
@@ -132,15 +152,23 @@ $a !== 'Spades'; // true
     del caso en sí.
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 print Suit::Spades->name;
 // imprime "Spades"
-?>
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     También es posible usar las funciones <function>defined</function> y <function>constant</function>
@@ -163,10 +191,9 @@ print Suit::Spades->name;
 
   <para>Para definir un equivalente escalar para una Enumeración, la sintaxis es la siguiente:</para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum Suit: string
 {
     case Hearts = 'H';
@@ -174,7 +201,6 @@ enum Suit: string
     case Clubs = 'C';
     case Spades = 'S';
 }
-?>
 ]]>
   </programlisting>
 
@@ -206,31 +232,47 @@ enum Suit: string
    especificado en la definición.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 print Suit::Clubs->value;
 // Imprime "C"
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Para hacer cumplir la propiedad <literal>value</literal> como de solo lectura, una variable no puede
    ser asignada como referencia a ella. Es decir, lo siguiente genera un error:
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 $suit = Suit::Clubs;
 $ref = &$suit->value;
-// Error: No se puede obtener una referencia a la propiedad Suit::$value
-?>
+// Error fatal: No se puede modificar indirectamente la propiedad de solo lectura Suit::$value
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Las enumeraciones respaldadas implementan una interfaz interna <interfacename>BackedEnum</interfacename>,
@@ -262,23 +304,37 @@ $ref = &$suit->value;
    en ambos modos.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
-$record = get_stuff_from_database($id);
-print $record['suit'];
+function get_stuff_from_database($id) {
+    return [
+        'suit' => 'S',
+    ];
+}
 
-$suit =  Suit::from($record['suit']);
-// Datos no válidos lanzan un ValueError: "X" no es un valor escalar válido para la enumeración "Suit"
-print $suit->value;
+$record = get_stuff_from_database(42);
+print $record['suit'] . "\n";
 
 $suit = Suit::tryFrom('A') ?? Suit::Spades;
 // Datos no válidos devuelven null, por lo que se usa Suit::Spades en su lugar.
-print $suit->value;
-?>
+print $suit->value . "\n";
+
+$suit =  Suit::from('X');
+// Datos no válidos lanzan un ValueError: "X" is not a valid backing scalar value for enum Suit
+print $suit->value . "\n";
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>Definir manualmente un método <literal>from()</literal> o <literal>tryFrom()</literal> en una Enumeración Respaldada resultará en un error fatal.</para>
 
@@ -293,10 +349,10 @@ print $suit->value;
    todos los casos de esa enumeración.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -327,15 +383,15 @@ enum Suit implements Colorful
 
 function paint(Colorful $c)
 {
-   /* ... */
+   print $c->color() . "\n";
 }
 
 paint(Suit::Clubs);  // Funciona
 
 print Suit::Diamonds->shape(); // imprime "Rectangle"
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    En este ejemplo, las cuatro instancias de <literal>Suit</literal> tienen dos métodos,
@@ -347,10 +403,9 @@ print Suit::Diamonds->shape(); // imprime "Rectangle"
    En una Enumeración Respaldada, la declaración de interfaz va después de la declaración del tipo de respaldo.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
    <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -372,7 +427,6 @@ enum Suit: string implements Colorful
         };
     }
 }
-?>
 ]]>
   </programlisting>
 
@@ -397,10 +451,9 @@ enum Suit: string implements Colorful
    (aunque este no es el código real que se ejecuta):
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -434,7 +487,6 @@ final class Suit implements UnitEnum, Colorful
         // Ver también la sección "Listado de valores".
     }
 }
-?>
 ]]>
   </programlisting>
 
@@ -453,10 +505,10 @@ final class Suit implements UnitEnum, Colorful
    enumeración en sí es principalmente para constructores alternativos. Por ejemplo:
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Size
 {
     case Small;
@@ -472,9 +524,11 @@ enum Size
         };
     }
 }
-?>
+
+var_dump(Size::fromLength(50));
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Los métodos estáticos pueden ser públicos, privados o protegidos, aunque en la práctica privado
@@ -493,10 +547,10 @@ enum Size
 
   <para>Una constante de enumeración puede referirse a un caso de enumeración:</para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Size
 {
     case Small;
@@ -505,9 +559,11 @@ enum Size
 
     public const Huge = self::Large;
 }
-?>
+
+var_dump(Size::Huge);
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.traits">
@@ -518,10 +574,10 @@ enum Size
    Solo pueden incluir métodos, métodos estáticos y constantes. Un trait con propiedades resultará en un error fatal.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -551,9 +607,13 @@ enum Suit implements Colorful
         };
     }
 }
-?>
+
+$suit = Suit::Spades;
+var_dump($suit->color());
+var_dump($suit->shape());
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.expressions">
@@ -573,10 +633,9 @@ enum Suit implements Colorful
    el acceso a propiedades continúan siendo operaciones no válidas en expresiones constantes.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 // Esta es una definición de Enumeración completamente legal.
 enum Direction implements ArrayAccess
 {
@@ -619,7 +678,6 @@ $x = Direction::Up['short'];
 var_dump("\$x is " . var_export($x, true));
 
 $foo = new Foo();
-?>
 ]]>
   </programlisting>
  </sect1>
@@ -673,16 +731,14 @@ $foo = new Foo();
    <methodname>ReflectionClass::newInstanceWithoutConstructor</methodname> en reflexión. Ambos resultarán en un error.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 $clovers = new Suit();
 // Error: No se puede instanciar la enumeración Suit
 
 $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor()
 // Error: No se puede instanciar la enumeración Suit
-?>
 ]]>
   </programlisting>
  </sect1>
@@ -697,15 +753,32 @@ $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor(
    todos los Casos definidos en el orden de declaración.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
-Suit::cases();
-// Produce: [Suit::Hearts, Suit::Diamonds, Suit::Clubs, Suit::Spades]
-?>
+var_dump(Suit::cases());
+
+enum SuitBacked: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
+
+var_dump(SuitBacked::cases());
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>Definir manualmente un método <literal>cases()</literal> en una Enumeración resultará en un error fatal.</para>
  </sect1>
@@ -719,17 +792,25 @@ Suit::cases();
    usar eso para establecer una variable al valor singleton existente. Eso asegura que:
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 Suit::Hearts === unserialize(serialize(Suit::Hearts));
 
 print serialize(Suit::Hearts);
 // E:11:"Suit:Hearts";
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Al deserializar, si no se puede encontrar una enumeración y un caso para coincidir con un valor serializado,
@@ -747,10 +828,10 @@ print serialize(Suit::Hearts);
    de los objetos para minimizar la confusión.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Foo {
     case Bar;
 }
@@ -772,9 +853,9 @@ Baz Enum:int {
     [value] => 5
 }
 */
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.object-differences.inheritance">
@@ -785,10 +866,9 @@ Baz Enum:int {
    Las clases tienen contratos en sus métodos:
   </simpara>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 class A {}
 class B extends A {}
 
@@ -797,7 +877,6 @@ function foo(A $a) {}
 function bar(B $b) {
     foo($b);
 }
-?>
 ]]>
  </programlisting>
 
@@ -811,10 +890,9 @@ function bar(B $b) {
    Las enumeraciones tienen contratos en sus casos, no en sus métodos:
   </simpara>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum ErrorCode {
     case SOMETHING_BROKE;
 }
@@ -826,8 +904,6 @@ function quux(ErrorCode $errorCode)
         ErrorCode::SOMETHING_BROKE => true,
     };
 }
-
-?>
 ]]>
   </programlisting>
 
@@ -840,10 +916,10 @@ function quux(ErrorCode $errorCode)
    Pero imagina que estuviera permitido extender enumeraciones:
   </simpara>
 
-  <programlisting role="php">
+
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 // Código de experimento mental donde las enumeraciones no son finales.
 // Nota: esto no funcionará realmente en PHP.
 enum MoreErrorCode extends ErrorCode {
@@ -855,10 +931,8 @@ function fot(MoreErrorCode $errorCode) {
 }
 
 fot(MoreErrorCode::PEBKAC);
-
-?>
 ]]>
- </programlisting>
+  </programlisting>
 
   <simpara>
    Bajo las reglas normales de herencia, una clase que extiende a otra pasará
@@ -881,10 +955,9 @@ fot(MoreErrorCode::PEBKAC);
   <para>
    <example>
     <title>Valores limitados básicos</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum SortOrder
 {
     case Asc;
@@ -895,7 +968,6 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
 {
      /* ... */
 }
-?>
 ]]>
     </programlisting>
     <para>
@@ -915,7 +987,6 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
     <programlisting role="php">
 <![CDATA[
 <?php
-
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -933,7 +1004,9 @@ enum UserStatus: string
         };
     }
 }
-?>
+
+$status = UserStatus::Suspended;
+var_dump($status->label());
 ]]>
     </programlisting>
 
@@ -953,11 +1026,31 @@ enum UserStatus: string
     <programlisting role="php">
 <![CDATA[
 <?php
+enum UserStatus: string
+{
+    case Pending = 'P';
+    case Active = 'A';
+    case Suspended = 'S';
+    case CanceledByUser = 'C';
+
+    public function label(): string
+    {
+        return match($this) {
+            self::Pending => 'Pending',
+            self::Active => 'Active',
+            self::Suspended => 'Suspended',
+            self::CanceledByUser => 'Canceled by user',
+        };
+    }
+}
 
 foreach (UserStatus::cases() as $case) {
-    printf('<option value="%s">%s</option>\n', $case->value, $case->label());
+    printf(
+        "<option value=\"%s\">%s</option>\n",
+        htmlentities($case->value),
+        htmlentities($case->label())
+    );
 }
-?>
 ]]>
     </programlisting>
    </example>


### PR DESCRIPTION
Espejo de php/doc-en#5479: se habilitan los ejemplos ejecutables (WASM) en `language/enumerations.xml`. Se incrustan las definiciones de `enum Suit` en cada bloque dependiente para que sea autosuficiente, y los `print` de comprobación se traducen al español; los mensajes de error en `<screen>` se mantienen en inglés.

Fixes #569