### PR TITLE
[Sync EN] Habilitar ejemplos WASM en language.namespaces

### DIFF
--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1651836ff309efd14a795eff44ee51455f66c7d3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1fade2bc5f160b23c2f46c3f854b833fab0e69f4 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 <chapter xml:id="language.namespaces" xmlns="http://docbook.org/ns/docbook"
- version="1.1">
+ version="1.1" annotations="interactive">
  <title>Los espacios de nombres</title>
 
  <sect1 xml:id="language.namespaces.rationale">
@@ -64,15 +64,18 @@ function mafonction() {}
 const MACONSTANTE = 1;
 
 $a = new MaClasse;
+print $a::class . "\n";
 $c = new \mon\nom\MaClasse; // Ver la sección "Espacio global"
+print $c::class . "\n";
 
 $a = strlen('bonjour'); // Ver "Uso de espacios de nombres: retorno al espacio global
+print $a . "\n";
 
 $d = namespace\MACONSTANTE; // Ver "El operador namespace y la constante __NAMESPACE__
+print $d . "\n";
 
 $d = __NAMESPACE__ . '\MACONSTANTE';
 echo constant($d); // Ver "Espacios de nombres y características dinámicas"
-?>
     ]]>
    </programlisting>
   </example>
@@ -108,7 +111,7 @@ echo constant($d); // Ver "Espacios de nombres y características dinámicas"
    clave <xref linkend="control-structures.declare" />.
    <example>
     <title>Declaración de un espacio de nombres</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet;
@@ -116,8 +119,6 @@ namespace MonProjet;
 const CONNEXION_OK = 1;
 class Connexion { /* ... */ }
 function connecte() { /* ... */ }
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -134,12 +135,11 @@ function connecte() { /* ... */ }
    espacios:
    <example>
     <title>Error de declaración de un espacio de nombres</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <html>
 <?php
 namespace MonProjet; // error fatal: el espacio de nombres debe ser el primer elemento del script
-?>
 ]]>
     </programlisting>
    </example>
@@ -160,7 +160,7 @@ namespace MonProjet; // error fatal: el espacio de nombres debe ser el primer el
    un nombre de espacio de nombres puede definirse con sus subniveles:
    <example>
     <title>Declaración de un espacio de nombres con jerarquía</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet\Sous\Niveau;
@@ -168,8 +168,6 @@ namespace MonProjet\Sous\Niveau;
 const CONNEXION_OK = 1;
 class Connexion { /* ... */ }
 function connecte() { /* ... */  }
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -189,7 +187,7 @@ function connecte() { /* ... */  }
   <para>
    <example>
     <title>Declaración de varios espacios de nombres, sintaxis de combinación simple</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet;
@@ -203,7 +201,6 @@ namespace AutreProjet;
 const CONNEXION_OK = 1;
 class Connexion { /* ... */ }
 function connecte() { /* ... */  }
-?>
 ]]>
     </programlisting>
    </example>
@@ -216,7 +213,7 @@ function connecte() { /* ... */  }
   <para>
    <example>
     <title>Declaración de varios espacios de nombres, sintaxis de llaves</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet {
@@ -232,7 +229,6 @@ const CONNEXION_OK = 1;
 class Connexion { /* ... */ }
 function connecte() { /* ... */  }
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -254,16 +250,22 @@ function connecte() { /* ... */  }
 namespace MonProjet {
 
 const CONNEXION_OK = 1;
-class Connexion { /* ... */ }
-function connecte() { /* ... */  }
+class Connexion {
+    public static function start() {
+        print __METHOD__ . "\n";
+    }
+}
+
+function connecte() {
+    print __FUNCTION__ . "\n";
+}
 }
 
 namespace { // código global
-session_start();
-$a = MonProjet\connecte();
-echo MonProjet\Connexion::start();
+print strlen("hi") . "\n";
+MonProjet\connecte();
+MonProjet\Connexion::start();
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -276,20 +278,26 @@ echo MonProjet\Connexion::start();
     <programlisting role="php">
      <![CDATA[
 <?php
-declare(encoding='UTF-8');
+declare(strict_types=1);
 namespace MonProjet {
 
 const CONNEXION_OK = 1;
-class Connexion { /* ... */ }
-function connecte() { /* ... */  }
+class Connexion {
+    public static function start() {
+        print __METHOD__ . "\n";
+    }
+}
+
+function connecte() {
+    print __FUNCTION__ . "\n";
+}
 }
 
 namespace { // código global
-session_start();
-$a = MonProjet\connecte();
-echo MonProjet\Connexion::start();
+print strlen("hi") . "\n";
+MonProjet\connecte();
+MonProjet\Connexion::start();
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -372,7 +380,7 @@ echo MonProjet\Connexion::start();
    Aquí hay un ejemplo de las tres sintaxis, en código real:
    <informalexample>
     <simpara>file1.php</simpara>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace Foo\Bar\sousespacedenoms;
@@ -383,11 +391,10 @@ class foo
 {
     static function methodestatique() {}
 }
-?>
      ]]>
     </programlisting>
     <simpara>file2.php</simpara>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace Foo\Bar;
@@ -415,7 +422,6 @@ echo sousespacedenoms\FOO; // Se convierte en la constante Foo\Bar\sousespaceden
 \Foo\Bar\foo(); // Se convierte en la función Foo\Bar\foo
 \Foo\Bar\foo::methodestatique(); // Se convierte en la clase Foo\Bar\foo, método methodestatique
 echo \Foo\Bar\FOO; // Se convierte en la constante Foo\Bar\FOO
-?>
      ]]>
     </programlisting>
    </informalexample>
@@ -436,10 +442,10 @@ function strlen() {}
 const INI_ALL = 3;
 class Exception {}
 
-$a = \strlen('hi'); // llama a la función global strlen
-$b = \INI_ALL; // acceso a una constante INI_ALL
+print \strlen('hi') . "\n"; // llama a la función global strlen
+print \INI_ALL . "\n"; // acceso a una constante INI_ALL
 $c = new \Exception('error'); // instancia la clase global Exception
-?>
+print $c::class . "\n";
      ]]>
     </programlisting>
    </example>
@@ -477,7 +483,6 @@ $obj = new $a; // muestra classname::__construct
 $b = 'funcname';
 $b(); // muestra funcname
 echo constant('constname'), "\n"; // muestra global
-?>
     ]]>
     </programlisting>
    </example>
@@ -515,7 +520,6 @@ $b = '\nomdelespacedenoms\funcname';
 $b(); // también muestra nomdelespacedenoms\funcname
 echo constant('\nomdelespacedenoms\constname'), "\n"; // muestra namespaced
 echo constant('nomdelespacedenoms\constname'), "\n"; // también muestra namespaced
-?>
     ]]>
     </programlisting>
    </example>
@@ -545,7 +549,6 @@ echo constant('nomdelespacedenoms\constname'), "\n"; // también muestra namespa
 namespace MonProjet;
 
 echo '"', __NAMESPACE__, '"'; // muestra "MonProjet"
-?>
 ]]>
     </programlisting>
    </example>
@@ -554,9 +557,7 @@ echo '"', __NAMESPACE__, '"'; // muestra "MonProjet"
     <programlisting role="php">
      <![CDATA[
 <?php
-
 echo '"', __NAMESPACE__, '"'; // muestra ""
-?>
 ]]>
     </programlisting>
    </example>
@@ -564,7 +565,7 @@ echo '"', __NAMESPACE__, '"'; // muestra ""
    dinámicamente nombres, como:
    <example>
     <title>Uso de __NAMESPACE__ para una construcción dinámica de nombres</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet;
@@ -574,7 +575,6 @@ function get($classname)
     $a = __NAMESPACE__ . '\\' . $classname;
     return new $a;
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -586,7 +586,7 @@ function get($classname)
    <literal>self</literal> de las clases.
    <example>
     <title>El operador namespace, en un espacio de nombres</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet;
@@ -601,13 +601,12 @@ namespace\sub\func(); // llama a la función MonProjet\sub\func()
 namespace\cname::method(); // llama al método estático "method" de la clase MonProjet\cname
 $a = new namespace\sub\cname(); // instancia un objeto de la clase MonProjet\sub\cname
 $b = namespace\CONSTANT; // asigna el valor de la constante MonProjet\CONSTANT a $b
-?>
 ]]>
     </programlisting>
    </example>
    <example>
     <title>El operador namespace, en el espacio de nombres global</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 
@@ -616,7 +615,6 @@ namespace\sub\func(); // llama a la función sub\func()
 namespace\cname::method(); // llama al método estático "method" de la clase cname
 $a = new namespace\sub\cname(); // instancia un objeto de la clase sub\cname
 $b = namespace\CONSTANT; // asigna el valor de la constante CONSTANT a $b
-?>
 ]]>
     </programlisting>
    </example>
@@ -640,7 +638,7 @@ $b = namespace\CONSTANT; // asigna el valor de la constante CONSTANT a $b
    Aquí hay un ejemplo que presenta los cinco tipos de importación:
    <example>
     <title>Importación y alias con el operador use</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace foo;
@@ -668,7 +666,6 @@ $a = new ArrayObject(array(1)); // instancia un objeto de la clase ArrayObject
 // Sin la instrucción "use ArrayObject" habríamos instanciado un objeto de la clase foo\ArrayObject
 func(); // Llama a la función My\Full\functionName
 echo CONSTANT; // muestra el valor de My\Full\CONSTANT
-?>
 ]]>
     </programlisting>
    </example>
@@ -682,14 +679,13 @@ echo CONSTANT; // muestra el valor de My\Full\CONSTANT
    Además, PHP admite atajos prácticos, como las instrucciones use múltiples.
    <example>
     <title>Importación y alias múltiples con el operador use</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
 
 $obj = new Another; // instancia un objeto de la clase My\Full\Classname
 NSname\subns\func(); // llama a la función My\Full\NSname\subns\func
-?>
 ]]>
     </programlisting>
    </example>
@@ -699,7 +695,7 @@ NSname\subns\func(); // llama a la función My\Full\NSname\subns\func
    a las clases, funciones y constantes dinámicas.
    <example>
     <title>Importación y nombres de espacios dinámicos</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
@@ -707,7 +703,6 @@ use My\Full\Classname as Another, My\Full\NSname;
 $obj = new Another; // instancia un objeto de la clase My\Full\Classname
 $a = 'Another';
 $obj = new $a;      // instancia un objeto de la clase Another
-?>
 ]]>
     </programlisting>
    </example>
@@ -717,7 +712,7 @@ $obj = new $a;      // instancia un objeto de la clase Another
    absolutos siguen siendo absolutos y no se modifican por una importación.
    <example>
     <title>Importación y nombres de espacios absolutos</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
@@ -726,7 +721,6 @@ $obj = new Another; // instancia un objeto de la clase My\Full\Classname
 $obj = new \Another; // instancia un objeto de la clase Another
 $obj = new Another\untruc; // instancia un objeto de la clase My\Full\Classname\untruc
 $obj = new \Another\untruc; // instancia un objeto de la clase Another\untruc
-?>
 ]]>
     </programlisting>
    </example>
@@ -753,7 +747,6 @@ function toGreenlandic
     use Languages\Danish;
     // ...
 }
-?>
 ]]>
      </programlisting>
     </example>
@@ -773,7 +766,7 @@ function toGreenlandic
     sola instrucción &use.namespace;.
    </para>
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -811,7 +804,7 @@ use const some\namespace\{ConstA, ConstB, ConstC};
    global, incluso en un contexto de espacio de nombres específico.
    <example>
     <title>Especificación de espacio de nombres global</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace A\B\C;
@@ -822,7 +815,6 @@ function fopen() {
      $f = \fopen(...); // llamada a fopen global
      return $f;
 }
-?>
     ]]>
     </programlisting>
    </example>
@@ -847,10 +839,11 @@ namespace A\B\C;
 class Exception extends \Exception {}
 
 $a = new Exception('hi'); // $a es un objeto de la clase A\B\C\Exception
+var_dump($a::class);
 $b = new \Exception('hi'); // $b es un objeto de la clase Exception
+var_dump($b::class);
 
 $c = new ArrayObject; // error fatal, clase A\B\C\ArrayObject no encontrada
-?>
     ]]>
     </programlisting>
    </example>
@@ -880,7 +873,6 @@ if (is_array('hi')) { // muestra "no es un array"
 } else {
     echo "no es un array\n";
 }
-?>
     ]]>
     </programlisting>
    </example>
@@ -1016,7 +1008,7 @@ if (is_array('hi')) { // muestra "no es un array"
   </para>
   <example>
    <title>Ejemplos de resolución de espacios de nombres</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace A;
@@ -1076,7 +1068,6 @@ A\B::foo();   // llama al método "foo" de la clase "B" del espacio de nombres "
 
 \A\B::foo();  // llama al método "foo" de la clase "B" del espacio de nombres "A"
               // si la clase "A\B" no se encuentra, intenta el autocargado en la clase "A\B"
-?>
 ]]>
    </programlisting>
   </example>
@@ -1189,7 +1180,7 @@ A\B::foo();   // llama al método "foo" de la clase "B" del espacio de nombres "
 <![CDATA[
 <?php
 $a = new \stdClass;
-?>
+print $a::class;
 ]]>
      </programlisting>
     </example>
@@ -1204,7 +1195,7 @@ $a = new \stdClass;
 <![CDATA[
 <?php
 $a = new stdClass;
-?>
+print $a::class;
 ]]>
      </programlisting>
     </example>
@@ -1220,14 +1211,16 @@ $a = new stdClass;
 <?php
 namespace foo;
 $a = new \stdClass;
+print $a::class . "\n";
 
-function test(\ArrayObject $parameter_type_example = null) {}
+function test(?\ArrayObject $parameter_type_example = null) {}
 
-$a = \DirectoryIterator::CURRENT_AS_FILEINFO;
+$a = \FilesystemIterator::CURRENT_AS_FILEINFO;
+print $a . "\n";
 
 // extensión de una clase interna o global
 class MyException extends \Exception {}
-?>
+print MyException::class . "\n";
 ]]>
      </programlisting>
     </example>
@@ -1249,20 +1242,22 @@ namespace foo;
 class MaClasse {}
 
 // uso de una clase en el espacio de nombres actual, como tipo de parámetro
-function test(MaClasse $parameter_type_example = null) {}
+function test(?MaClasse $parameter_type_example = null) {}
 
 // otra manera de usar una clase en el espacio de nombres actual como tipo de parámetro
-function test(\foo\MaClasse $parameter_type_example = null) {}
+function test2(?\foo\MaClasse $parameter_type_example = null) {}
 
 // extensión de una clase en el espacio de nombres actual
 class Extended extends MaClasse {}
+print Extended::class . "\n";
 
 // acceso a una función global
-$a = \globalfunc();
+$a = \strlen("test");
+print $a . "\n";
 
 // acceso a una constante global
 $b = \INI_ALL;
-?>
+print $b . "\n";
 ]]>
      </programlisting>
     </example>
@@ -1280,14 +1275,13 @@ $b = \INI_ALL;
     <literal>Exception</literal>.
     <example>
      <title>Nombres de espacios absolutos</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
 $a = new \mon\nom(); // instancia la clase "mon\nom"
 echo \strlen('hi'); // llama a la función "strlen"
 $a = \INI_ALL; // $a recibe el valor de la constante "INI_ALL"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1312,7 +1306,7 @@ $a = \INI_ALL; // $a recibe el valor de la constante "INI_ALL"
    <para>
     <example>
      <title>Nombres calificados</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
@@ -1322,7 +1316,6 @@ $a = new mon\nom(); // instancia la clase "foo\mon\nom"
 foo\bar::name(); // llama al método estático "name" en la clase "blah\blah\bar"
 mon\bar(); // llama a la función "foo\mon\bar"
 $a = mon\BAR; // asigna a $a el valor de la constante "foo\mon\BAR"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1346,7 +1339,7 @@ $a = mon\BAR; // asigna a $a el valor de la constante "foo\mon\BAR"
    <para>
     <example>
      <title>Clases sin calificación</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
@@ -1354,7 +1347,6 @@ use blah\blah as foo;
 
 $a = new nom(); // instancia la clase "foo\nom"
 foo::nom(); // llama al método estático "nom" en la clase "blah\blah"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1388,8 +1380,12 @@ use blah\blah as foo;
 
 const FOO = 1;
 
-function mon() {}
-function foo() {}
+function mon() {
+    print __FUNCTION__ . "\n";
+}
+function foo() {
+    print __FUNCTION__ . "\n";
+}
 function sort(&$a)
 {
     \sort($a); // Llamada a la función global "sort"
@@ -1398,14 +1394,16 @@ function sort(&$a)
 }
 
 mon(); // llama "foo\mon"
-$a = strlen('hi'); // llama a la función global "strlen" ya que "foo\strlen" no existe
+print strlen('hi') . "\n"; // llama a la función global "strlen" ya que "foo\strlen" no existe
 $arr = array(1,3,2);
 $b = sort($arr); // llama a la función "foo\sort"
-$c = foo(); // llama a la función "foo\foo": la importación no se aplica
+var_dump($b);
+foo(); // llama a la función "foo\foo": la importación no se aplica
 
 $a = FOO; // asigna a $a el valor de la constante "foo\FOO": la importación no se aplica
+print $a;
 $b = INI_ALL; // asigna a $b el valor de la constante "INI_ALL"
-?>
+print $b;
 ]]>
      </programlisting>
     </example>
@@ -1418,25 +1416,23 @@ $b = INI_ALL; // asigna a $b el valor de la constante "INI_ALL"
     La siguiente combinación de scripts es válida:
     <informalexample>
      <simpara>file1.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace mes\trucs;
 class MaClasse {}
-?>
      ]]>
      </programlisting>
      <simpara>another.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace another;
 class untruc {}
-?>
      ]]>
      </programlisting>
      <simpara>file2.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace mes\trucs;
@@ -1445,7 +1441,6 @@ include 'another.php';
 
 use another\untruc as MaClasse;
 $a = new MaClasse; // instancia la clase "untruc" del espacio de nombres another
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1458,14 +1453,13 @@ $a = new MaClasse; // instancia la clase "untruc" del espacio de nombres another
     MaClasse se define en el mismo archivo que la instrucción
     use.
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace mes\trucs;
 use another\untruc as MaClasse;
 class MaClasse {} // error fatal: MaClasse está en conflicto con la instrucción de importación
 $a = new MaClasse;
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1484,7 +1478,6 @@ namespace mes\trucs {
         class foo {}
     }
 }
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1497,7 +1490,6 @@ namespace mes\trucs {
 namespace mes\trucs\nested {
     class foo {}
 }
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1513,7 +1505,7 @@ namespace mes\trucs\nested {
     inesperado:
     <example>
      <title>Peligros de usar espacios de nombres en una cadena</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
       <![CDATA[
 <?php
 $a = "dangereux\nom"; // \n es una nueva línea en una cadena!
@@ -1521,7 +1513,6 @@ $obj = new $a;
 
 $a = 'pas\vraiment\dangereux'; // ningún problema aquí
 $obj = new $a;
-?>
       ]]>
      </programlisting>
     </example>
@@ -1539,7 +1530,7 @@ $obj = new $a;
     un error fatal si no está definida.
     <example>
      <title>Constantes no definidas</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
       <![CDATA[
 <?php
 namespace bar;
@@ -1547,7 +1538,6 @@ $a = FOO; // produce una advertencia: constante no definida "FOO", que toma el v
 $a = \FOO; // error fatal, constante de espacio de nombres no definida FOO
 $a = Bar\FOO; // error fatal, constante de espacio de nombres no definida bar\Bar\FOO
 $a = \Bar\FOO; // error fatal, constante de espacio de nombres no definida Bar\FOO
-?>
       ]]>
      </programlisting>
     </example>
@@ -1567,7 +1557,6 @@ namespace bar;
 const NULL = 0; // error fatal;
 const true = 'stupid'; // aún otro error fatal;
 // etc.
-?>
       ]]>
      </programlisting>
     </example>


### PR DESCRIPTION
Sincronización de php/doc-en#5478 (commit 1fade2bc5f).

Añade `annotations="interactive"` en el chapter, `annotations="non-interactive"` en los ejemplos no ejecutables, hace los demás ejecutables y actualiza el hash EN-Revision.

Closes #574