### PR TITLE
[Sync EN] Habilitar ejemplos WASM en language.variables

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 64007e9f6b23f70d8874be11c4eb9d45556b742f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
- <chapter xml:id="language.variables" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <chapter xml:id="language.variables" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+  annotations="interactive">
   <title>Variables</title>
 
   <sect1 xml:id="language.variables.basics">
@@ -44,7 +45,7 @@
 
    <example>
     <title>Valid variable names</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $var = 'Roberto';
@@ -53,7 +54,6 @@ echo "$var, $Var";      // Imprime "Roberto, Juan"
 
 $_4site = 'aún no';     // Válido; comienza con un carácter de subrayado
 $täyte = 'mansikka';    // Válido; 'ä' es ASCII (Extendido) 228
-?>
 ]]>
     </programlisting>
    </example>
@@ -84,7 +84,6 @@ $4site = 'aún no';     // Inválido; comienza con un número
 ${'invalid-name'} = 'bar';
 $name = 'invalid-name';
 echo ${'invalid-name'}, " ", $$name;
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -125,9 +124,8 @@ bar bar
 $foo = 'Bob';                // Asigna el valor 'Bob' a $foo
 $bar = &$foo;                // Referenciar $foo vía $bar.
 $bar = "Mi nombre es $bar";  // Modifica $bar...
-echo $bar;
-echo $foo;                   // $foo también se modifica.
-?>
+echo $bar . PHP_EOL;
+echo $foo . PHP_EOL;         // $foo también se modifica.
 ]]>
      </programlisting>
     </informalexample>
@@ -140,17 +138,37 @@ echo $foo;                   // $foo también se modifica.
      <programlisting role="php">
 <![CDATA[
 <?php
-$foo = 25;
-$bar = &$foo;      // Esta es una asignación válida.
-$bar = &(24 * 7);  // Inválida; referencia una expresión sin nombre.
-
+$original = 25;
+$ref1 = &$original;        // Esta es una asignación válida.
+$ref2 = &(24 * 7);         // Inválida; referencia una expresión sin nombre.
+]]>
+     </programlisting>
+    </informalexample>
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+// Tenga en cuenta la falta de & que indica un retorno por referencia en la declaración de la función.
+// Es decir, la función no retorna una referencia, por lo que el resultado no puede asignarse por referencia.
 function test()
 {
-   return 25;
+   $original = 25;
+   return $original;
 }
 
-$bar = &test();    // Inválido porque test() no devuelve una variable por referencia.
-?>
+// Nota: Se emite un aviso, pero el valor sin referencia es asignado
+$result1 = &test();        // Inválido porque test() no devuelve una variable por referencia.
+var_dump($result1);
+
+// Esta función está definida como retornando una referencia, pero no retorna una variable
+function &test2()
+{
+    return 26;             // Inválido porque el valor retornado no es una referencia a una variable.
+}
+
+// Nota: El valor sin referencia es asignado
+$result2 = &test2();
+var_dump($result2);
 ]]>
      </programlisting>
     </informalexample>
@@ -172,7 +190,6 @@ $bar = &test();    // Inválido porque test() no devuelve una variable por refer
 <?php
 // Una variable no definida Y no referenciada (sin contexto de uso).
 var_dump($variable_indefinida);
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -197,7 +214,7 @@ NULL
 <![CDATA[
 <?php
 $unset_array[] = 'valor'; // No producirá ninguna advertencia.
-?>
+var_dump($unset_array);
 ]]>
     </programlisting>
    </example>
@@ -267,12 +284,11 @@ $unset_array[] = 'valor'; // No producirá ninguna advertencia.
    </simpara>
    <example>
     <title>Ejemplo de una variable de ámbito global</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $a = 1;
 include 'b.inc'; // La variable $a estará disponible en el interior de b.inc
-?>
 ]]>
     </programlisting>
    </example>
@@ -298,9 +314,10 @@ $a = 1; // ámbito global
 
 function test()
 {
-    echo $a; // La variable $a no está definida ya que se refiere a una versión local de $a
+    var_dump($a); // La variable $a no está definida ya que se refiere a una versión local de $a
 }
-?>
+
+test();
 ]]>
     </programlisting>
    </example>
@@ -348,7 +365,6 @@ function Suma()
 
 Suma();
 echo $b;
-?>
 ]]>
      </programlisting>
       &example.outputs;
@@ -389,7 +405,6 @@ function Suma()
 
 Suma();
 echo $b;
-?>
 ]]>
      </programlisting>
     </example>
@@ -407,14 +422,13 @@ echo $b;
    <para>
     <example>
      <title>Ejemplo que demuestra las superglobales y el ámbito</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function test_superglobal()
 {
     echo $_POST['name'];
 }
-?>
 ]]>
      </programlisting>
     </example>
@@ -446,10 +460,13 @@ function test_superglobal()
 function test()
 {
     $a = 0;
-    echo $a;
+    echo $a . PHP_EOL;
     $a++;
 }
-?>
+
+test();
+test();
+test();
 ]]>
      </programlisting>
     </example>
@@ -472,10 +489,13 @@ function test()
 function test()
 {
     static $a = 0;
-    echo $a;
+    echo $a . PHP_EOL;
     $a++;
 }
-?>
+
+test();
+test();
+test();
 ]]>
      </programlisting>
     </example>
@@ -503,13 +523,14 @@ function test()
     static $count = 0;
 
     $count++;
-    echo $count;
+    echo $count . PHP_EOL;
     if ($count < 10) {
         test();
     }
     $count--;
 }
-?>
+
+test();
 ]]>
      </programlisting>
     </example>
@@ -523,7 +544,7 @@ function test()
    <para>
     <example>
      <title>Declarando variables estáticas</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo(){
@@ -534,7 +555,6 @@ function foo(){
     $int++;
     echo $int;
 }
-?>
 ]]>
      </programlisting>
     </example>
@@ -565,7 +585,6 @@ function exampleFunction($input) {
 // la variable estática no retendrá su valor.
 echo exampleFunction('A'); // Devolverá: Entrada: A, Contador: 1
 echo exampleFunction('B'); // Devolverá: Entrada: B, Contador: 1
-?>
 ]]>
     </programlisting>
    </example>
@@ -601,7 +620,6 @@ var_dump(Foo::counter()); // int(1)
 var_dump(Foo::counter()); // int(2)
 var_dump(Bar::counter()); // int(3), antes de PHP 8.1.0 int(1)
 var_dump(Bar::counter()); // int(4), antes de PHP 8.1.0 int(2)
-?>
 ]]>
     </programlisting>
    </example>
@@ -641,20 +659,19 @@ test_global_ref();
 var_dump($obj);
 test_global_noref();
 var_dump($obj);
-?>
 ]]>
     </programlisting>
-   </informalexample>
 
-   &example.outputs;
+    &example.outputs;
 
-   <screen>
+    <screen>
 <![CDATA[
 NULL
 object(stdClass)#1 (0) {
 }
 ]]>
-   </screen>
+    </screen>
+   </informalexample>
 
    <simpara>
     Un comportamiento similar se aplica a <literal>static</literal>. Las
@@ -706,12 +723,10 @@ $aun_obj1 = get_instance_ref();
 echo "\n";
 $obj2 = get_instance_noref();
 $aun_obj2 = get_instance_noref();
-?>
 ]]>
     </programlisting>
-   </informalexample>
-   &example.outputs;
-   <screen>
+    &example.outputs;
+    <screen>
 <![CDATA[
 Objeto estático: NULL
 Objeto estático: NULL
@@ -722,7 +737,8 @@ Objeto estático: object(stdClass)#3 (1) {
   int(1)
 }
 ]]>
-   </screen>
+    </screen>
+   </informalexample>
 
    <simpara>
     Este ejemplo demuestra que al asignar una referencia a una variable
@@ -746,7 +762,7 @@ Objeto estático: object(stdClass)#3 (1) {
 <![CDATA[
 <?php
 $a = 'hola';
-?>
+var_dump($a);
 ]]>
    </programlisting>
   </informalexample>
@@ -762,8 +778,9 @@ $a = 'hola';
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 'hola';
 $$a = 'mundo';
-?>
+var_dump($hola);
 ]]>
    </programlisting>
   </informalexample>
@@ -779,8 +796,9 @@ $$a = 'mundo';
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 'hola';
+$$a = 'mundo';
 echo "$a ${$a}";
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -793,8 +811,9 @@ echo "$a ${$a}";
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 'hola';
+$$a = 'mundo';
 echo "$a $hola";
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -858,8 +877,6 @@ echo $foo->{$start . $end} . "\n";
 $arr = 'arr';
 echo $foo->{$arr[1]} . "\n";
 echo $foo->{$arr}[1] . "\n";
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -920,12 +937,11 @@ Soy B.
    <para>
     <example>
      <title>Acceso a datos de un formulario HTML sencillo con POST</title>
-     <programlisting role="html">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 echo $_POST['username'];
 echo $_REQUEST['username'];
-?>
 ]]>
      </programlisting>
     </example>
@@ -960,7 +976,7 @@ echo $_REQUEST['username'];
    <para>
     <example>
      <title>Variables de formulario más complejas</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 if ($_POST) {
@@ -1055,12 +1071,11 @@ if ($_POST) {
    </simpara>
 
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-  setcookie("MiCookie[foo]", 'Prueba 1', time()+3600);
-  setcookie("MiCookie[bar]", 'Prueba 2', time()+3600);
-?>
+setcookie("MiCookie[foo]", 'Prueba 1', time()+3600);
+setcookie("MiCookie[bar]", 'Prueba 2', time()+3600);
 ]]>
      </programlisting>
     </informalexample>
@@ -1081,7 +1096,7 @@ if ($_POST) {
 
     <example>
      <title>Un ejemplo de <function>setcookie</function></title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 if (isset($_COOKIE['count'])) {
@@ -1091,7 +1106,6 @@ if (isset($_COOKIE['count'])) {
 }
 setcookie('conteo', $count, time()+3600);
 setcookie("Carrito[$count]", $item, time()+3600);
-?>
 ]]>
      </programlisting>
     </example>
@@ -1106,11 +1120,10 @@ setcookie("Carrito[$count]", $item, time()+3600);
      a un script. Sin embargo, hay que notar que el punto no es un
      carácter válido en el nombre de una variable PHP. Para conocer la razón,
      considere el siguiente ejemplo:
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $varname.ext;  /* nombre de variable inválido */
-?>
 ]]>
      </programlisting>
      Lo que el intérprete vé es el nombre de una variable <varname>$varname</varname>, seguido


### PR DESCRIPTION
Sincronización de php/doc-en#5455 (commit 64007e9f6b).

Añade `annotations="interactive"` en el chapter, `annotations="non-interactive"` en los ejemplos no ejecutables, hace los demás ejecutables y actualiza el hash EN-Revision.

Closes #576