### PR TITLE
[Sync EN] debug_backtrace(): precisar las condiciones de omision

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 26f18bad4964592e0020daa67f0bac81ae7aeb4c Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: a8dfc2c067cbaadab174f0470e3d0dd0bc811d73 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.debug-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -165,7 +165,7 @@
        <entry>object</entry>
        <entry>&object;</entry>
        <entry>
-        El <link linkend="language.oop5">objeto</link> actual.
+        El <link linkend="language.oop5">objeto</link> actual si <constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant> es proporcionado.
        </entry>
       </row>
       <row>
@@ -182,7 +182,7 @@
        <entry>&array;</entry>
        <entry>
         Si dentro de una función, esto lista los argumentos. Si
-        en un fichero incluido, esto lista los ficheros incluidos.
+        en un fichero incluido, esto lista los ficheros incluidos. A menos que <constant>DEBUG_BACKTRACE_IGNORE_ARGS</constant> sea proporcionado.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Sincronizacion de php/doc-en#5544 (commit a8dfc2c067).

Anade la mencion de `DEBUG_BACKTRACE_PROVIDE_OBJECT` para la clave `object` y de `DEBUG_BACKTRACE_IGNORE_ARGS` para la clave `args`.

Closes #577