### PR TITLE
[Sync EN] Improve fpm configuration reference (#4619)

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f0149750aedec8b2eaa46338d90213dc4767d8b3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1f01e2a8e478c63bd6598cde09235ec027b23dd5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>Configuración</title>
@@ -392,16 +392,16 @@
        <para>
         <literal>static</literal> - el número de procesos hijos es fijo (<literal>pm.max_children</literal>).
        </para>
-       <para>
+       <simpara>
         <literal>ondemand</literal> - los procesos se generan bajo demanda (cuando se solicita,
         a diferencia de dinámico, donde <literal>pm.start_servers</literal> se inician
-        cuando se inicia el servicio.
-       </para>
-       <para>
+        cuando se inicia el servicio).
+       </simpara>
+       <simpara>
         <literal>dynamic</literal> - el número de procesos hijos se establece dinámicamente en función de las
         siguientes directivas: <literal>pm.max_children</literal>, <literal>pm.start_servers</literal>,
         <literal>pm.min_spare_servers</literal>, <literal>pm.max_spare_servers</literal>.
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="pm.max-children">
@@ -410,12 +410,12 @@
        <type>int</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         El número de procesos hijos que se crearán cuando <literal>pm</literal> se establece en
         <literal>static</literal> y el número máximo de procesos hijos que se crearán
-        cuando <literal>pm</literal> se establece en <literal>dynamic</literal>. Esta
-        opción es obligatoria.
-       </para>
+        cuando <literal>pm</literal> se establece en <literal>dynamic</literal> o <literal>ondemand</literal>.
+        Esta opción es obligatoria.
+       </simpara>
        <para>
         Esta opción establece el límite en el número de solicitudes simultáneas que
         se atenderán. Equivalente a la directiva ApacheMaxClients con


### PR DESCRIPTION
Sync of php/doc-en#4619. Mirrors the `<para>` to `<simpara>` conversion, fixes a missing parenthesis in the `ondemand` description, and updates `pm.max_children` to mention `ondemand`.

Fixes #583