### PR TITLE
Revert "[Sync EN] Add (void) casting syntax for PHP 8.5 (#5546)"

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.type-juggling">
  <title>Manipulación de tipos</title>
@@ -317,12 +317,6 @@ var_dump($bar);
    <member><literal>(unset)</literal> - cast en <type>NULL</type></member>
   </simplelist>
 
-  <simpara>
-   El cast <link linkend="language.types.void.casting"><literal>(void)</literal></link>
-   también está disponible a partir de PHP 8.5.0, pero no es una conversión de valor.
-   Se utiliza como una sentencia para descartar explícitamente el resultado de una expresión.
-  </simpara>
-
   <warning>
    <para>
     <literal>(integer)</literal> es un alias del cast <literal>(int)</literal>.
@@ -428,7 +422,6 @@ if ($fst === $str) {
     <member><link linkend="language.types.object.casting">Convertir en object</link></member>
     <member><link linkend="language.types.resource.casting">Convertir en resource</link></member>
     <member><link linkend="language.types.null.casting">Convertir en NULL</link></member>
-    <member><link linkend="language.types.void.casting">Descartar un valor con <literal>(void)</literal></link></member>
     <member><link linkend="types.comparisons">Las tablas de comparación de tipo</link></member>
    </simplelist>
   </para>

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.void">
  <title>Void</title>
@@ -19,39 +19,6 @@
   </simpara>
  </note>
 
- <sect2 xml:id="language.types.void.casting">
-  <title>Descartar un valor con <literal>(void)</literal></title>
-
-  <simpara>
-   La sintaxis <literal>(void)</literal> puede utilizarse para descartar
-   explícitamente el resultado de una expresión. Esto es útil para indicar
-   que ignorar un valor de retorno es intencional, especialmente cuando se
-   llama a una función o método marcado con el atributo
-   <classname>NoDiscard</classname>.
-  </simpara>
-
-  <simpara>
-   A diferencia de otros casts, <literal>(void)</literal> no convierte el
-   valor a otro tipo y no produce un valor. Es una sentencia y no puede
-   utilizarse como parte de una expresión.
-  </simpara>
-
-  <example>
-   <title>Descartar un valor de retorno</title>
-   <programlisting role="php" annotations="non-interactive">
-    <![CDATA[
-<?php
-#[\NoDiscard]
-function process(): bool {
-    return true;
-}
-
-(void) process(); // Descartar explícitamente el valor de retorno
-?>
-]]>
-   </programlisting>
-  </example>
- </sect2>
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Reverts php/doc-es#588