### PR TITLE
Traducir restos de inglés y francés

### DIFF
--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -21,11 +21,10 @@
   son inmediatamente pasados al filtro, incluso si la aplicación
   PHP no está lista para leer estos datos.
   Si los datos ya están en espera en el buffer cuando un
-  filtro es añadido al flujo (<emphasis>appended</emphasis>), estos datos
+  filtro se <emphasis>añade al final</emphasis>, estos datos
   serán inmediatamente pasados al filtro, para que la modificación sea
-  transparente. Pero si se añade un filtro con
-  <emphasis>prepended</emphasis>, los datos
-  <emphasis>NO serán</emphasis> filtrados. Esperarán a que el próximo bloque llegue del recurso.
+  transparente. Pero si un filtro se <emphasis>antepone</emphasis>,
+  los datos <emphasis>NO serán</emphasis> filtrados. Esperarán a que el próximo bloque llegue del recurso.
  </para>
 
  <para>

--- a/appendices/migration70/new-functions.xml
+++ b/appendices/migration70/new-functions.xml
@@ -36,7 +36,7 @@
  </sect2>
 
  <sect2 xml:id="migration70.new-functions.errorfunc">
-  <title><link linkend="book.errorfunc">Gestión de errores y de journaux</link></title>
+  <title><link linkend="book.errorfunc">Gestión de errores y registros</link></title>
 
   <itemizedlist>
    <listitem>
@@ -96,7 +96,7 @@
  </sect2>
 
  <sect2 xml:id="migration70.new-functions.info">
-  <title><link linkend="book.info">Options/Info PHP</link></title>
+  <title><link linkend="book.info">Opciones/Info PHP</link></title>
 
   <itemizedlist>
    <listitem>
@@ -169,7 +169,7 @@
  </sect2>
 
  <sect2 xml:id="migration70.new-functions.zlib">
-  <title><link linkend="book.zlib">Compression Zlib</link></title>
+  <title><link linkend="book.zlib">Compresión Zlib</link></title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration72/deprecated.xml
+++ b/appendices/migration72/deprecated.xml
@@ -34,7 +34,7 @@ string(11) "INEXISTENTE"
  </sect2>
 
  <sect2 xml:id="migration72.deprecated.png2wbmp-jpeg2wbmp">
-  <title><function>png2wbmp</function> and <function>jpeg2wbmp</function></title>
+  <title><function>png2wbmp</function> y <function>jpeg2wbmp</function></title>
 
   <para>
    Las funciones <function>png2wbmp</function> y <function>jpeg2wbmp</function>
@@ -57,13 +57,13 @@ string(11) "INEXISTENTE"
  </sect2>
 
  <sect2 xml:id="migration72.deprecated.__autoload-method">
-  <title><function>__autoload</function> method</title>
+  <title>Método <function>__autoload</function></title>
 
   <para>
-   The <function>__autoload</function> method has been deprecated because it is
-   inferior to <function>spl_autoload_register</function> (due to it not being
-   able to chain autoloaders), and there is no interoperability between the two
-   autoloading styles.
+   El método <function>__autoload</function> se ha marcado como obsoleto porque es
+   inferior a <function>spl_autoload_register</function> (debido a que no permite
+   encadenar autocargadores), y no existe interoperabilidad entre los dos
+   estilos de autocarga.
   </para>
  </sect2>
 

--- a/appendices/migration72/new-functions.xml
+++ b/appendices/migration72/new-functions.xml
@@ -141,7 +141,7 @@
  </sect2>
 
  <sect2 xml:id="migration72.new-functions.mbstring">
-  <title><link linkend="book.mbstring">String Multibyte</link></title>
+  <title><link linkend="book.mbstring">Cadenas Multibyte</link></title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration73/constants.xml
+++ b/appendices/migration73/constants.xml
@@ -213,7 +213,7 @@
     <simpara><constant>CURL_SSLVERSION_TLSv1_3</constant></simpara>
    </listitem>
    <listitem>
-    <simpara><constant>CURL_VERSION_ALTSVC</constant> (as of PHP 7.3.6)</simpara>
+    <simpara><constant>CURL_VERSION_ALTSVC</constant> (a partir de PHP 7.3.6)</simpara>
    </listitem>
    <listitem>
     <simpara><constant>CURL_VERSION_ASYNCHDNS</constant></simpara>
@@ -225,7 +225,7 @@
     <simpara><constant>CURL_VERSION_CONV</constant></simpara>
    </listitem>
    <listitem>
-    <simpara><constant>CURL_VERSION_CURLDEBUG</constant> (as of PHP 7.3.6)</simpara>
+    <simpara><constant>CURL_VERSION_CURLDEBUG</constant> (a partir de PHP 7.3.6)</simpara>
    </listitem>
    <listitem>
     <simpara><constant>CURL_VERSION_DEBUG</constant></simpara>
@@ -255,7 +255,7 @@
     <simpara><constant>CURL_VERSION_NTLM_WB</constant></simpara>
    </listitem>
    <listitem>
-    <simpara><constant>CURL_VERSION_PSL</constant> (as of PHP 7.3.6)</simpara>
+    <simpara><constant>CURL_VERSION_PSL</constant> (a partir de PHP 7.3.6)</simpara>
    </listitem>
    <listitem>
     <simpara><constant>CURL_VERSION_SPNEGO</constant></simpara>

--- a/appendices/migration73/deprecated.xml
+++ b/appendices/migration73/deprecated.xml
@@ -20,7 +20,7 @@
   </sect3>
 
   <sect3 xml:id="migration73.deprecated.core.assert">
-   <title>Namespaced assert()</title>
+   <title>assert() con espacio de nombres</title>
 
    <para>
     Declarando una función llamada <literal>assert()</literal> dentro de un espacio
@@ -69,7 +69,7 @@
   </sect3>
 
   <sect3 xml:id="migration73.deprecated.core.strip-tags-streaming">
-   <title>Strip-Tags Streaming</title>
+   <title>Streaming de Strip-Tags</title>
 
    <para>
     La función <function>fgetss</function> y el <link
@@ -111,7 +111,7 @@
  </sect2>
 
  <sect2 xml:id="migration73.deprecated.mbstring">
-  <title>Multibyte String</title>
+  <title>Cadenas Multibyte</title>
 
   <para>
    El siguiente alias indocumentado <literal>mbereg_*()</literal> ha sido

--- a/appendices/migration73/incompatible.xml
+++ b/appendices/migration73/incompatible.xml
@@ -215,7 +215,7 @@ foo(...gen());
  </sect2>
 
  <sect2 xml:id="migration73.incompatible.bc">
-  <title>BCMath Arbitrary Precision Mathematics</title>
+  <title>BCMath: matemáticas de precisión arbitraria</title>
 
   <para>
    Todas las advertencias lanzadas por las <link linkend="ref.bc">funciones BCMath</link>

--- a/appendices/migration74/constants.xml
+++ b/appendices/migration74/constants.xml
@@ -20,7 +20,7 @@
  </sect2>
 
  <sect2 xml:id="migration74.constants.mbstring">
-  <title>Multibyte String</title>
+  <title>Cadenas Multibyte</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration74/incompatible.xml
+++ b/appendices/migration74/incompatible.xml
@@ -115,7 +115,7 @@
  </sect2>
 
  <sect2 xml:id="migration74.incompatible.bcmath">
-  <title>BCMath Arbitrary Precision Mathematics</title>
+  <title>BCMath: matemáticas de precisión arbitraria</title>
 
   <para>
    Las funciones BCMath advertirán ahora si se adopta un número mal formado, como <literal>"32foo"</literal>. El argumento será interpretado como cero, como antes.
@@ -183,7 +183,7 @@
  </sect2>
 
  <sect2 xml:id="migration74.incompatible.pdo">
-  <title>PHP Data Objects</title>
+  <title>PHP Data Objects (PDO)</title>
 
   <para>
    Un intento de serialización de una instancia de <classname>PDO</classname> o <classname>PDOStatement</classname> generará ahora una <classname>Exception</classname> en lugar de una <classname>PDOException</classname>, compatible con otras clases internas que no soportan la serialización.

--- a/appendices/migration74/new-functions.xml
+++ b/appendices/migration74/new-functions.xml
@@ -5,7 +5,7 @@
  <title>Nuevas funciones</title>
 
  <sect2 xml:id="migration74.new-functions.core">
-  <title>PHP Core</title>
+  <title>Núcleo de PHP</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -395,7 +395,7 @@
  </sect2>
 
  <sect2 xml:id="migration74.other-changes.hash">
-  <title>HASH Message Digest Framework</title>
+  <title>HASH (framework de resúmenes de mensaje)</title>
   <para>
    La extensión <link linkend="book.hash">hash</link> ya no puede ser desactivada y siempre forma parte de cualquier build de PHP, similar a la extensión <link linkend="book.datetime">date</link>.
   </para>

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -6,7 +6,7 @@
  <title>Cambios incompatibles hacia atrás</title>
 
  <sect2 xml:id="migration80.incompatible.core">
-  <title>PHP Core</title>
+  <title>Núcleo de PHP</title>
 
   <sect3 xml:id="migration80.incompatible.core.string-number-comparision">
    <title>Comparación de cadenas con números</title>
@@ -864,7 +864,7 @@ $array["key"];
  </sect2>
 
  <sect2 xml:id="migration80.incompatible.filter">
-  <title>Filter</title>
+  <title>Filtro</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration80/new-classes.xml
+++ b/appendices/migration80/new-classes.xml
@@ -107,7 +107,7 @@
  </sect2>
 
  <sect2 xml:id="migration80.new-classes.sysv">
-  <title>Systen V</title>
+  <title>System V</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -272,7 +272,7 @@ class ChildClass extends ParentClass {
  </sect2>
 
  <sect2 xml:id="migration80.new-features.filter">
-  <title>Filter</title>
+  <title>Filtro</title>
 
   <para>
    Se ha añadido <constant>FILTER_VALIDATE_BOOL</constant> como alias de

--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -19,7 +19,7 @@
  </sect2>
 
  <sect2 xml:id="migration80.other-changes.functions">
-  <title>Fucniones Cambiadas</title>
+  <title>Funciones cambiadas</title>
 
   <sect3 xml:id="migration80.other-changes.functions.reflection">
    <title>Reflection</title>
@@ -39,7 +39,7 @@
   </sect3>
 
   <sect3 xml:id="migration80.other-changes.functions.standard">
-   <title>Standard</title>
+   <title>Estándar</title>
 
    <para>
     Las funciones matemáticas <function>abs</function>, <function>ceil</function>,
@@ -255,7 +255,7 @@
  </sect2>
 
  <sect2 xml:id="migration80.other-changes.ini">
-  <title>Cambios al INI File Handling</title>
+  <title>Cambios en la gestión del archivo INI</title>
 
   <itemizedlist>
    <listitem>
@@ -268,8 +268,8 @@
    <listitem>
     <para>
      <!--<link linkend="ini.zend.exception-string-param-max-len">-->zend.exception_string_param_max_len<!--</link>-->
-     es una nueva directiva INI para establecer la longitud máxima del string de una stringified
-     stack strace.
+     es una nueva directiva INI para establecer la longitud máxima de la cadena
+     de una traza de pila convertida a cadena.
     </para>
    </listitem>
    </itemizedlist>

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -148,7 +148,7 @@
  </sect2>
 
  <sect2 xml:id="migration81.constants.standard">
-  <title>Standard</title>
+  <title>Estándar</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -32,7 +32,7 @@
   <title>Funciones cambiadas</title>
 
   <sect3 xml:id="migration81.other-changes.functions.core">
-   <title>Core</title>
+   <title>Núcleo</title>
 
    <para>
     El orden de las propiedades utilizadas en &foreach;, <function>var_dump</function>,
@@ -50,7 +50,7 @@
   </sect3>
 
   <sect3 xml:id="migration81.other-changes.functions.filter">
-   <title>Filter</title>
+   <title>Filtro</title>
 
    <para>
     La bandera <constant>FILTER_FLAG_ALLOW_OCTAL</constant> del filtro
@@ -92,7 +92,7 @@
   </sect3>
 
   <sect3 xml:id="migration81.other-changes.functions.standard">
-   <title>Standard</title>
+   <title>Estándar</title>
 
    <para>
     <function>syslog</function> ahora es seguro en términos de binarios.
@@ -173,7 +173,7 @@
   </sect3>
 
   <sect3 xml:id="migration81.other-changes.extensions.standard">
-   <title>Standard</title>
+   <title>Estándar</title>
 
    <para>
     <code>--with-password-argon2</code> ahora usa pkg-config para detectar libargon2.

--- a/appendices/migration82/constants.xml
+++ b/appendices/migration82/constants.xml
@@ -424,7 +424,7 @@
  </sect2>
 
  <sect2 xml:id="migration82.constants.filter">
-  <title>Filter</title>
+  <title>Filtro</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -96,7 +96,7 @@
  </sect2>
 
  <sect2 xml:id="migration82.deprecated.standard">
-  <title>Standard</title>
+  <title>Estándar</title>
 
   <para>
   <function>utf8_encode</function> y <function>utf8_decode</function>

--- a/appendices/migration82/new-functions.xml
+++ b/appendices/migration82/new-functions.xml
@@ -63,7 +63,7 @@
  </sect2>
 
  <sect2 xml:id="migration82.new-functions.standard">
-  <title>Standard</title>
+  <title>Estándar</title>
   <simplelist>
     <member><function>memory_reset_peak_usage</function></member>
     <member><function>ini_parse_quantity</function></member>

--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -120,7 +120,7 @@ compararse con <literal>0</literal>.
   <title>Otros cambios en las extensiones</title>
 
   <sect3 xml:id="migration82.other-changes.extensions.date">
-   <title>Date</title>
+   <title>Fecha</title>
 
    <para>
     Las propiedades de <classname>DatePeriod</classname> ahora están correctamente declaradas.
@@ -185,7 +185,7 @@ compararse con <literal>0</literal>.
   </sect3>
 
   <sect3 xml:id="migration82.other-changes.extensions.session">
-   <title>Session</title>
+   <title>Sesión</title>
 
    <para>
     Intentar modificar el
@@ -205,7 +205,7 @@ compararse con <literal>0</literal>.
   </sect3>
 
   <sect3 xml:id="migration82.other-changes.extensions.standard">
-   <title>Standard</title>
+   <title>Estándar</title>
 
    <para>
     <function>getimagesize</function> ahora informa las dimensiones reales de la imagen, bits y canales de las imágenes AVIF. Anteriormente, las dimensiones se informaban como 0x0,

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -121,7 +121,7 @@
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.standard">
-  <title>Standard</title>
+  <title>Estándar</title>
 
   <para>
    La función <function>assert_options</function> está ahora depreciada.

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -80,7 +80,7 @@
  </sect2>
 
  <sect2 xml:id="migration83.incompatible.date">
-  <title>Date</title>
+  <title>Fecha</title>
 
   <para>
    La extensión DateTime ha introducido excepciones y errores específicos de la extensión Date
@@ -167,7 +167,7 @@
  </sect2>
 
  <sect2 xml:id="migration83.incompatible.standard">
-  <title>Standard</title>
+  <title>Estándar</title>
 
   <para>
    La función <function>range</function> ha tenido varios cambios:

--- a/appendices/migration83/new-classes.xml
+++ b/appendices/migration83/new-classes.xml
@@ -5,7 +5,7 @@
  <title>Nuevas clases e interfaces</title>
 
  <sect2 xml:id="migration83.new-classes.date">
-  <title>Date</title>
+  <title>Fecha</title>
   <itemizedlist>
    <listitem>
     <simpara>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -84,7 +84,7 @@
   <title>Funciones cambiadas</title>
 
   <sect3 xml:id="migration83.other-changes.functions.core">
-   <title>Core</title>
+   <title>Núcleo</title>
 
    <para>
     <function>gc_status</function> ha añadido los siguientes 8 campos:
@@ -346,7 +346,7 @@
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.standard">
-   <title>Standard</title>
+   <title>Estándar</title>
 
    <para>
     El <constant>E_NOTICE</constant> emitido por <function>unserialize</function>
@@ -431,7 +431,7 @@
   <title>Otros cambios en las extensiones</title>
 
   <sect3 xml:id="migration83.other-changes.extensions.core">
-   <title>Core</title>
+   <title>Núcleo</title>
 
    <para>
     Usar los operadores de <link linkend="language.operators.increment">incremento/decremento</link>
@@ -560,7 +560,7 @@
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.performance.standard">
-   <title>Standard</title>
+   <title>Estándar</title>
 
    <para>
     La bandera <function>file</function> para la verificación de errores ahora es aproximadamente un 7% más rápida.

--- a/appendices/migration84/constants.xml
+++ b/appendices/migration84/constants.xml
@@ -5,7 +5,7 @@
  <title>Nuevas constantes globales</title>
 
  <sect2 xml:id="migration84.constants.core">
-  <title>Core</title>
+  <title>Núcleo</title>
 
   <simplelist>
    <member>

--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -542,7 +542,7 @@ $object = $reflector->newLazyGhost($initializer);
  </sect2>
 
  <sect2 xml:id="migration84.new-features.standard">
-  <title>Standard</title>
+  <title>Estándar</title>
 
   <!-- RFC: https://wiki.php.net/rfc/correctly_name_the_rounding_mode_and_make_it_an_enum -->
   <simpara>

--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -109,7 +109,7 @@
   <title>Funciones cambiadas</title>
 
   <sect3 xml:id="migration84.other-changes.functions.core">
-   <title>Core</title>
+   <title>Núcleo</title>
 
    <simpara>
     <function>trigger_error</function> y <function>user_error</function>
@@ -419,7 +419,7 @@
   </sect3>
 
   <sect3 xml:id="migration84.other-changes.functions.standard">
-   <title>Standard</title>
+   <title>Estándar</title>
 
    <simpara>
      El valor predeterminado del <literal>'cost'</literal> para el algoritmo de hashing <constant>PASSWORD_BCRYPT</constant>
@@ -629,7 +629,7 @@
   <title>Rendimiento</title>
 
   <sect3 xml:id="migration84.other-changes.performance.core">
-   <title>Core</title>
+   <title>Núcleo</title>
 
    <simpara>
     Mejora del rendimiento del análisis y la generación de números de punto flotante
@@ -747,7 +747,7 @@
   </sect3>
 
   <sect3 xml:id="migration84.other-changes.performance.standard">
-   <title>Standard</title>
+   <title>Estándar</title>
 
    <simpara>
     El rendimiento de <function>strspn</function> y

--- a/appendices/migration85/new-classes.xml
+++ b/appendices/migration85/new-classes.xml
@@ -23,7 +23,7 @@
  </sect2>
 
  <sect2 xml:id="migration85.new-classes.filter">
-  <title>Filter</title>
+  <title>Filtro</title>
   <simplelist>
    <member><classname>Filter\FilterException</classname></member>
    <member><classname>Filter\FilterFailedException</classname></member>

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -300,7 +300,7 @@ print T1 . PHP_EOL;   // Imprime "0"
  </sect2>
 
  <sect2 xml:id="migration85.new-features.filter">
-  <title>Filter</title>
+  <title>Filtro</title>
 
   <simpara>
    Añadida la nueva flag <constant>FILTER_THROW_ON_FAILURE</constant>, que se puede

--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -34,7 +34,7 @@
        <function>socket_addrinfo_explain</function>,
       </entry>
       <entry>
-       None
+       Ninguno
       </entry>
       <entry>AddressInfo (extensión sockets)</entry>
      </row>

--- a/appendices/userlandnaming.xml
+++ b/appendices/userlandnaming.xml
@@ -7,13 +7,13 @@
  <para>
   La siguiente es una guía para saber cómo elegir el mejor nombre para los
   identificadores del código del entorno del usuario PHP. Cuando se eligen
-  nombres para cualquier código que crea símbolos en el global namespace,
+  nombres para cualquier código que crea símbolos en el espacio de nombres global,
   es importante tener en cuenta los siguientes lineamientos para evitar que en
   futuras versiones de PHP estos choquen con los símbolos elegidos.
  </para>
 
  <section xml:id="userlandnaming.globalnamespace">
-  <title>Global Namespace</title>
+  <title>Espacio de nombres global</title>
   <para>
    Aquí hay una visión general de las construcciones de código que van al espacio de nombres global:
   </para>
@@ -97,7 +97,7 @@
  </section>
 
  <section xml:id="userlandnaming.tips">
-  <title>Tips</title>
+  <title>Consejos</title>
   <para>
    Con el fin de escribir código que funcione en el futuro, se recomienda no
    colocar muchas variables, funciones o clases en el espacio de nombres global. Esto

--- a/faq/build.xml
+++ b/faq/build.xml
@@ -71,7 +71,7 @@
     <answer>
      <para>
       Se debe asegurar de leer cuidadosamente las instrucciones
-      <link linkend="install.unix">installation</link> y notar que se necesita flex y bison instalados
+      de <link linkend="install.unix">instalación</link> y notar que se necesita flex y bison instalados
       para compilar PHP. Dependiendo de la configuración, se necesitará
       instalar bison y flex desde el paquete de origen, como un RPM
      </para>
@@ -105,7 +105,7 @@
      <para>
       Para mas información, leer el archivo de nivel superior
       de Apache <filename>INSTALL</filename> o las páginas del
-      manual de Apache <link xlink:href="&url.apachedso;">DSO manual</link>.
+      <link xlink:href="&url.apachedso;">manual sobre DSO</link>.
      </para>
     </answer>
    </qandaentry>
@@ -405,7 +405,7 @@ $ gcc -E test.c >/dev/null
       </para>
       <para>
        <screen>
-        Build complete.
+        Compilación completada.
         (Es seguro hacer caso omiso de las advertencias sobre tempnam y tmpnam).
        </screen>
       </para>

--- a/faq/installation.xml
+++ b/faq/installation.xml
@@ -170,11 +170,11 @@
      líneas en su fichero &httpd.conf;:
      <programlisting role="apache-conf">
 <![CDATA[
-# Extra Modules
+# Módulos adicionales
 AddModule mod_php.c
 AddModule mod_perl.c
 
-# Extra Modules
+# Módulos adicionales
 LoadModule php_module         modules/mod_php.so
 LoadModule php5_module        modules/libphp5.so
 LoadModule perl_module        modules/libperl.so

--- a/faq/obtaining.xml
+++ b/faq/obtaining.xml
@@ -74,7 +74,7 @@
       </listitem>
       <listitem>
        <simpara>
-        <link xlink:href="&url.ldap.bind9;">free LDAP server</link>.
+        <link xlink:href="&url.ldap.bind9;">servidor LDAP libre</link>.
        </simpara>
       </listitem>
       <listitem>

--- a/faq/using.xml
+++ b/faq/using.xml
@@ -59,11 +59,11 @@
 <![CDATA[
 <?php
 $empty = $post = array();
-foreach ($_POST as $nomvar => $valeurvar) {
+foreach ($_POST as $varname => $varvalue) {
     if (empty($varvalue)) {
-        $empty[$nomvar] = $valeurvar;
+        $empty[$varname] = $varvalue;
     } else {
-        $post[$nomvar] = $valeurvar;
+        $post[$varname] = $varvalue;
     }
 }
 
@@ -121,12 +121,12 @@ echo '</pre>';
      <programlisting role="php">
 <![CDATA[
 <?php
-function mafonction($argument)
+function myfunc($argument)
 {
     echo $argument + 10;
 }
 $variable = 10;
-echo "mafonction($variable) = " . mafonction($variable);
+echo "myfunc($variable) = " . myfunc($variable);
 ?>
 ]]>
     </programlisting>
@@ -205,8 +205,8 @@ echo "mafonction($variable) = " . mafonction($variable);
 <![CDATA[
 <?php
 $headers = getallheaders();
-foreach ($headers as $nom => $contenu) {
-    echo "headers[$nom] = $contenu<br />\n";
+foreach ($headers as $name => $content) {
+    echo "headers[$name] = $content<br />\n";
 }
 ?>
 ]]>

--- a/features/file-upload.xml
+++ b/features/file-upload.xml
@@ -282,9 +282,9 @@ foreach ($_FILES["pictures"]["error"] as $key => $error) {
   </warning>
   <para>
    <example>
-    <title>Telever un directorio entero</title>
+    <title>Cargar un directorio entero</title>
     <simpara>
-     En los campos de televersión de fichero HTML, es posible televersar un directorio entero con el atributo <literal>webkitdirectory</literal>. Esta funcionalidad es soportada en la mayoría de los navegadores modernos.
+     En los campos de carga de fichero HTML, es posible cargar un directorio entero con el atributo <literal>webkitdirectory</literal>. Esta funcionalidad es soportada en la mayoría de los navegadores modernos.
     </simpara>
     <simpara>
      Con la información <literal>full_path</literal>, es posible almacenar las rutas relativas o reconstruir la misma jerarquía de directorios en el directorio.

--- a/install/cloud/ec2.xml
+++ b/install/cloud/ec2.xml
@@ -4,10 +4,10 @@
  <sect1 xml:id="install.cloud.ec2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Amazon EC2</title>
   <para>
-   PHP instalará el <link xlink:href="&url.cloud.ec2;">EC2 cloud platform</link>.
+   PHP se instala en la <link xlink:href="&url.cloud.ec2;">plataforma de nube EC2</link>.
   </para>
   <para>
-  Ver acerca de <link xlink:href="&url.cloud.ec2.sdk;">AWS SDK for PHP</link>.
+   Vea también el <link xlink:href="&url.cloud.ec2.sdk;">AWS SDK for PHP</link>.
   </para>
  </sect1>
 

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -90,12 +90,12 @@
      <screen>
 <![CDATA[
 <IfModule mod_php5.c>
-    # If php is turned on, we respect .php and .phps files.
+    # Si php está activado, respetamos los ficheros .php y .phps.
     AddType application/x-httpd-php .php
     AddType application/x-httpd-php-source .phps
 
-    # Since most users will want index.php to work we
-    # also automatically enable index.php
+    # Como la mayoría de los usuarios querrá que index.php funcione,
+    # también activamos automáticamente index.php
     <IfModule mod_dir.c>
         DirectoryIndex index.html index.php
     </IfModule>

--- a/install/unix/commandline.xml
+++ b/install/unix/commandline.xml
@@ -28,7 +28,7 @@
   <simpara>
    Algunos <link linkend="reserved.variables.server">servidores suministrando
    variables de entorno</link> no se definen en las actuales
-   <link xlink:href="&url.rfc;3875">CGI/1.1 specification</link>.
+   <link xlink:href="&url.rfc;3875">especificación CGI/1.1</link>.
    Sólo las siguientes variables no se definen: <varname>AUTH_TYPE</varname>,
    <varname>CONTENT_LENGTH</varname>, <varname>CONTENT_TYPE</varname>,
    <varname>GATEWAY_INTERFACE</varname>, <varname>PATH_INFO</varname>,
@@ -37,7 +37,7 @@
    <varname>REMOTE_IDENT</varname>, <varname>REMOTE_USER</varname>,
    <varname>REQUEST_METHOD</varname>, <varname>SCRIPT_NAME</varname>,
    <varname>SERVER_NAME</varname>, <varname>SERVER_PORT</varname>,
-   <varname>SERVER_PROTOCOL</varname>, and <varname>SERVER_SOFTWARE</varname>.
+   <varname>SERVER_PROTOCOL</varname> y <varname>SERVER_SOFTWARE</varname>.
     Todo lo demás debe ser tratado como "extensiones de proveedor".
   </simpara>
  </sect2>

--- a/install/unix/nginx.xml
+++ b/install/unix/nginx.xml
@@ -151,9 +151,9 @@ vim /usr/local/etc/php-fpm.d/www.conf
    <informalexample xml:id="install.unix.nginx.modify.phpfpm.usergroup">
     <screen>
 <![CDATA[
-; Unix user/group of processes
-; Note: The user is mandatory. If the group is not set, the default user's group
-;       will be used.
+; Usuario/grupo Unix de los procesos
+; Nota: el usuario es obligatorio. Si no se define el grupo, se usará el grupo
+;       por defecto del usuario.
 user = www-data
 group = www-data
 ]]>

--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -55,12 +55,12 @@
     <title>PHP y Apache 2.x como controlador</title>
     <programlisting role="apache-conf">
 <![CDATA[
-# before PHP 8.0.0 the name of the module was php7_module
+# antes de PHP 8.0.0 el nombre del módulo era php7_module
 LoadModule php_module "c:/php/php8apache2_4.dll"
 <FilesMatch \.php$>
     SetHandler application/x-httpd-php
 </FilesMatch>
-# configure the path to php.ini
+# configurar la ruta a php.ini
 PHPIniDir "C:/php"
 ]]>
     </programlisting>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -57,24 +57,24 @@
    <programlisting role="php">
    <![CDATA[
 <?php
-namespace mon\nom; // Ver la sección "Definición de espacios de nombres"
+namespace mi\nombre; // Ver la sección "Definición de espacios de nombres"
 
-class MaClasse {}
-function mafonction() {}
-const MACONSTANTE = 1;
+class MiClase {}
+function mifuncion() {}
+const MICONSTANTE = 1;
 
-$a = new MaClasse;
+$a = new MiClase;
 print $a::class . "\n";
-$c = new \mon\nom\MaClasse; // Ver la sección "Espacio global"
+$c = new \mi\nombre\MiClase; // Ver la sección "Espacio global"
 print $c::class . "\n";
 
-$a = strlen('bonjour'); // Ver "Uso de espacios de nombres: retorno al espacio global
+$a = strlen('hola'); // Ver "Uso de espacios de nombres: retorno al espacio global
 print $a . "\n";
 
-$d = namespace\MACONSTANTE; // Ver "El operador namespace y la constante __NAMESPACE__
+$d = namespace\MICONSTANTE; // Ver "El operador namespace y la constante __NAMESPACE__
 print $d . "\n";
 
-$d = __NAMESPACE__ . '\MACONSTANTE';
+$d = __NAMESPACE__ . '\MICONSTANTE';
 echo constant($d); // Ver "Espacios de nombres y características dinámicas"
     ]]>
    </programlisting>

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -61,7 +61,7 @@ class A {
     public int $prop;
 }
 class B extends A {
-    // Ilegal: read-write -> readonly
+    // Ilegal: lectura-escritura -> readonly
     public readonly int $prop;
 }
 ?>

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -424,18 +424,18 @@ class Person {
     <programlisting role="php">
 <![CDATA[
 <?php
-class Utiliser
+class User
 {
-    public string $Utilisername {
+    public string $username {
         final set => strtolower($value);
     }
 }
 
-class Manager extends Utiliser
+class Manager extends User
 {
-    public string $Utilisername {
+    public string $username {
         // Esto está permitido
-        get => strtoupper($this->Utilisername);
+        get => strtoupper($this->username);
 
         // Esto NO está permitido, ya que set es final en el padre.
         set => strtoupper($value);
@@ -477,7 +477,7 @@ class PositivePoint extends Point
     public int $x {
         set {
             if ($value < 0) {
-                throw new \InvalidArgumentException('Too small');
+                throw new \InvalidArgumentException('Demasiado pequeño');
             }
             $this->x = $value;
         }
@@ -532,7 +532,7 @@ class PositivePoint extends Point
     public int $x {
         set {
             if ($value < 0) {
-                throw new \InvalidArgumentException('Too small');
+                throw new \InvalidArgumentException('Demasiado pequeño');
             }
             parent::$x::set($value);
         }
@@ -587,7 +587,7 @@ class CaseFoldingStrings extends Strings
    <member><function>serialize</function>: Utiliza el valor bruto</member>
    <member><function>unserialize</function>: Utiliza el valor bruto</member>
    <member><link linkend="object.serialize">__serialize()</link>/<link linkend="object.unserialize">__unserialize()</link>: Lógica propia, utiliza los hooks de recuperación/definición</member>
-   <member>Array casting: Utiliza el valor bruto</member>
+   <member>Conversión a array: Utiliza el valor bruto</member>
    <member><function>var_export</function>: Utiliza el hook de recuperación</member>
    <member><function>json_encode</function>: Utiliza el hook de recuperación</member>
    <member><interfacename>JsonSerializable</interfacename>: Lógica propia, utiliza el hook de recuperación</member>

--- a/language/types/iterable.xml
+++ b/language/types/iterable.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: PhilDaiguille -->
 <sect1 xml:id="language.types.iterable">
- <title>Itérables</title>
+ <title>Iterables</title>
 
  <para>
   Un <type>Iterable</type> es un alias de tipo integrado durante la compilación para

--- a/reference/apcu/book.xml
+++ b/reference/apcu/book.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="book.apcu">
  <?phpdoc extension-membership="pecl" ?>
- <title>APC User Cache</title>
+ <title>Caché de usuario APC</title>
  <titleabbrev>APCu</titleabbrev>
 
  <preface xml:id="intro.apcu">

--- a/reference/apcu/functions/apcu-dec.xml
+++ b/reference/apcu/functions/apcu-dec.xml
@@ -76,7 +76,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Let's do something with success", PHP_EOL;
+echo "Hagamos algo con éxito", PHP_EOL;
 
 apcu_store('anumber', 42);
 
@@ -88,7 +88,7 @@ echo apcu_dec('anumber', 10, $success), PHP_EOL;
 
 var_dump($success);
 
-echo "Now, let's fail", PHP_EOL, PHP_EOL;
+echo "Ahora, hagamos que falle", PHP_EOL, PHP_EOL;
 
 apcu_store('astring', 'foo');
 
@@ -102,13 +102,13 @@ var_dump($fail);
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Let's do something with success
+Hagamos algo con éxito
 42
 41
 31
 21
 bool(true)
-Now, let's fail
+Ahora, hagamos que falle
 
 bool(false)
 bool(false)

--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -418,13 +418,13 @@ array(1) {
 <![CDATA[
 <?php
 $arr = [
-    'v1' => 'First release',
-    'v2' => 'Second release',
-    'v3' => 'Third release',
+    'v1' => 'Primera versión',
+    'v2' => 'Segunda versión',
+    'v3' => 'Tercera versión',
 ];
 // Nota: Anterior a 7.4.0, se debe utilizar la sintaxis más larga para las
 // funciones anónimas en su lugar.
-$callback = fn(string $k, string $v): string => "$k was the $v";
+$callback = fn(string $k, string $v): string => "$k era la $v";
 $result = array_map($callback, array_keys($arr), array_values($arr));
 var_dump($result);
 ?>
@@ -435,11 +435,11 @@ var_dump($result);
 <![CDATA[
 array(3) {
   [0]=>
-  string(24) "v1 was the First release"
+  string(24) "v1 era la Primera versión"
   [1]=>
-  string(25) "v2 was the Second release"
+  string(25) "v2 era la Segunda versión"
   [2]=>
-  string(24) "v3 was the Third release"
+  string(24) "v3 era la Tercera versión"
 }
 ]]>
     </screen>

--- a/reference/array/functions/array-udiff.xml
+++ b/reference/array/functions/array-udiff.xml
@@ -178,9 +178,9 @@ class MyCalendar {
 $myCalendar = new MyCalendar;
 
 // Registra algunas citas para esta semana
-$myCalendar->bookAppointment(new DateTime('Monday this week'), "Cleaning GoogleGuy's apartment.");
-$myCalendar->bookAppointment(new DateTime('Wednesday this week'), "Going on a snowboarding trip.");
-$myCalendar->bookAppointment(new DateTime('Friday this week'), "Fixing buggy code.");
+$myCalendar->bookAppointment(new DateTime('Monday this week'), "Limpiar el apartamento de GoogleGuy.");
+$myCalendar->bookAppointment(new DateTime('Wednesday this week'), "Ir a un viaje de snowboard.");
+$myCalendar->bookAppointment(new DateTime('Friday this week'), "Arreglar código con errores.");
 
 // Verifica la disponibilidad en días, comparando las fechas $booked con las fechas $free
 echo "Estoy disponible en los siguientes días esta semana...\n\n";
@@ -205,9 +205,9 @@ Thursday
 
 Estoy ocupado en los siguientes días esta semana...
 
-Monday: Cleaning GoogleGuy's apartment.
-Wednesday: Going on a snowboarding trip.
-Friday: Fixing buggy code.
+Monday: Limpiar el apartamento de GoogleGuy.
+Wednesday: Ir a un viaje de snowboard.
+Friday: Arreglar código con errores.
 ]]>
     </screen>
    </example>

--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -146,7 +146,7 @@ if (in_array(array('p', 'h'), $a)) {
 }
 
 if (in_array(array('f', 'i'), $a)) {
-    echo "'fi' was found\n";
+    echo "'fi' ha sido encontrado\n";
 }
 
 if (in_array('o', $a)) {

--- a/reference/array/functions/list.xml
+++ b/reference/array/functions/list.xml
@@ -119,15 +119,15 @@ $info = array('coffee', 'brown', 'caffeine');
 
 // Listando todas las variables
 list($drink, $color, $power) = $info;
-echo "$drink is $color and $power makes it special.\n";
+echo "$drink es $color y $power lo hace especial.\n";
 
 // Listando algunas de ellas
 list($drink, , $power) = $info;
-echo "$drink has $power.\n";
+echo "$drink tiene $power.\n";
 
 // O saltemos solo a la tercera
 list( , , $power) = $info;
-echo "I need $power!\n";
+echo "¡Necesito $power!\n";
 
 // list() no funciona con strings
 list($bar) = "abcde";

--- a/reference/array/reference.xml
+++ b/reference/array/reference.xml
@@ -9,7 +9,7 @@
    <para>
     Ver también <function>is_array</function>, <function>explode</function>,
     <function>implode</function>,
-    <function>preg_split</function>, and <function>unset</function>.
+    <function>preg_split</function> y <function>unset</function>.
    </para>
  </partintro>
 

--- a/reference/bc/bcmath/number/pow.xml
+++ b/reference/bc/bcmath/number/pow.xml
@@ -55,7 +55,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>positive</entry>
+       <entry>positivo</entry>
        <entry>(<property>BcMath\Number::scale</property> de la potencia base) * (el valor del <parameter>exponent</parameter>)</entry>
       </row>
       <row>
@@ -63,7 +63,7 @@
        <entry><literal>0</literal></entry>
       </row>
       <row>
-       <entry>negative</entry>
+       <entry>negativo</entry>
        <entry>Entre (<property>BcMath\Number::scale</property> de la potencia base) y (<property>BcMath\Number::scale
        </property> de la potencia base + <literal>10</literal>)</entry>
       </row>

--- a/reference/bc/bcmath/number/round.xml
+++ b/reference/bc/bcmath/number/round.xml
@@ -216,7 +216,7 @@ object(BcMath\Number)#8 (2) {
    <programlisting role="php">
 <![CDATA[
 <?php
-echo 'Rounding modes with 9.5' . PHP_EOL;
+echo 'Modos de redondeo con 9.5' . PHP_EOL;
 $number = new BcMath\Number('9.5');
 var_dump(
     $number->round(0, RoundingMode::HalfAwayFromZero),
@@ -230,7 +230,7 @@ var_dump(
 );
 
 echo PHP_EOL;
-echo 'Rounding modes with 8.5' . PHP_EOL;
+echo 'Modos de redondeo con 8.5' . PHP_EOL;
 $number = new BcMath\Number('8.5');
 var_dump(
     $number->round(0, RoundingMode::HalfAwayFromZero),
@@ -248,7 +248,7 @@ var_dump(
    &example.outputs;
    <screen role="php">
 <![CDATA[
-Rounding modes with 9.5
+Modos de redondeo con 9.5
 object(BcMath\Number)#3 (2) {
   ["value"]=>
   string(2) "10"
@@ -298,7 +298,7 @@ object(BcMath\Number)#17 (2) {
   int(0)
 }
 
-Rounding modes with 8.5
+Modos de redondeo con 8.5
 object(BcMath\Number)#1 (2) {
   ["value"]=>
   string(1) "9"
@@ -361,56 +361,56 @@ object(BcMath\Number)#3 (2) {
 $positive = new BcMath\Number('1.55');
 $negative = new BcMath\Number('-1.55');
 
-echo 'Using RoundingMode::HalfAwayFromZero with 1 decimal digit precision' . PHP_EOL;
+echo 'Uso de RoundingMode::HalfAwayFromZero con precisión de 1 dígito decimal' . PHP_EOL;
 var_dump(
     $positive->round(1, RoundingMode::HalfAwayFromZero),
     $negative->round(1, RoundingMode::HalfAwayFromZero),
 );
 
 echo PHP_EOL;
-echo 'Using RoundingMode::HalfTowardsZero with 1 decimal digit precision' . PHP_EOL;
+echo 'Uso de RoundingMode::HalfTowardsZero con precisión de 1 dígito decimal' . PHP_EOL;
 var_dump(
     $positive->round(1, RoundingMode::HalfTowardsZero),
     $negative->round(1, RoundingMode::HalfTowardsZero),
 );
 
 echo PHP_EOL;
-echo 'Using RoundingMode::HalfEven with 1 decimal digit precision' . PHP_EOL;
+echo 'Uso de RoundingMode::HalfEven con precisión de 1 dígito decimal' . PHP_EOL;
 var_dump(
     $positive->round(1, RoundingMode::HalfEven),
     $negative->round(1, RoundingMode::HalfEven),
 );
 
 echo PHP_EOL;
-echo 'Using RoundingMode::HalfOdd with 1 decimal digit precision' . PHP_EOL;
+echo 'Uso de RoundingMode::HalfOdd con precisión de 1 dígito decimal' . PHP_EOL;
 var_dump(
     $positive->round(1, RoundingMode::HalfOdd),
     $negative->round(1, RoundingMode::HalfOdd),
 );
 
 echo PHP_EOL;
-echo 'Using RoundingMode::TowardsZero with 1 decimal digit precision' . PHP_EOL;
+echo 'Uso de RoundingMode::TowardsZero con precisión de 1 dígito decimal' . PHP_EOL;
 var_dump(
     $positive->round(1, RoundingMode::TowardsZero),
     $negative->round(1, RoundingMode::TowardsZero),
 );
 
 echo PHP_EOL;
-echo 'Using RoundingMode::AwayFromZero with 1 decimal digit precision' . PHP_EOL;
+echo 'Uso de RoundingMode::AwayFromZero con precisión de 1 dígito decimal' . PHP_EOL;
 var_dump(
     $positive->round(1, RoundingMode::AwayFromZero),
     $negative->round(1, RoundingMode::AwayFromZero),
 );
 
 echo PHP_EOL;
-echo 'Using RoundingMode::NegativeInfinity with 1 decimal digit precision' . PHP_EOL;
+echo 'Uso de RoundingMode::NegativeInfinity con precisión de 1 dígito decimal' . PHP_EOL;
 var_dump(
     $positive->round(1, RoundingMode::NegativeInfinity),
     $negative->round(1, RoundingMode::NegativeInfinity),
 );
 
 echo PHP_EOL;
-echo 'Using RoundingMode::PositiveInfinity with 1 decimal digit precision' . PHP_EOL;
+echo 'Uso de RoundingMode::PositiveInfinity con precisión de 1 dígito decimal' . PHP_EOL;
 var_dump(
     $positive->round(1, RoundingMode::PositiveInfinity),
     $negative->round(1, RoundingMode::PositiveInfinity),
@@ -421,7 +421,7 @@ var_dump(
    &example.outputs;
    <screen role="php">
 <![CDATA[
-Using RoundingMode::HalfAwayFromZero with 1 decimal digit precision
+Uso de RoundingMode::HalfAwayFromZero con precisión de 1 dígito decimal
 object(BcMath\Number)#4 (2) {
   ["value"]=>
   string(3) "1.6"
@@ -435,7 +435,7 @@ object(BcMath\Number)#5 (2) {
   int(1)
 }
 
-Using RoundingMode::HalfTowardsZero with 1 decimal digit precision
+Uso de RoundingMode::HalfTowardsZero con precisión de 1 dígito decimal
 object(BcMath\Number)#4 (2) {
   ["value"]=>
   string(3) "1.5"
@@ -449,7 +449,7 @@ object(BcMath\Number)#6 (2) {
   int(1)
 }
 
-Using RoundingMode::HalfEven with 1 decimal digit precision
+Uso de RoundingMode::HalfEven con precisión de 1 dígito decimal
 object(BcMath\Number)#4 (2) {
   ["value"]=>
   string(3) "1.6"
@@ -463,7 +463,7 @@ object(BcMath\Number)#7 (2) {
   int(1)
 }
 
-Using RoundingMode::HalfOdd with 1 decimal digit precision
+Uso de RoundingMode::HalfOdd con precisión de 1 dígito decimal
 object(BcMath\Number)#4 (2) {
   ["value"]=>
   string(3) "1.5"
@@ -477,7 +477,7 @@ object(BcMath\Number)#8 (2) {
   int(1)
 }
 
-Using RoundingMode::TowardsZero with 1 decimal digit precision
+Uso de RoundingMode::TowardsZero con precisión de 1 dígito decimal
 object(BcMath\Number)#4 (2) {
   ["value"]=>
   string(3) "1.5"
@@ -491,7 +491,7 @@ object(BcMath\Number)#9 (2) {
   int(1)
 }
 
-Using RoundingMode::AwayFromZero with 1 decimal digit precision
+Uso de RoundingMode::AwayFromZero con precisión de 1 dígito decimal
 object(BcMath\Number)#4 (2) {
   ["value"]=>
   string(3) "1.6"
@@ -505,7 +505,7 @@ object(BcMath\Number)#10 (2) {
   int(1)
 }
 
-Using RoundingMode::NegativeInfinity with 1 decimal digit precision
+Uso de RoundingMode::NegativeInfinity con precisión de 1 dígito decimal
 object(BcMath\Number)#4 (2) {
   ["value"]=>
   string(3) "1.5"
@@ -519,7 +519,7 @@ object(BcMath\Number)#11 (2) {
   int(1)
 }
 
-Using RoundingMode::PositiveInfinity with 1 decimal digit precision
+Uso de RoundingMode::PositiveInfinity con precisión de 1 dígito decimal
 object(BcMath\Number)#4 (2) {
   ["value"]=>
   string(3) "1.6"

--- a/reference/bc/functions/bcdiv.xml
+++ b/reference/bc/functions/bcdiv.xml
@@ -95,7 +95,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>bcdiv</function> example</title>
+   <title>Ejemplo de <function>bcdiv</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/classobj/examples.xml
+++ b/reference/classobj/examples.xml
@@ -69,7 +69,7 @@ class Spinach extends Vegetable {
    <programlisting role="php">
 <![CDATA[
 <?php
-// register autoloader to load classes
+// registra el autoloader para cargar las clases
 spl_autoload_register();
 function printProperties($obj)
 {
@@ -87,23 +87,23 @@ function printMethods($obj)
 function objectBelongsTo($obj, $class)
 {
     if (is_subclass_of($obj, $class)) {
-        echo "Object belongs to class " . get_class($obj);
-        echo ", a subclass of $class\n";
+        echo "El objeto pertenece a la clase " . get_class($obj);
+        echo ", una subclase de $class\n";
     } else {
-        echo "Object does not belong to a subclass of $class\n";
+        echo "El objeto no pertenece a una subclase de $class\n";
     }
 }
-// instantiate 2 objects
+// instancia 2 objetos
 $veggie = new Vegetable(true, "blue");
 $leafy = new Spinach();
-// print out information about objects
+// imprime información sobre los objetos
 echo "veggie: CLASS " . get_class($veggie) . "\n";
 echo "leafy: CLASS " . get_class($leafy);
 echo ", PARENT " . get_parent_class($leafy) . "\n";
-// show veggie properties
+// muestra las propiedades de veggie
 echo "\nveggie: Properties\n";
 printProperties($veggie);
-// and leafy methods
+// y los métodos de leafy
 echo "\nleafy: Methods\n";
 printMethods($leafy);
 echo "\nParentage:\n";
@@ -127,8 +127,8 @@ leafy: Methods
         function isEdible()
         function getColor()
 Parentage:
-Object does not belong to a subclass of Spinach
-Object belongs to class Spinach, a subclass of Vegetable
+El objeto no pertenece a una subclase de Spinach
+El objeto pertenece a la clase Spinach, una subclase de Vegetable
 ]]>
    </screen>
    <para>

--- a/reference/classobj/functions/class-exists.xml
+++ b/reference/classobj/functions/class-exists.xml
@@ -76,7 +76,7 @@ spl_autoload_register(function ($class_name) {
 
     // Verifica si el include ha declarado la clase
     if (!class_exists($class_name, false)) {
-        throw new LogicException("Unable to load class: $class_name");
+        throw new LogicException("No se puede cargar la clase: $class_name");
     }
 });
 

--- a/reference/cmark/book.xml
+++ b/reference/cmark/book.xml
@@ -12,14 +12,14 @@
   Esta extensión proporciona acceso a la implementación de referencia de CommonMark, una versión racionalizada de la sintaxis de Markdown con una especificación.
   </simpara>
   <formalpara>
-    <title>Parsing:</title>
+    <title>Análisis sintáctico:</title>
     <para>
     La extensión CommonMark proporciona una sencilla API de análisis sintáctico:
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.commonmark-parse')/db:refsect1[@role='description']/descendant::db:methodsynopsis)"/>
     </para>
   </formalpara>
   <formalpara>
-    <title>Rendering:</title>
+    <title>Renderizado:</title>
     <para>
     La extensión CommonMark proporciona una sencilla API de renderizado que soporta múltiples formatos:
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.commonmark-render')/db:refsect1[@role='description']/descendant::db:methodsynopsis)"/>

--- a/reference/cmark/commonmark.parser.xml
+++ b/reference/cmark/commonmark.parser.xml
@@ -12,7 +12,7 @@
   <section xml:id="commonmark-parser.intro">
    &reftitle.intro;
    <simpara>
-    Proporciona un analizador incremental como alternativa a la simple función de análisis de la API Parsing
+    Proporciona un analizador incremental como alternativa a la simple función de análisis de la API de análisis sintáctico
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/cmark/functions/commonmark.parse.xml
+++ b/reference/cmark/functions/commonmark.parse.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.commonmark-parse">
  <refnamediv>
   <refname>CommonMark\Parse</refname>
-  <refpurpose>Parsing</refpurpose>
+  <refpurpose>Análisis sintáctico</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/com/com.xml
+++ b/reference/com/com.xml
@@ -65,8 +65,8 @@
 <![CDATA[
 <?php
 // iniciar Word
-$word = new com("word.application") or die("Unable to instantiate Word");
-echo "Loaded Word, version {$word->Version}\n";
+$word = new com("word.application") or die("No se ha podido instanciar Word");
+echo "Word cargado, versión {$word->Version}\n";
 
 // traerlo al frente
 $word->Visible = 1;
@@ -75,8 +75,8 @@ $word->Visible = 1;
 $word->Documents->Add();
 
 // hacer cosas
-$word->Selection->TypeText("This is a test...");
-$word->Documents[1]->SaveAs("Useless test.doc");
+$word->Selection->TypeText("Esto es una prueba...");
+$word->Documents[1]->SaveAs("Prueba inútil.doc");
 
 // cerrar Word
 $word->Quit();
@@ -95,7 +95,7 @@ $word = null;
 <![CDATA[
 <?php
 
-$conn = new com("ADODB.Connection") or die("Cannot start ADO");
+$conn = new com("ADODB.Connection") or die("No se ha podido iniciar ADO");
 $conn->Open("Provider=SQLOLEDB; Data Source=localhost;
 Initial Catalog=database; User ID=user; Password=password");
 

--- a/reference/com/com/construct.xml
+++ b/reference/com/com/construct.xml
@@ -98,7 +98,7 @@
           <entry>El dominio del <literal>servidor</literal>.</entry>
          </row>
          <row>
-          <entry>Drapeaux</entry>
+          <entry>Banderas</entry>
           <entry>&integer;</entry>
           <entry>
            Una o más de las siguientes constantes, ensambladas juntas gracias al OU lógico:

--- a/reference/componere/componere.patch.xml
+++ b/reference/componere/componere.patch.xml
@@ -42,7 +42,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Constructors</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Constructores</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.componere-patch')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>

--- a/reference/componere/componere/abstract/definition/addinterface.xml
+++ b/reference/componere/componere/abstract/definition/addinterface.xml
@@ -42,7 +42,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <type>Definition</type> se registró

--- a/reference/componere/componere/abstract/definition/addmethod.xml
+++ b/reference/componere/componere/abstract/definition/addmethod.xml
@@ -50,7 +50,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <type>Definition</type> se registró

--- a/reference/componere/componere/abstract/definition/addtrait.xml
+++ b/reference/componere/componere/abstract/definition/addtrait.xml
@@ -42,7 +42,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <type>Definition</type> se registró

--- a/reference/componere/componere/definition/addconstant.xml
+++ b/reference/componere/componere/definition/addconstant.xml
@@ -49,7 +49,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <type>Definition</type> fué registrado

--- a/reference/componere/componere/definition/addproperty.xml
+++ b/reference/componere/componere/definition/addproperty.xml
@@ -50,7 +50,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <type>Definition</type> se registró

--- a/reference/componere/componere/definition/construct.xml
+++ b/reference/componere/componere/definition/construct.xml
@@ -67,7 +67,7 @@
  </refsect1>
 
   <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>InvalidArgumentException</type> si se intenta reemplazar una clase interna

--- a/reference/componere/componere/definition/getclosure.xml
+++ b/reference/componere/componere/definition/getclosure.xml
@@ -41,7 +41,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <type>Definition</type> se registró

--- a/reference/componere/componere/definition/getclosures.xml
+++ b/reference/componere/componere/definition/getclosures.xml
@@ -28,7 +28,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <type>Definition</type> se registró

--- a/reference/componere/componere/definition/register.xml
+++ b/reference/componere/componere/definition/register.xml
@@ -21,7 +21,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <type>Definition</type> fué registrada

--- a/reference/componere/componere/method/setprivate.xml
+++ b/reference/componere/componere/method/setprivate.xml
@@ -24,7 +24,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si el nivel de acceso fue establecido previamente

--- a/reference/componere/componere/method/setprotected.xml
+++ b/reference/componere/componere/method/setprotected.xml
@@ -24,7 +24,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si el nivel de acceso fue establecido previamente

--- a/reference/componere/componere/patch/construct.xml
+++ b/reference/componere/componere/patch/construct.xml
@@ -45,7 +45,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si una clase en <parameter>interfaces</parameter> no se puede encontrar

--- a/reference/componere/componere/patch/derive.xml
+++ b/reference/componere/componere/patch/derive.xml
@@ -42,7 +42,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>InvalidArgumentException</type> si <parameter>instance</parameter> no es compatible

--- a/reference/componere/componere/patch/getclosure.xml
+++ b/reference/componere/componere/patch/getclosure.xml
@@ -41,7 +41,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si <parameter>name</parameter> no se pudo encontrar

--- a/reference/componere/componere/value/construct.xml
+++ b/reference/componere/componere/value/construct.xml
@@ -35,7 +35,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>InvalidArgumentException</type> si <parameter>default</parameter> no tiene un valor adecuado

--- a/reference/componere/componere/value/setprivate.xml
+++ b/reference/componere/componere/value/setprivate.xml
@@ -28,7 +28,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si el nivel de acceso fue establecido previamente

--- a/reference/componere/componere/value/setprotected.xml
+++ b/reference/componere/componere/value/setprotected.xml
@@ -28,7 +28,7 @@
  </refsect1>
 
  <refsect1 role="exceptions">
-  <title>Exceptions</title>
+  <title>Excepciones</title>
   <warning>
    <simpara>
     Lanzará <type>RuntimeException</type> si el nivel de acceso fue establecido previamente

--- a/reference/ctype/functions/ctype-digit.xml
+++ b/reference/ctype/functions/ctype-digit.xml
@@ -77,7 +77,7 @@ La cadena wsl!12 no consiste completamente de dígitos.
   </para>
   <para>
    <example>
-    <title>Un ejemplo de <function>ctype_digit</function> comparando strings con integers</title>
+    <title>Un ejemplo de <function>ctype_digit</function> comparando cadenas con enteros</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ctype/functions/ctype-space.xml
+++ b/reference/ctype/functions/ctype-space.xml
@@ -60,16 +60,16 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$strings = array(
-    'string1' => "\n\r\t",
-    'string2' => "\narf12",
-    'string3' => '\n\r\t' // note las comillas simples
+$cadenas = array(
+    'cadena1' => "\n\r\t",
+    'cadena2' => "\narf12",
+    'cadena3' => '\n\r\t' // observe las comillas simples
 );
-foreach ($strings as $name => $testcase) {
-    if (ctype_space($testcase)) {
-        echo "The string '$name' consists of whitespace characters only.\n";
+foreach ($cadenas as $nombre => $caso_prueba) {
+    if (ctype_space($caso_prueba)) {
+        echo "La cadena '$nombre' contiene únicamente caracteres de espacio en blanco.\n";
     } else {
-        echo "The string '$name' contains non-whitespace characters.\n";
+        echo "La cadena '$nombre' contiene caracteres que no son de espacio en blanco.\n";
     }
 }
 ?>
@@ -78,9 +78,9 @@ foreach ($strings as $name => $testcase) {
     &example.outputs;
     <screen>
 <![CDATA[
-The string 'string1' consists of whitespace characters only.
-The string 'string2' contains non-whitespace characters.
-The string 'string3' contains non-whitespace characters.
+La cadena 'cadena1' contiene únicamente caracteres de espacio en blanco.
+La cadena 'cadena2' contiene caracteres que no son de espacio en blanco.
+La cadena 'cadena3' contiene caracteres que no son de espacio en blanco.
 ]]>
     </screen>
    </example>

--- a/reference/cubrid/cubridmysql/cubrid-query.xml
+++ b/reference/cubrid/cubridmysql/cubrid-query.xml
@@ -86,7 +86,7 @@ $conn = cubrid_connect('localhost', 33000, 'demodb');
 
 $result = cubrid_query('SELECT * WHERE 1=1');
 if (!$result) {
-    die('Invalid query: ' . cubrid_error());
+    die('Consulta inválida: ' . cubrid_error());
 }
 
 ?>

--- a/reference/cubrid/functions/cubrid-close-request.xml
+++ b/reference/cubrid/functions/cubrid-close-request.xml
@@ -48,7 +48,7 @@
 <?php
 $con = cubrid_connect ("localhost", 33000, "demodb", "dba", "");
 if ($con) {
-   echo "connected successfully";
+   echo "conectado con éxito";
    $req = cubrid_execute ( $con, "select * from members",
                            CUBRID_INCLUDE_OID | CUBRID_ASYNC);
    if ($req) {

--- a/reference/cubrid/functions/cubrid-connect.xml
+++ b/reference/cubrid/functions/cubrid-connect.xml
@@ -87,7 +87,7 @@ printf("\n");
 $conn = cubrid_connect("localhost", 33000, "demodb", "dba");
 
 if (!$conn) {
-    die('Connect Error ('. cubrid_error_code() .')' . cubrid_error_msg());
+    die('Error de conexión ('. cubrid_error_code() .')' . cubrid_error_msg());
 }
 
 $db_params = cubrid_get_db_parameter($conn);

--- a/reference/cubrid/functions/cubrid-free-result.xml
+++ b/reference/cubrid/functions/cubrid-free-result.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <simpara>
    Esta función libera la memoria ocupada por los datos del resultado. Devuelve
-   &true; on success or &false; en caso de error. Observe que sólo se puede liberar el
+   &true; en caso de éxito o &false; en caso de error. Observe que sólo se puede liberar el
    buffer de obtención del cliente, y si se quiere liberar toda la memoria, use la función
    <function>cubrid_close_request</function>.
   </simpara>

--- a/reference/cubrid/functions/cubrid-get-client-info.xml
+++ b/reference/cubrid/functions/cubrid-get-client-info.xml
@@ -47,7 +47,7 @@ printf("\n");
 $conn = cubrid_connect("localhost", 33088, "demodb");
 
 if (!$conn) {
-    die('Connect Error ('. cubrid_error_code() .')' . cubrid_error_msg());
+    die('Error de conexión ('. cubrid_error_code() .')' . cubrid_error_msg());
 }
 
 $db_params = cubrid_get_db_parameter($conn);

--- a/reference/cubrid/functions/cubrid-get-db-parameter.xml
+++ b/reference/cubrid/functions/cubrid-get-db-parameter.xml
@@ -180,7 +180,7 @@ printf("\n");
 $conn = cubrid_connect("localhost", 33088, "demodb");
 
 if (!$conn) {
-    die('Connect Error ('. cubrid_error_code() .')' . cubrid_error_msg());
+    die('Error de conexión ('. cubrid_error_code() .')' . cubrid_error_msg());
 }
 
 $db_params = cubrid_get_db_parameter($conn);

--- a/reference/cubrid/functions/cubrid-get-server-info.xml
+++ b/reference/cubrid/functions/cubrid-get-server-info.xml
@@ -50,7 +50,7 @@ printf("\n");
 $conn = cubrid_connect("localhost", 33088, "demodb");
 
 if (!$conn) {
-    die('Connect Error ('. cubrid_error_code() .')' . cubrid_error_msg());
+    die('Error de conexión ('. cubrid_error_code() .')' . cubrid_error_msg());
 }
 
 $db_params = cubrid_get_db_parameter($conn);

--- a/reference/cubrid/functions/cubrid-lob-close.xml
+++ b/reference/cubrid/functions/cubrid-lob-close.xml
@@ -51,7 +51,7 @@ cubrid_execute($conn,"CREATE TABLE doc (id INT, doc_content CLOB)");
 cubrid_execute($conn,"INSERT INTO doc VALUES (5,'hello,cubrid')");
 
 $lobs = cubrid_lob_get($conn, "SELECT doc_content FROM doc WHERE id=5");
-echo "Doc size: ".cubrid_lob_size($lobs[0])." bytes";
+echo "Tamaño del documento: ".cubrid_lob_size($lobs[0])." bytes";
 cubrid_lob_export($conn, $lobs[0], "doc_5.txt");
 cubrid_lob_close($lobs);
 cubrid_disconnect($conn);

--- a/reference/cubrid/functions/cubrid-lob-export.xml
+++ b/reference/cubrid/functions/cubrid-lob-export.xml
@@ -64,7 +64,7 @@ cubrid_execute($conn,"CREATE TABLE doc (id INT, doc_content CLOB)");
 cubrid_execute($conn,"INSERT INTO doc VALUES (5,'hello,cubrid')");
 
 $lobs = cubrid_lob_get($conn, "SELECT doc_content FROM doc WHERE id=5");
-echo "Doc size: ".cubrid_lob_size($lobs[0])." bytes";
+echo "Tamaño del documento: ".cubrid_lob_size($lobs[0])." bytes";
 cubrid_lob_export($conn, $lobs[0], "doc_5.txt");
 cubrid_lob_close($lobs);
 cubrid_disconnect($conn);

--- a/reference/cubrid/functions/cubrid-lob-get.xml
+++ b/reference/cubrid/functions/cubrid-lob-get.xml
@@ -64,7 +64,7 @@ cubrid_execute($conn,"CREATE TABLE doc (id INT, doc_content CLOB)");
 cubrid_execute($conn,"INSERT INTO doc VALUES (5,'hello,cubrid')");
 
 $lobs = cubrid_lob_get($conn, "SELECT doc_content FROM doc WHERE id=5");
-echo "Doc size: ".cubrid_lob_size($lobs[0])." bytes";
+echo "Tamaño del documento: ".cubrid_lob_size($lobs[0])." bytes";
 cubrid_lob_export($conn, $lobs[0], "doc_5.txt");
 cubrid_lob_close($lobs);
 cubrid_disconnect($conn);

--- a/reference/cubrid/functions/cubrid-pconnect-with-url.xml
+++ b/reference/cubrid/functions/cubrid-pconnect-with-url.xml
@@ -197,7 +197,7 @@ if ($con) {
   </example>
 
   <example>
-   <title><function>cubrid_pconnect_with_url</function> url with properties example</title>
+   <title>Ejemplo de <function>cubrid_pconnect_with_url</function> con URL y propiedades</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/cubrid/functions/cubrid-version.xml
+++ b/reference/cubrid/functions/cubrid-version.xml
@@ -46,7 +46,7 @@ printf("\n");
 $conn = cubrid_connect("localhost", 33088, "demodb", "dba");
 
 if (!$conn) {
-    die('Connect Error ('. cubrid_error_code() .')' . cubrid_error_msg());
+    die('Error de conexión ('. cubrid_error_code() .')' . cubrid_error_msg());
 }
 
 $db_params = cubrid_get_db_parameter($conn);

--- a/reference/cubrid/setup.xml
+++ b/reference/cubrid/setup.xml
@@ -30,7 +30,7 @@
    los resultados de una consulta de tipos de datos BLOB/CLOB.
   </simpara>
   <section xml:id="cubrid.resources.connection-identifier">
-   <title>connection identifier</title>
+   <title>identificador de conexión</title>
    <simpara>
     Un identificador de conexión devuelto por <function>cubrid_connect</function>,
     <function>cubrid_connect_with_url</function>,
@@ -39,19 +39,19 @@
    </simpara>
   </section>
   <section xml:id="cubrid.resources.request-identifier">
-   <title>request identifier</title>
+   <title>identificador de solicitud</title>
    <simpara>
     Un identificador de solicitud devuelto por <function>cubrid_prepare</function> y <function>cubrid_execute</function>.
    </simpara>
   </section>
   <section xml:id="cubrid.resources.lob-identifier">
-   <title>LOB identifier</title>
+   <title>identificador LOB</title>
    <simpara>
     Un identificador LOB devuelto por <function>cubrid_lob_get</function>.
    </simpara>
   </section>
   <section xml:id="cubrid.resources.lob2-identifier">
-   <title>LOB2 identifier</title>
+   <title>identificador LOB2</title>
    <simpara>
     Un identificador LOB devuelto por <function>cubrid_lob2_new</function> u obtenido
     de un conjunto de resultados.

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -58,7 +58,6 @@
   <listitem>
    <simpara>
     La cadena del certificado TLS.
-    TLS certificate chain
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_multi_setopt.xml
+++ b/reference/curl/constants_curl_multi_setopt.xml
@@ -128,7 +128,7 @@
    </term>
    <listitem>
     <para>
-     Pasar una <type>fermeture</type> que será registrada para gestionar las poussées del servidor
+     Pasar una <type>Closure</type> que será registrada para gestionar las inserciones del servidor
      y debe tener la siguiente firma:
      <methodsynopsis>
       <type>int</type><methodname><replaceable>pushfunction</replaceable></methodname>
@@ -149,7 +149,7 @@
        <term><parameter>pushed_ch</parameter></term>
        <listitem>
         <simpara>
-         Un nuevo gestor cURL para la solicitud poussée.
+         Un nuevo gestor cURL para la solicitud insertada.
         </simpara>
        </listitem>
       </varlistentry>
@@ -157,13 +157,13 @@
        <term><parameter>headers</parameter></term>
        <listitem>
         <simpara>
-         Los encabezados de la promesa de poussée.
+         Los encabezados de la promesa de inserción.
         </simpara>
        </listitem>
       </varlistentry>
      </variablelist>
      La función push debe devolver ya sea
-     <constant>CURL_PUSH_OK</constant> si puede gestionar la poussée, o
+     <constant>CURL_PUSH_OK</constant> si puede gestionar la inserción, o
      <constant>CURL_PUSH_DENY</constant> para rechazarla.
      Disponible a partir de PHP 7.1.0 y cURL 7.44.0
     </para>

--- a/reference/curl/functions/curl-multi-info-read.xml
+++ b/reference/curl/functions/curl-multi-info-read.xml
@@ -63,8 +63,8 @@
     <tgroup cols="2">
      <thead>
       <row>
-       <entry>Key:</entry>
-       <entry>Value:</entry>
+       <entry>Clave:</entry>
+       <entry>Valor:</entry>
       </row>
      </thead>
      <tbody>

--- a/reference/curl/functions/curl-share-init-persistent.xml
+++ b/reference/curl/functions/curl-share-init-persistent.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.curl-share-init-persistent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_share_init_persistent</refname>
-  <refpurpose>Inicializa un gestor cURL "share" <emphasis role="bold">persistent</emphasis></refpurpose>
+  <refpurpose>Inicializa un gestor cURL "share" <emphasis role="bold">persistente</emphasis></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,10 +14,10 @@
    <methodparam><type>array</type><parameter>share_options</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Inicializa un gestor cURL "share" <emphasis role="bold">persistent</emphasis>
-   con las opciones de partage dadas. A diferencia de <function>curl_share_init</function>,
+   Inicializa un gestor cURL "share" <emphasis role="bold">persistente</emphasis>
+   con las opciones de compartición dadas. A diferencia de <function>curl_share_init</function>,
    los gestores creados por esta función no serán destruidos al final de la
-   petición PHP. Si se encuentra un gestor de partage persistente con el mismo conjunto
+   petición PHP. Si se encuentra un gestor de compartición persistente con el mismo conjunto
    de <parameter>share_options</parameter>, será reutilizado.
   </simpara>
  </refsect1>
@@ -36,7 +36,7 @@
       <simpara>
        <constant>CURL_LOCK_DATA_COOKIE</constant>
        no está permitido y, si se especifica, esta función lanzará una
-       <exceptionname>ValueError</exceptionname>. El partage de cookies entre las peticiones PHP
+       <exceptionname>ValueError</exceptionname>. La compartición de cookies entre las peticiones PHP
        puede llevar a una mezcla involuntaria de cookies sensibles entre los usuarios.
       </simpara>
      </note>
@@ -88,10 +88,10 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="function.curl-share-init-persistent.example.basic">
-   <title><function>curl_share_init_persistent</function> example</title>
+   <title>Ejemplo de <function>curl_share_init_persistent</function></title>
    <simpara>
     Este ejemplo creará un gestor cURL "share" persistente y demostrará
-    el partage de conexiones entre ellos. Si se ejecuta en un SAPI PHP
+    la compartición de conexiones entre ellos. Si se ejecuta en un SAPI PHP
     de larga duración, <literal>$sh</literal> sobrevivirá entre las peticiones SAPI.
    </simpara>
 

--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -62,7 +62,7 @@
  </variablelist>
 
  <variablelist>
-  <title><constant>DATE_<replaceable>*</replaceable></constant> constants</title>
+  <title>Constantes <constant>DATE_<replaceable>*</replaceable></constant></title>
   <varlistentry xml:id="constant.date-atom">
    <term>
     <constant>DATE_ATOM</constant>
@@ -208,7 +208,7 @@
    </term>
    <listitem>
     <simpara>
-     Same as <constant>DATE_ATOM</constant>.
+     Igual que <constant>DATE_ATOM</constant>.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -111,7 +111,7 @@
     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-// Each set of intervals is equal.
+// Cada conjunto de intervalos es equivalente.
 $i = new DateInterval('P1D');
 $i = DateInterval::createFromDateString('1 day');
 

--- a/reference/datetime/datetimeinterface/diff.xml
+++ b/reference/datetime/datetimeinterface/diff.xml
@@ -150,7 +150,7 @@ echo $interval->format("%H:%I:%S (Días completos: %a)"), "\n";
   </example>
 
   <example>
-   <title><methodname>DateTimeInterface::diff</methodname> range</title>
+   <title>Rango de <methodname>DateTimeInterface::diff</methodname></title>
    <para>
     El valor devuelto es la cantidad de tiempo exacto entre
     <parameter>$this</parameter> y <parameter>$targetObject</parameter>.

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -448,10 +448,10 @@ echo date_format($date, 'Y-m-d H:i:s');
     <programlisting role="php">
 <![CDATA[
 <?php
-// set the default timezone to use.
+// establece la zona horaria predeterminada a usar.
 date_default_timezone_set('UTC');
 
-// now
+// ahora
 $date = new DateTimeImmutable();
 
 // Imprime algo como: Wednesday
@@ -460,7 +460,7 @@ echo $date->format('l'), "\n";
 // Imprime algo como: Wednesday 19th of October 2022 08:40:48 AM
 echo $date->format('l jS \o\f F Y h:i:s A'), "\n";
 
-/* use the constants in the format parameter */
+/* usa las constantes en el parámetro de formato */
 // imprime algo como: Wed, 19 Oct 2022 08:40:48 +0000
 echo $date->format(DateTimeInterface::RFC2822), "\n";
 ?>

--- a/reference/datetime/examples.xml
+++ b/reference/datetime/examples.xml
@@ -22,16 +22,16 @@
 <![CDATA[
 <?php
 $dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New_York"));
-echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Inicio: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->add(new DateInterval("PT3H"));
-echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Fin:    ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Start: 2015-11-01 00:00:00 -04:00
-End:   2015-11-01 02:00:00 -05:00
+Inicio:2015-11-01 00:00:00 -04:00
+Fin:2015-11-01 02:00:00 -05:00
 ]]>
     </screen>
    </example>
@@ -48,16 +48,16 @@ End:   2015-11-01 02:00:00 -05:00
 <![CDATA[
 <?php
 $dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New_York"));
-echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Inicio: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+24 hours");
-echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Fin:    ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Start: 2015-11-01 00:00:00 -04:00
-End:   2015-11-02 00:00:00 -05:00
+Inicio:2015-11-01 00:00:00 -04:00
+Fin:2015-11-02 00:00:00 -05:00
 ]]>
     </screen>
    </example>
@@ -73,28 +73,28 @@ End:   2015-11-02 00:00:00 -05:00
     <programlisting role="php">
 <![CDATA[
 <?php
-echo "Normal year:\n"; // February has 28 days
+echo "Año normal:\n"; // febrero tiene 28 días
 $dt = new DateTimeImmutable("2015-01-31 00:00:00", new DateTimeZone("America/New_York"));
-echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Inicio: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+1 month");
-echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Fin:    ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 
-echo "Leap year:\n"; // February has 29 days
+echo "Año bisiesto:\n"; // febrero tiene 29 días
 $dt = new DateTimeImmutable("2016-01-31 00:00:00", new DateTimeZone("America/New_York"));
-echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Inicio: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+1 month");
-echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Fin:    ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Normal year:
-Start: 2015-01-31 00:00:00 -05:00
-End:   2015-03-03 00:00:00 -05:00
-Leap year:
-Start: 2016-01-31 00:00:00 -05:00
-End:   2016-03-02 00:00:00 -05:00
+Año normal:
+Inicio:2015-01-31 00:00:00 -05:00
+Fin:2015-03-03 00:00:00 -05:00
+Año bisiesto:
+Inicio:2016-01-31 00:00:00 -05:00
+Fin:2016-03-02 00:00:00 -05:00
 ]]>
     </screen>
     <simpara>
@@ -104,28 +104,28 @@ End:   2016-03-02 00:00:00 -05:00
     <programlisting role="php">
 <![CDATA[
 <?php
-echo "Normal year:\n"; // February has 28 days
+echo "Año normal:\n"; // febrero tiene 28 días
 $dt = new DateTimeImmutable("2015-01-31 00:00:00", new DateTimeZone("America/New_York"));
-echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Inicio: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("last day of next month");
-echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Fin:    ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 
-echo "Leap year:\n"; // February has 29 days
+echo "Año bisiesto:\n"; // febrero tiene 29 días
 $dt = new DateTimeImmutable("2016-01-31 00:00:00", new DateTimeZone("America/New_York"));
-echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Inicio: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("last day of next month");
-echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "Fin:    ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Normal year:
-Start: 2015-01-31 00:00:00 -05:00
-End:   2015-02-28 00:00:00 -05:00
-Leap year:
-Start: 2016-01-31 00:00:00 -05:00
-End:   2016-02-29 00:00:00 -05:00
+Año normal:
+Inicio:2015-01-31 00:00:00 -05:00
+Fin:2015-02-28 00:00:00 -05:00
+Año bisiesto:
+Inicio:2016-01-31 00:00:00 -05:00
+Fin:2016-02-29 00:00:00 -05:00
 ]]>
     </screen>
    </example>

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -36,7 +36,7 @@
    <simpara>
     60 es permitido para los segundos, ya que a veces cadenas de fechas con
     este segundo intercalar aparecen. Pero PHP implementa el tiempo Unix
-    donde "60" no es un número de segundos válido y así overflow.
+    donde "60" no es un número de segundos válido y, por tanto, desborda.
    </simpara>
   </listitem>
   <listitem>

--- a/reference/datetime/functions/date-parse-from-format.xml
+++ b/reference/datetime/functions/date-parse-from-format.xml
@@ -190,17 +190,17 @@ Array
 $date = "26 August 2022 22:30 pm";
 $parsed = date_parse_from_format("j F Y G:i a", $date);
 
-echo "Warnings count: ", $parsed['warning_count'], "\n";
+echo "Número de advertencias: ", $parsed['warning_count'], "\n";
 foreach ($parsed['warnings'] as $position => $message) {
-    echo "\tOn position {$position}: {$message}\n";
+    echo "\tEn la posición {$position}: {$message}\n";
 }
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Warnings count: 1
-	On position 23: The parsed time was invalid
+Número de advertencias: 1
+	En la posición 23: The parsed time was invalid
 ]]>
     </screen>
    </example>
@@ -218,18 +218,18 @@ Warnings count: 1
 $date = "26 August 2022 CEST";
 $parsed = date_parse_from_format("j F Y H:i", $date);
 
-echo "Errors count: ", $parsed['error_count'], "\n";
+echo "Número de errores: ", $parsed['error_count'], "\n";
 foreach ($parsed['errors'] as $position => $message) {
-    echo "\tOn position {$position}: {$message}\n";
+    echo "\tEn la posición {$position}: {$message}\n";
 }
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Errors count: 3
-	On position 15: A two digit hour could not be found
-	On position 19: Not enough data available to satisfy format
+Número de errores: 3
+	En la posición 15: A two digit hour could not be found
+	En la posición 19: Not enough data available to satisfy format
 ]]>
     </screen>
    </example>

--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -99,7 +99,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>date</function> examples</title>
+    <title>Ejemplos de <function>date</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -113,8 +113,8 @@ echo date("l") . "\n";
 // Imprime algo como: Monday 8th of August 2005 03:12:46 PM
 echo date('l jS \of F Y h:i:s A') . "\n";
 
-// Imprime: July 1, 2000 is on a Saturday
-echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000)) . "\n";
+// Imprime: 1 de julio de 2000 cae en sábado
+echo "1 de julio de 2000 cae en " . date("l", mktime(0, 0, 0, 7, 1, 2000)) . "\n";
 
 /* Usar las constantes en el parámetro de formato */
 // Imprime algo como: Wed, 25 Sep 2013 15:28:57 -0700
@@ -163,11 +163,11 @@ echo date("m.d.y") . "\n";                         // 03.10.01
 echo date("j, n, Y") . "\n";                       // 10, 3, 2001
 echo date("Ymd") . "\n";                           // 20010310
 echo date('h-i-s, j-m-y, it is w Day') . "\n";     // 05-16-18, 10-03-01, 1631 1618 6 Satpm01
-echo date('\i\t \i\s \t\h\e jS \d\a\y.') . "\n";   // it is the 10th day.
+echo date('\i\t \i\s \t\h\e jS \d\a\y.') . "\n";   // es el día 10.
 echo date("D M j G:i:s T Y") . "\n";               // Sat Mar 10 17:16:18 MST 2001
-echo date('H:m:s \m \i\s\ \m\o\n\t\h') . "\n";     // 17:03:18 m is month
+echo date('H:m:s \m \i\s\ \m\o\n\t\h') . "\n";     // 17:03:18 m es el mes
 echo date("H:i:s") . "\n";                         // 17:16:18
-echo date("Y-m-d H:i:s") . "\n";                   // 2001-03-10 17:16:18 (the MySQL DATETIME format)
+echo date("Y-m-d H:i:s") . "\n";                   // 2001-03-10 17:16:18 (el formato DATETIME de MySQL)
 ]]>
     </programlisting>
    </example>

--- a/reference/datetime/functions/gmmktime.xml
+++ b/reference/datetime/functions/gmmktime.xml
@@ -162,13 +162,13 @@
 <?php
 date_default_timezone_set("Indian/Maldives");
 
-echo "July 1, 2000 is on a " . date("l", gmmktime(0, 0, 0, 7, 1, 2000));
+echo "1 de julio de 2000 cae en " . date("l", gmmktime(0, 0, 0, 7, 1, 2000));
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-July 1, 2000 is on a Saturday
+1 de julio de 2000 cae en Saturday
 ]]>
     </screen>
    </example>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -170,8 +170,8 @@
 // Establece la zona horaria a utilizar.
 date_default_timezone_set('UTC');
 
-// Imprime: July 1, 2000 is on a Saturday
-echo "July 1, 2000 is on a " . date("l", mktime(0, 0, 0, 7, 1, 2000)) . "\n";
+// Imprime: 1 de julio de 2000 cae en sábado
+echo "1 de julio de 2000 cae en " . date("l", mktime(0, 0, 0, 7, 1, 2000)) . "\n";
 
 // Imprime algo como: 2006-04-05T01:02:03+00:00
 echo date('c', mktime(1, 2, 3, 4, 5, 2006)) . "\n";
@@ -180,7 +180,7 @@ echo date('c', mktime(1, 2, 3, 4, 5, 2006)) . "\n";
     &example.outputs.similar;
     <screen>
 <![CDATA[
-July 1, 2000 is on a Saturday
+1 de julio de 2000 cae en Saturday
 2006-04-05T01:02:03+00:00
 ]]>
     </screen>
@@ -265,17 +265,17 @@ print date('c', $nextyear) . "\n";
 <?php
 
 $lastday = mktime(0, 0, 0, 3, 0, 2000);
-echo 'Last day in Feb 2000 is: ', date('d', $lastday) . "\n";
+echo 'El último día en Feb 2000 es: ', date('d', $lastday) . "\n";
 
 $lastday = mktime(0, 0, 0, 4, -31, 2000);
-echo 'Last day in Feb 2000 is: ', date('d', $lastday) . "\n";
+echo 'El último día en Feb 2000 es: ', date('d', $lastday) . "\n";
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Last day in Feb 2000 is: 29
-Last day in Feb 2000 is: 29
+El último día en Feb 2000 es: 29
+El último día en Feb 2000 es: 29
 ]]>
     </screen>
    </example>

--- a/reference/datetime/functions/strftime.xml
+++ b/reference/datetime/functions/strftime.xml
@@ -589,7 +589,7 @@ $strftimeFormats = array(
 // Resultados
 $strftimeValues = array();
 
-// 2value los formatos mientras se eliminan los errores
+// Evalúa los formatos suprimiendo los errores
 foreach ($strftimeFormats as $format => $description) {
     if (false !== ($value = @strftime("%{$format}"))) {
         $strftimeValues[$format] = $value;

--- a/reference/dba/functions/dba-key-split.xml
+++ b/reference/dba/functions/dba-key-split.xml
@@ -40,8 +40,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve un array en la forma <literal>array(0 =&gt; group, 1 =&gt;
-   nom_valeur)</literal>. Esta función devuelve &false; si
+   Devuelve un array en la forma <literal>array(0 =&gt; grupo, 1 =&gt;
+   nombre_valor)</literal>. Esta función devuelve &false; si
    <parameter>key</parameter> es &null; o &false;.
   </simpara>
  </refsect1>

--- a/reference/dir/reference.xml
+++ b/reference/dir/reference.xml
@@ -11,8 +11,8 @@
   <para>
    Para funciones relacionadas, como <function>dirname</function>,
    <function>is_dir</function>, <function>mkdir</function>, y
-   <function>rmdir</function>, visita
-   <link linkend="ref.filesystem">Filesystem</link> sección.
+   <function>rmdir</function>, visite la sección
+   <link linkend="ref.filesystem">Sistema de ficheros</link>.
   </para>
  </partintro>
 

--- a/reference/dom/domdocument/createattribute.xml
+++ b/reference/dom/domdocument/createattribute.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="domdocument.createattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DOMDocument::createAttribute</refname>
-  <refpurpose>Crear nuevo attribute</refpurpose>
+  <refpurpose>Crea un nuevo atributo</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/dom/domdocument/createelementns.xml
+++ b/reference/dom/domdocument/createelementns.xml
@@ -130,9 +130,9 @@ $root->appendChild($item);
 
 echo $doc->saveXML(), "\n";
 
-echo $item->namespaceURI, "\n"; // Outputs: http://base.google.com/ns/1.0
-echo $item->prefix, "\n";       // Outputs: g
-echo $item->localName, "\n";    // Outputs: item_type
+echo $item->namespaceURI, "\n"; // Imprime: http://base.google.com/ns/1.0
+echo $item->prefix, "\n";       // Imprime: g
+echo $item->localName, "\n";    // Imprime: item_type
 ?>
 ]]>
     </programlisting>

--- a/reference/ds/ds/map/diff.xml
+++ b/reference/ds/ds/map/diff.xml
@@ -48,7 +48,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link xlink:href="&url.wiki.complement;">Complement</link> en Wikipedia</member>
+    <member><link xlink:href="&url.wiki.complement;">Complemento</link> en Wikipedia</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/ds/ds/map/intersect.xml
+++ b/reference/ds/ds/map/intersect.xml
@@ -56,7 +56,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link xlink:href="&url.wiki.intersection;">Intersection</link> en Wikipedia</member>
+    <member><link xlink:href="&url.wiki.intersection;">Intersección</link> en Wikipedia</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/ds/ds/map/union.xml
+++ b/reference/ds/ds/map/union.xml
@@ -53,7 +53,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link xlink:href="&url.wiki.union.set;">>Union</link> en Wikipedia</member>
+    <member><link xlink:href="&url.wiki.union.set;">Unión</link> en Wikipedia</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/ds/ds/set/intersect.xml
+++ b/reference/ds/ds/set/intersect.xml
@@ -49,7 +49,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link xlink:href="&url.wiki.intersection;">Intersection</link> en Wikipedia</member>
+    <member><link xlink:href="&url.wiki.intersection;">Intersección</link> en Wikipedia</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/ds/ds/set/union.xml
+++ b/reference/ds/ds/set/union.xml
@@ -47,7 +47,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link xlink:href="&url.wiki.union.set;">Union</link> en Wikipedia</member>
+    <member><link xlink:href="&url.wiki.union.set;">Unión</link> en Wikipedia</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/ds/ds/vector/contains.xml
+++ b/reference/ds/ds/vector/contains.xml
@@ -55,7 +55,7 @@ var_dump($vector->contains('c', 'd'));           // false
 
 var_dump($vector->contains(...['c', 'b', 'a'])); // true
 
-// Always strict
+// Siempre estricto
 var_dump($vector->contains(1));                  // true
 var_dump($vector->contains('1'));                // false
 

--- a/reference/eio/examples.xml
+++ b/reference/eio/examples.xml
@@ -22,7 +22,7 @@ eio_cancel($petición);
 // Esta vez eio_nop() será procesada
 eio_nop(EIO_PRI_DEFAULT, "mi_llamada_retorno_nop", "2");
 
-// Process requests
+// Procesar las peticiones
 eio_event_loop();
 ?>
 ]]>
@@ -148,7 +148,7 @@ function mi_grupo_llamada_retorno_fichero_abierto($datos, $resultado) {
  eio_grp_add($grupo, $petición);
 }
 
-/* Is called when eio_read() done */
+/* Se llama cuando eio_read() termina */
 function mi_grupo_llamada_retorno_fichero_leído($datos, $resultado) {
  global $mi_df_fichero, $grupo;
 

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -72,7 +72,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-// Create temporary file
+// Crear el fichero temporal
 $nombre_fichero_temp = dirname(__FILE__) ."/fichero-eio.tmp";
 touch($nombre_fichero_temp);
 

--- a/reference/eio/functions/eio-readahead.xml
+++ b/reference/eio/functions/eio-readahead.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-readahead">
  <refnamediv>
   <refname>eio_readahead</refname>
-  <refpurpose>Perform file readahead into page cache</refpurpose>
+  <refpurpose>Realiza una lectura anticipada del fichero en la caché de páginas</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/eio/functions/eio-readdir.xml
+++ b/reference/eio/functions/eio-readdir.xml
@@ -332,7 +332,7 @@
     <refsect1 role="examples">
      &reftitle.examples;
      <example>
-      <title><function>eio_readdir</function> example</title>
+      <title>Ejemplo de <function>eio_readdir</function></title>
       <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/eio/functions/eio-symlink.xml
+++ b/reference/eio/functions/eio-symlink.xml
@@ -78,7 +78,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>eio_symlink</function> example</title>
+   <title>Ejemplo de <function>eio_symlink</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/enchant/configure.xml
+++ b/reference/enchant/configure.xml
@@ -6,7 +6,7 @@
  &reftitle.install;
  <simpara>
   Partiendo del principio de que las
-  <link linkend="enchant.requirements">bibliothèques requises</link>
+  <link linkend="enchant.requirements">bibliotecas requeridas</link>
   están instaladas, los usuarios pueden activar enchant añadiendo la opción
   <option role="configure">--with-enchant[=dir]</option>
   durante la compilación de PHP.

--- a/reference/enchant/functions/enchant-broker-dict-exists.xml
+++ b/reference/enchant/functions/enchant-broker-dict-exists.xml
@@ -67,7 +67,7 @@
 $tag = 'en_US';
 $r = enchant_broker_init();
 if (enchant_broker_dict_exists($r,$tag)) {
-    echo $tag . " dictionary found.\n";
+    echo "Diccionario " . $tag . " encontrado.\n";
 }
 ?>
 ]]>

--- a/reference/enchant/functions/enchant-dict-is-added.xml
+++ b/reference/enchant/functions/enchant-dict-is-added.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-is-added">
  <refnamediv>
   <refname>enchant_dict_is_added</refname>
-  <refpurpose>Si el 'mot' existe o no en esta sesión de ortografía</refpurpose>
+  <refpurpose>Si la palabra existe o no en esta sesión de ortografía</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/errorfunc/functions/error-reporting.xml
+++ b/reference/errorfunc/functions/error-reporting.xml
@@ -55,8 +55,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna el nivel de <link linkend="ini.error-reporting">error_reporting</link>,
-   <emphasis>before</emphasis> de que sea cambiado a <parameter>error_level</parameter>
+   Retorna el nivel de <link linkend="ini.error-reporting">error_reporting</link>
+   <emphasis>antes</emphasis> de que sea cambiado a <parameter>error_level</parameter>
   </para>
   <note>
    <simpara>

--- a/reference/errorfunc/functions/set-exception-handler.xml
+++ b/reference/errorfunc/functions/set-exception-handler.xml
@@ -45,7 +45,7 @@
        </methodsynopsis>
       </para>
       <para>
-       &null; puede ser pasado en su lugar, para re-initializar este manejador
+       &null; puede ser pasado en su lugar, para reinicializar este manejador
        a su estado inicial.
       </para>
      </listitem>

--- a/reference/ev/evstat/construct.xml
+++ b/reference/ev/evstat/construct.xml
@@ -107,7 +107,7 @@
 <?php
 // Uso de un intervalo de 10 segundos.
  $w = new EvStat("/var/log/messages", 10, function ($w) {
- echo "/var/log/messages changed\n";
+ echo "/var/log/messages ha cambiado\n";
 
  $attr = $w->attr();
 

--- a/reference/exec/functions/escapeshellarg.xml
+++ b/reference/exec/functions/escapeshellarg.xml
@@ -24,7 +24,7 @@
    debe ser utilizada para tratar individualmente cada uno de los argumentos
    a pasar al Shell. Las funciones Shell son <function>exec</function>,
    <function>system</function> y los operadores
-   <link linkend="language.operators.execution">backtick operator</link>.
+   <link linkend="language.operators.execution">comillas invertidas</link>.
   </para>
   <para>
    En Windows, <function>escapeshellarg</function> reemplaza en su lugar los
@@ -82,7 +82,7 @@ system('ls '.escapeshellarg($dir));
     <member><function>exec</function></member>
     <member><function>popen</function></member>
     <member><function>system</function></member>
-    <member><link linkend="language.operators.execution">backtick operator</link></member>
+    <member><link linkend="language.operators.execution">comillas invertidas</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/exec.xml
+++ b/reference/exec/functions/exec.xml
@@ -129,7 +129,7 @@
 $output=null;
 $retval=null;
 exec('whoami', $output, $retval);
-echo "Returned with status $retval and output:\n";
+echo "Devuelto con estado $retval y salida:\n";
 print_r($output);
 ?>
 ]]>
@@ -137,7 +137,7 @@ print_r($output);
     &example.outputs.similar;
     <screen>
 <![CDATA[
-Returned with status 0 and output:
+Devuelto con estado 0 y salida:
 Array
 (
     [0] => cmb
@@ -163,7 +163,7 @@ Array
     <member><function>passthru</function></member>
     <member><function>escapeshellcmd</function></member>
     <member><function>pcntl_exec</function></member>
-    <member><link linkend="language.operators.execution">los guiones bajos</link></member>
+    <member><link linkend="language.operators.execution">comillas invertidas</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/passthru.xml
+++ b/reference/exec/functions/passthru.xml
@@ -113,7 +113,7 @@
     <member><function>system</function></member>
     <member><function>popen</function></member>
     <member><function>escapeshellcmd</function></member>
-    <member><link linkend="language.operators.execution">los guiones bajos</link></member>
+    <member><link linkend="language.operators.execution">comillas invertidas</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    <function>shell_exec</function> es idéntico a los
-   <link linkend="language.operators.execution">backticks</link>.
+   <link linkend="language.operators.execution">comillas invertidas</link>.
   </para>
   <note>
    <para>

--- a/reference/exif/functions/exif-thumbnail.xml
+++ b/reference/exif/functions/exif-thumbnail.xml
@@ -117,7 +117,7 @@ if ($image!==false) {
     exit;
 } else {
     // no hay miniatura disponible, tratamiento del error aquí
-    echo 'No thumbnail available';
+    echo 'No hay miniatura disponible';
 }
 ?>
 ]]>

--- a/reference/expect/examples.xml
+++ b/reference/expect/examples.xml
@@ -80,7 +80,7 @@ while (true) {
                             break;
 
                         case SHELL:
-                            // Run update:
+                            // Ejecutar la actualización:
                             if (strstr ($uname, "x86_64")) {
                                     fwrite ($stream, "rpm -Uhv http://mirrorsite/somepath/some_64bit.rpm\n");
                             } else {

--- a/reference/expect/functions/expect-expectl.xml
+++ b/reference/expect/functions/expect-expectl.xml
@@ -143,23 +143,23 @@ $stream = fopen("expect://scp user@remotehost:/var/log/messages /home/user/messa
 
 $cases = array(
     // array(patrón, valor que se devolverá si el patrón es encontrado)
-    array("password:", "asked for password"),
-    array("yes/no)?",  "asked for yes/no")
+    array("password:", "pidió la contraseña"),
+    array("yes/no)?",  "pidió sí/no")
 );
 
 while (true) {
     switch (expect_expectl($stream, $cases)) {
-        case "asked for password":
-            fwrite($stream, "my password\n");
+        case "pidió la contraseña":
+            fwrite($stream, "mi_contraseña\n");
             break;
-        case "asked for yes/no":
+        case "pidió sí/no":
             fwrite($stream, "yes\n");
             break;
         case EXP_TIMEOUT:
         case EXP_EOF:
-            break 2; // break tanto la sentencia switch y el bucle while
+            break 2; // sale tanto del switch como del bucle while
         default:
-            die("Error has occurred!");
+            die("¡Ha ocurrido un error!");
     }
 }
 

--- a/reference/fdf/functions/fdf-errno.xml
+++ b/reference/fdf/functions/fdf-errno.xml
@@ -19,7 +19,7 @@
   </simpara>
   <simpara>
    Un mensaje de error es accesible a través de la función
-   <function>fdf_error</function> function.
+   <function>fdf_error</function>.
   </simpara>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-next-field-name.xml
+++ b/reference/fdf/functions/fdf-next-field-name.xml
@@ -64,7 +64,7 @@ $fdf = fdf_open($HTTP_FDF_DATA);
 for ($field = fdf_next_field_name($fdf);
     $field != "";
     $field = fdf_next_field_name($fdf, $field)) {
-    echo "field: $field\n";
+    echo "campo: $field\n";
 }
 ?>
 ]]>

--- a/reference/filter/examples.xml
+++ b/reference/filter/examples.xml
@@ -120,7 +120,7 @@ if (filter_var($sanitized_a, FILTER_VALIDATE_EMAIL)) {
 
 $sanitized_b = filter_var($b, FILTER_SANITIZE_EMAIL);
 if (filter_var($sanitized_b, FILTER_VALIDATE_EMAIL)) {
-    echo "Esta dirección de correo saneada is considered valid.";
+    echo "Esta dirección de correo saneada se considera válida.";
 } else {
     echo "Esta dirección de correo saneada (b) no es válida.\n";
 }

--- a/reference/filter/functions/filter-list.xml
+++ b/reference/filter/functions/filter-list.xml
@@ -25,8 +25,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un array con los nombres de todos los filtros soportados, el array
-   are no such filters. Los índices de este array no son los IDs de los filtros,
+   Devuelve un array con los nombres de todos los filtros soportados, o un array
+   vacío si no hay tales filtros. Los índices de este array no son los IDs de los filtros,
    estos se pueden obtener con <function>filter_id</function> a partir de un nombre.
   </para>
  </refsect1>

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -114,7 +114,7 @@ bool(false)
   </example>
 
   <example>
-   <title>Example validating entries of an array</title>
+   <title>Ejemplo validando entradas de un array</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ftp/ftp.connection.xml
+++ b/reference/ftp/ftp.connection.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.ftp-connection" role="class" xmlns="http://docbook.org/ns/docbook">
- <title>The FTP\Connection class</title>
+ <title>La clase FTP\Connection</title>
  <titleabbrev>FTP\Connection</titleabbrev>
 
  <partintro>

--- a/reference/ftp/functions/ftp-login.xml
+++ b/reference/ftp/functions/ftp-login.xml
@@ -88,7 +88,7 @@ $ftp_user = "foo";
 $ftp_pass = "bar";
 
 // Establecimiento de una conexión básica
-$ftp = ftp_connect($ftp_server) or die("Couldn't connect to $ftp_server");
+$ftp = ftp_connect($ftp_server) or die("No se ha podido conectar a $ftp_server");
 
 // Intento de autenticación
 if (@ftp_login($ftp, $ftp_user, $ftp_pass)) {

--- a/reference/ftp/functions/ftp-ssl-connect.xml
+++ b/reference/ftp/functions/ftp-ssl-connect.xml
@@ -124,7 +124,7 @@ $ftp = ftp_ssl_connect($ftp_server);
 $login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 if (!$login_result) {
     // PHP ya habrá lanzado un mensaje de nivel E_WARNING en este caso
-    die("can't login");
+    die("no se ha podido iniciar sesión");
 }
 
 echo ftp_pwd($ftp);

--- a/reference/funchand/functions/register-tick-function.xml
+++ b/reference/funchand/functions/register-tick-function.xml
@@ -64,7 +64,7 @@
 declare(ticks=1);
 
 function my_tick_function($param) {
-    echo "Tick callback function called with param: $param\n";
+    echo "Función de retorno tick llamada con el parámetro: $param\n";
 }
 
 register_tick_function('my_tick_function', true);

--- a/reference/gettext/functions/gettext.xml
+++ b/reference/gettext/functions/gettext.xml
@@ -66,10 +66,10 @@ textdomain("myPHPApp");
 // La traducción se busca en ./locale/de_DE/LC_MESSAGES/myPHPApp.mo
 
 // Mostrar un mensaje de prueba
-echo gettext("Bienvenue dans mon application PHP");
+echo gettext("Bienvenido a mi aplicación PHP");
 
 // O utiliza el alias _() para reemplazar gettext()
-echo _("Passez une bonne journée");
+echo _("Que tengas un buen día");
 ?>
 ]]>
     </programlisting>

--- a/reference/gmp/functions/gmp-cmp.xml
+++ b/reference/gmp/functions/gmp-cmp.xml
@@ -52,13 +52,13 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>gmp_cmp</function> example</title>
+   <title>Ejemplo de <function>gmp_cmp</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$cmp1 = gmp_cmp("1234", "1000"); // greater than
-$cmp2 = gmp_cmp("1000", "1234"); // less than
-$cmp3 = gmp_cmp("1234", "1234"); // equal to
+$cmp1 = gmp_cmp("1234", "1000"); // mayor que
+$cmp2 = gmp_cmp("1000", "1234"); // menor que
+$cmp3 = gmp_cmp("1234", "1234"); // igual a
 
 echo "$cmp1 $cmp2 $cmp3\n";
 ?>

--- a/reference/gmp/functions/gmp-div-r.xml
+++ b/reference/gmp/functions/gmp-div-r.xml
@@ -62,7 +62,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The remainder, as a GMP number.
+   El resto, como número GMP.
   </para>
  </refsect1>
 
@@ -70,7 +70,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>gmp_div_r</function> example</title>
+    <title>Ejemplo de <function>gmp_div_r</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/gmp/functions/gmp-gcdext.xml
+++ b/reference/gmp/functions/gmp-gcdext.xml
@@ -21,11 +21,11 @@
    un arreglo con los elementos respectivos g, s y t.
   </para>
   <para>
-   Ésta función puede ser usada para resolver ecuaciones de diofántica lineal equations en dos
-   variables. Estas son ecuaciones que permiten solo soluciones enteras y tienen la forma:
+   Esta función puede ser usada para resolver ecuaciones diofánticas lineales en dos
+   variables. Son ecuaciones que solo admiten soluciones enteras y tienen la forma:
    <literal>a*x + b*y = c</literal>.
-   Para más información, vaya a <link xlink:href="&url.diophantine-equation;">"Diophantine
-   Equation" en la página MathWorld</link>
+   Para más información, vaya a <link xlink:href="&url.diophantine-equation;">"Ecuación
+   diofántica" en la página MathWorld</link>
   </para>
  </refsect1>
 
@@ -76,7 +76,7 @@ $eq_res = gmp_add(gmp_mul($a, $r['s']), gmp_mul($b, $r['t']));
 $check_res = (gmp_strval($g) == gmp_strval($eq_res));
 
 if ($check_gcd && $check_res) {
-    $fmt = "Solution: %d*%d + %d*%d = %d\n";
+    $fmt = "Solución: %d*%d + %d*%d = %d\n";
     printf($fmt, gmp_strval($a), gmp_strval($r['s']), gmp_strval($b),
     gmp_strval($r['t']), gmp_strval($r['g']));
 } else {

--- a/reference/gmp/functions/gmp-invert.xml
+++ b/reference/gmp/functions/gmp-invert.xml
@@ -56,7 +56,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-echo gmp_invert("5", "10"); // sin inverso no inverse, ninguna salida, el resultado es falso
+echo gmp_invert("5", "10"); // sin inverso, ninguna salida, el resultado es falso
 $invert = gmp_invert("5", "11");
 echo gmp_strval($invert) . "\n";
 ?>

--- a/reference/gmp/functions/gmp-popcount.xml
+++ b/reference/gmp/functions/gmp-popcount.xml
@@ -48,9 +48,9 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$pop1 = gmp_init("10000101", 2); // 3 1's
+$pop1 = gmp_init("10000101", 2); // tres 1
 echo gmp_popcount($pop1) . "\n";
-$pop2 = gmp_init("11111110", 2); // 7 1's
+$pop2 = gmp_init("11111110", 2); // siete 1
 echo gmp_popcount($pop2) . "\n";
 ?>
 ]]>

--- a/reference/gmp/functions/gmp-powm.xml
+++ b/reference/gmp/functions/gmp-powm.xml
@@ -70,7 +70,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>gmp_powm</function> example</title>
+    <title>Ejemplo de <function>gmp_powm</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/gmp/functions/gmp-random-seed.xml
+++ b/reference/gmp/functions/gmp-random-seed.xml
@@ -83,17 +83,17 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// set the seed
+// definir la semilla
 gmp_random_seed(100);
 
 var_dump(gmp_strval(gmp_random(1)));
 
-// set the seed to something else
+// definir la semilla a otro valor
 gmp_random_seed(gmp_init(-100));
 
 var_dump(gmp_strval(gmp_random_bits(10)));
 
-// set the seed to something invalid
+// definir una semilla con un valor inválido
 var_dump(gmp_random_seed('not a number'));
 ]]>
     </programlisting>

--- a/reference/gmp/functions/gmp-setbit.xml
+++ b/reference/gmp/functions/gmp-setbit.xml
@@ -115,7 +115,7 @@ echo gmp_strval($a), ' -> 0b', gmp_strval($a, 2), "\n";
 <?php
 $a = gmp_init("0xff");
 echo gmp_strval($a), ' -> 0b', gmp_strval($a, 2), "\n";
-gmp_setbit($a, 0, false); // clear bit at index 0
+gmp_setbit($a, 0, false); // limpia el bit en el índice 0
 echo gmp_strval($a), ' -> 0b', gmp_strval($a, 2), "\n";
 ?>
 ]]>

--- a/reference/gnupg/functions/gnupg-encrypt.xml
+++ b/reference/gnupg/functions/gnupg-encrypt.xml
@@ -60,7 +60,7 @@
 <?php
 $res = gnupg_init();
 gnupg_addencryptkey($res,"8660281B6051D071D94B5B230549F9DC851566DC");
-$enc = gnupg_encrypt($res, "juste un test");
+$enc = gnupg_encrypt($res, "sólo una prueba");
 echo $enc;
 ?>
 ]]>
@@ -73,7 +73,7 @@ echo $enc;
 <?php
 $gpg = new gnupg();
 $gpg->addencryptkey("8660281B6051D071D94B5B230549F9DC851566DC");
-$enc = $gpg->encrypt("juste un test");
+$enc = $gpg->encrypt("sólo una prueba");
 echo $enc;
 ?>
 ]]>

--- a/reference/gnupg/functions/gnupg-encryptsign.xml
+++ b/reference/gnupg/functions/gnupg-encryptsign.xml
@@ -62,7 +62,7 @@
 $res = gnupg_init();
 gnupg_addencryptkey($res,"8660281B6051D071D94B5B230549F9DC851566DC");
 gnupg_addsignkey($res,"8660281B6051D071D94B5B230549F9DC851566DC","test");
-$enc = gnupg_encryptsign($res, "juste un test");
+$enc = gnupg_encryptsign($res, "sólo una prueba");
 echo $enc;
 ?>
 ]]>
@@ -76,7 +76,7 @@ echo $enc;
 $gpg = new gnupg();
 $gpg->addencryptkey("8660281B6051D071D94B5B230549F9DC851566DC");
 $gpg->addsignkey("8660281B6051D071D94B5B230549F9DC851566DC","test");
-$enc = $gpg->encryptsign("juste un test");
+$enc = $gpg->encryptsign("sólo una prueba");
 echo $enc;
 ?>
 ]]>

--- a/reference/gnupg/functions/gnupg-sign.xml
+++ b/reference/gnupg/functions/gnupg-sign.xml
@@ -62,7 +62,7 @@
 <?php
 $res = gnupg_init();
 gnupg_addsignkey($res,"8660281B6051D071D94B5B230549F9DC851566DC","test");
-$signed = gnupg_sign($res, "juste un test");
+$signed = gnupg_sign($res, "sólo una prueba");
 echo $signed;
 ?>
 ]]>

--- a/reference/hash/book.xml
+++ b/reference/hash/book.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 <book xml:id="book.hash" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <?phpdoc extension-membership="core" ?>
- <title>HASH Message Digest Framework</title>
+ <title>HASH (framework de resúmenes de mensaje)</title>
  <titleabbrev>Hash</titleabbrev>
 
  <!-- {{{ preface -->

--- a/reference/hash/constants.xml
+++ b/reference/hash/constants.xml
@@ -14,7 +14,7 @@
    </term>
    <listitem>
     <simpara>
-     Flag opcional para <function>hash_init</function>.
+     Indicador opcional para <function>hash_init</function>.
      Indica que el algoritmo de clave HMAC debe ser aplicado al contexto
      actual de hash.
     </simpara>

--- a/reference/hash/functions/hash-copy.xml
+++ b/reference/hash/functions/hash-copy.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna una copia del contexto de hachado Hashing Context.
+   Retorna una copia del contexto de hash.
   </para>
  </refsect1>
 

--- a/reference/hash/functions/hash-equals.xml
+++ b/reference/hash/functions/hash-equals.xml
@@ -74,15 +74,15 @@
 <?php
 $secretKey = '8uRhAeH89naXfFXKGOEj';
 
-// Value and signature are provided by the user, e.g. within the URL
-// and retrieved using $_GET.
+// El valor y la firma son proporcionados por el usuario, p. ej. en la URL
+// y recuperados mediante $_GET.
 $value = 'username=rasmuslerdorf';
 $signature = '8c35009d3b50caf7f5d2c1e031842e6b7823a1bb781d33c5237cd27b57b5f327';
 
 if (hash_equals(hash_hmac('sha256', $value, $secretKey), $signature)) {
-    echo "The value is correctly signed.", PHP_EOL;
+    echo "El valor está firmado correctamente.", PHP_EOL;
 } else {
-    echo "The value was tampered with.", PHP_EOL;
+    echo "El valor ha sido manipulado.", PHP_EOL;
 }
 ?>
 ]]>
@@ -90,7 +90,7 @@ if (hash_equals(hash_hmac('sha256', $value, $secretKey), $signature)) {
     &example.outputs;
     <screen>
 <![CDATA[
-The value is correctly signed.
+El valor está firmado correctamente.
 ]]>
     </screen>
    </example>

--- a/reference/ibase/functions/ibase-service-attach.xml
+++ b/reference/ibase/functions/ibase-service-attach.xml
@@ -78,8 +78,8 @@
         ibase_service_detach($service);
 
         // Mostrar la información
-        echo "Server version: " . $server_version . "<br/>";
-        echo "Server implementation: " . $server_implementation;
+        echo "Versión del servidor: " . $server_version . "<br/>";
+        echo "Implementación del servidor: " . $server_implementation;
     }
     else {
         // Mostrar un mensaje en caso de error
@@ -111,8 +111,8 @@
         ibase_service_detach($service);
 
         // Mostrar la información
-        echo "Server version: " . $server_version . "<br/>";
-        echo "Server implementation: " . $server_implementation;
+        echo "Versión del servidor: " . $server_version . "<br/>";
+        echo "Implementación del servidor: " . $server_implementation;
     }
     else {
         // Mostrar un mensaje en caso de error

--- a/reference/ibm_db2/functions/db2-rollback.xml
+++ b/reference/ibm_db2/functions/db2-rollback.xml
@@ -69,17 +69,17 @@ if ($conn) {
     $res = db2_fetch_array( $stmt );
     echo $res[0] . "\n";
 
-    // Turn AUTOCOMMIT off
+    // Desactivar AUTOCOMMIT
     db2_autocommit($conn, DB2_AUTOCOMMIT_OFF);
 
-    // Delete all rows from ANIMALS
+    // Eliminar todas las filas de ANIMALS
     db2_exec($conn, "DELETE FROM animals");
 
     $stmt = db2_exec($conn, "SELECT count(*) FROM animals");
     $res = db2_fetch_array( $stmt );
     echo $res[0] . "\n";
 
-    // Roll back the DELETE statement
+    // Deshacer la sentencia DELETE
     db2_rollback( $conn );
 
     $stmt = db2_exec( $conn, "SELECT count(*) FROM animals" );

--- a/reference/iconv/functions/ob-iconv-handler.xml
+++ b/reference/iconv/functions/ob-iconv-handler.xml
@@ -65,7 +65,7 @@ ob_start("ob_iconv_handler"); // empieza a usarse el buffer de salida
    <simplelist>
     <member><function>iconv_get_encoding</function></member>
     <member><function>iconv_set_encoding</function></member>
-    <member><link linkend="ref.outcontrol">output-control functions</link></member>
+    <member><link linkend="ref.outcontrol">funciones de control de salida</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/image/configure.xml
+++ b/reference/image/configure.xml
@@ -122,9 +122,9 @@
       </entry>
      </row>
      <row>
-      <entry><literal>TrueType strings</literal></entry>
+      <entry><literal>cadenas TrueType</literal></entry>
       <entry>
-       Para activar el soporte de strings TrueType,
+       Para activar el soporte de cadenas TrueType,
        añadir la opción
        <option role="configure">--enable-gd-native-ttf</option>.
        (Esta opción no tiene efecto y ha sido eliminada desde PHP 7.2.0.)

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -202,9 +202,9 @@ if ($size && $fp) {
       <row>
        <entry>8.2.0</entry>
        <entry>
-        Devuelve las dimensiones actuales de la imagen, bits y strings de imágenes AVIF;
+        Devuelve las dimensiones actuales de la imagen, bits y canales de imágenes AVIF;
         previamente, las dimensiones eran reportadas como <literal>0x0</literal>,
-        y bits y strings no eran reportados en absoluto.
+        y bits y canales no eran reportados en absoluto.
        </entry>
       </row>
       <row>

--- a/reference/image/functions/imagecreatefromstring.xml
+++ b/reference/image/functions/imagecreatefromstring.xml
@@ -101,7 +101,7 @@ if ($im !== false) {
     imagepng($im);
 }
 else {
-    echo 'An error occurred.';
+    echo 'Ha ocurrido un error.';
 }
 ?>
 ]]>

--- a/reference/image/functions/imagepng.xml
+++ b/reference/image/functions/imagepng.xml
@@ -63,7 +63,7 @@
       </para>
       <caution>
        <simpara>
-        El argumento <parameter>filters</parameter> es ignorado por system libgd.
+        El argumento <parameter>filters</parameter> es ignorado por la libgd del sistema.
        </simpara>
       </caution>
      </listitem>

--- a/reference/image/functions/imagestring.xml
+++ b/reference/image/functions/imagestring.xml
@@ -47,7 +47,7 @@
      <term><parameter>string</parameter></term>
      <listitem>
       <para>
-       El string a escribir.
+       La cadena a escribir.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick.xml
+++ b/reference/imagick/imagick.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference role="class" xml:id="class.imagick" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>La classe <classname>Imagick</classname></title>
+ <title>La clase <classname>Imagick</classname></title>
  <titleabbrev>Imagick</titleabbrev>
  <partintro>
   <section xml:id="imagick.synopsis">

--- a/reference/imap/functions/imap-rfc822-parse-adrlist.xml
+++ b/reference/imap/functions/imap-rfc822-parse-adrlist.xml
@@ -66,7 +66,7 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>"adl"</literal> : at domain source route (NDT : ???)
+      <literal>"adl"</literal> : ruta de origen «at-domain»
      </simpara>
     </listitem>
    </itemizedlist>

--- a/reference/info/functions/gc-enable.xml
+++ b/reference/info/functions/gc-enable.xml
@@ -101,7 +101,7 @@ Use the PEAR Coding Standards
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="features.gc">Garbage Collection</link></member>
+    <member><link linkend="features.gc">Recolección de basura</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/intl/collator/compare.xml
+++ b/reference/intl/collator/compare.xml
@@ -135,13 +135,13 @@ $c = new Collator( 'en' );
 $c->setStrength( Collator::PRIMARY );
 if ( $c->compare( 'Séan', 'Sean' ) == 0 )
 {
-    echo "The same\n";
+    echo "Iguales\n";
 }
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
-     The same
+     Iguales
     </screen>
     <para>
      Este ejemplo solicita al collator que compare solo teniendo en cuenta

--- a/reference/intl/constants.xml
+++ b/reference/intl/constants.xml
@@ -613,7 +613,7 @@
     </term>
     <listitem>
      <simpara>
-      Alias of <constant>U_PLUGIN_ERROR_LIMIT</constant>.
+      Alias de <constant>U_PLUGIN_ERROR_LIMIT</constant>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -624,8 +624,8 @@
     </term>
     <listitem>
      <simpara>
-      This must always be the last warning value to indicate
-      the limit for UErrorCode warnings (last warning code +1).
+      Debe ser siempre el último valor de advertencia para indicar
+      el límite de las advertencias UErrorCode (último código de advertencia +1).
      </simpara>
     </listitem>
    </varlistentry>
@@ -636,7 +636,7 @@
     </term>
     <listitem>
      <simpara>
-      Start of information results (semantically successful).
+      Inicio de los resultados de información (semánticamente exitosos).
      </simpara>
     </listitem>
    </varlistentry>
@@ -647,7 +647,7 @@
     </term>
     <listitem>
      <simpara>
-      The requested file cannot be found.
+      No se ha podido encontrar el fichero solicitado.
      </simpara>
     </listitem>
    </varlistentry>
@@ -658,7 +658,7 @@
     </term>
     <listitem>
      <simpara>
-      The limit for format library errors.
+      Límite de los errores de la biblioteca de formato.
      </simpara>
     </listitem>
    </varlistentry>
@@ -669,7 +669,7 @@
     </term>
     <listitem>
      <simpara>
-      Start of format library errors.
+      Inicio de los errores de la biblioteca de formato.
      </simpara>
     </listitem>
    </varlistentry>
@@ -801,7 +801,7 @@
     </term>
     <listitem>
      <simpara>
-      Indicates an incorrect argument value.
+      Indica un valor de argumento incorrecto.
      </simpara>
     </listitem>
    </varlistentry>
@@ -812,7 +812,7 @@
     </term>
     <listitem>
      <simpara>
-      Character conversion: Illegal input sequence.
+      Conversión de caracteres: secuencia de entrada ilegal.
      </simpara>
     </listitem>
    </varlistentry>
@@ -823,7 +823,7 @@
     </term>
     <listitem>
      <simpara>
-      Unused as of ICU 2.4.
+      No utilizado a partir de ICU 2.4.
      </simpara>
     </listitem>
    </varlistentry>
@@ -834,7 +834,7 @@
     </term>
     <listitem>
      <simpara>
-      A special character is outside its allowed context.
+      Un carácter especial está fuera de su contexto permitido.
      </simpara>
     </listitem>
    </varlistentry>
@@ -845,7 +845,7 @@
     </term>
     <listitem>
      <simpara>
-      ISO-2022 illlegal escape sequence.
+      Secuencia de escape ilegal ISO-2022.
      </simpara>
     </listitem>
    </varlistentry>
@@ -856,7 +856,7 @@
     </term>
     <listitem>
      <simpara>
-      Pad symbol misplaced in number pattern.
+      Símbolo de relleno mal ubicado en el patrón numérico.
      </simpara>
     </listitem>
    </varlistentry>
@@ -867,7 +867,7 @@
     </term>
     <listitem>
      <simpara>
-      Trying to access the index that is out of bounds.
+      Intento de acceder a un índice fuera de rango.
      </simpara>
     </listitem>
    </varlistentry>
@@ -878,7 +878,7 @@
     </term>
     <listitem>
      <simpara>
-      Indicates a bug in the library code.
+      Indica un bug en el código de la biblioteca.
      </simpara>
     </listitem>
    </varlistentry>
@@ -889,7 +889,7 @@
     </term>
     <listitem>
      <simpara>
-      Internal transliterator system error.
+      Error interno del sistema de transliterator.
      </simpara>
     </listitem>
    </varlistentry>
@@ -900,7 +900,7 @@
     </term>
     <listitem>
      <simpara>
-      Character conversion: Unmappable input sequence. In other APIs: Invalid character.
+      Conversión de caracteres: secuencia de entrada no mapeable. En otras APIs: carácter inválido.
      </simpara>
     </listitem>
    </varlistentry>
@@ -911,7 +911,7 @@
     </term>
     <listitem>
      <simpara>
-      Data format is not what is expected.
+      El formato de los datos no es el esperado.
      </simpara>
     </listitem>
    </varlistentry>
@@ -922,7 +922,7 @@
     </term>
     <listitem>
      <simpara>
-      A <literal>'&amp;fn()'</literal> rule specifies an unknown transliterator.
+      Una regla <literal>'&amp;fn()'</literal> especifica un transliterator desconocido.
      </simpara>
     </listitem>
    </varlistentry>
@@ -933,7 +933,7 @@
     </term>
     <listitem>
      <simpara>
-      A <literal>'::id'</literal> rule specifies an unknown transliterator.
+      Una regla <literal>'::id'</literal> especifica un transliterator desconocido.
      </simpara>
     </listitem>
    </varlistentry>
@@ -944,7 +944,7 @@
     </term>
     <listitem>
      <simpara>
-      Unused as of ICU 2.4.
+      No utilizado a partir de ICU 2.4.
      </simpara>
     </listitem>
    </varlistentry>
@@ -955,7 +955,7 @@
     </term>
     <listitem>
      <simpara>
-      A <literal>'::id'</literal> rule was passed to the RuleBasedTransliterator parser.
+      Se pasó una regla <literal>'::id'</literal> al parser de RuleBasedTransliterator.
      </simpara>
     </listitem>
    </varlistentry>
@@ -966,7 +966,7 @@
     </term>
     <listitem>
      <simpara>
-      Requested operation can not be completed with ICU in its current state.
+      La operación solicitada no puede completarse con ICU en su estado actual.
      </simpara>
     </listitem>
    </varlistentry>
@@ -977,7 +977,7 @@
     </term>
     <listitem>
      <simpara>
-      Conversion table file not found.
+      Archivo de tabla de conversión no encontrado.
      </simpara>
     </listitem>
    </varlistentry>
@@ -988,7 +988,7 @@
     </term>
     <listitem>
      <simpara>
-      Conversion table file found, but corrupted.
+      Archivo de tabla de conversión encontrado, pero corrupto.
      </simpara>
     </listitem>
    </varlistentry>
@@ -999,8 +999,8 @@
     </term>
     <listitem>
      <simpara>
-      Unable to convert a <code>UChar*</code> string to <code>char*</code>
-      with the invariant converter.
+      No se puede convertir una cadena <code>UChar*</code> a <code>char*</code>
+      con el convertidor invariante.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1011,7 +1011,7 @@
     </term>
     <listitem>
      <simpara>
-      Grouping symbol in exponent pattern.
+      Símbolo de agrupación en el patrón de exponente.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1022,7 +1022,7 @@
     </term>
     <listitem>
      <simpara>
-      A <literal>'use'</literal> pragma is invalid.
+      Un pragma <literal>'use'</literal> es inválido.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1033,7 +1033,7 @@
     </term>
     <listitem>
      <simpara>
-      Elements of a rule are misplaced.
+      Los elementos de una regla están mal ubicados.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1044,7 +1044,7 @@
     </term>
     <listitem>
      <simpara>
-      A <code>UnicodeSet</code> pattern is invalid.
+      Un patrón <code>UnicodeSet</code> es inválido.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1055,7 +1055,7 @@
     </term>
     <listitem>
      <simpara>
-      Unused as of ICU 2.4.
+      No utilizado a partir de ICU 2.4.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1066,7 +1066,7 @@
     </term>
     <listitem>
      <simpara>
-      A Unicode escape pattern is invalid.
+      Un patrón de escape Unicode es inválido.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1077,7 +1077,7 @@
     </term>
     <listitem>
      <simpara>
-      A variable definition is invalid.
+      Una definición de variable es inválida.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1088,7 +1088,7 @@
     </term>
     <listitem>
      <simpara>
-      A variable reference is invalid.
+      Una referencia de variable es inválida.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1099,7 +1099,7 @@
     </term>
     <listitem>
      <simpara>
-      Memory allocation error.
+      Error de asignación de memoria.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1110,7 +1110,7 @@
     </term>
     <listitem>
      <simpara>
-      Unable to parse a message (message format).
+      No se puede analizar un mensaje (formato de mensaje).
      </simpara>
     </listitem>
    </varlistentry>
@@ -1121,7 +1121,7 @@
     </term>
     <listitem>
      <simpara>
-      Unused as of ICU 2.4.
+      No utilizado a partir de ICU 2.4.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1132,7 +1132,7 @@
     </term>
     <listitem>
      <simpara>
-      A start anchor appears at an illegal position.
+      Un ancla de inicio aparece en una posición ilegal.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1418,7 +1418,7 @@
     </term>
     <listitem>
      <simpara>
-      This must always be the last value to indicate the limit for regexp errors.
+      Este debe ser siempre el último valor para indicar el límite de los errores de regexp.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1429,7 +1429,7 @@
     </term>
     <listitem>
      <simpara>
-      Start of codes indicating Regexp failures.
+      Inicio de los códigos que indican fallos de regexp.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1440,7 +1440,7 @@
     </term>
     <listitem>
      <simpara>
-      An internal error (bug) was detected.
+      Se detectó un error interno (bug).
      </simpara>
     </listitem>
    </varlistentry>
@@ -1451,7 +1451,7 @@
     </term>
     <listitem>
      <simpara>
-      Back-reference to a non-existent capture group.
+      Retro-referencia a un grupo de captura inexistente.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1462,7 +1462,7 @@
     </term>
     <listitem>
      <simpara>
-      Invalid value for match mode flags.
+      Valor inválido para los flags del modo de coincidencia.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1473,7 +1473,7 @@
     </term>
     <listitem>
      <simpara>
-      <code>RegexMatcher</code> in invalid state for requested operation.
+      <code>RegexMatcher</code> en estado inválido para la operación solicitada.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1484,7 +1484,7 @@
     </term>
     <listitem>
      <simpara>
-      Look-Behind pattern matches must have a bounded maximum length.
+      Las coincidencias del patrón Look-Behind deben tener una longitud máxima acotada.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1495,7 +1495,7 @@
     </term>
     <listitem>
      <simpara>
-      In <literal>{min,max}</literal>, max is less than min.
+      En <literal>{min,max}</literal>, max es menor que min.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1506,7 +1506,7 @@
     </term>
     <listitem>
      <simpara>
-      Incorrectly nested parentheses in regexp pattern.
+      Paréntesis anidados incorrectamente en el patrón regexp.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1517,7 +1517,7 @@
     </term>
     <listitem>
      <simpara>
-      Decimal number is too large.
+      El número decimal es demasiado grande.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1528,7 +1528,7 @@
     </term>
     <listitem>
      <simpara>
-      Incorrect Unicode property.
+      Propiedad Unicode incorrecta.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1539,7 +1539,7 @@
     </term>
     <listitem>
      <simpara>
-      Syntax error in regexp pattern.
+      Error de sintaxis en el patrón regexp.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1550,7 +1550,7 @@
     </term>
     <listitem>
      <simpara>
-      Regexps cannot have <code>UnicodeSet</code>s containing strings.
+      Los regexps no pueden tener <code>UnicodeSet</code>s que contengan cadenas.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1561,7 +1561,7 @@
     </term>
     <listitem>
      <simpara>
-      Use of regexp feature that is not yet implemented.
+      Uso de una característica regexp que aún no está implementada.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1572,7 +1572,7 @@
     </term>
     <listitem>
      <simpara>
-      An operation is requested over a resource that does not support it.
+      Se solicita una operación sobre un recurso que no la soporta.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1583,7 +1583,7 @@
     </term>
     <listitem>
      <simpara>
-      A rule is hidden by an earlier more general rule.
+      Una regla está oculta por una regla más general anterior.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1594,7 +1594,7 @@
     </term>
     <listitem>
      <simpara>
-      A <code>SafeClone</code> operation required allocating memory (informational only).
+      Una operación <code>SafeClone</code> requirió la asignación de memoria (solo informativo).
      </simpara>
     </listitem>
    </varlistentry>
@@ -1605,8 +1605,8 @@
     </term>
     <listitem>
      <simpara>
-      Number of levels requested in <code>getBound</code> is higher
-      than the number of levels in the sort key.
+      El número de niveles solicitados en <code>getBound</code> es mayor
+      que el número de niveles en la clave de ordenación.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1617,7 +1617,7 @@
     </term>
     <listitem>
      <simpara>
-      This must always be the last value to indicate the limit for standard errors.
+      Este debe ser siempre el último valor para indicar el límite de los errores estándar.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1628,8 +1628,8 @@
     </term>
     <listitem>
      <simpara>
-      ICU has to use compatibility layer to construct the service.
-      Expect performance/memory usage degradation.
+      ICU debe usar la capa de compatibilidad para construir el servicio.
+      Se debe esperar una degradación del rendimiento/uso de memoria.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1640,7 +1640,7 @@
     </term>
     <listitem>
      <simpara>
-      ICU cannot construct a service from this state, as it is no longer supported.
+      ICU no puede construir un servicio a partir de este estado, ya que ya no es soportado.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1651,7 +1651,7 @@
     </term>
     <listitem>
      <simpara>
-      An output string could not be NUL-terminated because output <code>length==destCapacity</code>.
+      Una cadena de salida no pudo ser terminada en NUL porque la salida <code>length==destCapacity</code>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1662,7 +1662,7 @@
     </term>
     <listitem>
      <simpara>
-      Alias of <constant>U_IDNA_CHECK_BIDI_ERROR</constant>.
+      Alias de <constant>U_IDNA_CHECK_BIDI_ERROR</constant>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1673,7 +1673,7 @@
     </term>
     <listitem>
      <simpara>
-      Alias of <constant>U_IDNA_PROHIBITED_ERROR</constant>.
+      Alias de <constant>U_IDNA_PROHIBITED_ERROR</constant>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1684,7 +1684,7 @@
     </term>
     <listitem>
      <simpara>
-      Alias of <constant>U_IDNA_UNASSIGNED_ERROR</constant>.
+      Alias de <constant>U_IDNA_UNASSIGNED_ERROR</constant>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1695,8 +1695,8 @@
     </term>
     <listitem>
      <simpara>
-      There are too many aliases in the path to the requested resource.
-      It is very possible that a circular alias definition has occured.
+      Hay demasiados alias en la ruta al recurso solicitado.
+      Es muy posible que haya ocurrido una definición de alias circular.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1707,7 +1707,7 @@
     </term>
     <listitem>
      <simpara>
-      A dangling backslash.
+      Una barra invertida colgante.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1718,7 +1718,7 @@
     </term>
     <listitem>
      <simpara>
-      Character conversion: Incomplete input sequence.
+      Conversión de caracteres: secuencia de entrada incompleta.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1729,7 +1729,7 @@
     </term>
     <listitem>
      <simpara>
-      A closing <literal>')'</literal> is missing.
+      Falta un <literal>')'</literal> de cierre.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1740,7 +1740,7 @@
     </term>
     <listitem>
      <simpara>
-      A segment reference does not correspond to a defined segment.
+      Una referencia a un segmento no corresponde a un segmento definido.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1751,7 +1751,7 @@
     </term>
     <listitem>
      <simpara>
-      A variable reference does not correspond to a defined variable.
+      Una referencia a una variable no corresponde a una variable definida.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1762,7 +1762,7 @@
     </term>
     <listitem>
      <simpara>
-      Syntax error in format pattern.
+      Error de sintaxis en el patrón de formato.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1773,7 +1773,7 @@
     </term>
     <listitem>
      <simpara>
-      Braces do not match in message pattern.
+      Las llaves no coinciden en el patrón del mensaje.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1784,7 +1784,7 @@
     </term>
     <listitem>
      <simpara>
-      A special character was not quoted or escaped.
+      Un carácter especial no fue entrecomillado ni escapado.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1795,7 +1795,7 @@
     </term>
     <listitem>
      <simpara>
-      Unused as of ICU 2.4.
+      No utilizado a partir de ICU 2.4.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1806,7 +1806,7 @@
     </term>
     <listitem>
      <simpara>
-      Requested operation not supported in current context.
+      La operación solicitada no está soportada en el contexto actual.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1817,7 +1817,7 @@
     </term>
     <listitem>
      <simpara>
-      ISO-2022 unsupported escape sequence.
+      Secuencia de escape ISO-2022 no soportada.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1828,7 +1828,7 @@
     </term>
     <listitem>
      <simpara>
-      Unused as of ICU 2.4.
+      No utilizado a partir de ICU 2.4.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1839,7 +1839,7 @@
     </term>
     <listitem>
      <simpara>
-      A closing single quote is missing.
+      Falta una comilla simple de cierre.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1850,7 +1850,7 @@
     </term>
     <listitem>
      <simpara>
-      Collator is options only and no base is specified.
+      El collator solo tiene opciones y no se ha especificado una base.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1861,7 +1861,7 @@
     </term>
     <listitem>
      <simpara>
-      A resource bundle lookup returned a result from the root locale (not an error).
+      Una búsqueda en un resource bundle devolvió un resultado de la configuración local raíz (no es un error).
      </simpara>
     </listitem>
    </varlistentry>
@@ -1872,7 +1872,7 @@
     </term>
     <listitem>
      <simpara>
-      A resource bundle lookup returned a fallback result (not an error).
+      Una búsqueda en un resource bundle devolvió un resultado de respaldo (no es un error).
      </simpara>
     </listitem>
    </varlistentry>
@@ -1883,7 +1883,7 @@
     </term>
     <listitem>
      <simpara>
-      Too many stand-ins generated for the given variable range.
+      Se generaron demasiados sustitutos para el rango de variables dado.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1894,7 +1894,7 @@
     </term>
     <listitem>
      <simpara>
-      The variable range overlaps characters used in rules.
+      El rango de variables se superpone con caracteres utilizados en las reglas.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1905,7 +1905,7 @@
     </term>
     <listitem>
      <simpara>
-      No error, no warning.
+      Sin error, sin advertencia.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/intl/dateformatter/get-timezone-id.xml
+++ b/reference/intl/dateformatter/get-timezone-id.xml
@@ -65,9 +65,9 @@ $fmt = datefmt_create(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-echo 'timezone_id of the formatter is: ' . datefmt_get_timezone_id($fmt) . "\n";
+echo 'El timezone_id del formateador es:' . datefmt_get_timezone_id($fmt) . "\n";
 datefmt_set_timezone($fmt, 'Europe/Madrid');
-echo 'Now timezone_id of the formatter is: ' . datefmt_get_timezone_id($fmt);
+echo 'Ahora el timezone_id del formateador es:' . datefmt_get_timezone_id($fmt);
 
 ?>
 ]]>
@@ -85,9 +85,9 @@ $fmt = new IntlDateFormatter(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
-echo 'timezone_id of the formatter is: ' . $fmt->getTimezoneId() . "\n";
+echo 'El timezone_id del formateador es:' . $fmt->getTimezoneId() . "\n";
 $fmt->setTimezone('Europe/Madrid');
-echo 'Now timezone_id of the formatter is: ' . $fmt->getTimezoneId();
+echo 'Ahora el timezone_id del formateador es:' . $fmt->getTimezoneId();
 
 ?>
 ]]>
@@ -96,8 +96,8 @@ echo 'Now timezone_id of the formatter is: ' . $fmt->getTimezoneId();
   &example.outputs;
   <screen>
 <![CDATA[
-timezone_id of the formatter is: America/Los_Angeles
-Now timezone_id of the formatter is: Europe/Madrid
+El timezone_id del formateador es:America/Los_Angeles
+Ahora el timezone_id del formateador es:Europe/Madrid
 ]]>
   </screen>
  </refsect1>

--- a/reference/intl/dateformatter/set-pattern.xml
+++ b/reference/intl/dateformatter/set-pattern.xml
@@ -78,11 +78,11 @@ $fmt = datefmt_create(
     IntlDateFormatter::GREGORIAN,
     'MM/dd/yyyy'
 );
-echo 'Pattern of the formatter is : ', datefmt_get_pattern($fmt), PHP_EOL;
-echo 'First Formatted output with pattern is ', datefmt_format($fmt, 0), PHP_EOL;
+echo 'El patrón del formateador es: ', datefmt_get_pattern($fmt), PHP_EOL;
+echo 'La primera salida formateada con el patrón es ', datefmt_format($fmt, 0), PHP_EOL;
 datefmt_set_pattern($fmt, 'yyyyMMdd hh:mm:ss z');
-echo 'Now pattern of the formatter is : ', datefmt_get_pattern($fmt), PHP_EOL;
-echo 'Second Formatted output with pattern is ', datefmt_format($fmt, 0), PHP_EOL;
+echo 'Ahora el patrón del formateador es: ', datefmt_get_pattern($fmt), PHP_EOL;
+echo 'La segunda salida formateada con el patrón es ', datefmt_format($fmt, 0), PHP_EOL;
 ?>
 ]]>
    </programlisting>
@@ -99,11 +99,11 @@ $fmt = new IntlDateFormatter(
     IntlDateFormatter::GREGORIAN,
     'MM/dd/yyyy'
 );
-echo 'Pattern of the formatter is : ', $fmt->getPattern(), PHP_EOL;
-echo 'First Formatted output is ', $fmt->format(0), PHP_EOL;
+echo 'El patrón del formateador es: ', $fmt->getPattern(), PHP_EOL;
+echo 'La primera salida formateada es ', $fmt->format(0), PHP_EOL;
 $fmt->setPattern('yyyyMMdd hh:mm:ss z');
-echo 'Now pattern of the formatter is : ', $fmt->getPattern(), PHP_EOL;
-echo 'Second Formatted output is ', $fmt->format(0), PHP_EOL;
+echo 'Ahora el patrón del formateador es: ', $fmt->getPattern(), PHP_EOL;
+echo 'La segunda salida formateada es ', $fmt->format(0), PHP_EOL;
 ?>
 ]]>
    </programlisting>
@@ -111,10 +111,10 @@ echo 'Second Formatted output is ', $fmt->format(0), PHP_EOL;
   &example.outputs;
   <screen>
 <![CDATA[
-Pattern of the formatter is : MM/dd/yyyy
-First Formatted output is 12/31/1969
-Now pattern of the formatter is : yyyyMMdd hh:mm:ss z
-Second Formatted output is 19691231 04:00:00 PST
+El patrón del formateador es: MM/dd/yyyy
+La primera salida formateada es 12/31/1969
+Ahora el patrón del formateador es: yyyyMMdd hh:mm:ss z
+La segunda salida formateada es 19691231 04:00:00 PST
 ]]>
   </screen>
  </refsect1>

--- a/reference/intl/numberformatter/parse-currency.xml
+++ b/reference/intl/numberformatter/parse-currency.xml
@@ -84,7 +84,7 @@
 <?php
 $fmt = numfmt_create( 'de_DE', NumberFormatter::CURRENCY );
 $num = "1.234.567,89\xc2\xa0$";
-echo "We have ".numfmt_parse_currency($fmt, $num, $curr)." in $curr\n";
+echo "Tenemos ".numfmt_parse_currency($fmt, $num, $curr)." en $curr\n";
 ?>
 ]]>
    </programlisting>
@@ -96,7 +96,7 @@ echo "We have ".numfmt_parse_currency($fmt, $num, $curr)." in $curr\n";
 <?php
 $fmt = new NumberFormatter( 'de_DE', NumberFormatter::CURRENCY );
 $num = "1.234.567,89\xc2\xa0$";
-echo "We have ".$fmt->parseCurrency($num, $curr)." in $curr\n";
+echo "Tenemos ".$fmt->parseCurrency($num, $curr)." en $curr\n";
 ?>
 ]]>
    </programlisting>
@@ -104,7 +104,7 @@ echo "We have ".$fmt->parseCurrency($num, $curr)." in $curr\n";
   &example.outputs;
   <screen>
 <![CDATA[
-We have 1234567.89 in USD
+Tenemos 1234567.89 en USD
 ]]>
   </screen>
  </refsect1>

--- a/reference/intl/numberformatter/set-attribute.xml
+++ b/reference/intl/numberformatter/set-attribute.xml
@@ -128,26 +128,26 @@ Digits: 2
 $fmt = new NumberFormatter('en_US', NumberFormatter::DECIMAL);
 $fmt->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
 
-echo "Default rounding mode:\n";
-echo $fmt->format(3.789), "\n"; // 3.79 (rounded up)
-echo $fmt->format(3.781), "\n"; // 3.78 (rounded down)
+echo "Modo de redondeo por defecto:\n";
+echo $fmt->format(3.789), "\n"; // 3.79 (redondeado hacia arriba)
+echo $fmt->format(3.781), "\n"; // 3.78 (redondeado hacia abajo)
 
 $fmt->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
 
-echo "\nWith ROUND_DOWN (truncate):\n";
-echo $fmt->format(3.789), "\n"; // 3.78 (truncated)
-echo $fmt->format(3.781), "\n"; // 3.78 (truncated)
+echo "\nCon ROUND_DOWN (truncar):\n";
+echo $fmt->format(3.789), "\n"; // 3.78 (truncado)
+echo $fmt->format(3.781), "\n"; // 3.78 (truncado)
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Default rounding mode:
+Modo de redondeo por defecto:
 3.79
 3.78
 
-With ROUND_DOWN (truncate):
+Con ROUND_DOWN (truncar):
 3.78
 3.78
 ]]>

--- a/reference/ldap/functions/ldap-exop-refresh.xml
+++ b/reference/ldap/functions/ldap-exop-refresh.xml
@@ -17,7 +17,6 @@
   </methodsynopsis>
   <para>
    Realiza una operación extendida de actualización y devuelve los datos.
-   Performs a Refresh extended operation and returns the data.
   </para>
  </refsect1>
 

--- a/reference/ldap/ldap.connection.xml
+++ b/reference/ldap/ldap.connection.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.ldap-connection" role="class" xmlns="http://docbook.org/ns/docbook">
- <title>The LDAP\Connection class</title>
+ <title>La clase LDAP\Connection</title>
  <titleabbrev>LDAP\Connection</titleabbrev>
 
  <partintro>

--- a/reference/ldap/ldap.result.xml
+++ b/reference/ldap/ldap.result.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.ldap-result" role="class" xmlns="http://docbook.org/ns/docbook">
- <title>The LDAP\Result class</title>
+ <title>La clase LDAP\Result</title>
  <titleabbrev>LDAP\Result</titleabbrev>
 
  <partintro>

--- a/reference/ldap/ldap.resultentry.xml
+++ b/reference/ldap/ldap.resultentry.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.ldap-result-entry" role="class" xmlns="http://docbook.org/ns/docbook">
- <title>The LDAP\ResultEntry class</title>
+ <title>La clase LDAP\ResultEntry</title>
  <titleabbrev>LDAP\ResultEntry</titleabbrev>
 
  <partintro>

--- a/reference/libxml/functions/libxml-get-errors.xml
+++ b/reference/libxml/functions/libxml-get-errors.xml
@@ -78,22 +78,22 @@ function display_xml_error($error, $xml)
 
     switch ($error->level) {
         case LIBXML_ERR_WARNING:
-            $return .= "Warning $error->code: ";
+            $return .= "Advertencia $error->code: ";
             break;
          case LIBXML_ERR_ERROR:
             $return .= "Error $error->code: ";
             break;
         case LIBXML_ERR_FATAL:
-            $return .= "Fatal Error $error->code: ";
+            $return .= "Error fatal $error->code: ";
             break;
     }
 
     $return .= trim($error->message) .
-               "\n  Line: $error->line" .
-               "\n  Column: $error->column";
+               "\n  Línea: $error->line" .
+               "\n  Columna: $error->column";
 
     if ($error->file) {
-        $return .= "\n  File: $error->file";
+        $return .= "\n  Fichero: $error->file";
     }
 
     return "$return\n\n--------------------------------------------\n\n";
@@ -107,9 +107,9 @@ function display_xml_error($error, $xml)
 <![CDATA[
   <titles>PHP: Behind the Parser</title>
 ----------------------------------------------^
-Fatal Error 76: Opening and ending tag mismatch: titles line 4 and title
-  Line: 4
-  Column: 46
+Error fatal 76: Opening and ending tag mismatch: titles line 4 and title
+  Línea: 4
+  Columna: 46
 
 --------------------------------------------
 ]]>

--- a/reference/lua/luaclosure/invoke.xml
+++ b/reference/lua/luaclosure/invoke.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="luaclosure.invoke">
  <refnamediv>
   <refname>LuaClosure::__invoke</refname>
-  <refpurpose>Invoke luaclosure</refpurpose>
+  <refpurpose>Invoca el luaclosure</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/luasandbox/luasandbox/getversioninfo.xml
+++ b/reference/luasandbox/luasandbox/getversioninfo.xml
@@ -32,7 +32,7 @@
   <informaltable>
    <tgroup cols="3">
     <thead>
-     <row><entry>element</entry><entry>type</entry><entry>description</entry></row>
+     <row><entry>elemento</entry><entry>tipo</entry><entry>descripción</entry></row>
     </thead>
     <tbody>
      <row>

--- a/reference/luasandbox/luasandbox/pauseusagetimer.xml
+++ b/reference/luasandbox/luasandbox/pauseusagetimer.xml
@@ -58,7 +58,7 @@ $sandbox->setCPULimit( 1 );
 function doWait( $t ) {
     $end = microtime( true ) + $t;
     while ( microtime( true ) < $end ) {
-        // waste CPU cycles
+        // gasta ciclos de CPU
     }
 }
 

--- a/reference/mail/functions/mail.xml
+++ b/reference/mail/functions/mail.xml
@@ -221,7 +221,7 @@
 <![CDATA[
 <?php
 // El mensaje
-$message = "Line 1\r\nLine 2\r\nLine 3";
+$message = "Línea 1\r\nLínea 2\r\nLínea 3";
 
 // En caso de que nuestras líneas contengan más de 70 caracteres, las cortamos utilizando wordwrap()
 $message = wordwrap($message, 70, "\r\n");

--- a/reference/mailparse/functions/mailparse-uudecode-all.xml
+++ b/reference/mailparse/functions/mailparse-uudecode-all.xml
@@ -71,8 +71,8 @@
 $texto = <<<EOD
 To: fred@example.com
 
-hello, this is some text hello.
-blah blah blah.
+hola, esto es un texto cualquiera.
+bla bla bla.
 
 begin 644 test.txt
 /=&AI<R!I<R!A('1E<W0*
@@ -86,7 +86,7 @@ fwrite($aa, $texto);
 
 $datos = mailparse_uudecode_all($aa);
 
-echo "BODY\n";
+echo "CUERPO\n";
 readfile($datos[0]["filename"]);
 echo "UUE ({$datos[1]['origfilename']})\n";
 readfile($datos[1]["filename"]);
@@ -101,11 +101,11 @@ unlink($datos[1]["filename"]);
    &example.outputs;
    <screen>
 <![CDATA[
-BODY
+CUERPO
 To: fred@example.com
 
-hello, this is some text hello.
-blah blah blah.
+hola, esto es un texto cualquiera.
+bla bla bla.
 
 UUE (test.txt)
 this is a test

--- a/reference/math/functions/asin.xml
+++ b/reference/math/functions/asin.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.asin" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>asin</refname>
-  <refpurpose>Arc sinus</refpurpose>
+  <refpurpose>Arco seno</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -14,7 +14,7 @@
    <methodparam><type>float</type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Se devuelve el arc sinus de <parameter>num</parameter>
+   Se devuelve el arco seno de <parameter>num</parameter>
    (<parameter>num</parameter> en radianes).
    <function>asin</function> es la función inversa de
    <function>sin</function>, lo que significa que
@@ -41,7 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   El arc sinus de <parameter>num</parameter>, en radianes.
+   El arco seno de <parameter>num</parameter>, en radianes.
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/mbstring/constants.xml
+++ b/reference/mbstring/constants.xml
@@ -128,8 +128,7 @@
    <listitem>
     <simpara>
      Realiza una conversión simple a title-case.
-     Performs simple title-case fold conversion.
-     Esto no cambia la longitud del string.
+     Esto no cambia la longitud de la cadena.
      Disponible desde PHP 7.3.
     </simpara>
    </listitem>

--- a/reference/mbstring/functions/mb-language.xml
+++ b/reference/mbstring/functions/mb-language.xml
@@ -36,9 +36,9 @@
        <tgroup cols="4">
         <thead>
          <row>
-          <entry>Language</entry>
-          <entry>Charset</entry>
-          <entry>Encoding</entry>
+          <entry>Idioma</entry>
+          <entry>Juego de caracteres</entry>
+          <entry>Codificación</entry>
           <entry>Alias</entry>
          </row>
         </thead>

--- a/reference/mcrypt/functions/mcrypt-decrypt.xml
+++ b/reference/mcrypt/functions/mcrypt-decrypt.xml
@@ -38,8 +38,8 @@
     <listitem>
      <simpara>
       La clave utilizada durante el cifrado de los datos. Si el tamaño de la clave
-      proporcionada no es soportado por el cipher, la función emitirá un
-      warning y devolverá &false;
+      proporcionada no es soportado por el cipher, la función emitirá una
+      advertencia y devolverá &false;
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mcrypt/functions/mcrypt-encrypt.xml
+++ b/reference/mcrypt/functions/mcrypt-encrypt.xml
@@ -42,8 +42,8 @@
     <listitem>
      <simpara>
       La clave con la que se cifrarán los datos. Si el tamaño de la clave
-      proporcionada no es compatible con el cipher, la función emitirá un
-      warning y devolverá &false;
+      proporcionada no es compatible con el cipher, la función emitirá una
+      advertencia y devolverá &false;
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
+++ b/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
@@ -29,9 +29,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -46,9 +46,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -49,9 +49,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -41,9 +41,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
@@ -43,9 +43,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
@@ -42,9 +42,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
@@ -52,9 +52,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -38,10 +38,10 @@
        <tgroup cols="4">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
-          <entry>Default</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
+          <entry>Por defecto</entry>
          </row>
         </thead>
         <tbody>
@@ -77,9 +77,9 @@
              <tgroup cols="3">
               <thead>
                <row>
-                <entry>Option</entry>
-                <entry>Type</entry>
-                <entry>Description</entry>
+                <entry>Opción</entry>
+                <entry>Tipo</entry>
+                <entry>Descripción</entry>
                </row>
               </thead>
               <tbody>

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -35,9 +35,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -47,9 +47,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -42,9 +42,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -41,9 +41,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/server/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadcommand.xml
@@ -44,9 +44,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
@@ -42,9 +42,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -52,9 +52,9 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -49,9 +49,9 @@
        <tgroup cols="4">
         <thead>
          <row>
-          <entry>Option</entry>
-          <entry>Type</entry>
-          <entry>Description</entry>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
          </row>
         </thead>
         <tbody>

--- a/reference/mqseries/functions/mqseries-back.xml
+++ b/reference/mqseries/functions/mqseries-back.xml
@@ -91,7 +91,7 @@
   <note>
    <simpara>
     <function>mqseries_back</function> no funciona cuando un
-    cliente MQSeries Client se conecta al Queue Manager.
+    cliente MQSeries Client se conecta al gestor de colas.
    </simpara>
   </note>
  </refsect1>

--- a/reference/mqseries/functions/mqseries-put1.xml
+++ b/reference/mqseries/functions/mqseries-put1.xml
@@ -54,7 +54,7 @@
      <parameter>objDesc</parameter>
     </term>
     <listitem>
-     <simpara>Descripteur del objeto (MQOD).</simpara>
+     <simpara>Descriptor del objeto (MQOD).</simpara>
      <simpara>
       Esta estructura identifica la cola en la que se añadirá el mensaje.
      </simpara>
@@ -65,7 +65,7 @@
      <parameter>msgDesc</parameter>
     </term>
     <listitem>
-     <simpara>Descripteur del mensaje (MQMD).</simpara>
+     <simpara>Descriptor del mensaje (MQMD).</simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/mysql/functions/mysql-pconnect.xml
+++ b/reference/mysql/functions/mysql-pconnect.xml
@@ -12,7 +12,7 @@
   <warning>
    &mysql.alternative.note;
    <simplelist role="alternatives">
-    <member><function>mysqli_connect</function> con <literal>p:</literal> host prefix</member>
+    <member><function>mysqli_connect</function> con el prefijo de host <literal>p:</literal></member>
     <member><methodname>PDO::__construct</methodname> con <constant>PDO::ATTR_PERSISTENT</constant> como una opción de controlador</member>
    </simplelist>
   </warning>

--- a/reference/mysql/functions/mysql-unbuffered-query.xml
+++ b/reference/mysql/functions/mysql-unbuffered-query.xml
@@ -12,7 +12,7 @@
   <warning>
    &mysql.alternative.note;
    <simplelist role="alternatives">
-    <member>See: <link linkend="mysqlinfo.concepts.buffering">Consultas almacenadas y no almacenadas en buffer</link></member>
+    <member>Véase: <link linkend="mysqlinfo.concepts.buffering">Consultas almacenadas y no almacenadas en buffer</link></member>
    </simplelist>
   </warning>
  </refsynopsisdiv>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1099,7 +1099,7 @@ $res->close();
     <listitem>
      <simpara>
       El número total de columnas de tipo
-      <literal>MYSQL_TYPE_STRING</literal>, <literal>MYSQL_TYPE_VARSTRING</literal>, or <literal>MYSQL_TYPE_VARCHAR</literal>
+      <literal>MYSQL_TYPE_STRING</literal>, <literal>MYSQL_TYPE_VARSTRING</literal> o <literal>MYSQL_TYPE_VARCHAR</literal>
       recuperadas desde una consulta normal (protocolo de texto MySQL).
      </simpara>
     </listitem>
@@ -1110,7 +1110,7 @@ $res->close();
     <listitem>
      <simpara>
       El número total de columnas de tipo
-      <literal>MYSQL_TYPE_STRING</literal>, <literal>MYSQL_TYPE_VARSTRING</literal>, or <literal>MYSQL_TYPE_VARCHAR</literal>
+      <literal>MYSQL_TYPE_STRING</literal>, <literal>MYSQL_TYPE_VARSTRING</literal> o <literal>MYSQL_TYPE_VARCHAR</literal>
       recuperadas desde una declaración preparada (protocolo binario MySQL).
      </simpara>
     </listitem>

--- a/reference/network/book.xml
+++ b/reference/network/book.xml
@@ -5,7 +5,7 @@
 
 <book xml:id="book.network" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="core" ?>
- <title>Network</title>
+ <title>Red</title>
 
  <!-- {{{ preface -->
  <preface xml:id="intro.network">

--- a/reference/network/functions/header-register-callback.xml
+++ b/reference/network/functions/header-register-callback.xml
@@ -50,7 +50,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="header-register-callback.example.basic">
-   <title><function>header_register_callback</function> example</title>
+   <title>Ejemplo de <function>header_register_callback</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -431,7 +431,7 @@ one : cookieone
   <simplelist>
    <member><function>header</function></member>
    <member><function>setrawcookie</function></member>
-   <member><link linkend="features.cookies">cookies section</link></member>
+   <member><link linkend="features.cookies">sección sobre cookies</link></member>
    <member><link xlink:href="&url.rfc;6265">RFC 6265</link></member>
    <member><link xlink:href="&url.rfc;2109">RFC 2109</link></member>
   </simplelist>

--- a/reference/oauth/oauth/setrequestengine.xml
+++ b/reference/oauth/oauth/setrequestengine.xml
@@ -72,7 +72,7 @@ $consumer->setRequestEngine(OAUTH_REQENGINE_STREAMS);
   &reftitle.seealso;
   <simplelist>
    <member><link linkend="book.curl">Curl</link></member>
-   <member><link linkend="book.stream">PHP streams</link></member>
+   <member><link linkend="book.stream">flujos PHP</link></member>
    <member><classname>OAuthException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/oauth/oauthprovider/is2leggedendpoint.xml
+++ b/reference/oauth/oauthprovider/is2leggedendpoint.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   An <classname>OAuthProvider</classname> <type>object</type>.
+   Un <type>object</type> de <classname>OAuthProvider</classname>.
   </simpara>
  </refsect1>
 

--- a/reference/oci8/taf.xml
+++ b/reference/oci8/taf.xml
@@ -203,7 +203,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>return value</parameter></term>
+     <term><parameter>valor de retorno</parameter></term>
      <listitem>
       <para>
        <itemizedlist>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -383,7 +383,7 @@
    Las funciones CMS utilizan banderas que se especifican utilizando
    una máscara de bits que incluye una o más de las siguientes opciones:
    <table>
-    <title><acronym>CMS</acronym> CONSTANTS</title>
+    <title>Constantes <acronym>CMS</acronym></title>
     <tgroup cols="2">
      <thead>
       <row>

--- a/reference/openssl/functions/openssl-password-verify.xml
+++ b/reference/openssl/functions/openssl-password-verify.xml
@@ -105,9 +105,9 @@
 $hash = openssl_password_hash('argon2id', 'my-secret-password');
 
 if (openssl_password_verify('argon2id', 'my-secret-password', $hash)) {
-    echo 'Password matches.';
+    echo 'La contraseña coincide.';
 } else {
-    echo 'Password does not match.';
+    echo 'La contraseña no coincide.';
 }
 ?>
 ]]>

--- a/reference/openssl/functions/openssl-pkcs12-export.xml
+++ b/reference/openssl/functions/openssl-pkcs12-export.xml
@@ -42,7 +42,7 @@
      <listitem>
       <para>
        Clave privada del archivo <acronym>PKCS</acronym>#12.
-       Consulte <link linkend="openssl.certparams">Public/Private Key Parameters</link> para obtener la lista de valores válidos.
+       Consulte <link linkend="openssl.certparams">Parámetros de claves pública/privada</link> para obtener la lista de valores válidos.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-pkey-get-details.xml
+++ b/reference/openssl/functions/openssl-pkey-get-details.xml
@@ -67,7 +67,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>&Description;</entry>
         </row>
        </thead>
@@ -117,7 +117,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>&Description;</entry>
         </row>
        </thead>
@@ -155,7 +155,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>&Description;</entry>
         </row>
        </thead>
@@ -197,7 +197,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>&Description;</entry>
         </row>
        </thead>

--- a/reference/openssl/ini.xml
+++ b/reference/openssl/ini.xml
@@ -54,7 +54,7 @@
     </term>
     <listitem>
      <para>
-      Ubicación del archivo Certificate Authority en el sistema de archivos local
+      Ubicación del archivo de Autoridad de Certificación en el sistema de archivos local
       que debería ser utilizado con la opción de contexto verify_peer para autenticar
       la identidad del par remoto.
      </para>

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -320,7 +320,7 @@
   </para>
   <para>
    PHP incluye dos gestores de salida internos:
-   <literal>"default output handler"</literal>
+   <literal>"default output handler"</literal> (el gestor de salida por defecto)
    y <literal>"URL-Rewriter"</literal> (que está integrado en
    su propio búfer de salida y solo hasta dos instancias del mismo pueden iniciarse).
   </para>

--- a/reference/parallel/parallel.events.xml
+++ b/reference/parallel/parallel.events.xml
@@ -34,22 +34,22 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Input</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Entrada</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='input']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback/>
     </xi:include>
 
-    <classsynopsisinfo role="comment">Targets</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Objetivos</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='targets']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback/>
     </xi:include>
 
-    <classsynopsisinfo role="comment">Behaviour</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Comportamiento</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='behaviour']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback/>
     </xi:include>
 
-    <classsynopsisinfo role="comment">Polling</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Sondeo</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='polling']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback/>
     </xi:include>

--- a/reference/parallel/parallel/future/value.xml
+++ b/reference/parallel/parallel/future/value.xml
@@ -42,7 +42,7 @@
   </warning>
   <warning>
    <simpara>
-    Relaunch una <type>Throwable</type> no atrapada en la tarea.
+    Vuelve a lanzar una <type>Throwable</type> no capturada en la tarea.
    </simpara>
   </warning>
  </refsect1>

--- a/reference/parle/pattern.matching.xml
+++ b/reference/parle/pattern.matching.xml
@@ -262,7 +262,7 @@
     <tgroup cols="3">
      <thead>
       <row>
-       <entry>Secuencia</entry><entry>Greedy</entry><entry>Descripción</entry>
+       <entry>Secuencia</entry><entry>Voraz</entry><entry>Descripción</entry>
       </row>
      </thead>
      <tbody>
@@ -270,13 +270,13 @@
        <entry>...|...</entry><entry>-</entry><entry>Probar los subpatrones en alternancia.</entry>
       </row>
       <row>
-       <entry>*</entry><entry>yes</entry><entry>Corresponde 0 o más veces.</entry>
+       <entry>*</entry><entry>sí</entry><entry>Corresponde 0 o más veces.</entry>
       </row>
       <row>
-       <entry>+</entry><entry>yes</entry><entry>Corresponde 1 o más veces.</entry>
+       <entry>+</entry><entry>sí</entry><entry>Corresponde 1 o más veces.</entry>
       </row>
       <row>
-       <entry>?</entry><entry>yes</entry><entry>Corresponde 0 o 1 vez.</entry>
+       <entry>?</entry><entry>sí</entry><entry>Corresponde 0 o 1 vez.</entry>
       </row>
       <row>
        <entry>{n}</entry><entry>no</entry><entry>Corresponde exactamente n veces.</entry>
@@ -285,7 +285,7 @@
        <entry>{n,}</entry><entry>no</entry><entry>Corresponde al menos n veces.</entry>
       </row>
       <row>
-       <entry>{n,m}</entry><entry>yes</entry><entry>Corresponde al menos n veces pero no más de m veces.</entry>
+       <entry>{n,m}</entry><entry>sí</entry><entry>Corresponde al menos n veces pero no más de m veces.</entry>
       </row>
       <row>
        <entry>*?</entry><entry>no</entry><entry>Corresponde 0 o más veces.</entry>

--- a/reference/password/reference.xml
+++ b/reference/password/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: no -->
 
 <reference xml:id="ref.password" xmlns="http://docbook.org/ns/docbook">
- <title>&Functions; de hashing de contraseñas</title>
+ <title>&Functions; de hash de contraseñas</title>
 
  &reference.password.entities.functions;
 

--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -565,7 +565,7 @@
    <listitem>
     <simpara>
      Genera/restituye un punto de control.
-     Disponible a partir de PHP 8.4.0 (uniquely on DragonFlyBSD).
+     Disponible a partir de PHP 8.4.0 (únicamente en DragonFlyBSD).
     </simpara>
    </listitem>
   </varlistentry>
@@ -577,7 +577,7 @@
    <listitem>
     <simpara>
      Genera/restituye un punto de control y sale.
-     Disponible a partir de PHP 8.4.0 (uniquely on DragonFlyBSD).
+     Disponible a partir de PHP 8.4.0 (únicamente en DragonFlyBSD).
     </simpara>
    </listitem>
   </varlistentry>
@@ -1481,7 +1481,7 @@
   </varlistentry>
  </variablelist>
  <variablelist xml:id="pcntl.constants.fork">
-  <title>FORK_* constants</title>
+  <title>Constantes FORK_*</title>
   <varlistentry xml:id="constant.fork-nosigchld">
    <term>
     <constant>FORK_NOSIGCHLD</constant>
@@ -1504,7 +1504,7 @@
   </varlistentry>
  </variablelist>
  <variablelist xml:id="pcntl.constants.rf">
-  <title>RF* constants</title>
+  <title>Constantes RF*</title>
   <varlistentry xml:id="constant.rfcfdg">
    <term>
     <constant>RFCFDG</constant>

--- a/reference/pcntl/pcntl.qosclass.xml
+++ b/reference/pcntl/pcntl.qosclass.xml
@@ -45,7 +45,7 @@
 
      <enumitem>
       <enumidentifier>Utility</enumidentifier>
-      <enumitemdescription>Pcntl\QosClass::Utility description</enumitemdescription>
+      <enumitemdescription>Descripción de Pcntl\QosClass::Utility</enumitemdescription>
      </enumitem>
 
      <enumitem>

--- a/reference/pcre/functions/preg-last-error.xml
+++ b/reference/pcre/functions/preg-last-error.xml
@@ -27,7 +27,7 @@
 preg_match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar');
 
 if (preg_last_error() == PREG_BACKTRACK_LIMIT_ERROR) {
-    echo 'Backtrack limit was exhausted!';
+    echo '¡Se ha agotado el límite de retroceso!';
 }
 
 ?>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -185,7 +185,7 @@ array(4) {
         ya que <parameter>pattern</parameter> puede contener aserciones como
         <emphasis>^</emphasis>, <emphasis>$</emphasis> o
         <emphasis>(?&lt;=x)</emphasis>.
-        Compare:
+        Compárese:
         <informalexample>
          <programlisting role="php">
 <![CDATA[

--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -38,7 +38,7 @@
      </row>
      <row>
       <entry>
-       <constant>PDO::FETCH_BOTH</constant> (Default)
+       <constant>PDO::FETCH_BOTH</constant> (por defecto)
       </entry>
       <entry>
        Array indexado tanto por el número de columna como por el nombre.

--- a/reference/pdo/pdo/commit.xml
+++ b/reference/pdo/pdo/commit.xml
@@ -79,7 +79,7 @@ $dbh->commit();
   </para>
   <para>
    <example>
-    <title>Committing a DDL transaction</title>
+    <title>Confirmando una transacción DDL</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/pdo/pdo/construct.xml
+++ b/reference/pdo/pdo/construct.xml
@@ -60,7 +60,7 @@
           <para><userinput>uri:file:///path/to/dsnfile</userinput></para>
          </listitem>
         </varlistentry>
-        <varlistentry><term>Aliasing</term>
+        <varlistentry><term>Alias</term>
          <listitem>
           <para>
            <parameter>dsn</parameter> está compuesto por un nombre

--- a/reference/pdo/pdo/errorinfo.xml
+++ b/reference/pdo/pdo/errorinfo.xml
@@ -86,7 +86,7 @@
 <![CDATA[
 <?php
 /* Provoca un error -- sintaxis SQL incorrecta */
-$stmt = $dbh->prepare('mauvaise syntaxe sql');
+$stmt = $dbh->prepare('sintaxis sql incorrecta');
 if (!$stmt) {
    echo "\nPDO::errorInfo():\n";
    print_r($dbh->errorInfo());

--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -27,7 +27,7 @@
    <title>Cursores desplazables</title>
    <simpara>
     PDO_CUBRID soporta los cursores desplazables. El tipo de cursor por omisión es
-    forward only, y se puede utilizar el argumento driver_options en
+    de solo avance, y se puede utilizar el argumento driver_options en
     <methodname>PDO::prepare</methodname> para cambiar el tipo de cursor.
    </simpara>
   </section>
@@ -153,7 +153,7 @@ fpassthru($result[0]);
    </para>
   </section>
   <section>
-   <title>Tipo de datos Collection</title>
+   <title>Tipo de datos Colección</title>
 
    <simpara>
     PDO_CUBRID soporta los tipos de datos SET/MULTISET/SEQUENCE.
@@ -206,7 +206,7 @@ var_Dump($ret);
     </example>
 
     <para>
-     Tipos de datos CUBRID Bind para el quinto argumento de
+     Tipos de datos de enlace CUBRID para el quinto argumento de
      <methodname>PDOStatement::bindParam</methodname>:
      <simplelist>
       <member>CHAR</member>

--- a/reference/pdo_firebird/pdo-firebird.xml
+++ b/reference/pdo_firebird/pdo-firebird.xml
@@ -148,7 +148,7 @@
      <term><constant>Pdo\Firebird::READ_COMMITTED</constant></term>
      <listitem>
       <simpara>
-       Flag que indica que el nivel de aislamiento de la transacción <acronym>ANSI</acronym>
+       Bandera que indica que el nivel de aislamiento de la transacción <acronym>ANSI</acronym>
        es read committed.
        Este es el comportamiento por omisión.
       </simpara>
@@ -158,7 +158,7 @@
      <term><constant>Pdo\Firebird::REPEATABLE_READ</constant></term>
      <listitem>
       <simpara>
-       Flag que indica que el nivel de aislamiento de la transacción <acronym>ANSI</acronym>
+       Bandera que indica que el nivel de aislamiento de la transacción <acronym>ANSI</acronym>
        es repeatable read.
        Esto corresponde al nivel de aislamiento "snapshot" de Firebird.
       </simpara>
@@ -168,7 +168,7 @@
      <term><constant>Pdo\Firebird::SERIALIZABLE</constant></term>
      <listitem>
       <simpara>
-       Flag que indica que el nivel de aislamiento de la transacción <acronym>ANSI</acronym>
+       Bandera que indica que el nivel de aislamiento de la transacción <acronym>ANSI</acronym>
        es serializable.
        Esto corresponde al nivel de aislamiento "snapshot table stability" de Firebird.
       </simpara>

--- a/reference/pdo_mysql/ini.xml
+++ b/reference/pdo_mysql/ini.xml
@@ -8,7 +8,7 @@
  &extension.runtime;
  <para>
   <table>
-   <title>Opciones de configuración del driver PDO_MYSQL</title>
+   <title>Opciones de configuración del controlador PDO_MYSQL</title>
    <tgroup cols="3">
     <thead>
      <row>
@@ -59,8 +59,8 @@
     </term>
     <listitem>
      <para>
-      Se activa el depurado para el driver PDO_MYSQL. Esta configuración solo
-      está disponible cuando el driver PDO_MYSQL es compilado con mysqlnd
+      Se activa el depurado para el controlador PDO_MYSQL. Esta configuración solo
+      está disponible cuando el controlador PDO_MYSQL es compilado con mysqlnd
       y en modo de depurado PDO.
      </para>
     </listitem>

--- a/reference/pdo_pgsql/pdo/pgsql/lobcreate.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobcreate.xml
@@ -31,7 +31,7 @@
    antes de eliminar la última fila que referencia el OID en toda la base de datos;
    de lo contrario, los objetos grandes no referenciados permanecerán en el servidor indefinidamente.
    Además, los objetos grandes no tienen controles de acceso.
-   Una alternativa es el tipo de columna bytea, que puede ser de hasta 1 Go de tamaño,
+   Una alternativa es el tipo de columna bytea, que puede ser de hasta 1 GB de tamaño,
    y este tipo de columna gestiona de manera transparente el almacenamiento para un tamaño de fila óptimo.
   </simpara>
   <note>

--- a/reference/pdo_sqlsrv/configure.xml
+++ b/reference/pdo_sqlsrv/configure.xml
@@ -5,7 +5,7 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ref.pdo-sqlsrv.installation">
  &reftitle.install;
  <simpara>
-  La versión más reciente del controlador está disponible para su descarga aquí :
+  La versión más reciente del controlador está disponible para su descarga aquí:
   <link xlink:href="&url.sqlsrv;">descarga SQLSRV</link>.
   Las fuentes del controlador se alojan en un <link xlink:href="&url.sqlsrv.repo;">repositorio público</link>.
  </simpara>

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -192,7 +192,7 @@ $c = new PDO("sqlsrv:Server=localhost,1521;Database=bddtest", "Utilisateur", "Mo
     <para>
      El siguiente ejemplo muestra cómo conectarse a una base de datos SQL Azure con
      el ID servidor 12345abcde. Tenga en cuenta que, al conectarse a Azure con PDO,
-     su nombre de usuario será Utilisateur@12345abcde (Utilisateur@IdServidor).
+     su nombre de usuario será Usuario@12345abcde (Usuario@IdServidor).
      <programlisting>
 <![CDATA[
 $c = new PDO("sqlsrv:Server=12345abcde.database.windows.net;Database=bddtest", "Utilisateur@12345abcde", "MotDePasse");

--- a/reference/pgsql/functions/pg-client-encoding.xml
+++ b/reference/pgsql/functions/pg-client-encoding.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>pg_client_encoding</refname>
   <refpurpose>
-   Lee el encodage del cliente
+   Lee la codificación del cliente
   </refpurpose>
  </refnamediv>
 
@@ -18,17 +18,17 @@
   <para>
    PostgreSQL soporta la conversión automática entre el servidor y el cliente
    para ciertos juegos de caracteres. <function>pg_client_encoding</function>
-   devuelve el encodage del cliente. El string de retorno será uno de los encodages
+   devuelve la codificación del cliente. La cadena devuelta será una de las codificaciones
    estándar de PostgreSQL.
   </para>
   <note>
    <para>
     Si la biblioteca libpq es compilada sin
-    el soporte de encodage multiocteto,
+    el soporte de codificaciones multibyte,
     <function>pg_client_encoding</function> devolverá siempre
-    <literal>SQL_ASCII</literal>. El soporte de encodage depende de la versión
-    de PostgreSQL. Consúltese la documentación de PostgreSQL sobre los
-    encodages soportados.
+    <literal>SQL_ASCII</literal>. El soporte de codificaciones depende de la versión
+    de PostgreSQL. Consúltese la documentación de PostgreSQL sobre las
+    codificaciones soportadas.
    </para>
    <para>
     Anteriormente, esta función se llamaba <function>pg_clientencoding</function>.
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   El encodage del cliente.
+   La codificación del cliente.
   </para>
  </refsect1>
 
@@ -88,17 +88,17 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Assume $conn siendo una conexión a una base de datos ISO-8859-1
+// Se asume que $conn es una conexión a una base de datos ISO-8859-1
 $encoding = pg_client_encoding($conn);
 
-echo "El encodage del cliente es: ", $encoding, "\n";
+echo "La codificación del cliente es: ", $encoding, "\n";
 ?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-El encodage del cliente es: ISO-8859-1
+La codificación del cliente es: ISO-8859-1
 ]]>
     </screen>
    </example>

--- a/reference/phar/Phar/interceptFileFuncs.xml
+++ b/reference/phar/Phar/interceptFileFuncs.xml
@@ -56,7 +56,7 @@ include 'phar://' . __FILE__ . '/fichero.php';
    </example>
   </para>
   <para>
-   Suponiendo que este phar se llama <literal>/ruta/hacia/monphar.phar</literal> y contiene
+   Suponiendo que este phar se llama <literal>/ruta/hacia/miphar.phar</literal> y contiene
    <literal>fichero.php</literal> y
    <literal>fichero2.txt</literal>, si <literal>fichero.php</literal> contiene este código:
   </para>
@@ -76,8 +76,8 @@ echo file_get_contents('fichero2.txt');
    Normalmente, PHP buscaría en el directorio actual el archivo llamado <literal>file2.txt</literal>,
    es decir, en el directorio de fichero.php o el directorio actual del usuario de la línea
    de comandos. <function>Phar::interceptFileFuncs</function> indica
-   a PHP que considere <literal>phar:///ruta/hacia/monphar.phar/</literal> como directorio actual
-   y así abre en el ejemplo anterior el archivo <literal>phar:///ruta/hacia/monphar.phar/fichero2.txt</literal>.
+   a PHP que considere <literal>phar:///ruta/hacia/miphar.phar/</literal> como directorio actual
+   y así abre en el ejemplo anterior el archivo <literal>phar:///ruta/hacia/miphar.phar/fichero2.txt</literal>.
   </para>
  </refsect1>
 

--- a/reference/phar/Phar/webPhar.xml
+++ b/reference/phar/Phar/webPhar.xml
@@ -191,16 +191,16 @@ $mimes = array(
     <title>Ejemplo con <function>Phar::webPhar</function></title>
     <para>
      En el ejemplo siguiente, el phar creado mostrará <literal>Hola mundo</literal>
-     si alguien llama a <literal>/monphar.phar/index.php</literal> o
-     <literal>/monphar.phar</literal>, y mostrará la fuente de
-     <literal>index.phps</literal> si <literal>/monphar.phar/index.phps</literal> es llamado.
+     si alguien llama a <literal>/miphar.phar/index.php</literal> o
+     <literal>/miphar.phar</literal>, y mostrará la fuente de
+     <literal>index.phps</literal> si <literal>/miphar.phar/index.phps</literal> es llamado.
     </para>
     <programlisting role="php">
 <![CDATA[
 <?php
 // el archivo phar es creado:
 try {
-    $phar = new Phar('monphar.phar');
+    $phar = new Phar('miphar.phar');
     $phar['index.php'] = '<?php echo "Hola mundo"; ?>';
     $phar['index.phps'] = '<?php echo "Hola mundo"; ?>';
     $phar->setStub('<?php

--- a/reference/phar/PharFileInfo/construct.xml
+++ b/reference/phar/PharFileInfo/construct.xml
@@ -28,9 +28,9 @@
      <listitem>
       <para>
        La URL completa para recuperar un fichero. Si se desea recuperar
-       la información del fichero <literal>mon/fichier.php</literal>
+       la información del fichero <literal>mi/fichero.php</literal>
        del phar <literal>boo.phar</literal>, se deberá especificar
-       <literal>phar://boo.phar/mon/fichier.php</literal>.
+       <literal>phar://boo.phar/mi/fichero.php</literal>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/phar/fileformat.xml
+++ b/reference/phar/fileformat.xml
@@ -231,7 +231,7 @@ __HALT_COMPILER();
    comprimidas son soportadas por la compresión zlib DEFLATE, y solo las lecturas comprimidas por
    la compresión bzip2. No hay límite en el número de archivos dentro de un archivo phar
    basado en zip. Los directorios vacíos se almacenan en el archivo zip como archivos con una barra final,
-   como <literal>mon/repertoire/</literal>
+   como <literal>mi/directorio/</literal>
   </para>
  </section>
  <section xml:id="phar.fileformat.phar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -406,7 +406,7 @@ __HALT_COMPILER();
   </para>
   <para>
    Se debe notar que a partir de la API 1.1.1, los directorios vacíos son almacenados como nombres de archivo
-   con una barra final como <literal>mon/repertoire/</literal>
+   con una barra final como <literal>mi/directorio/</literal>
   </para>
   <para>
    Los valores reconocidos de flags bitmapped específicos del archivo son:

--- a/reference/phar/using.xml
+++ b/reference/phar/using.xml
@@ -139,8 +139,8 @@ openssl_pkey_export($public, $pkey);
    ]]>
   </programlisting>
   debe ser guardada por separado del archivo phar que verifica. Si el archivo phar es guardado
-  como <literal>/ruta/hacia/mon.phar</literal>, la clave pública debe ser guardada como
-  <literal>/ruta/hacia/mon.phar.pubkey</literal>, de lo contrario phar no será capaz de verificar
+  como <literal>/ruta/hacia/mi.phar</literal>, la clave pública debe ser guardada como
+  <literal>/ruta/hacia/mi.phar.pubkey</literal>, de lo contrario phar no será capaz de verificar
   la firma OpenSSL.
  </para>
  <para>
@@ -275,17 +275,17 @@ file_put_contents('phar://mon.phar/unfichero.php', 0, $context);
    <programlisting role="php">
 <![CDATA[
 <?php
-$p = new Phar('/ruta/hacia/monphar.phar', 0, 'monphar.phar');
+$p = new Phar('/ruta/hacia/miphar.phar', 0, 'miphar.phar');
 ?>
 ]]>
    </programlisting>
   </informalexample>
  </para>
  <para>
-  Un archivo Phar vacío será creado como <literal>/ruta/hacia/monphar.phar</literal>,
-  o si <literal>/ruta/hacia/monphar.phar</literal> ya existe, será abierto
-  de nuevo. El término <literal>monphar.phar</literal> demuestra el concepto de un alias
-  que puede ser utilizado para referenciar <literal>/ruta/hacia/monphar.phar</literal> en URLs como esto:
+  Un archivo Phar vacío será creado como <literal>/ruta/hacia/miphar.phar</literal>,
+  o si <literal>/ruta/hacia/miphar.phar</literal> ya existe, será abierto
+  de nuevo. El término <literal>miphar.phar</literal> demuestra el concepto de un alias
+  que puede ser utilizado para referenciar <literal>/ruta/hacia/miphar.phar</literal> en URLs como esto:
  </para>
  <para>
   <informalexample>
@@ -293,11 +293,11 @@ $p = new Phar('/ruta/hacia/monphar.phar', 0, 'monphar.phar');
 <![CDATA[
 <?php
 // estas dos llamadas a file_get_contents() son equivalentes si
-// /ruta/hacia/monphar.phar tiene un alias explícito de "monphar.phar"
+// /ruta/hacia/miphar.phar tiene un alias explícito de "miphar.phar"
 // en su manifiesto, o si el phar fue inicializado con la instanciación de
 // el objeto Phar del ejemplo anterior
-$f = file_get_contents('phar:///ruta/hacia/monphar.phar/algo.txt');
-$f = file_get_contents('phar://monphar.phar/algo.txt');
+$f = file_get_contents('phar:///ruta/hacia/miphar.phar/algo.txt');
+$f = file_get_contents('phar://miphar.phar/algo.txt');
 ?>
 ]]>
    </programlisting>
@@ -310,14 +310,14 @@ $f = file_get_contents('phar://monphar.phar/algo.txt');
    <listitem>
     <simpara>
      <literal>$a = $p['fichero.php']</literal> crea una <classname>PharFileInfo</classname>
-     que se refiere al contenido de <literal>phar://monphar.phar/fichero.php</literal>
+     que se refiere al contenido de <literal>phar://miphar.phar/fichero.php</literal>
     </simpara>
    </listitem>
    <listitem>
     <simpara>
      <literal>$p['fichero.php'] = $v</literal> crea un nuevo fichero
-     (<literal>phar://monphar.phar/fichero.php</literal>), o sobrescribe
-     un fichero existente dentro de <literal>monphar.phar</literal>.  <literal>$v</literal>
+     (<literal>phar://miphar.phar/fichero.php</literal>), o sobrescribe
+     un fichero existente dentro de <literal>miphar.phar</literal>.  <literal>$v</literal>
      puede ser una cadena o un puntero a un fichero abierto, en cuyo caso
      el contenido del fichero será utilizado para crear el nuevo fichero. Tenga en cuenta que
      <literal>$p-&gt;addFromString('fichero.php', $v)</literal> es equivalente en términos de
@@ -330,15 +330,15 @@ $f = file_get_contents('phar://monphar.phar/algo.txt');
    <listitem>
     <simpara>
      <literal>isset($p['fichero.php'])</literal> puede ser utilizado para determinar
-     si <literal>phar://monphar.phar/fichero.php</literal> existe dentro de
-     <literal>monphar.phar</literal>.
+     si <literal>phar://miphar.phar/fichero.php</literal> existe dentro de
+     <literal>miphar.phar</literal>.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
      <literal>unset($p['fichero.php'])</literal> elimina
-     <literal>phar://monphar.phar/fichero.php</literal> de
-     <literal>monphar.phar</literal>.
+     <literal>phar://miphar.phar/fichero.php</literal> de
+     <literal>miphar.phar</literal>.
     </simpara>
    </listitem>
   </itemizedlist>

--- a/reference/posix/functions/posix-eaccess.xml
+++ b/reference/posix/functions/posix-eaccess.xml
@@ -100,7 +100,7 @@
 $file = 'some_file';
 
 if (posix_eaccess($file, POSIX_R_OK | POSIX_W_OK)) {
-    echo 'The file is readable and writable!';
+    echo '¡El fichero se puede leer y escribir!';
 
 } else {
     $error = posix_get_last_error();

--- a/reference/posix/functions/posix-geteuid.xml
+++ b/reference/posix/functions/posix-geteuid.xml
@@ -63,7 +63,7 @@ echo posix_geteuid()."\n"; //10000
     <member><function>posix_getpwuid</function></member>
     <member><function>posix_getuid</function></member>
     <member><function>posix_setuid</function></member>
-    <member>POSIX man page GETEUID(2)</member>
+    <member>Página GETEUID(2) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getgid.xml
+++ b/reference/posix/functions/posix-getgid.xml
@@ -60,7 +60,7 @@ echo 'Mi id efectivo de grupo es '.posix_getegid(); //40
     <member><function>posix_getgrgid</function></member>
     <member><function>posix_getegid</function></member>
     <member><function>posix_setgid</function></member>
-    <member>POSIX man page GETGID(2)</member>
+    <member>Página GETGID(2) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getgrgid.xml
+++ b/reference/posix/functions/posix-getgrgid.xml
@@ -130,7 +130,7 @@ Array
     <member><function>posix_getgrnam</function></member>
     <member><function>filegroup</function></member>
     <member><function>stat</function></member>
-    <member>POSIX man page GETGRNAM(3)</member>
+    <member>Página GETGRNAM(3) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getgrnam.xml
+++ b/reference/posix/functions/posix-getgrnam.xml
@@ -127,7 +127,7 @@ Array
     <member><function>posix_getgrgid</function></member>
     <member><function>filegroup</function></member>
     <member><function>stat</function></member>
-    <member>POSIX man page GETGRNAM(3)</member>
+    <member>Página GETGRNAM(3) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getlogin.xml
+++ b/reference/posix/functions/posix-getlogin.xml
@@ -51,7 +51,7 @@ echo posix_getlogin(); //apache
   <para>
    <simplelist>
     <member><function>posix_getpwnam</function></member>
-    <member>POSIX man page GETLOGIN(3)</member>
+    <member>Página GETLOGIN(3) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getpid.xml
+++ b/reference/posix/functions/posix-getpid.xml
@@ -51,7 +51,7 @@ echo posix_getpid(); //8805
   <para>
    <simplelist>
     <member><function>posix_kill</function></member>
-    <member>POSIX man page GETPID(2)</member>
+    <member>Página GETPID(2) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getpwnam.xml
+++ b/reference/posix/functions/posix-getpwnam.xml
@@ -152,7 +152,7 @@ Array
   <para>
    <simplelist>
     <member><function>posix_getpwuid</function></member>
-    <member>POSIX man page GETPWNAM(3)</member>
+    <member>Página GETPWNAM(3) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getsid.xml
+++ b/reference/posix/functions/posix-getsid.xml
@@ -72,7 +72,7 @@ echo posix_getsid($pid); //8805
     <member>
      <function>posix_setsid</function>
     </member>
-    <member>POSIX man page GETSID(2)</member>
+    <member>Página GETSID(2) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getuid.xml
+++ b/reference/posix/functions/posix-getuid.xml
@@ -52,7 +52,7 @@ echo posix_getuid(); //10000
    <simplelist>
     <member>
      <function>posix_getpwuid</function></member>
-    <member>POSIX man page GETUID(2)</member>
+    <member>Página GETUID(2) del man de POSIX</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-uname.xml
+++ b/reference/posix/functions/posix-uname.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns un hash de cadena con información sobre el
+   Devuelve un hash de cadena con información sobre el
    sistema. Los índices del hash son
    <itemizedlist>
     <listitem><simpara>

--- a/reference/pspell/pspell.config.xml
+++ b/reference/pspell/pspell.config.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pspell-config" role="class" xmlns="http://docbook.org/ns/docbook">
- <title>The PSpell\Config class</title>
+ <title>La clase PSpell\Config</title>
  <titleabbrev>PSpell\Config</titleabbrev>
 
  <partintro>

--- a/reference/pspell/pspell.dictionary.xml
+++ b/reference/pspell/pspell.dictionary.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pspell-dictionary" role="class" xmlns="http://docbook.org/ns/docbook">
- <title>The PSpell\Dictionary class</title>
+ <title>La clase PSpell\Dictionary</title>
  <titleabbrev>PSpell\Dictionary</titleabbrev>
 
  <partintro>

--- a/reference/rnp/functions/rnp-key-export-revocation.xml
+++ b/reference/rnp/functions/rnp-key-export-revocation.xml
@@ -60,7 +60,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>Tipo de datos</entry>
          <entry>&Description;</entry>
         </row>

--- a/reference/rnp/functions/rnp-key-get-info.xml
+++ b/reference/rnp/functions/rnp-key-get-info.xml
@@ -51,7 +51,7 @@
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Key</entry>
+      <entry>Clave</entry>
       <entry>Tipo de datos</entry>
       <entry>&Description;</entry>
      </row>

--- a/reference/rnp/functions/rnp-key-revoke.xml
+++ b/reference/rnp/functions/rnp-key-revoke.xml
@@ -59,7 +59,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>Tipo de datos</entry>
          <entry>&Description;</entry>
         </row>

--- a/reference/rnp/functions/rnp-op-encrypt.xml
+++ b/reference/rnp/functions/rnp-op-encrypt.xml
@@ -59,7 +59,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>Tipo de dato</entry>
          <entry>&Description;</entry>
         </row>

--- a/reference/rnp/functions/rnp-op-sign-cleartext.xml
+++ b/reference/rnp/functions/rnp-op-sign-cleartext.xml
@@ -60,7 +60,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>Tipo de dato</entry>
          <entry>&Description;</entry>
         </row>

--- a/reference/rnp/functions/rnp-op-sign-detached.xml
+++ b/reference/rnp/functions/rnp-op-sign-detached.xml
@@ -60,7 +60,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>Tipo de dato</entry>
          <entry>&Description;</entry>
         </row>

--- a/reference/rnp/functions/rnp-op-sign.xml
+++ b/reference/rnp/functions/rnp-op-sign.xml
@@ -60,7 +60,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Key</entry>
+         <entry>Clave</entry>
          <entry>Tipo de datos</entry>
          <entry>&Description;</entry>
         </row>

--- a/reference/rnp/functions/rnp-op-verify-detached.xml
+++ b/reference/rnp/functions/rnp-op-verify-detached.xml
@@ -60,7 +60,7 @@
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Key</entry>
+      <entry>Clave</entry>
       <entry>Tipo de datos</entry>
       <entry>&Description;</entry>
      </row>
@@ -121,7 +121,7 @@
   <tgroup cols="2">
    <thead>
     <row>
-     <entry>Key</entry>
+     <entry>Clave</entry>
      <entry>Tipo de datos</entry>
      <entry>&Description;</entry>
     </row>

--- a/reference/rnp/functions/rnp-op-verify.xml
+++ b/reference/rnp/functions/rnp-op-verify.xml
@@ -36,7 +36,6 @@
     <listitem>
      <simpara>
       Los datos firmados.
-      Signed data.
      </simpara>
     </listitem>
    </varlistentry>
@@ -52,7 +51,7 @@
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Key</entry>
+      <entry>Clave</entry>
       <entry>Tipo de datos</entry>
       <entry>&Description;</entry>
      </row>
@@ -113,7 +112,7 @@
     <tgroup cols="2">
      <thead>
       <row>
-       <entry>Key</entry>
+       <entry>Clave</entry>
        <entry>Tipo de datos</entry>
        <entry>&Description;</entry>
       </row>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -161,13 +161,13 @@
       <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
       <entry>"32"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Disponible a partir de PHP 7.1.0. Obsolète a partir de PHP 8.4.0.</entry>
+      <entry>Disponible a partir de PHP 7.1.0. Obsoleto a partir de PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.sid-bits-per-character">session.sid_bits_per_character</link></entry>
       <entry>"4"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Disponible a partir de PHP 7.1.0. Obsolète a partir de PHP 8.4.0.</entry>
+      <entry>Disponible a partir de PHP 7.1.0. Obsoleto a partir de PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.upload-progress.enabled">session.upload_progress.enabled</link></entry>

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -491,7 +491,7 @@
   </sect2>
 
   <sect2 xml:id="features.session.security.management.csrf">
-   <title>Attaques CSRF (Cross-Site Request Forgeries)</title>
+   <title>Ataques CSRF (Cross-Site Request Forgeries)</title>
 
    <para>
     Las sesiones y las autenticaciones no protegen contra los

--- a/reference/simdjson/constants.xml
+++ b/reference/simdjson/constants.xml
@@ -13,7 +13,7 @@
    <listitem>
     <simpara>
      Este analizador no puede manejar un documento tan voluminoso.
-     Se lanza al analizar una cadena JSON de más de 4 Gio.
+     Se lanza al analizar una cadena JSON de más de 4 GiB.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/simdjson/functions/simdjson-decode.xml
+++ b/reference/simdjson/functions/simdjson-decode.xml
@@ -37,7 +37,7 @@
      <simpara>
       Esta función analiza las entradas válidas que
       <function>json_decode</function> puede decodificar,
-      siempre que sean inferiores a 4 Go de longitud.
+      siempre que sean inferiores a 4 GB de longitud.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/simdjson/functions/simdjson-is-valid.xml
+++ b/reference/simdjson/functions/simdjson-is-valid.xml
@@ -34,7 +34,7 @@
       <simpara>
        Esta función valida las entradas que
        <function>json_decode</function> puede decodificar,
-       siempre que sean inferiores a 4 Go de longitud.
+       siempre que sean inferiores a 4 GB de longitud.
       </simpara>
     </listitem>
    </varlistentry>

--- a/reference/simdjson/functions/simdjson-key-value.xml
+++ b/reference/simdjson/functions/simdjson-key-value.xml
@@ -36,7 +36,7 @@
       <simpara>
        Esta función analiza las entradas válidas que
        <function>json_decode</function> puede decodificar,
-       siempre que sean inferiores a 4 Go de longitud.
+       siempre que sean inferiores a 4 GB de longitud.
       </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/functions/snmp-set-enum-print.xml
+++ b/reference/snmp/functions/snmp-set-enum-print.xml
@@ -30,7 +30,7 @@
     <listitem>
      <simpara>
       Dado que el valor es interpretado como un bool por
-      la biblioteca Net-SNMP library, puede valer "0" o "1".
+      la biblioteca Net-SNMP, puede valer "0" o "1".
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/functions/snmp-set-valueretrieval.xml
+++ b/reference/snmp/functions/snmp-set-valueretrieval.xml
@@ -25,7 +25,7 @@
     </term>
     <listitem>
      <table>
-      <title>types</title>
+      <title>Tipos</title>
       <tgroup cols="2">
        <tbody>
         <row>

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -60,7 +60,7 @@
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
      <simpara>
-      El protocolo de autenticación (MD5 or SHA)
+      El protocolo de autenticación (MD5 o SHA)
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/snmp/geterrno.xml
+++ b/reference/snmp/snmp/geterrno.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.geterrno">
  <refnamediv>
   <refname>SNMP::getErrno</refname>
-  <refpurpose>Get last error code</refpurpose>
+  <refpurpose>Obtiene el último código de error</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/snmp/snmp/set.xml
+++ b/reference/snmp/snmp/set.xml
@@ -99,8 +99,7 @@
    </programlisting>
   </example>
   <example xml:id="snmp.set.example.multiple">
-   <title>Define varios valores utilizando una sola llamada al método <methodname>SNMP::set</methodname>
-    call</title>
+   <title>Define varios valores utilizando una sola llamada al método <methodname>SNMP::set</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/security/cgi-bin.xml
+++ b/security/cgi-bin.xml
@@ -88,9 +88,9 @@
      petición de redireccionada la solicitud, puedes habilitar la directiva ini <link linkend="ini.cgi.force-redirect">cgi.force_redirect</link>.  Usted todavía tiene que asegurarse que sus
      scripts de PHP no confían en una forma o en otra para llamar el script,
      ni directamente <filename
-     role="php">http://my.host/cgi-bin/php/dir/script.php</filename>
+     role="php">http://mi.servidor/cgi-bin/php/directorio/script.php</filename>
      ni por redirección <filename
-     role="php">http://my.host/dir/script.php</filename>.
+     role="php">http://mi.servidor/directorio/script.php</filename>.
     </simpara>
     <simpara>
      La redirección puede ser configurada en Apache utilizando directivas


### PR DESCRIPTION
Sweep que traduce a español fragmentos en inglés o francés (títulos, comentarios y cadenas en ejemplos, prosa) restantes de copy-paste antiguos.