### PR TITLE
Traducir restos de inglés y francés (2/2)

### DIFF
--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5208882ce3910d599e339209f967e183b49ba6ef Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5f720ab2b9c8122d1a127684748712fc57a24d06 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="tokens" xmlns="http://docbook.org/ns/docbook">
  <title>Lista de tokens del analizador</title>
@@ -995,6 +995,13 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><link linkend="language.oop5.paamayim-nekudotayim">resolución de ámbito</link>. Definido también
      como <constant>T_DOUBLE_COLON</constant>.</entry>
     </row>
+    <row xml:id="constant.t-pipe">
+     <entry><constant>T_PIPE</constant></entry>
+     <entry>|></entry>
+     <entry>
+      <link linkend="language.operators.functional">operadores funcionales</link> (disponible a partir de PHP 8.5.0)
+     </entry>
+    </row>
     <row xml:id="constant.t-plus-equal">
      <entry>
       <constant>T_PLUS_EQUAL</constant>
@@ -1296,6 +1303,11 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
      <entry>$foo</entry>
      <entry><link linkend="language.variables">variables</link></entry>
+    </row>
+    <row xml:id="constant.t-void-cast">
+     <entry><constant>T_VOID_CAST</constant></entry>
+     <entry>(void)</entry>
+     <entry><link linkend="language.types.void">conversión void</link> (disponible a partir de PHP 8.5.0)</entry>
     </row>
     <row xml:id="constant.t-while">
      <entry>

--- a/reference/memcached/memcached/construct.xml
+++ b/reference/memcached/memcached/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1d8068ecb070fdc360d750e0c1f3f15796e61ec0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c49d175bb3853b8851e961ac01a6f0b24de42269 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="memcached.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -40,16 +40,25 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
-       <!-- TODO Document constructor params -->
-      </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>Memcached</type><parameter>memcached</parameter></methodparam>
+       <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>persistent_id</parameter></methodparam>
+      </methodsynopsis>
+      <simpara>
+       El parámetro <parameter>callback</parameter> es llamado cuando se
+       establece la conexión. Debe ser un <type>callable</type> PHP válido
+       que reciba el objeto <classname>Memcached</classname> como su primer
+       parámetro, y <parameter>persistent_id</parameter> como el segundo.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>connection_str</parameter></term>
      <listitem>
       <para>
-       <!-- TODO Document constructor params -->
+       Este parámetro se utiliza para pasar opciones de conexión adicionales
+       a los servidores memcache, como el peso de un servidor en un clúster.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/soap/soapclient.xml
+++ b/reference/soap/soapclient.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 <reference xml:id="class.soapclient" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>La classe <classname>SoapClient</classname></title>
+ <title>La clase <classname>SoapClient</classname></title>
  <titleabbrev>SoapClient</titleabbrev>
 
  <partintro>
@@ -12,7 +12,7 @@
   <section xml:id="soapclient.intro">
    &reftitle.intro;
    <para>
-    La classe <classname>SoapClient</classname> proporciona un cliente para los
+    La clase <classname>SoapClient</classname> proporciona un cliente para los
     servidores <link xlink:href="&spec.soap1.1;">SOAP 1.1</link> y
     <link xlink:href="&spec.soap1.2;">SOAP 1.2</link>.
     Puede ser utilizado con o sin modo WSDL.

--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -592,7 +592,7 @@
           </para>
           <para>
            Esta opción es <emphasis role="strong">obsoleta</emphasis> a partir de PHP 8.1.0.
-           Una alternativa más flexible, que permite especificar versiones individuales de TLS, consiste en utilizar la opción <link linkend="soapclient.construct.options.stream-context"><parameter>contexto_de_flux</parameter></link> con el parámetro de contexto 'crypto_method'.
+           Una alternativa más flexible, que permite especificar versiones individuales de TLS, consiste en utilizar la opción <link linkend="soapclient.construct.options.stream-context"><parameter>stream_context</parameter></link> con el parámetro de contexto 'crypto_method'.
            <informalexample>
             <programlisting role="php">
 <![CDATA[

--- a/reference/soap/soapclient/setlocation.xml
+++ b/reference/soap/soapclient/setlocation.xml
@@ -83,7 +83,7 @@ $client = new SoapClient('http://example.com/webservice.php?wsdl');
 
 $client->__setLocation('http://www.somethirdparty.com');
 
-$old_location = $client->__setLocation(); // unsets the location option
+$old_location = $client->__setLocation(); // desactiva la opción de ubicación
 
 echo $old_location;
 

--- a/reference/sockets/functions/socket-create.xml
+++ b/reference/sockets/functions/socket-create.xml
@@ -151,7 +151,7 @@
        y <constant>SOL_UDP</constant> pueden ser utilizadas.
       </para>
       <table>
-       <title>Protocoles Comunes</title>
+       <title>Protocolos Comunes</title>
        <tgroup cols="2">
         <thead>
          <row>

--- a/reference/sockets/functions/socket-recv.xml
+++ b/reference/sockets/functions/socket-recv.xml
@@ -191,7 +191,7 @@ if ($result === false) {
 
 $in = "HEAD / HTTP/1.1\r\n";
 $in .= "Host: www.example.com\r\n";
-$in .= "Connexion: Cerrada\r\n\r\n";
+$in .= "Connection: close\r\n\r\n";
 $out = '';
 
 echo "Enviando una solicitud HTTP HEAD...";
@@ -228,7 +228,7 @@ Last-Modified: Tue, 15 Nov 2005 13:24:10 GMT
 ETag: "b80f4-1b6-80bfd280"
 Accept-Ranges: bytes
 Content-Length: 438
-Connexion : Cerrada
+Connection: close
 Content-Type: text/html; charset=UTF-8
 
 OK.

--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-encrypt.xml
@@ -36,7 +36,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Datos adicionales autentificados. Esto se utiliza en la verificación de la etiqueta de autentificación
+      Datos adicionales autenticados. Esto se utiliza en la verificación de la etiqueta de autenticación
       añadida al texto cifrado, pero no se cifra ni se almacena en el texto cifrado.
      </simpara>
     </listitem>
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve el texto cifrado y la etiqueta de autentificación como una cadena de bytes en bruto.
+   Devuelve el texto cifrado y la etiqueta de autenticación como una cadena de bytes en bruto.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
@@ -38,7 +38,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Adicional, datos autenticados. Esto se utiliza en la verificación de la etiqueta de autenticación
+      Datos adicionales autenticados. Esto se utiliza en la verificación de la etiqueta de autenticación
       añadida al texto cifrado, pero no se cifra ni se almacena en el texto cifrado.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-decrypt.xml
@@ -38,7 +38,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Adicional, datos autentificados. Esto se utiliza en la verificación de la etiqueta de autentificación
+      Datos adicionales autenticados. Esto se utiliza en la verificación de la etiqueta de autenticación
       añadida al texto cifrado, pero no se cifra ni se almacena en el texto cifrado.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
@@ -37,7 +37,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Adicional, datos autentificados. Esto se utiliza en la verificación de la etiqueta de autentificación
+      Datos adicionales autenticados. Esto se utiliza en la verificación de la etiqueta de autenticación
       añadida al texto cifrado, pero no se cifra ni se almacena en el texto cifrado.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
@@ -17,7 +17,7 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Cifra y autentifica con ChaCha20-Poly1305 (variante IETF).
+   Cifra y autentica con ChaCha20-Poly1305 (variante IETF).
   </simpara>
   <simpara>
    La variante IETF utiliza nonces de 96 bits y contadores internos de 32 bits, en lugar de 64 bits para ambos.
@@ -40,7 +40,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Datos adicionales autentificados. Esto se utiliza en la verificación de la etiqueta de autentificación
+      Datos adicionales autenticados. Esto se utiliza en la verificación de la etiqueta de autenticación
       añadida al texto cifrado, pero no se cifra ni se almacena en el texto cifrado.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
@@ -40,7 +40,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Adicional, datos autenticados. Esto se utiliza en la verificación de la etiqueta de autenticación
+      Datos adicionales autenticados. Esto se utiliza en la verificación de la etiqueta de autenticación
       añadida al texto cifrado, pero no se cifra ni se almacena en el texto cifrado.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-box-seal-open.xml
+++ b/reference/sodium/functions/sodium-crypto-box-seal-open.xml
@@ -52,7 +52,7 @@
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <example xml:id="sodium-crypto-box-seal-open.example.basic"><!-- {{{ -->
-   <title><function>sodium_crypto_box_seal_open</function> example</title>
+   <title>Ejemplo de <function>sodium_crypto_box_seal_open</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/sodium/functions/sodium-crypto-generichash-final.xml
+++ b/reference/sodium/functions/sodium-crypto-generichash-final.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-generichash-final">
  <refnamediv>
   <refname>sodium_crypto_generichash_final</refname>
-  <refpurpose>Completa el hachado</refpurpose>
+  <refpurpose>Completa el hash</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>SODIUM_CRYPTO_GENERICHASH_BYTES</constant></initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   El método de finalización para la API de hachado genérico en streaming.
+   El método de finalización para la API de hash genérico en streaming.
   </simpara>
 
  </refsect1>
@@ -27,7 +27,7 @@
     <term><parameter>state</parameter></term>
     <listitem>
      <simpara>
-      El estado de hachado devuelto por <function>sodium_crypto_generichash_init</function>
+      El estado de hash devuelto por <function>sodium_crypto_generichash_init</function>
      </simpara>
     </listitem>
    </varlistentry>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   El hachado criptográfico.
+   El hash criptográfico.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-generichash-init.xml
+++ b/reference/sodium/functions/sodium-crypto-generichash-init.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-generichash-init">
  <refnamediv>
   <refname>sodium_crypto_generichash_init</refname>
-  <refpurpose>Inicializa un hachage para el streaming</refpurpose>
+  <refpurpose>Inicializa un hash para el streaming</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>SODIUM_CRYPTO_GENERICHASH_BYTES</constant></initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   El método de inicialización para la API de hachage genérico en streaming.
+   El método de inicialización para la API de hash genérico en streaming.
   </simpara>
 
  </refsect1>
@@ -27,7 +27,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
-      La clave de hachage genérico.
+      La clave de hash genérico.
      </simpara>
     </listitem>
    </varlistentry>
@@ -35,7 +35,7 @@
     <term><parameter>length</parameter></term>
     <listitem>
      <simpara>
-      El tamaño de la salida esperada de la función de hachage.
+      El tamaño de la salida esperada de la función de hash.
      </simpara>
     </listitem>
    </varlistentry>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve un estado de hachage, serializado en forma de una string binaria bruta.
+   Devuelve un estado de hash, serializado en forma de una string binaria bruta.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-generichash-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-generichash-keygen.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-generichash-keygen">
  <refnamediv>
   <refname>sodium_crypto_generichash_keygen</refname>
-  <refpurpose>Genera una clave de hachaje genérico aleatoria</refpurpose>
+  <refpurpose>Genera una clave de hash genérico aleatoria</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Genera una clave aleatoria para su uso con la API de hachaje genérico.
+   Genera una clave aleatoria para su uso con la API de hash genérico.
   </simpara>
 
  </refsect1>

--- a/reference/sodium/functions/sodium-crypto-generichash-update.xml
+++ b/reference/sodium/functions/sodium-crypto-generichash-update.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-generichash-update">
  <refnamediv>
   <refname>sodium_crypto_generichash_update</refname>
-  <refpurpose>Añade un mensaje a un hachaje</refpurpose>
+  <refpurpose>Añade un mensaje a un hash</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>message</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Añade un mensaje al estado de hachaje interno.
+   Añade un mensaje al estado de hash interno.
   </simpara>
 
  </refsect1>
@@ -35,7 +35,7 @@
     <term><parameter>message</parameter></term>
     <listitem>
      <simpara>
-      Los datos a añadir al estado de hachaje.
+      Los datos a añadir al estado de hash.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sodium/functions/sodium-crypto-kx-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-kx-keypair.xml
@@ -36,7 +36,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="sodium-crypto-kx-keypair.example.basic">
-   <title><function>sodium_crypto_kx_keypair</function> uso</title>
+   <title>Uso de <function>sodium_crypto_kx_keypair</function></title>
    <simpara>
     Crear una nueva pareja de claves y recuperar la clave secreta y la clave pública asociada.
    </simpara>

--- a/reference/sodium/functions/sodium-crypto-pwhash-scryptsalsa208sha256-str-verify.xml
+++ b/reference/sodium/functions/sodium-crypto-pwhash-scryptsalsa208sha256-str-verify.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-pwhash-scryptsalsa208sha256-str-verify">
  <refnamediv>
   <refname>sodium_crypto_pwhash_scryptsalsa208sha256_str_verify</refname>
-  <refpurpose>Verifica si la contraseña corresponde a una cadena de hachaje de contraseña</refpurpose>
+  <refpurpose>Verifica si la contraseña corresponde a una cadena de hash de contraseña</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sodium/functions/sodium-crypto-pwhash-scryptsalsa208sha256-str.xml
+++ b/reference/sodium/functions/sodium-crypto-pwhash-scryptsalsa208sha256-str.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-pwhash-scryptsalsa208sha256-str">
  <refnamediv>
   <refname>sodium_crypto_pwhash_scryptsalsa208sha256_str</refname>
-  <refpurpose>Devuelve un hachaje codificado en ASCII</refpurpose>
+  <refpurpose>Devuelve un hash codificado en ASCII</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sodium/functions/sodium-crypto-pwhash-str-needs-rehash.xml
+++ b/reference/sodium/functions/sodium-crypto-pwhash-str-needs-rehash.xml
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>memlimit</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Determina si una contraseña debe ser rehacheada, basado en el hachage actual <parameter>opslimit</parameter> y <parameter>memlimit</parameter>.
+   Determina si una contraseña debe ser rehacheada, basado en el hash actual <parameter>opslimit</parameter> y <parameter>memlimit</parameter>.
   </simpara>
 
  </refsect1>
@@ -28,7 +28,7 @@
     <term><parameter>password</parameter></term>
     <listitem>
      <simpara>
-      El hachage de la contraseña
+      El hash de la contraseña
      </simpara>
     </listitem>
    </varlistentry>
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve &true; si el memlimit/opslimit proporcionado no corresponde a lo que está almacenado en el hachage.
+   Devuelve &true; si el memlimit/opslimit proporcionado no corresponde a lo que está almacenado en el hash.
    Devuelve &false; si corresponden.
   </simpara>
  </refsect1>

--- a/reference/sodium/functions/sodium-crypto-pwhash-str.xml
+++ b/reference/sodium/functions/sodium-crypto-pwhash-str.xml
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>memlimit</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Utiliza un algoritmo de hachéo intensivo en CPU y memoria con un sel generado aleatoriamente, y límites de memoria y CPU para generar un hash codificado en ASCII adecuado para el almacenamiento de contraseñas.
+   Utiliza un algoritmo de hash intensivo en CPU y memoria con una sal generada aleatoriamente, y límites de memoria y CPU para generar un hash codificado en ASCII adecuado para el almacenamiento de contraseñas.
   </simpara>
  </refsect1>
 
@@ -94,7 +94,7 @@ $argon2id$v=19$m=65536,t=2,p=1$oWIfdaXwWwhVmovOBc2NAQ$EbsZ+JnZyyavkafS0hoc4HdaOB
     Los hashes son calculados utilizando el algoritmo Argon2ID,
     proporcionando resistencia tanto a ataques GPU como a ataques por canales laterales.
     A diferencia de la función <function>password_hash</function>,
-    no hay parámetro de sel (un sel es generado automáticamente),
+    no hay parámetro de sal (una sal es generada automáticamente),
     y los parámetros <parameter>opslimit</parameter> y
     <parameter>memlimit</parameter> no son opcionales.
    </simpara>

--- a/reference/sodium/functions/sodium-crypto-shorthash.xml
+++ b/reference/sodium/functions/sodium-crypto-shorthash.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-shorthash">
  <refnamediv>
   <refname>sodium_crypto_shorthash</refname>
-  <refpurpose>Calcula un hachage corto de un mensaje y una clave</refpurpose>
+  <refpurpose>Calcula un hash corto de un mensaje y una clave</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,12 +15,12 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>sodium_crypto_shorthash</function> envuelve una función de hachaje llamada
-   SipHash-2-4, que es ideal para implementar tablas de hachaje que no son susceptibles
-   a ataques de denegación de servicio por colisión de hachaje (Hash-DoS).
+   <function>sodium_crypto_shorthash</function> envuelve una función hash llamada
+   SipHash-2-4, que es ideal para implementar tablas hash que no son susceptibles
+   a ataques de denegación de servicio por colisión de hash (Hash-DoS).
   </simpara>
   <simpara>
-   SipHash-2-4 no es una función de hachaje criptográfico general.
+   SipHash-2-4 no es una función hash criptográfica general.
   </simpara>
 
  </refsect1>
@@ -40,7 +40,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
-      La clave de hachaje.
+      La clave de hash.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor.xml
@@ -22,7 +22,7 @@
 
   <caution>
    <simpara>
-    Este cifrado no es autentificado y no previene ataques de texto cifrado elegido.
+    Este cifrado no es autenticado y no previene ataques de texto cifrado elegido.
     Asegúrese de combinar el texto cifrado con un código de autenticación de mensaje,
     por ejemplo con la función <function>sodium_crypto_aead_xchacha20poly1305_ietf_encrypt</function>,
     o <function>sodium_crypto_auth</function>.

--- a/reference/solr/solrdismaxquery/settiebreaker.xml
+++ b/reference/solr/solrdismaxquery/settiebreaker.xml
@@ -25,7 +25,7 @@
     <term><parameter>tieBreaker</parameter></term>
     <listitem>
      <para>
-        El parámetro <emphasis>tie</emphasis> especifica un valor float (que debería ser algo mucho menor que 1) para ser utilizado como briseur d'égalité en las consultas DisMax.
+        El parámetro <emphasis>tie</emphasis> especifica un valor float (que debería ser algo mucho menor que 1) para ser utilizado como criterio de desempate en las consultas DisMax.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/solr/solrquery/sethighlightsimplepre.xml
+++ b/reference/solr/solrquery/sethighlightsimplepre.xml
@@ -18,7 +18,7 @@
   <para>
    Establece el texto que aparece antes de un término remarcado.
   </para>
-  <para><![CDATA[ The default is <em> ]]></para>
+  <para><![CDATA[ El valor por omisión es <em> ]]></para>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/sqlite3/sqlite3/construct.xml
+++ b/reference/sqlite3/sqlite3/construct.xml
@@ -126,7 +126,7 @@
 $db = new SQLite3('mysqlitedb.db');
 
 $db->exec('CREATE TABLE foo (bar TEXT)');
-$db->exec("INSERT INTO foo (bar) VALUES ('This is a test')");
+$db->exec("INSERT INTO foo (bar) VALUES ('Esto es una prueba')");
 
 $result = $db->query('SELECT bar FROM foo');
 var_dump($result->fetchArray());

--- a/reference/sqlite3/sqlite3/setauthorizer.xml
+++ b/reference/sqlite3/sqlite3/setauthorizer.xml
@@ -68,9 +68,9 @@
       <row><entry><constant>SQLite3::SELECT</constant></entry><entry>&null;</entry><entry>&null;</entry></row>
       <row><entry><constant>SQLite3::TRANSACTION</constant></entry><entry>Operación</entry><entry>&null;</entry></row>
       <row><entry><constant>SQLite3::UPDATE</constant></entry><entry>Nombre de la tabla</entry><entry>Nombre de la columna</entry></row>
-      <row><entry><constant>SQLite3::ATTACH</constant></entry><entry>Filename</entry><entry>&null;</entry></row>
+      <row><entry><constant>SQLite3::ATTACH</constant></entry><entry>Nombre de fichero</entry><entry>&null;</entry></row>
       <row><entry><constant>SQLite3::DETACH</constant></entry><entry>Nombre de la base de datos</entry><entry>&null;</entry></row>
-      <row><entry><constant>SQLite3::ALTER_TABLE</constant></entry><entry>Nombre Database</entry><entry>Nombre de la tabla</entry></row>
+      <row><entry><constant>SQLite3::ALTER_TABLE</constant></entry><entry>Nombre de la base de datos</entry><entry>Nombre de la tabla</entry></row>
       <row><entry><constant>SQLite3::REINDEX</constant></entry><entry>Nombre del índice</entry><entry>&null;</entry></row>
       <row><entry><constant>SQLite3::ANALYZE</constant></entry><entry>Nombre de la tabla</entry><entry>&null;</entry></row>
       <row><entry><constant>SQLite3::CREATE_VTABLE</constant></entry><entry>Nombre de la tabla</entry><entry>Nombre del módulo</entry></row>

--- a/reference/sqlite3/sqlite3stmt/bindvalue.xml
+++ b/reference/sqlite3/sqlite3stmt/bindvalue.xml
@@ -157,7 +157,7 @@
 $db = new SQLite3(':memory:');
 
 $db->exec('CREATE TABLE foo (id INTEGER, bar STRING)');
-$db->exec("INSERT INTO foo (id, bar) VALUES (1, 'Ceci est un test')");
+$db->exec("INSERT INTO foo (id, bar) VALUES (1, 'Esto es una prueba')");
 
 $stmt = $db->prepare('SELECT bar FROM foo WHERE id=:id');
 $stmt->bindValue(':id', 1, SQLITE3_INTEGER);
@@ -172,7 +172,7 @@ var_dump($result->fetchArray(SQLITE3_ASSOC));
 <![CDATA[
 array(1) {
   ["bar"]=>
-  string(16) "Ceci est un test"
+  string(18) "Esto es una prueba"
 }
 ]]>
     </screen>

--- a/reference/sqlsrv/functions/sqlsrv-cancel.xml
+++ b/reference/sqlsrv/functions/sqlsrv-cancel.xml
@@ -81,7 +81,7 @@ while( ($row = sqlsrv_fetch_array( $stmt)) && $salesTotal <=100000)
      $count++;
 }
 
-echo "$count sales accounted for the first $$salesTotal in revenue.<br />";
+echo "$count ventas suman los primeros $$salesTotal en ingresos.<br />";
 
 // Cancela los resultados pendientes. La sentencia se puede reutilizar.
 sqlsrv_cancel( $stmt);

--- a/reference/sqlsrv/functions/sqlsrv-configure.xml
+++ b/reference/sqlsrv/functions/sqlsrv-configure.xml
@@ -48,7 +48,7 @@
    <tbody>
     <row>
      <entry>WarningsReturnAsErrors</entry>
-     <entry>1 (&true;) or 0 (&false;)</entry>
+     <entry>1 (&true;) o 0 (&false;)</entry>
     </row>
     <row>
      <entry>LogSubsystems</entry>

--- a/reference/sqlsrv/functions/sqlsrv-send-stream-data.xml
+++ b/reference/sqlsrv/functions/sqlsrv-send-stream-data.xml
@@ -60,7 +60,7 @@ if( $conn === false ) {
 $sql = "UPDATE Table_1 SET data = ( ?) WHERE id = 100";
 
 // Abre los datos como flujo y los coloca en el array $params.
-$data = fopen( "data://text/plain,[ Lengthy content here. ]", "r");
+$data = fopen( "data://text/plain,[ Contenido largo aquí. ]", "r");
 $params = array( &$data);
 
 // Prepara la petición. Uso del array $options para desactivar

--- a/reference/stats/reference.xml
+++ b/reference/stats/reference.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: c6542ce8631c4150d7e49573cf7e64e604ef20b2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <reference xml:id="ref.stats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>&Functions; de Statistic</title>
+ <title>&Functions; estadísticas</title>
 
  &reference.stats.entities.functions;
 

--- a/reference/stomp/book.xml
+++ b/reference/stomp/book.xml
@@ -11,7 +11,7 @@
   <simpara>
    Esta extensión permite a aplicaciones php comunicarse con cualquier Message Brokers compatible con el protocolo STOMP,
    a través de sencillas interfaces procedurales orientadas a objetos.
-   <link xlink:href="&url.stomp;">Stomp official site</link>
+   <link xlink:href="&url.stomp;">Sitio oficial de Stomp</link>
   </simpara>
  </preface>
 

--- a/reference/stomp/stompframe.xml
+++ b/reference/stomp/stompframe.xml
@@ -62,19 +62,19 @@
     <varlistentry xml:id="stompframe.props.command">
      <term><varname>command</varname></term>
      <listitem>
-      <simpara>Frame command.</simpara>
+      <simpara>Comando de la trama.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="stompframe.props.headers">
      <term><varname>headers</varname></term>
      <listitem>
-      <simpara>Frame headers (&array;).</simpara>
+      <simpara>Encabezados de la trama (&array;).</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="stompframe.props.body">
      <term><varname>body</varname></term>
      <listitem>
-      <simpara>Frame body.</simpara>
+      <simpara>Cuerpo de la trama.</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/svm/setup.xml
+++ b/reference/svm/setup.xml
@@ -10,7 +10,7 @@
    LIBSVM es requerido, y está disponible a través de algunos gestores de paquetes
    - libsvm-devel para el sistema basado en RPM o libsvm-dev para los basados en
    Debian. Como alternativa, está disponible directamente desde el sitio web.
-   Si está instalando desde el <link xlink:href="&url.svm;">Website Oficial</link>
+   Si está instalando desde el <link xlink:href="&url.svm;">sitio web oficial</link>
    algunos pasos son necesarios ya que el paquete no se instala automáticamente.
    Por ejemplo, suponiendo que la última versión es la 3.1:
   </simpara>

--- a/reference/svm/svm.xml
+++ b/reference/svm/svm.xml
@@ -181,7 +181,7 @@
   <section xml:id="svm.constants">
    &reftitle.constants;
    <section xml:id="svm.constants.types">
-    <title>SVM Constants</title>
+    <title>Constantes SVM</title>
     <variablelist>
 
      <varlistentry xml:id="svm.constants.c-svc">

--- a/reference/svm/svm/crossvalidate.xml
+++ b/reference/svm/svm/crossvalidate.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="svm.crossvalidate">
  <refnamediv>
   <refname>SVM::crossvalidate</refname>
-  <refpurpose>Test los argumentos de entrenamiento en los subconjuntos de datos de entrenamiento</refpurpose>
+  <refpurpose>Prueba los argumentos de entrenamiento en los subconjuntos de datos de entrenamiento</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/svm/svmmodel/getlabels.xml
+++ b/reference/svm/svmmodel/getlabels.xml
@@ -2,10 +2,10 @@
 <!-- $Revision$ -->
 <!-- EN-Revision: 1ca2d4af9471f44743281e6949cb53b8afcaefb8 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="svmmodel.getlabels">
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="svmmodel.getetiquetas">
  <refnamediv>
   <refname>SVMModel::getLabels</refname>
-  <refpurpose>Recupera los labels utilizados para entrenar el modelo</refpurpose>
+  <refpurpose>Recupera los etiquetas utilizados para entrenar el modelo</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Devuelve un array de labels utilizados para entrenar el modelo.
+   Devuelve un array de etiquetas utilizados para entrenar el modelo.
    Para los casos de regresión y para las clases móviles solas,
    un array vacío es devuelto.
   </simpara>
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve un array de labels.
+   Devuelve un array de etiquetas.
   </simpara>
  </refsect1>
 

--- a/reference/svm/svmmodel/predict-probability.xml
+++ b/reference/svm/svmmodel/predict-probability.xml
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve el valor predicho. Esto será un label de clase en el caso
+   Devuelve el valor predicho. Esto será una etiqueta de clase en el caso
    de una clasificación, un valor real en el caso de una regresión.
    Lanza una excepción de tipo SVMException en caso de error.
   </simpara>

--- a/reference/svm/svmmodel/predict.xml
+++ b/reference/svm/svmmodel/predict.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve el valor predicho. Esto puede ser un label de clase
+   Devuelve el valor predicho. Esto puede ser una etiqueta de clase
    en el caso de una clasificación, un valor real en el caso
    de una regresión. Lanza una excepción SVMException en caso de error.
   </simpara>

--- a/reference/svn/constants.xml
+++ b/reference/svn/constants.xml
@@ -193,7 +193,7 @@
   </varlistentry>
  </variablelist>
  <variablelist xml:id="svn.constants.status">
-  <title>constantes de trabajo con status de copias</title>
+  <title>constantes de trabajo con estado de copias</title>
   <varlistentry xml:id="constant.svn-wc-status-none">
    <term>
     <constant>SVN_WC_STATUS_NONE</constant>
@@ -201,7 +201,7 @@
    </term>
    <listitem>
     <simpara>
-     Status no existe
+     Estado no existe
     </simpara>
    </listitem>
   </varlistentry>
@@ -350,7 +350,7 @@
   </varlistentry>
  </variablelist>
  <variablelist xml:id="svn.constants.type">
-  <title>Node type constants</title>
+  <title>Constantes de tipo de nodo</title>
   <varlistentry xml:id="constant.svn-node-none">
    <term>
     <constant>SVN_NODE_NONE</constant>

--- a/reference/svn/functions/svn-commit.xml
+++ b/reference/svn/functions/svn-commit.xml
@@ -62,7 +62,7 @@
     <term><parameter>recursive</parameter></term>
     <listitem>
      <simpara>
-      Flag de tipo booleano para desactivar la recursividad
+      Bandera de tipo booleano para desactivar la recursividad
       al enviar directorios en el array <parameter>targets</parameter>.
       Por omisión, vale &true;.
      </simpara>

--- a/reference/swoole/constants.xml
+++ b/reference/swoole/constants.xml
@@ -2806,7 +2806,7 @@
     </term>
     <listitem>
      <simpara>
-      Verrour de spin.
+      Bloqueo de espera activa (spinlock).
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/swoole/swoole.coroutine.lock.xml
+++ b/reference/swoole/swoole.coroutine.lock.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 <reference xml:id="class.swoole-coroutine-lock" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The Swoole\Coroutine\Lock class</title>
+ <title>La clase Swoole\Coroutine\Lock</title>
  <titleabbrev>Swoole\Coroutine\Lock</titleabbrev>
 
  <partintro>
@@ -72,7 +72,7 @@
   <section xml:id="swoole-coroutine-lock.examples">
    &reftitle.examples;
    <example xml:id="swoole-coroutine-lock.example.basic">
-    <title>Basic usage</title>
+    <title>Uso básico</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/swoole/swoole.runtime.xml
+++ b/reference/swoole/swoole.runtime.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 <reference xml:id="class.swoole-runtime" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The Swoole\Runtime class</title>
+ <title>La clase Swoole\Runtime</title>
  <titleabbrev>Swoole\Runtime</titleabbrev>
 
  <partintro>

--- a/reference/swoole/swoole/http/response/rawcookie.xml
+++ b/reference/swoole/swoole/http/response/rawcookie.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="swoole-http-response.rawcookie" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Http\Response::rawcookie</refname>
-  <refpurpose>Define los cookies bruts de la respuesta HTTP.</refpurpose>
+  <refpurpose>Define las cookies sin formato de la respuesta HTTP.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sync/book.xml
+++ b/reference/sync/book.xml
@@ -10,7 +10,7 @@
  <preface xml:id="intro.sync">
   &reftitle.intro;
   <simpara>
-   La extensión <literal>sync</literal> introduce la sincronización de objetos cross-plataforma en PHP.
+   La extensión <literal>sync</literal> introduce la sincronización de objetos multiplataforma en PHP.
    Los Mutex nombrados o no, los semáforos, los eventos, los objetos de
    lectura-escritura y la memoria compartida se beneficiarán de una sincronización a nivel del sistema operativo tanto en
    los sistemas POSIX (i.e. Linux) como en los sistemas Windows.

--- a/reference/sync/syncsemaphore.xml
+++ b/reference/sync/syncsemaphore.xml
@@ -13,11 +13,11 @@
   <section xml:id="syncsemaphore.intro">
    &reftitle.intro;
    <simpara>
-    Una implementación multiplataforma, nativa de los objetos Sémaphore nombrados o no nombrados.
+    Una implementación multiplataforma, nativa de los objetos Semáforo nombrados o no nombrados.
    </simpara>
    <simpara>
-    Un sémaphore restringe el acceso a un recurso limitado a un número limitado
-    de instancias. Los sémaphores difieren de los mutexes en el sentido de que permiten
+    Un semáforo restringe el acceso a un recurso limitado a un número limitado
+    de instancias. Los semáforos difieren de los mutexes en el sentido de que permiten
     a más de una instancia acceder a un recurso al mismo tiempo, mientras que el mutex
     solo permite una instancia a la vez.
    </simpara>

--- a/reference/tidy/constants.xml
+++ b/reference/tidy/constants.xml
@@ -1621,7 +1621,7 @@
   </term>
   <listitem>
    <simpara>
-    XML section
+    Sección XML
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/tidy/tidy/errorbuffer.xml
+++ b/reference/tidy/tidy/errorbuffer.xml
@@ -9,7 +9,7 @@
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
-  <para>&style.oop; (property):</para>
+  <para>&style.oop; (propiedad):</para>
   <fieldsynopsis><modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><varname linkend="tidy.props.errorbuffer">tidy-&gt;errorBuffer</varname></fieldsynopsis>
   <para>&style.procedural;:</para>
   <methodsynopsis>

--- a/reference/tidy/tidy/getoptdoc.xml
+++ b/reference/tidy/tidy/getoptdoc.xml
@@ -28,7 +28,7 @@
   </para>
   <note>
    <para>
-    Se requiere al menos la librería libtidy del 25 April del 2005 paa que la función esté
+    Se requiere al menos la librería libtidy del 25 de abril del 2005 para que la función esté
     disponible.
    </para>
   </note>

--- a/reference/ui/functions/ui.quit.xml
+++ b/reference/ui/functions/ui.quit.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.ui-quit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>UI\quit</refname>
-  <refpurpose>Sale de la boucle UI</refpurpose>
+  <refpurpose>Sale de la bucle UI</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Debe hacer que la boucle principal se detenga
+   Debe hacer que la bucle principal se detenga
   </para>
 
  </refsect1>

--- a/reference/ui/functions/ui.run.xml
+++ b/reference/ui/functions/ui.run.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.ui-run" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>UI\run</refname>
-  <refpurpose>Entra en la boucle UI</refpurpose>
+  <refpurpose>Entra en la bucle UI</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Debe hacer que PHP entre en la boucle principal. Por omisión, el control no será devuelto a la función llamadora.
+   Debe hacer que PHP entre en la bucle principal. Por omisión, el control no será devuelto a la función llamadora.
   </para>
 
  </refsect1>

--- a/reference/uodbc/book.xml
+++ b/reference/uodbc/book.xml
@@ -34,7 +34,7 @@
     que se usan para comunicarse de forma nativa con las bases de datos comparten
     los mismos nombres y la misma sintaxis que las funciones de ODBC. Sin embargo,
     al construir PHP con soporte para iODBC, se permite el uso de cualquier controlador
-    que cumpla con ODBC en las aplicaciones de PHP. Hay más unformaicón disponible
+    que cumpla con ODBC en las aplicaciones de PHP. Hay más información disponible
     sobre iODBC en <link xlink:href="&url.iodbc;">www.iodbc.org</link>
     con la alternativa unixODBC disponible en
     <link xlink:href="&url.unixodbc;">www.unixodbc.org</link>.

--- a/reference/uopz/book.xml
+++ b/reference/uopz/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68c2c871505aadf983f16113c5b077b335ce8d76 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <book xml:id="book.uopz" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -11,7 +11,7 @@
  <preface xml:id="intro.uopz">
   &reftitle.intro;
   <para>
-   La extensión uopz - User Operations for Zend (NdT : las operaciones de usuario para Zend) -
+   La extensión uopz - User Operations for Zend (N. del T.: operaciones de usuario para Zend) -
    expone las funcionalidades del motor Zend, normalmente utilizadas durante
    la compilación y la ejecución, para permitir la modificación de las
    estructuras internas que representan el código PHP, y para que el código

--- a/reference/uopz/functions/uopz-set-return.xml
+++ b/reference/uopz/functions/uopz-set-return.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f541242dd3feb4f8a80c89317293d5f5d2c537ad Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.uopz-set-return" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -75,7 +75,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve true en caso de éxito, de lo contrario false.
+   Devuelve &true; en caso de éxito, de lo contrario &false;.
   </para>
  </refsect1>
 

--- a/reference/uopz/functions/uopz-unset-return.xml
+++ b/reference/uopz/functions/uopz-unset-return.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.uopz-unset-return" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   true en caso de éxito.
+   &true; en caso de éxito.
   </para>
  </refsect1>
 

--- a/reference/uri/uri.uricomparisonmode.xml
+++ b/reference/uri/uri.uricomparisonmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9e2dd56cb1b2fb3e97eed9b16b4b94ac0dbefadc Maintainer: lacatoire Status: ready -->
 <reference xml:id="enum.uri-uricomparisonmode" role="enum" xmlns="http://docbook.org/ns/docbook">
  <title>La enumeración Uri\UriComparisonMode</title>
  <titleabbrev>Uri\UriComparisonMode</titleabbrev>
@@ -8,6 +8,12 @@
   <section xml:id="enum.uri-uricomparisonmode.intro">
    &reftitle.intro;
    <simpara>
+    Especifica si el componente <literal>fragment</literal> debe afectar
+    al resultado de una comparación de URI.
+   </simpara>
+   <simpara>
+    Si el fragmento se excluye de la comparación, dos URIs se compararán
+    como si ninguna de ellas tuviera un componente <literal>fragment</literal>.
    </simpara>
   </section>
 

--- a/reference/url/book.xml
+++ b/reference/url/book.xml
@@ -10,7 +10,7 @@
  <preface xml:id="intro.url">
   &reftitle.intro;
   <para>
-   Tratar con cadenas URL: codificación, decodificaicón y conversión.
+   Tratar con cadenas URL: codificación, decodificación y conversión.
   </para>
  </preface>
 

--- a/reference/url/functions/base64-decode.xml
+++ b/reference/url/functions/base64-decode.xml
@@ -82,7 +82,7 @@ Estos datos son una cadena codificada.
   <para>
    <simplelist>
     <member><function>base64_encode</function></member>
-    <member><link xlink:href="&url.rfc;2045">RFC 2045</link> section 6.8</member>
+    <member><link xlink:href="&url.rfc;2045">RFC 2045</link> sección 6.8</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/url/functions/base64-encode.xml
+++ b/reference/url/functions/base64-encode.xml
@@ -79,7 +79,7 @@ VGhpcyBpcyBhbiBlbmNvZGVkIHN0cmluZw==
     <member><function>base64_decode</function></member>
     <member><function>chunk_split</function></member>
     <member><function>convert_uuencode</function></member>
-    <member><link xlink:href="&url.rfc;2045">RFC 2045</link> section 6.8</member>
+    <member><link xlink:href="&url.rfc;2045">RFC 2045</link> sección 6.8</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/varnish/varnishadmin/construct.xml
+++ b/reference/varnish/varnishadmin/construct.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="varnishadmin.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>VarnishAdmin::__construct</refname>
-  <refpurpose>VarnishAdmin constructor</refpurpose>
+  <refpurpose>Constructor de VarnishAdmin</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -51,7 +51,7 @@ VARNISH_CONFIG_COMPAT - varnish major version compatibility
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>ejemplo de <function>VarnishAdmin::__construct</function></title>
+   <title>Ejemplo con <function>VarnishAdmin::__construct</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/win32service/constants.xml
+++ b/reference/win32service/constants.xml
@@ -230,7 +230,7 @@
   </table>
 
   <table xml:id="win32service.constants.controlsaccepted">
-  <title>Masque binaire de Mensaje de Control de Servicio de Win32Service</title>
+  <title>Máscara binaria de Mensaje de Control de Servicio de Win32Service</title>
    <tgroup cols="3">
     <thead>
      <row>
@@ -599,7 +599,7 @@
       <entry><constant>WIN32_ERROR_PATH_NOT_FOUND</constant></entry>
       <entry><literal>0x00000003</literal></entry>
       <entry>
-       El servicio de fichero binario no ha podido ser encontrado.
+       El fichero binario del servicio no ha podido ser encontrado.
       </entry>
      </row>
      <row xml:id="constant.win32-error-service-already-running">

--- a/reference/win32service/functions/win32-add-service-env-var.xml
+++ b/reference/win32service/functions/win32-add-service-env-var.xml
@@ -63,11 +63,11 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Se lanzará una <classname>ValueError</classname> si la
+   Se lanzará una <classname>ValueError</classname> si el
    valor del parámetro <parameter>service</parameter> está vacío.
   </para>
   <para>
-   Se lanzará una <classname>ValueError</classname> si la
+   Se lanzará una <classname>ValueError</classname> si el
    valor del parámetro <parameter>varname</parameter> está vacío.
   </para>
   <para>

--- a/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
+++ b/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
@@ -23,12 +23,12 @@
   </para>
   <para>
    Una vez iniciado, el proceso del servicio debe hacer dos cosas. La primera es
-   informar al Service Control Manager que el servicio está en ejecución. La segunda
+   informar al Gestionador de Control de Servicio que el servicio está en ejecución. La segunda
    es llamar a la función <function>win32_set_service_status</function> con la constante
    <constant>WIN32_SERVICE_RUNNING</constant>. Si necesita lanzar procesos largos antes
    de que el servicio se inicie, puede usar la constante
    <constant>WIN32_SERVICE_START_PENDING</constant>. La segunda es continuar
-   verificando con el Service Control Manager para determinar si el servicio se
+   verificando con el Gestionador de Control de Servicio para determinar si el servicio se
    detiene o no. Esto implica llamar periódicamente a la función
    <function>win32_get_last_control_message</function> y tratar el código devuelto.
   </para>

--- a/reference/win32service/rightinfo/get-domain.xml
+++ b/reference/win32service/rightinfo/get-domain.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 48783163fcd8ebcc23329269d3e87d38003ea24e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 77485af0887729557f9676bdb54bc60d2aa051ef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="win32service-rightinfo.get-domain" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>null</type><type>string</type></type> <methodname>Win32Service\RightInfo::getDomain</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type> <methodname>Win32Service\RightInfo::getDomain</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/win32service/rightinfo/get-full-username.xml
+++ b/reference/win32service/rightinfo/get-full-username.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 48783163fcd8ebcc23329269d3e87d38003ea24e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 77485af0887729557f9676bdb54bc60d2aa051ef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="win32service-rightinfo.get-full-username" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,11 +10,11 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>null</type><type>string</type></type> <methodname>Win32Service\RightInfo::getFullUsername</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type> <methodname>Win32Service\RightInfo::getFullUsername</methodname>
    <void />
   </methodsynopsis>
   <para>
-   Devuelve el dominio y el nombre de usuario separados por un anti-slash <literal>\</literal>.
+   Devuelve el dominio y el nombre de usuario separados por una barra invertida <literal>\</literal>.
   </para>
  </refsect1>
 

--- a/reference/win32service/rightinfo/get-username.xml
+++ b/reference/win32service/rightinfo/get-username.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 48783163fcd8ebcc23329269d3e87d38003ea24e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 77485af0887729557f9676bdb54bc60d2aa051ef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="win32service-rightinfo.get-username" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>null</type><type>string</type></type> <methodname>Win32Service\RightInfo::getUsername</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type> <methodname>Win32Service\RightInfo::getUsername</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/wincache/functions/wincache-ucache-get.xml
+++ b/reference/wincache/functions/wincache-ucache-get.xml
@@ -58,7 +58,7 @@
   </simpara>
   <simpara>
    El parámetro <parameter>key</parameter> es un array, el parámetro <parameter>success</parameter>
-   siempre se establece en &true;. El array devuelto (pares nombre => valor) will
+   siempre se establece en &true;. El array devuelto (pares nombre => valor)
    contendrá sólo aquellos pares nombre => valor en donde la operación de obtención de caché de
    usuario se ha realizado correctamente. Si ninguna de las claves del array encuentran una coincidencia
    en la caché del usuario, un array vacío será devuelto.

--- a/reference/xdiff/book.xml
+++ b/reference/xdiff/book.xml
@@ -25,7 +25,7 @@
    parches binarios. Las nuevas funciones - <function>xdiff_string_rabdiff</function>
    <function>xdiff_file_rabdiff</function> generan salidas compatibles con funciones más antiguas
    pero suelen ser más rápidas y generan resultados más pequeños. Para más detalles sobre los métodos de
-   la generación de parches binarios y diferencias entre ellos, por favor consulte la website
+   la generación de parches binarios y diferencias entre ellos, por favor consulte el sitio web
    <link xlink:href="&url.xdiff;">libxdiff</link>.
   </para>
   <para>

--- a/reference/xdiff/functions/xdiff-file-bpatch.xml
+++ b/reference/xdiff/functions/xdiff-file-bpatch.xml
@@ -69,7 +69,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>xdiff_file_bpatch</function> example</title>
+    <title>Ejemplo de <function>xdiff_file_bpatch</function></title>
     <para>
      El siguiente código aplica una diferencia binaria a un archivo.
     </para>

--- a/reference/xhprof/book.xml
+++ b/reference/xhprof/book.xml
@@ -4,7 +4,7 @@
 
 <book xml:id="book.xhprof" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
- <title>Hierarchical Profiler</title>
+ <title>Perfilador jerárquico</title>
  <titleabbrev>Xhprof</titleabbrev>
 
  <preface xml:id="intro.xhprof">

--- a/reference/xlswriter/xlsx-format.xml
+++ b/reference/xlswriter/xlsx-format.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.vtiful-kernel-format" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The Vtiful\Kernel\Format class</title>
+ <title>La clase Vtiful\Kernel\Format</title>
  <titleabbrev>Vtiful\Kernel\Format</titleabbrev>
 
  <partintro>
@@ -34,7 +34,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Constantes</classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>

--- a/reference/xlswriter/xlsx-kernel.xml
+++ b/reference/xlswriter/xlsx-kernel.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c44e9cb68b9b65771f9c45db2c07a06c63d71359 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.vtiful-kernel-excel" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The Vtiful\Kernel\Excel class</title>
+ <title>La clase Vtiful\Kernel\Excel</title>
  <titleabbrev>Vtiful\Kernel\Excel</titleabbrev>
 
  <partintro>

--- a/reference/xlswriter/xlsx-kernel/auto-filter.xml
+++ b/reference/xlswriter/xlsx-kernel/auto-filter.xml
@@ -27,7 +27,7 @@
     <term><parameter>scope</parameter></term>
     <listitem>
      <para>
-      Celda de inicio y final del string de coordenadas.
+      Celda de inicio y final de la cadena de coordenadas.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xlswriter/xlsx-kernel/insert-formula.xml
+++ b/reference/xlswriter/xlsx-kernel/insert-formula.xml
@@ -45,7 +45,7 @@
     <term><parameter>formula</parameter></term>
     <listitem>
      <para>
-      formula string
+      Cadena de fórmula
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xlswriter/xlsx-kernel/insert-text.xml
+++ b/reference/xlswriter/xlsx-kernel/insert-text.xml
@@ -53,7 +53,7 @@
     <term><parameter>format</parameter></term>
     <listitem>
      <para>
-      Formato string
+      Cadena de formato
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xlswriter/xlsx-kernel/merge-cells.xml
+++ b/reference/xlswriter/xlsx-kernel/merge-cells.xml
@@ -28,7 +28,7 @@
     <term><parameter>scope</parameter></term>
     <listitem>
      <para>
-      strings de coordenadas de inicio y fin de la celda
+      Cadenas de coordenadas de inicio y fin de la celda
      </para>
     </listitem>
    </varlistentry>
@@ -36,7 +36,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <para>
-      datos string
+      Cadena de datos
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xlswriter/xlsx-kernel/set-column.xml
+++ b/reference/xlswriter/xlsx-kernel/set-column.xml
@@ -29,7 +29,7 @@
     <term><parameter>range</parameter></term>
     <listitem>
      <para>
-      los string de coordenadas de inicio y fin de la celda
+      Las cadenas de coordenadas de inicio y fin de la celda
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xlswriter/xlsx-kernel/set-row.xml
+++ b/reference/xlswriter/xlsx-kernel/set-row.xml
@@ -29,7 +29,7 @@
     <term><parameter>range</parameter></term>
     <listitem>
      <para>
-      los strings de coordenadas de inicio y fin de la celda
+      Las cadenas de coordenadas de inicio y fin de la celda
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xml/error-codes.xml
+++ b/reference/xml/error-codes.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: c0b9e812f0539442a3b4b60155077dca393054cc Maintainer: carlos Status: ready -->
 <!-- Reviewed: no -->
 <article xml:id="xml.error-codes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Error Codes</title>
+ <title>Códigos de error</title>
  <para>
     Las siguientes constantes se definen para códigos de error XML (como
   los que devuelve <function> xml_parse </function>):

--- a/reference/xml/functions/xml-set-element-handler.xml
+++ b/reference/xml/functions/xml-set-element-handler.xml
@@ -51,7 +51,7 @@
           <simpara>
            Contiene el nombre del elemento que provocó la llamada del
            gestor. Si el analizador gestiona la
-           <link linkend="xml.case-folding">casse</link>, este
+           <link linkend="xml.case-folding">caja</link>, este
            elemento estará en mayúsculas.
           </simpara>
          </listitem>
@@ -65,7 +65,7 @@
            Las claves de este array serán los nombres de los atributos,
            y los valores serán los valores correspondientes de los atributos.
            Los nombres de los atributos estarán en mayúsculas si el analizador gestiona
-           la <link linkend="xml.case-folding">casse</link>.
+           la <link linkend="xml.case-folding">caja</link>.
            Los valores de los atributos <emphasis>permanecerán inalterados</emphasis>.
           </simpara>
           <simpara>
@@ -97,7 +97,7 @@
           <simpara>
            Contiene el nombre del elemento que provocó la llamada del
            gestor. Si el analizador gestiona la
-           <link linkend="xml.case-folding">casse</link>, este
+           <link linkend="xml.case-folding">caja</link>, este
            elemento estará en mayúsculas.
           </simpara>
          </listitem>

--- a/reference/xmldiff/book.xml
+++ b/reference/xmldiff/book.xml
@@ -10,7 +10,7 @@
  <preface xml:id="intro.xmldiff">
   &reftitle.intro;
   <para>
-   Esta extensión es capaz de calcular las diferencias de dos documentos XML y luego aplicarlas en el documento de origen. El diff es un documento XML que contiene en sus nodos, en formato legible por humanos, las instruciones para copiar/insertar/eliminar. Objetos del tipo DOMDocument, ficheros locales y strings en memoria pueden ser procesados.
+   Esta extensión es capaz de calcular las diferencias de dos documentos XML y luego aplicarlas en el documento de origen. El diff es un documento XML que contiene en sus nodos, en formato legible por humanos, las instruciones para copiar/insertar/eliminar. Objetos del tipo DOMDocument, ficheros locales y cadenas en memoria pueden ser procesados.
   </para>
  </preface>
 

--- a/reference/xmldiff/xmldiff-file/diff.xml
+++ b/reference/xmldiff/xmldiff-file/diff.xml
@@ -17,7 +17,7 @@
    <methodparam><type>string</type><parameter>to</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Diferencia dos archivos XML locales y produce un string con la información de diferenciación.
+   Diferencia dos archivos XML locales y produce una cadena con la información de diferenciación.
   </para>
  </refsect1>
 
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   String con el documento XML que contiene la información diferencial o NULL.
+   Cadena con el documento XML que contiene la información diferencial o NULL.
   </para>
  </refsect1>
 

--- a/reference/xmldiff/xmldiff-file/merge.xml
+++ b/reference/xmldiff/xmldiff-file/merge.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   String con el nuevo documento XML o NULL.
+   Cadena con el nuevo documento XML o NULL.
   </para>
  </refsect1>
 

--- a/reference/xmldiff/xmldiff-memory/diff.xml
+++ b/reference/xmldiff/xmldiff-memory/diff.xml
@@ -17,7 +17,7 @@
    <methodparam><type>string</type><parameter>to</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Diferenciar dos string que contienen documentos XML y producir la información diferencial.
+   Diferenciar dos cadenas que contienen documentos XML y producir la información diferencial.
   </para>
  </refsect1>
 
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   String con el documento XML que contiene la información del diferencia o NULL.
+   Cadena con el documento XML que contiene la información del diferencia o NULL.
   </para>
  </refsect1>
 

--- a/reference/xmldiff/xmldiff-memory/merge.xml
+++ b/reference/xmldiff/xmldiff-memory/merge.xml
@@ -46,7 +46,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   String con el nuevo documento XML o NULL.
+   Cadena con el nuevo documento XML o NULL.
   </para>
  </refsect1>
 

--- a/reference/xmlrpc/configure.xml
+++ b/reference/xmlrpc/configure.xml
@@ -6,7 +6,7 @@
  <para>
   El XML-RPC soportado en PHP no está activado por defecto. Se necesita
   usar la opción configuración de <option role="configure">--with-xmlrpc[=DIR]</option>
-  cuando es compilado el PHP para activar el soporte a XML-RPC support.
+  cuando es compilado el PHP para activar el soporte a XML-RPC.
  </para>
 </section>
 

--- a/reference/xmlrpc/functions/xmlrpc-encode-request.xml
+++ b/reference/xmlrpc/functions/xmlrpc-encode-request.xml
@@ -48,7 +48,7 @@
         <listitem><para>output_type: php, <emphasis>xml</emphasis></para></listitem>
         <listitem><para>verbosity: no_white_space, newlines_only, <emphasis>pretty</emphasis></para></listitem>
         <listitem><para>escaping: cdata, <emphasis>non-ascii, non-print, markup</emphasis>
-          (puede ser un string con un valor o un array con varios valores)</para></listitem>
+          (puede ser una cadena con un valor o un array con varios valores)</para></listitem>
         <listitem><para>version: simple, <emphasis>xmlrpc</emphasis>, soap 1.1, auto</para></listitem>
         <listitem><para>encoding: <emphasis>iso-8859-1</emphasis>, otros juegos de caracteres soportados por iconv</para></listitem>
        </itemizedlist>
@@ -62,7 +62,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve un string que contiene la representación XML de la solicitud.
+   Devuelve una cadena que contiene la representación XML de la solicitud.
   </para>
  </refsect1>
 

--- a/reference/xmlrpc/functions/xmlrpc-is-fault.xml
+++ b/reference/xmlrpc/functions/xmlrpc-is-fault.xml
@@ -35,8 +35,8 @@
   &reftitle.returnvalues;
   <para>
    Devuelve &true; si embargo si el argumento significa fallo retorna, &false;. La descripción de
-   la falla o falta está disponible en <literal>$arg["faultString"]</literal>, fault
-   el código está en <literal>$arg["faultCode"]</literal>.
+   la falla o falta está disponible en <literal>$arg["faultString"]</literal>, y
+   el código de fallo está en <literal>$arg["faultCode"]</literal>.
   </para>
  </refsect1>
 

--- a/reference/xmlrpc/functions/xmlrpc-set-type.xml
+++ b/reference/xmlrpc/functions/xmlrpc-set-type.xml
@@ -35,7 +35,7 @@
      <term><parameter>type</parameter></term>
      <listitem>
       <para>
-       'base64' or 'datetime'
+       'base64' o 'datetime'
       </para>
      </listitem>
     </varlistentry>
@@ -62,7 +62,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>A <function>xmlrpc_set_type</function> example</title>
+    <title>Ejemplo de <function>xmlrpc_set_type</function></title>
     <para>
     </para>
     <programlisting role="php">

--- a/reference/xmlwriter/xmlwriter/flush.xml
+++ b/reference/xmlwriter/xmlwriter/flush.xml
@@ -21,7 +21,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>empty</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Vacía el buffer actual.
+   Vacía el búfer actual.
   </para>
  </refsect1>
 
@@ -34,7 +34,7 @@
      <term><parameter>empty</parameter></term>
      <listitem>
       <para>
-       Si se debe vaciar el buffer o no.
+       Si se debe vaciar el búfer o no.
        Por omisión, este parámetro vale &true;.
       </para>
      </listitem>
@@ -47,8 +47,8 @@
   &reftitle.returnvalues;
   <para>
    Si se abrió el gestor de escritura en memoria,
-   esta función devuelve el buffer XML generado. Si se utiliza
-   una URI, esta función escribirá el buffer y devolverá
+   esta función devuelve el búfer XML generado. Si se utiliza
+   una URI, esta función escribirá el búfer y devolverá
    el número de bytes escritos.
   </para>
  </refsect1>

--- a/reference/xmlwriter/xmlwriter/openmemory.xml
+++ b/reference/xmlwriter/xmlwriter/openmemory.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>XMLWriter::openMemory</refname>
   <refname>xmlwriter_open_memory</refname>
-  <refpurpose>Crea un nuevo xmlwriter utilizando la memoria para la visualización del string</refpurpose>
+  <refpurpose>Crea un nuevo xmlwriter utilizando la memoria para la visualización de la cadena</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -21,7 +21,7 @@
   </methodsynopsis>
   <para>
    Crea un nuevo objeto <classname>XMLWriter</classname>,
-   utilizando la memoria para la visualización de las string.
+   utilizando la memoria para la visualización de las cadenas.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/xmlwriter/xmlwriter/outputmemory.xml
+++ b/reference/xmlwriter/xmlwriter/outputmemory.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>XMLWriter::outputMemory</refname>
   <refname>xmlwriter_output_memory</refname>
-  <refpurpose>Devuelve el actual buffer</refpurpose>
+  <refpurpose>Devuelve el actual búfer</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -21,7 +21,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>flush</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Devuelve el buffer actual.
+   Devuelve el búfer actual.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -33,7 +33,7 @@
      <term><parameter>flush</parameter></term>
      <listitem>
       <para>
-       Si se mantiene la salida del buffer o no. Por defecto es &true;.
+       Si se mantiene la salida del búfer o no. Por defecto es &true;.
       </para>
      </listitem>
     </varlistentry>
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Devuelve el buffer actual como un string.
+   Devuelve el búfer actual como una cadena.
   </para>
  </refsect1>
 

--- a/reference/xmlwriter/xmlwriter/setindentstring.xml
+++ b/reference/xmlwriter/xmlwriter/setindentstring.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>XMLWriter::setIndentString</refname>
   <refname>xmlwriter_set_indent_string</refname>
-  <refpurpose>Define la string a utilizar para la indentación</refpurpose>
+  <refpurpose>Define la cadena a utilizar para la indentación</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -21,7 +21,7 @@
    <methodparam><type>string</type><parameter>indentation</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Define la string que se utilizará para indentar cada elemento/atributo
+   Define la cadena que se utilizará para indentar cada elemento/atributo
    de un documento XML.
   </para>
  </refsect1>
@@ -34,7 +34,7 @@
      <term><parameter>indentation</parameter></term>
      <listitem>
       <para>
-       La string para la indentación.
+       La cadena para la indentación.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xmlwriter/xmlwriter/text.xml
+++ b/reference/xmlwriter/xmlwriter/text.xml
@@ -36,7 +36,7 @@
        El contenido del texto.
        Los caracteres <literal>&lt;</literal>, <literal>&gt;</literal>,
        <literal>&amp;</literal> y <literal>"</literal> se escriben como
-       referencias de entidades (c.à.d. <literal>&amp;lt;</literal>,
+       referencias de entidades (es decir, <literal>&amp;lt;</literal>,
        <literal>&amp;gt;</literal>, <literal>&amp;amp;</literal> y
        <literal>&amp;quot;</literal>, respectivamente).
        Todos los otros caracteres <literal>&apos;</literal> incluidos se escriben

--- a/reference/xmlwriter/xmlwriter/writeraw.xml
+++ b/reference/xmlwriter/xmlwriter/writeraw.xml
@@ -33,7 +33,7 @@
      <term><parameter>content</parameter></term>
      <listitem>
       <para>
-       El string a escribir.
+       La cadena a escribir.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xsl/examples.xml
+++ b/reference/xsl/examples.xml
@@ -98,7 +98,7 @@
     <title>Errores de compaginación e impresión</title>
     <para>
      El siguiente ejemplo captura y muestra los errores de libxml que se producen al llamar a
-     <methodname>XSLTProcessor::importStyleSheet</methodname> on una hoja de
+     <methodname>XSLTProcessor::importStyleSheet</methodname> con una hoja de
      estilo que contiene un error.
     </para>
     <programlisting role="php">

--- a/reference/xsl/xsltprocessor/getsecurityprefs.xml
+++ b/reference/xsl/xsltprocessor/getsecurityprefs.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   A bitmask consisting of <constant>XSL_SECPREF_READ_FILE</constant>,
+   Una máscara de bits compuesta por <constant>XSL_SECPREF_READ_FILE</constant>,
    <constant>XSL_SECPREF_WRITE_FILE</constant>,
    <constant>XSL_SECPREF_CREATE_DIRECTORY</constant>,
    <constant>XSL_SECPREF_READ_NETWORK</constant>,

--- a/reference/xsl/xsltprocessor/setsecurityprefs.xml
+++ b/reference/xsl/xsltprocessor/setsecurityprefs.xml
@@ -26,7 +26,7 @@
      <term><parameter>preferences</parameter></term>
      <listitem>
       <para>
-       Las nuevas preferencias de seguridad. Las siguientes constantes pueden ser ORed:
+       Las nuevas preferencias de seguridad. Las siguientes constantes pueden combinarse con OR:
        <constant>XSL_SECPREF_READ_FILE</constant>,
        <constant>XSL_SECPREF_WRITE_FILE</constant>,
        <constant>XSL_SECPREF_CREATE_DIRECTORY</constant>,

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -28,7 +28,7 @@
     <term><parameter>prefix</parameter></term>
     <listitem>
      <para>
-       &string; prefix
+       Prefijo &string;
      </para>
     </listitem>
    </varlistentry>

--- a/reference/yaf/yaf-loader.xml
+++ b/reference/yaf/yaf-loader.xml
@@ -88,7 +88,7 @@ class Bootstrap extends Yaf_Bootstrap_Abstract{
 
     Ahora los ejemplos de autocarga:
     <example>
-     <title>Load class example</title>
+     <title>Ejemplo de carga de clases</title>
      <programlisting role="shell">
 <![CDATA[
 class Foo_Bar_Test =>

--- a/reference/yaml/examples.xml
+++ b/reference/yaml/examples.xml
@@ -5,7 +5,7 @@
 <chapter xml:id="yaml.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
  <example>
-  <title>Yaml Example</title>
+  <title>Ejemplo de Yaml</title>
   <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaml/functions/yaml-emit-file.xml
+++ b/reference/yaml/functions/yaml-emit-file.xml
@@ -75,7 +75,7 @@
       <para>
        Manejadores de contenido para emitir nodos YAML. <type>array</type>
        asociativo de nombre de clase de asignaciones =&gt; <type>callable</type>. Véase
-       <link linkend="yaml.callbacks.emit">emit callbacks</link> para más
+       <link linkend="yaml.callbacks.emit">emitir llamadas de retorno</link> para más
        detalles.
       </para>
      </listitem>

--- a/reference/yaz/functions/yaz-ccl-conf.xml
+++ b/reference/yaz/functions/yaz-ccl-conf.xml
@@ -44,7 +44,7 @@
       </para>
       <para>
        La asignación es una secuencia de el tipo de atributo, de los valores de los atributos pares.
-       El tipo de atributo y el valor del atributo Attribute-type es separado por un signo
+       El tipo de atributo y el valor del atributo están separados por un signo
        (<literal>=</literal>). Cada par es separado por un epacio en blanco.
       </para>
       <para>

--- a/reference/yaz/functions/yaz-ccl-parse.xml
+++ b/reference/yaz/functions/yaz-ccl-parse.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.yaz-ccl-parse" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>yaz_ccl_parse</refname>
-  <refpurpose>Inviocar el analizador Invoke CCL</refpurpose>
+  <refpurpose>Invocar el analizador CCL</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/yaz/functions/yaz-errno.xml
+++ b/reference/yaz/functions/yaz-errno.xml
@@ -19,7 +19,7 @@
   <para>
    <function>yaz_errno</function> debe ser llamado después de la actividad de
    red para cada servidor - (después del retorno de <function>yaz_wait</function>) para determinar
-   el éxito o el fracaso de la última operación (p. e.j. search).
+   el éxito o el fracaso de la última operación (p. ej. búsqueda).
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/yaz/functions/yaz-hits.xml
+++ b/reference/yaz/functions/yaz-hits.xml
@@ -60,7 +60,7 @@
    está en $array[0], segunda subconsulta en $array[1], y así sucesivamente.
   </para>
   <table>
-   <title>searchresult members</title>
+   <title>Miembros de searchresult</title>
    <tgroup cols="2">
     <colspec colwidth="1*" colname="element"/>
     <colspec colwidth="2*" colname="description"/>

--- a/reference/yaz/functions/yaz-record.xml
+++ b/reference/yaz/functions/yaz-record.xml
@@ -219,7 +219,7 @@ print_r($ar);
 ?>
 ]]>
     </programlisting>
-    will output:
+    mostrará:
     <screen>
 <![CDATA[
 Array

--- a/reference/yaz/functions/yaz-search.xml
+++ b/reference/yaz/functions/yaz-search.xml
@@ -107,9 +107,8 @@
        </tgroup>
       </table>
       <para>
-       Se muestra más información sobre atributos en el link
-       <link xlink:href="&url.yaz-loc-bib1;">Z39.50 Maintenance Agency</link>
-       site.
+       Se muestra más información sobre atributos en el sitio
+       <link xlink:href="&url.yaz-loc-bib1;">Z39.50 Maintenance Agency</link>.
       </para>
       <note>
        <para>
@@ -132,7 +131,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Query Examples</title>
+   <title>Ejemplos de consulta</title>
    <para>
     Se puede buscar por términos sencillos, como en el caso siguiente:
     <screen>

--- a/reference/yaz/functions/yaz-sort.xml
+++ b/reference/yaz/functions/yaz-sort.xml
@@ -55,7 +55,7 @@
       </para>
       <para>
        <variablelist>
-        <title>Sort Flags</title>
+        <title>Banderas de ordenación</title>
         <varlistentry>
          <term><literal>a</literal></term>
          <listitem>

--- a/reference/yaz/functions/yaz-wait.xml
+++ b/reference/yaz/functions/yaz-wait.xml
@@ -63,7 +63,7 @@
   &reftitle.returnvalues;
   <para>
    &return.success;
-   En modo event, retorna un recource &return.falseforfailure;.
+   En modo evento, retorna un recurso &return.falseforfailure;.
   </para>
  </refsect1>
 </refentry>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -926,7 +926,7 @@
    </term>
    <listitem>
     <simpara>
-     Unexpected length of data.
+     Longitud de datos inesperada.
      Disponible a partir de PHP 8.3.0 y PECL zip 1.22.0, respectivamente,
      si se compila con libzip ≥ 1.10.0.
     </simpara>
@@ -939,7 +939,7 @@
    </term>
    <listitem>
     <simpara>
-     Not allowed in torrentzip.
+     No permitido en torrentzip.
      Disponible a partir de PHP 8.3.0 y PECL zip 1.22.0, respectivamente,
      si se compila con libzip ≥ 1.10.0.
     </simpara>
@@ -979,7 +979,7 @@
    </term>
    <listitem>
     <simpara>
-     Traditional PKWARE encryption. Disponible a partir de PHP 8.0.0 y PECL zip 1.19.0, respectivamente.
+     Cifrado tradicional PKWARE. Disponible a partir de PHP 8.0.0 y PECL zip 1.19.0, respectivamente.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1026,7 +1026,7 @@
    </term>
    <listitem>
     <simpara>
-     Unknown encryption algorithm. Disponible a partir de PHP 8.0.0 y PECL zip 1.19.0, respectivamente.
+     Algoritmo de cifrado desconocido. Disponible a partir de PHP 8.0.0 y PECL zip 1.19.0, respectivamente.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -113,7 +113,7 @@
       <row>
        <entry>8.3.0, PECL zip 1.22.2</entry>
        <entry>
-        <constant>ZipArchive::LENGTH_TO_END</constant> and <constant>ZipArchive::LENGTH_UNCHECKED</constant> were added.
+        Se añadieron <constant>ZipArchive::LENGTH_TO_END</constant> y <constant>ZipArchive::LENGTH_UNCHECKED</constant>.
        </entry>
       </row>
      </tbody>

--- a/reference/zip/ziparchive/getfromindex.xml
+++ b/reference/zip/ziparchive/getfromindex.xml
@@ -44,7 +44,7 @@
      <listitem>
       <para>
        Las flags usadas para abrir el fichero. Los siguientes valores
-       pueden ser Ored.
+       pueden combinarse con OR.
        <itemizedlist>
         <listitem>
          <simpara>

--- a/reference/zip/ziparchive/registercancelcallback.xml
+++ b/reference/zip/ziparchive/registercancelcallback.xml
@@ -49,7 +49,7 @@
    la operación en alguna condición de operación.
   </simpara>
   <example>
-   <title>Archive a file</title>
+   <title>Archivar un fichero</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/registerprogresscallback.xml
+++ b/reference/zip/ziparchive/registerprogresscallback.xml
@@ -57,7 +57,7 @@
    la progresión.
   </simpara>
   <example>
-   <title>Archive a file</title>
+   <title>Archivar un fichero</title>
    <programlisting role="php">
 <![CDATA[
 $zip = new ZipArchive();

--- a/reference/zip/ziparchive/setencryptionindex.xml
+++ b/reference/zip/ziparchive/setencryptionindex.xml
@@ -36,7 +36,7 @@
      <term><parameter>method</parameter></term>
      <listitem>
       <simpara>
-       El método de cifrado definido por una de las constantes ZipArchive::EM_ constants.
+       El método de cifrado definido por una de las constantes ZipArchive::EM_.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/setencryptionname.xml
+++ b/reference/zip/ziparchive/setencryptionname.xml
@@ -34,7 +34,7 @@
      <term><parameter>method</parameter></term>
      <listitem>
       <simpara>
-       El método de encriptación definido por una de las constantes ZipArchive::EM_constants.
+       El método de encriptación definido por una de las constantes ZipArchive::EM_.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zlib/functions/gzcompress.xml
+++ b/reference/zlib/functions/gzcompress.xml
@@ -21,8 +21,8 @@
   </para>
   <para>
    Para detalles sobre el algoritmo de compresión ZLIB, ver el
-   documento "<link xlink:href="&url.rfc;1950">ZLIB Compressed Data Format
-   Specification version 3.3</link>" (RFC 1950).
+   documento "<link xlink:href="&url.rfc;1950">Especificación del formato de datos
+   comprimidos ZLIB versión 3.3</link>" (RFC 1950).
   </para>
   <note>
    <para>

--- a/reference/zlib/functions/gzdeflate.xml
+++ b/reference/zlib/functions/gzdeflate.xml
@@ -21,8 +21,8 @@
   </para>
   <para>
    Para más detalles sobre el algoritmo de compresión DEFLATE ver el
-   documento "<link xlink:href="&url.rfc;1951">DEFLATE Compressed Data Format
-   Specification version 1.3</link>" (RFC 1951).
+   documento "<link xlink:href="&url.rfc;1951">Especificación del formato de datos
+   comprimidos DEFLATE versión 1.3</link>" (RFC 1951).
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/zlib/functions/gzencode.xml
+++ b/reference/zlib/functions/gzencode.xml
@@ -21,8 +21,8 @@
   </para>
   <para>
    Para más información sobre el formato de archivo GZIP, ver el
-   documento: <link xlink:href="&url.rfc;1952">GZIP file format specification
-   version 4.3</link> (RFC 1952).
+   documento: <link xlink:href="&url.rfc;1952">Especificación del formato de archivo GZIP
+   versión 4.3</link> (RFC 1952).
   </para>
  </refsect1>
 

--- a/reference/zmq/zmq.xml
+++ b/reference/zmq/zmq.xml
@@ -428,7 +428,7 @@
      <varlistentry xml:id="zmq.constants.socket-stream">
       <term><constant>ZMQ::SOCKET_STREAM</constant></term>
       <listitem>
-       <para>Utilizada para enviar y recibir datos TCP de un par que no sea ØMQ. Disponible si se compila con ZeroMQ 4.0 o superior (Value: &integer;).</para>
+       <para>Utilizada para enviar y recibir datos TCP de un par que no sea ØMQ. Disponible si se compila con ZeroMQ 4.0 o superior (Valor: &integer;).</para>
       </listitem>
      </varlistentry>
 

--- a/reference/zmq/zmqcontext/getsocket.xml
+++ b/reference/zmq/zmqcontext/getsocket.xml
@@ -76,7 +76,7 @@
    <example>
     <title>Un ejemplo de <function>ZMQContext</function></title>
     <para>
-     Basic usage
+     Uso básico
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/zmq/zmqdevice/setidletimeout.xml
+++ b/reference/zmq/zmqdevice/setidletimeout.xml
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>timeout</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Establece el valor del tiempo de espera de la retrollamada de inactividad. La retrollamada de inactividad se invoca periódicamente invoked cuando el dispositivo está
+   Establece el valor del tiempo de espera de la retrollamada de inactividad. La retrollamada de inactividad se invoca periódicamente cuando el dispositivo está
    inactivo.
   </para>
  </refsect1>

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -565,14 +565,14 @@
       <term><constant>Zookeeper::DELETED_EVENT</constant></term>
       <listitem>
        <para>Se ha eliminado un nodo</para>
-       <para>Esto sólo se genera por los relojes de los nodos. Estos relojes se ajustan usando Zookeeper::exists and Zookeeper::get.</para>
+       <para>Esto sólo se genera por los relojes de los nodos. Estos relojes se ajustan usando Zookeeper::exists y Zookeeper::get.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="zookeeper.constants.changed-event">
       <term><constant>Zookeeper::CHANGED_EVENT</constant></term>
       <listitem>
        <para>Un nodo ha cambiado</para>
-       <para>Esto sólo lo generan los relojes de los nodos. Estos relojes se ajustan usando Zookeeper::exists and Zookeeper::get.</para>
+       <para>Esto sólo lo generan los relojes de los nodos. Estos relojes se ajustan usando Zookeeper::exists y Zookeeper::get.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="zookeeper.constants.child-event">

--- a/reference/zookeeper/zookeeper/create.xml
+++ b/reference/zookeeper/zookeeper/create.xml
@@ -85,7 +85,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="zookeeper.create.example.basic">
-   <title><methodname>Zookeeper::create</methodname> example</title>
+   <title>Ejemplo de <methodname>Zookeeper::create</methodname></title>
    <para>
      Crea un nuevo nodo.
    </para>

--- a/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
+++ b/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
@@ -16,9 +16,9 @@
    <methodparam><type>bool</type><parameter>yesOrNo</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Si se establece en true, hará que el cliente se conecte a los quorum peers en el orden especificado en la llamada
-   a zookeeper_init(). Un valor falso causará que zookeeper_init() intercambie los puntos finales de los quorum peers,
-   lo que es bueno para una distribución más uniforme de las conexiones de los clientes entre los quorum peers.
+   Si se establece en true, hará que el cliente se conecte a los nodos del quórum en el orden especificado en la llamada
+   a zookeeper_init(). Un valor falso causará que zookeeper_init() intercambie los puntos finales de los nodos del quórum,
+   lo que es bueno para una distribución más uniforme de las conexiones de los clientes entre los nodos del quórum.
    El cliente ZooKeeper C utiliza false por defecto.
   </para>
  </refsect1>

--- a/reference/zookeeper/zookeeper/setwatcher.xml
+++ b/reference/zookeeper/zookeeper/setwatcher.xml
@@ -40,7 +40,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Este método emite un error PHP/warning cuando el número de parámetros o los tipos son incorrectos
+   Este método emite un error/advertencia PHP cuando el número de parámetros o los tipos son incorrectos
    o es imposible cambiar el observador.
   </para>
   <caution>


### PR DESCRIPTION
Continuación de #601: barrido EN/FR → ES en los sub-directorios restantes de reference/.