### PR TITLE
Sincronizar EN-Revision y conversiones estructurales

### DIFF
--- a/language/predefined/variables/argc.xml
+++ b/language/predefined/variables/argc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 660a9ebe1fc4ae3a32104381090f70bce652ee75 Maintainer: chuso Status: ready -->
+<!-- EN-Revision: a6d209f4ff71ccba3f1255902827f5df3e092ff9 Maintainer: chuso Status: ready -->
 
 <refentry role="variable" xml:id="reserved.variables.argc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/geterrorreply.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/geterrorreply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.geterrorreply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,8 +14,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Document</type><type>null</type></type><methodname>MongoDB\Driver\Exception\BulkWriteCommandException::getErrorReply</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,11 +25,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un error de comando de nivel superior que ocurrió al intentar comunicarse
    con el servidor o al ejecutar la escritura masiva. Este valor puede ser &null; si la excepción
    fue lanzada debido a errores que ocurrieron en escrituras individuales.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getpartialresult.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getpartialresult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.getpartialresult" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,8 +14,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\BulkWriteCommandResult</type><type>null</type></type><methodname>MongoDB\Driver\Exception\BulkWriteCommandException::getPartialResult</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,13 +25,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un <classname>MongoDB\Driver\BulkWriteCommandResult</classname>
    que proporciona los resultados de cada una de las operaciones exitosas que se realizaron antes
    de que se encontrara el error. El valor devuelto será &null; si no se puede
    determinar si al menos una escritura se realizó con éxito (y
    fue reconocida).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteconcernerrors.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteconcernerrors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.getwriteconcernerrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,8 +14,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Exception\BulkWriteCommandException::getWriteConcernErrors</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,12 +25,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un array de cada uno de los <classname>MongoDB\Driver\WriteConcernError</classname>s
    que se produjeron durante la ejecución de la escritura masiva. Esta lista puede tener
    múltiples entradas si se necesitó más de un comando de servidor para ejecutar la
    escritura masiva.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteerrors.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteerrors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.getwriteerrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,8 +14,8 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Exception\BulkWriteCommandException::getWriteErrors</methodname>
    <void />
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,13 +25,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un array de <classname>MongoDB\Driver\WriteError</classname> que se
    produjeron durante la ejecución de la escritura individual. Las claves del array
    corresponden al índice de la operación de escritura en
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. Esta lista
    contendrá como máximo una entrada si la escritura masiva estaba ordenada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/bulkwriteexception/getwriteresult.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwriteexception/getwriteresult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-bulkwriteexception.getwriteresult" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,13 +14,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteResult</type><methodname>MongoDB\Driver\Exception\BulkWriteException::getWriteResult</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\WriteResult</classname> para la operación
    de escritura fallida. Los métodos
    <function>MongoDB\Driver\WriteResult::getWriteErrors</function> y
    <function>MongoDB\Driver\WriteResult::getWriteConcernError</function>
    pueden ser utilizados para obtener detalles adicionales sobre el error.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -31,10 +31,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El <classname>MongoDB\Driver\WriteResult</classname> para la operación
    de escritura fallida.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/exception/commandexception/getresultdocument.xml
+++ b/reference/mongodb/mongodb/driver/exception/commandexception/getresultdocument.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e60f8596d36312e7339dc95e690194172337a91 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-commandexception.getresultdocument" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Exception\CommandException::getResultDocument</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el documento resultante para el comando fallido.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El documento resultante para el comando fallido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/exception/runtimeexception/haserrorlabel.xml
+++ b/reference/mongodb/mongodb/driver/exception/runtimeexception/haserrorlabel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-runtimeexception.haserrorlabel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,7 +15,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Exception\RuntimeException::hasErrorLabel</methodname>
    <methodparam><type>string</type><parameter>errorLabel</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve si el <parameter>errorLabel</parameter> ha sido definido para esta excepción.
    Los labels de error son definidos por el servidor o por la extensión para
    indicar situaciones específicas donde se desea decidir cómo manejar
@@ -24,7 +24,7 @@
    (como un error de red o un conflicto de transacción) sin problemas.
    Ejemplos de labels de error son <literal>TransientTransactionError</literal>
    y <literal>UnknownTransactionCommitResult</literal>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -34,7 +34,7 @@
    <varlistentry>
     <term><parameter>errorLabel</parameter></term>
     <listitem>
-     <para>El nombre del <literal>errorLabel</literal> a verificar.</para>
+     <simpara>El nombre del <literal>errorLabel</literal> a verificar.</simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -42,10 +42,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Si el <literal>errorLabel</literal> proporcionado está asociado con esta
    excepción.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/exception/unexpectedvalueexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/unexpectedvalueexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-exception-unexpectedvalueexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase MongoDB\Driver\Exception\UnexpectedValueException</title>
@@ -10,10 +10,10 @@
 <!-- {{{ MongoDB\Driver\Exception\UnexpectedValueException intro -->
   <section xml:id="mongodb-driver-exception-unexpectedvalueexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Lanzada cuando el controlador encuentra un valor inesperado (por ejemplo, durante la serialización
     o deserialización BSON).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/exception/writeexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/writeexception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-exception-writeexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -22,10 +22,10 @@
   <!-- {{{ MongoDB\Driver\Exception\WriteException intro -->
   <section xml:id="mongodb-driver-exception-writeexception.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Clase base para las excepciones lanzadas por una operación de escritura
     fallida. La excepción encapsula un objeto <classname>MongoDB\Driver\WriteResult</classname>.
-   </para>
+   </simpara>
   </section>
   <!-- }}} -->
 
@@ -86,10 +86,10 @@
     <varlistentry xml:id="mongodb-driver-exception-writeexception.props.writeresult">
      <term><varname>writeResult</varname></term>
      <listitem>
-      <para>
+      <simpara>
        <classname>MongoDB\Driver\WriteResult</classname> asociado a la operación
        de escritura fallida.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -98,8 +98,7 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
+       <informaltable>
      <tgroup cols="2">
       <thead>
        <row>
@@ -117,18 +116,17 @@
        <row>
         <entry>PECL mongodb 1.5.0</entry>
         <entry>
-         <para>
+         <simpara>
           Esta clase ahora extiende
           <classname>MongoDB\Driver\Exception\ServerException</classname>
           en lugar de
           <classname>MongoDB\Driver\Exception\RuntimeException</classname>.
-         </para>
+         </simpara>
         </entry>
        </row>
       </tbody>
      </tgroup>
     </informaltable>
-   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/exception/writeexception/getwriteresult.xml
+++ b/reference/mongodb/mongodb/driver/exception/writeexception/getwriteresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeexception.getwriteresult" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,13 +15,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteResult</type><methodname>MongoDB\Driver\Exception\WriteException::getWriteResult</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\WriteResult</classname> para la operación de escritura
    que falló. Los métodos
    <function>MongoDB\Driver\WriteResult::getWriteErrors</function> y
    <function>MongoDB\Driver\WriteResult::getWriteConcernError</function>
    pueden ser utilizados para recuperar más detalles sobre el fallo.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -32,10 +32,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El <classname>MongoDB\Driver\WriteResult</classname> para la operación de escritura
    que falló.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/manager/addsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/manager/addsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.addsubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Manager::addSubscriber</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Registra un observador de eventos de monitoreo con este Manager. El observador
    será notificado de todos los eventos para este Manager.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Si <parameter>subscriber</parameter> ya está registrado con este manager, esta
@@ -32,9 +32,9 @@
    <varlistentry>
     <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un observador de eventos de monitoreo a registrar con este Manager.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -42,9 +42,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
+++ b/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> <!-- EN-Revision: cc6f9ee922cc02771942f435f66fbd008bf5788d Maintainer: PhilDaiguille Status: ready -->
+<?xml version="1.0" encoding="utf-8"?> <!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.createclientencryption" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ClientEncryption</type><methodname>MongoDB\Driver\Manager::createClientEncryption</methodname>
    <methodparam><type>array</type><parameter>options</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construye un nuevo objeto <classname>MongoDB\Driver\ClientEncryption</classname> con las opciones especificadas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -50,9 +50,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve una nueva instancia de <classname>MongoDB\Driver\ClientEncryption</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -83,51 +83,51 @@
          ahora una opción <literal>"sessionToken"</literal>, que puede ser utilizada
          para autenticarse con credenciales AWS temporales.
         </para>
-        <para>
+        <simpara>
          Añadido <literal>"tlsDisableOCSPEndpointCheck"</literal> a la opción
          <literal>"tlsOptions"</literal>.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Si se especifica un documento vacío para el proveedor KMS <literal>"azure"</literal> o
          <literal>"gcp"</literal>, el controlador intentará
          configurar el proveedor utilizando
          <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Las credenciales automáticas</link>.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.15.0</entry>
        <entry>
-        <para>
+        <simpara>
          Si se especifica un documento vacío para el proveedor KMS <literal>"aws"</literal>,
          el controlador intentará configurar el proveedor utilizando
          <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Las credenciales automáticas</link>.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.12.0</entry>
        <entry>
-        <para>
+        <simpara>
          KMIP es ahora soportado como proveedor KMS para el cifrado
          del lado del cliente y puede ser configurado en la opción <literal>"kmsProviders"</literal>.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Añadida la opción <literal>"tlsOptions"</literal>.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.10.0</entry>
        <entry>
-        <para>
+        <simpara>
          Azure y GCP son ahora soportados como proveedores KMS para el cifrado
          del lado del cliente y pueden ser configurados en la opción
          <literal>"kmsProviders"</literal>.
          Las cadenas codificadas en base64 son ahora aceptadas como alternativa a
          <classname>MongoDB\BSON\Binary</classname>
          para las opciones en <literal>"kmsProviders"</literal>.
-        </para>
+        </simpara>
        </entry>
       </row>
      </tbody>

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,21 +15,21 @@
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta una o varias operaciones de escritura en el servidor primario.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Un <classname>MongoDB\Driver\BulkWrite</classname> puede ser construido con
    una o varias operaciones de escritura de tipos variados (por ejemplo, actualizaciones, eliminaciones e inserciones). El controlador intentará enviar las
    operaciones del mismo tipo al servidor en el menor número de solicitudes posible
    para optimizar los intercambios.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    El valor por omisión de la opción <literal>"writeConcern"</literal> será
    deducido a partir de una transacción activa (indicada por la opción
    <literal>"session"</literal>), seguida de la
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -82,7 +82,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -133,7 +133,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-manager.executebulkwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,22 +15,22 @@
    <methodparam><type>MongoDB\Driver\BulkWriteCommand</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta una o varias operaciones de escritura en el servidor primario utilizando el
    comando <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
    introducido en MongoDB 8.0.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Una <classname>MongoDB\Driver\BulkWriteCommand</classname> puede ser construida
    con una o varias operaciones de escritura de tipos variados (por ejemplo, inserciones,
    actualizaciones y eliminaciones). Cada operación de escritura puede apuntar a una colección diferente.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    El valor por omisión para la opción <literal>"writeConcern"</literal> será
    deducido de una transacción activa (indicada por la opción
    <literal>"session"</literal>), seguida por
    <link linkend="mongodb-driver-manager.construct-uri">la URI de conexión</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -84,12 +84,12 @@
   &reftitle.examples;
   <example>
    <title>Operaciones de escritura mixtas</title>
-   <para>
+   <simpara>
     Las operaciones de escritura mixtas (por ejemplo, inserción, actualización y eliminación) serán enviadas
     al servidor utilizando una sola
     comando
     <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,24 +15,24 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Selecciona un servidor en función de la opción <literal>"readPreference"</literal>
    y ejecuta el comando en ese servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método no aplica ninguna lógica especial al comando. Los valores
    por defecto de las opciones <literal>"readPreference"</literal>,
    <literal>"readConcern"</literal> y <literal>"writeConcern"</literal> serán
    deducidos a partir de una transacción activa (indicada por la opción
    <literal>"session"</literal>). Si no hay una transacción activa, se utilizará
    una preferencia de lectura primaria para la selección del servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Los valores por defecto no serán <emphasis>no</emphasis> deducidos a partir de
    la <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
    Por lo tanto, se recomienda a los usuarios utilizar métodos de comando de lectura
    y/o escritura específicos si es posible.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -86,7 +86,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -129,7 +129,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="examples">
@@ -223,13 +223,13 @@ object(stdClass)#7 (2) {
 
   <example>
    <title>Limitar el tiempo de ejecución de un comando</title>
-   <para>
+   <simpara>
     El tiempo de ejecución de un comando puede ser limitado especificando un valor para
     <literal>"maxTimeMS"</literal> en el documento <classname>MongoDB\Driver\Command</classname>.
     Tenga en cuenta que este límite de tiempo se aplica en el lado del servidor y no tiene en cuenta
     la latencia de la red. Ver <link xlink:href="&url.mongodb.docs.maxtimems;">Terminar las operaciones en curso
     </link> en el manual de MongoDB para más información.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -249,10 +249,10 @@ var_dump($cursor->toArray()[0]);
 ?>
 ]]>
    </programlisting>
-   <para>
+   <simpara>
     Si el comando no logra completarse después de un segundo de ejecución en el servidor,
     se lanzará una <classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname>.
-   </para>
+   </simpara>
   </example>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,16 +15,16 @@
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Selecciona un servidor en función de la opción <literal>"readPreference"</literal>
    y ejecuta la consulta en ese servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Los valores por omisión de la opción <literal>"readPreference"</literal> y de
    la opción <literal>"readConcern"</literal> de la consulta serán deducidos a
    partir de una transacción activa (indicada por la opción <literal>"session"</literal>),
    seguida de la <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -73,7 +73,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -108,7 +108,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="examples">
@@ -160,14 +160,14 @@ object(stdClass)#7 (1) {
 
   <example>
    <title>Limitar el tiempo de ejecución de una consulta</title>
-   <para>
+   <simpara>
     La opción <literal>"maxTimeMS"</literal> de la clase
     <classname>MongoDB\Driver\Query</classname> puede ser utilizada para limitar
     el tiempo de ejecución de una consulta. Tenga en cuenta que este límite de tiempo es
     aplicado en el lado del servidor y no tiene en cuenta la latencia de la red. Ver
     <link xlink:href="&url.mongodb.docs.maxtimems;">Terminar las operaciones en curso
     </link> en el manual de MongoDB para más información.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -189,12 +189,12 @@ foreach ($cursor as $document) {
 ?>
 ]]>
    </programlisting>
-   <para>
+   <simpara>
     Si la consulta no logra terminar después de un segundo de ejecución
     en el servidor, una
     <classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname>
     será lanzada.
-   </para>
+   </simpara>
   </example>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,18 +15,18 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Selecciona un servidor en función de la opción <literal>"readPreference"</literal>
    y ejecuta el comando en este servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará una lógica específica a los comandos que leen (por ejemplo
    <link xlink:href="&url.mongodb.docs;reference/command/distinct/">distinct</link>).
    Los valores por omisión de las opciones <literal>"readPreference"</literal> y
    <literal>"readConcern"</literal> serán deducidos a partir de una transacción activa
    (indicada por la opción <literal>"session"</literal>), seguida de la
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c90167b57a4b5a81acc18f9f952022e062b08104 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,17 +15,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta un comando en el servidor primario.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará una lógica específica a los comandos que leen y escriben
    (por ejemplo <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
    Los valores por omisión de las opciones <literal>"readConcern"</literal> y
    <literal>"writeConcern"</literal> serán deducidos a partir de una transacción activa
    (indicada por la opción <literal>"session"</literal>), seguida de la
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -78,7 +78,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -99,7 +99,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,16 +15,16 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta el comando en el servidor primario.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará una lógica específica a los comandos que escriben (por ejemplo
    <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
    Los valores por omisión de la opción <literal>"writeConcern"</literal> serán deducidos a
    partir de una transacción activa (indicada por la opción <literal>"session"</literal>), seguida de
    la <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Este método no está destinado a ser utilizado para ejecutar
@@ -87,7 +87,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -108,7 +108,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/getencryptedfieldsmap.xml
+++ b/reference/mongodb/mongodb/driver/manager/getencryptedfieldsmap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6c44e7b831d1ee04c932847b83a19cecfd51c98e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.getencryptedfieldsmap" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Manager::getEncryptedFieldsMap</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve la opción de cifrado automático <literal>encryptedFieldsMap</literal>
    para el Manager, si se ha especificado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    La opción de cifrado automático <literal>encryptedFieldsMap</literal> para el
    Manager, o &null; si no se ha especificado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getreadconcern.xml
+++ b/reference/mongodb/mongodb/driver/manager/getreadconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.getreadconcern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ReadConcern</type><methodname>MongoDB\Driver\Manager::getReadConcern</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\ReadConcern</classname> para el
    Manager, que se deriva de sus opciones URI. Es el ReadConcern por omisión
    para las peticiones y comandos ejecutados en el Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El <classname>MongoDB\Driver\ReadConcern</classname> para el Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getreadpreference.xml
+++ b/reference/mongodb/mongodb/driver/manager/getreadpreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.getreadpreference" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ReadPreference</type><methodname>MongoDB\Driver\Manager::getReadPreference</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\ReadPreference</classname> para el
    Manager, que se deriva de sus opciones URI. Es el ReadPreference por omisión
    para las peticiones y comandos ejecutados en el Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El <classname>MongoDB\Driver\ReadPreference</classname> para el Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getservers.xml
+++ b/reference/mongodb/mongodb/driver/manager/getservers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2de5fb458e886b011050a210c6f406ca9ed51c75 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.getservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Manager::getServers</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve un &array; de instancias <classname>MongoDB\Driver\Server</classname> a las que está conectado este gestor.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Dado que el controlador se conecta perezosamente a la base de datos, este método puede devolver un &array; vacío si se llama antes de ejecutar una operación en el <classname>MongoDB\Driver\Manager</classname>.
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un &array; de instancias <classname>MongoDB\Driver\Server</classname> a las que está conectado este gestor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/getwriteconcern.xml
+++ b/reference/mongodb/mongodb/driver/manager/getwriteconcern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.getwriteconcern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteConcern</type><methodname>MongoDB\Driver\Manager::getWriteConcern</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\WriteConcern</classname> para el
    Manager, que se deriva de sus opciones URI. Es el WriteConcern por omisión
    para las escrituras y comandos ejecutados en el Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El <classname>MongoDB\Driver\WriteConcern</classname> para el Manager.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/removesubscriber.xml
+++ b/reference/mongodb/mongodb/driver/manager/removesubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40dbbc56e321e36deee0f82df820c91fa79087cb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.removesubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Manager::removeSubscriber</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Elimina un observador de eventos de supervisión de este Manager.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Si <parameter>subscriber</parameter> no está ya registrado con este
@@ -30,9 +30,9 @@
    <varlistentry>
     <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un observador de eventos de supervisión a eliminar de este Manager.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -40,9 +40,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/manager/selectserver.xml
+++ b/reference/mongodb/mongodb/driver/manager/selectserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 929fb17986921c8aadadb7c7bd877ee6f7a7126e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.selectserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Manager::selectServer</methodname>
    <methodparam choice="opt"><type class="union"><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>readPreference</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Selecciona un <classname>MongoDB\Driver\Server</classname> correspondiente a
    <parameter>readPreference</parameter>. Si <parameter>readPreference</parameter>
    es &null; o se omite, el servidor primario será seleccionado por omisión. Esto puede
    ser utilizado para preseleccionar un servidor a fin de realizar una verificación
    de versión antes de ejecutar una operación.
-  </para>
+  </simpara>
   <note>
    <simpara>
     A diferencia de <function>MongoDB\Driver\Manager::getServers</function>, este
@@ -36,10 +36,10 @@
    <varlistentry>
     <term><parameter>readPreference</parameter> (<classname>MongoDB\Driver\ReadPreference</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       Las preferencias de lectura a utilizar para seleccionar un servidor. Si
       &null; o se omite, el servidor primario será seleccionado por omisión.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -47,10 +47,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un <classname>MongoDB\Driver\Server</classname> correspondiente a la
    preferencia de lectura.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -63,8 +63,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -83,7 +82,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.startsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Session</type><methodname>MongoDB\Driver\Manager::startSession</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Crear una <classname>MongoDB\Driver\Session</classname> para las opciones dadas.
    La sesión puede luego ser especificada durante la ejecución de comandos, consultas
    y operaciones de escritura.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Una <classname>MongoDB\Driver\Session</classname> solo puede ser utilizada con el
@@ -54,11 +54,11 @@
             en la sesión será ordenada de manera causal después de la operación de lectura
             o escritura previa. Definir a &false; para desactivar la coherencia causal.
            </para>
-           <para>
+           <simpara>
             Ver
             <link xlink:href="&url.mongodb.docs;core/read-isolation-consistency-recency/#causal-consistency">Consistencia causal</link>
             en el manual de MongoDB para más información.
-           </para>
+           </simpara>
           </entry>
           <entry>&true;</entry>
          </row>
@@ -66,11 +66,11 @@
           <entry>defaultTransactionOptions</entry>
           <entry><type>array</type></entry>
           <entry>
-           <para>
+           <simpara>
             Las opciones por defecto a aplicar a las transacciones recién creadas. Estas
             opciones se utilizan a menos que sean reemplazadas cuando una transacción es
             iniciada con un valor diferente para cada opción.
-           </para>
+           </simpara>
            <para>
             <table>
              <title>options</title>
@@ -91,9 +91,9 @@
              </tgroup>
             </table>
            </para>
-           <para>
+           <simpara>
             Esta opción está disponible en MongoDB 4.0+.
-           </para>
+           </simpara>
           </entry>
           <entry><literal>[]</literal></entry>
          </row>
@@ -101,7 +101,7 @@
           <entry>snapshot</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Configura las lecturas instantáneas en una sesión. Si &true;, un timestamp será
             obtenido de la primera operación de lectura soportada en la sesión
             (es decir, <literal>find</literal>, <literal>aggregate</literal>, o
@@ -109,18 +109,18 @@
             en la sesión utilizarán luego un nivel de coherencia de lectura <literal>"snapshot"</literal>
             para leer datos mayoritariamente comprometidos desde ese timestamp. Definir
             a &false; para desactivar las lecturas instantáneas.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Las lecturas instantáneas requieren MongoDB 5.0+ y no pueden ser utilizadas
             con la coherencia causal, transacciones o operaciones de escritura. Si
             <literal>"snapshot"</literal> es &true;,
             <literal>"causalConsistency"</literal> será por defecto &false;.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Ver
             <link xlink:href="&url.mongodb.docs;reference/read-concern-snapshot/#read-concern-and-atclustertime">Read Concern "instantáneas"</link>
             en el manual de MongoDB para más información.
-           </para>
+           </simpara>
           </entry>
           <entry>&false;</entry>
          </row>
@@ -135,9 +135,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve una <classname>MongoDB\Driver\Session</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -172,18 +172,18 @@
       <row>
        <entry>PECL mongodb 1.6.0</entry>
        <entry>
-        <para>
+        <simpara>
          La opción <literal>"maxCommitTimeMS"</literal> fue añadida a
          <literal>"defaultTransactionOptions"</literal>.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.5.0</entry>
        <entry>
-        <para>
+        <simpara>
          La opción <literal>"defaultTransactionOptions"</literal> fue añadida.
-        </para>
+        </simpara>
        </entry>
       </row>
      </tbody>

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getcommandname.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getcommandname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getcommandname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getCommandName</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el nombre de la orden (por ejemplo <literal>"find"</literal>,
    <literal>"aggregate"</literal>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getdatabasename.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getdatabasename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ca33dfb525027bb876fd0239060f5441e377ed0b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getdatabasename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la base de datos sobre la cual se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getdurationmicros.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getdurationmicros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getdurationmicros" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getDurationMicros</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    La duración de la orden es un valor calculado que incluye el tiempo para enviar
    el mensaje y recibir la respuesta del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la duración de la orden en microsegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/geterror.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/geterror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.geterror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la <classname>Exception</classname> asociada al comando fallido.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de host del servidor en el que se ejecutó la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getoperationid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getoperationid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getoperationid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getOperationId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El ID de la operación es generado por la extensión y puede ser utilizado para ligar eventos
    juntos, como operaciones de escritura masiva, que pueden haber sido divididas en varias
    órdenes a nivel de protocolo.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Dado que varias órdenes pueden compartir el mismo ID de operación, no es fiable
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la operación de la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto del servidor en el cual la orden fue ejecutada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getreply.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getreply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getreply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getReply</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El documento de respuesta será convertido de BSON a PHP utilizando las reglas de
    <link linkend="mongodb.persistence.deserialization">deserialización</link>
    por omisión (por ejemplo, los documentos BSON serán convertidos en <type>stdClass</type>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el documento de respuesta del comando en forma de un
    objeto <classname>stdClass</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getrequestid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getrequestid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getrequestid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getRequestId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El identificador de la petición es generado por la extensión y puede ser utilizado para asociar
    este <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname> con un
    <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname> anterior.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la petición de la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserver.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,14 +9,14 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Este método ha sido <emphasis>DEPRECADO</emphasis> a partir de la versión
     1.20.0 de la extensión y ha sido eliminado en la versión 2.0. Las aplicaciones deben utilizar
     <methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getHost</methodname>
     y
     <methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getPort</methodname>
     en su lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -26,9 +26,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> en el cual se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,9 +38,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> en el cual se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -52,8 +52,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -66,7 +65,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserverconnectionid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserverconnectionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6b1dd7035f8a4428081faa43e6e244e4b89f495 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getserverconnectionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getServerConnectionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el identificador de conexión del servidor para la orden. El identificador de conexión del servidor es
    distinto del servidor (es decir,
    <function>MongoDB\Driver\Monitoring\CommandFailedEvent::getServer</function>)
    y es devuelto en el campo "connectionId" de una respuesta de orden <literal>hello</literal>
    MongoDB 4.2+.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de conexión del servidor, o &null; si no está disponible.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserviceid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/getserviceid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a1632139847f823b9a715fba7648945faf60f5f4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.getserviceid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getServiceId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Cuando el controlador está conectado a un clúster MongoDB a través de un equilibrador de carga,
    el identificador del servicio corresponde al campo <literal>serviceId</literal> en la
    respuesta de la comanda <literal>hello</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador del servicio del equilibrador de carga, o &null; si el controlador no está
    conectado a un equilibrador de carga.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getcommand.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getCommand</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El documento devuelto será convertido de BSON a PHP utilizando las reglas de
    <link linkend="mongodb.persistence.deserialization">deserialización</link>
    por omisión (por ejemplo, los documentos BSON serán convertidos en <type>stdClass</type>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el documento de comando en forma de objeto <classname>stdClass</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getcommandname.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getcommandname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getcommandname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getCommandName</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el nombre del comando (por ejemplo, <literal>"find"</literal>,
    <literal>"aggregate"</literal>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre del comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getdatabasename.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getdatabasename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getdatabasename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la base de datos sobre la cual se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre del host del servidor en el que se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getoperationid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getoperationid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getoperationid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getOperationId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El identificador de la operación es generado por la extensión y puede ser utilizado
    para vincular eventos juntos, tales como operaciones de escritura en masa, que pueden haber sido divididas en varias órdenes a nivel del
    protocolo.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Dado que varias órdenes pueden compartir el mismo identificador de operación, no es fiable utilizar este valor para asociar objetos de evento entre sí. El identificador de la petición devuelto por
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la operación de la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto del servidor en el que se ejecutó la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getrequestid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getrequestid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getrequestid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,14 +13,14 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getRequestId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El identificador de la solicitud es generado por la extensión y puede ser utilizado
    para asociar este evento
    <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname>
    con un
    <classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname> o
    <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname> posterior.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la solicitud de la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserver.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,14 +9,14 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Este método ha sido <emphasis>DEPRECADO</emphasis> a partir de la versión
     1.20.0 de la extensión y ha sido eliminado en la versión 2.0. Las aplicaciones deben utilizar
     <methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getHost</methodname>
     y
     <methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getPort</methodname>
     en su lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -26,9 +26,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> en el que se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,9 +38,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> en el que se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -52,8 +52,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -66,7 +65,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserverconnectionid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserverconnectionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6b1dd7035f8a4428081faa43e6e244e4b89f495 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getserverconnectionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getServerConnectionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el identificador de conexión del servidor para la orden. El identificador de conexión del servidor es
    distinto del servidor (es decir,
    <function>MongoDB\Driver\Monitoring\CommandFailedEvent::getServer</function>)
    y es devuelto en el campo "connectionId" de una respuesta de orden <literal>hello</literal>
    MongoDB 4.2+.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de conexión del servidor, o &null; si no está disponible.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserviceid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserviceid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a1632139847f823b9a715fba7648945faf60f5f4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandstartedevent.getserviceid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandStartedEvent::getServiceId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Cuando el controlador está conectado a un clúster MongoDB a través de un equilibrador de carga,
    el identificador del servicio corresponde al campo <literal>serviceId</literal> en la
    respuesta de la orden <literal>hello</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador del servicio del equilibrador de carga, o &null; si el controlador no está
    conectado a un equilibrador de carga.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-commandsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La interfaz MongoDB\Driver\Monitoring\CommandSubscriber</title>
@@ -10,11 +10,11 @@
 <!-- {{{ MongoDB\Driver\Monitoring\CommandSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-commandsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Las clases pueden implementar esta interfaz para registrar un observador
     de eventos que es notificado para cada evento de comando iniciado,
     <xref linkend="mongodb.tutorial.apm" /> para más información.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -46,8 +46,7 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
+       <informaltable>
      <tgroup cols="2">
       <thead>
        <row>
@@ -61,7 +60,6 @@
       </tbody>
      </tgroup>
     </informaltable>
-   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandfailed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandfailed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandfailed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandFailed</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\CommandFailedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si el observador está registrado, este método es llamado cuando una orden falla.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandFailedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre la orden fallida.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandstarted.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandstarted.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandstarted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\CommandStartedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si el observador está registrado, este método es llamado cuando una orden es enviada
    al servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandStartedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre la orden iniciada.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandsucceeded.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandsucceeded.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandsucceeded" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandSucceeded</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\CommandSucceededEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si el observador está registrado, este método es llamado cuando un
    comando tiene éxito.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandSucceededEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre el comando exitoso.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getcommandname.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getcommandname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getcommandname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getCommandName</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el nombre del comando (por ejemplo <literal>"find"</literal>,
    <literal>"aggregate"</literal>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre del comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getdatabasename.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getdatabasename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ca33dfb525027bb876fd0239060f5441e377ed0b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getdatabasename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de la base de datos sobre la cual se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getdurationmicros.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getdurationmicros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getdurationmicros" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getDurationMicros</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    La duración del comando es un valor calculado que incluye el tiempo para enviar
    el mensaje y recibir la respuesta del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la duración del comando en microsegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de host del servidor en el que se ejecutó el comando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getoperationid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getoperationid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getoperationid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getOperationId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El identificador de la operación es generado por la extensión y puede ser utilizado para vincular eventos
    juntos tales como operaciones de escritura en masa, que pueden haber sido divididas
    en varias órdenes a nivel del protocolo.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Dado que varias órdenes pueden compartir el mismo identificador de operación, no es fiable
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la operación de la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f4735579d3c42b38955ec493ff7e6ba0f2bd750 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto del servidor en el cual la orden fue ejecutada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getreply.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getreply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getreply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getReply</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El documento de respuesta será convertido de BSON a PHP utilizando las reglas de
    <link linkend="mongodb.persistence.deserialization">deserialización</link>
    por omisión (por ejemplo, los documentos BSON serán convertidos en <type>stdClass</type>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el documento de respuesta de la orden en forma de un objeto
    <classname>stdClass</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getrequestid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getrequestid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getrequestid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getRequestId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El identificador de la solicitud es generado por la extensión y puede ser utilizado para asociar
    este <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname> con un
    <classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname> anterior.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la solicitud de la orden.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserver.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,14 +9,14 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Este método ha sido <emphasis>DEPRECADO</emphasis> a partir de la versión
     1.20.0 de la extensión y ha sido eliminado en la versión 2.0. Las aplicaciones deben utilizar
     <methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getHost</methodname>
     y
     <methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getPort</methodname>
     en su lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -26,10 +26,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> en el cual el comando
    fue ejecutado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,10 +39,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> en el cual el comando
    fue ejecutado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -54,8 +54,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -68,7 +67,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserverconnectionid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserverconnectionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6b1dd7035f8a4428081faa43e6e244e4b89f495 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getserverconnectionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getServerConnectionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el identificador de conexión del servidor para la orden. El identificador de conexión del servidor es
    distinto del servidor (es decir,
    <function>MongoDB\Driver\Monitoring\CommandSucceededEvent::getServer</function>)
    y es devuelto en el campo "connectionId" de una respuesta de orden <literal>hello</literal>
    MongoDB 4.2+.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de conexión del servidor, o &null; si no está disponible.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserviceid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsucceededevent/getserviceid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a1632139847f823b9a715fba7648945faf60f5f4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-commandsucceededevent.getserviceid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\ObjectId</type><type>null</type></type><methodname>MongoDB\Driver\Monitoring\CommandSucceededEvent::getServiceId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Cuando el controlador está conectado a un clúster MongoDB a través de un balanceador de carga,
    el identificador del servicio corresponde al campo <literal>serviceId</literal> en la
    respuesta de la orden <literal>hello</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador del servicio del balanceador de carga, o &null; si el controlador no está
    conectado a un balanceador de carga.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-logsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La interfaz MongoDB\Driver\Monitoring\LogSubscriber</title>
@@ -10,12 +10,12 @@
 <!-- {{{ MongoDB\Driver\Monitoring\LogSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-logsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Las clases que implementan esta interfaz pueden ser registradas como observadores y recibir mensajes de registro de la extensión. Esto es similar al registro de depuración basado en flujos (es decir, <link linkend="ini.mongodb.debug">mongodb.debug</link>) excepto que los mensajes de registro de nivel trace no son <emphasis>recibidos</emphasis>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Al igual que con el registro basado en flujos, solo es posible registrar un registrador globalmente utilizando <function>MongoDB\Driver\Monitoring\addSubscriber</function>. La extensión no es capaz de distinguir los mensajes de registro para objetos <classname>MongoDB\Driver\Manager</classname> individuales.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -90,54 +90,54 @@
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-error">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_ERROR</constant></term>
      <listitem>
-      <para>
+      <simpara>
        El nivel de registro de error. Una condición de error que la extensión no es capaz de reportar a través de su API. Es el nivel de registro más severo de la extensión.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-critical">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_CRITICAL</constant></term>
      <listitem>
-      <para>
+      <simpara>
        El nivel de registro crítico. Una condición de error con una severidad ligeramente inferior. Esta constante existe para la coherencia con libmongoc; sin embargo, la extensión es poco susceptible de utilizarla en la práctica.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-warning">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_WARNING</constant></term>
      <listitem>
-      <para>
+      <simpara>
        El nivel de registro de advertencia. Indica una situación donde un comportamiento indeseable de la aplicación puede ocurrir.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-message">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_MESSAGE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        El nivel de registro de mensaje o notificación. Indica un evento inusual pero no problemático.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-info">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_INFO</constant></term>
      <listitem>
-      <para>
+      <simpara>
        El nivel de registro de información. Información de alto nivel sobre el comportamiento normal del controlador.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-monitoring-logsubscriber.constants.level-debug">
      <term><constant>MongoDB\Driver\Monitoring\LogSubscriber::LEVEL_DEBUG</constant></term>
      <listitem>
-      <para>
+      <simpara>
        El nivel de registro de depuración. Información detallada que puede ser útil durante la depuración de una aplicación.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/mongodb/mongodb/driver/monitoring/logsubscriber/log.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/logsubscriber/log.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-logsubscriber.log" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam><type>string</type><parameter>domain</parameter></methodparam>
    <methodparam><type>string</type><parameter>message</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si el observador está registrado, este método es llamado para cada mensaje
    de registro registrado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,26 +27,26 @@
    <varlistentry>
     <term><parameter>level</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       El nivel de gravedad. Será uno de los
       <link linkend="mongodb-driver-monitoring-logsubscriber.constants">constantes de interfaz</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>domain</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       El nombre del componente del controlador que emitió el mensaje de registro.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>message</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       El mensaje de registro.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -54,9 +54,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-sdamsubscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La interfaz MongoDB\Driver\Monitoring\SDAMSubscriber</title>
@@ -10,13 +10,13 @@
 <!-- {{{ MongoDB\Driver\Monitoring\SDAMSubscriber intro -->
   <section xml:id="mongodb-driver-monitoring-sdamsubscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Las clases pueden implementar esta interfaz para registrar un observador
     de eventos que es notificado para diversos eventos SDAM. Ver las
     especificaciones <link xlink:href="&url.mongodb.sdam;">Descubrimiento y supervisión de server</link>
     y <link xlink:href="&url.mongodb.sdam-monitoring;">Supervisión de SDAM</link>
     para más información.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -48,8 +48,7 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
+       <informaltable>
      <tgroup cols="2">
       <thead>
        <row>
@@ -63,7 +62,6 @@
       </tbody>
      </tgroup>
     </informaltable>
-   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverchanged.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverchanged.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverchanged" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverChanged</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerChangedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando una
    descripción de servidor cambia. Por ejemplo, el tipo de un servidor pasando de secundario a
    primario resultaría en un cambio de la descripción de ese servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerChangedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre la descripción de
       servidor modificada.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverclosed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverclosed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverclosed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverClosed</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerClosedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando un servidor existente
    es retirado de la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerClosedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre el servidor cerrado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatfailed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatfailed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverheartbeatfailed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverHeartbeatFailed</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando un latido de servidor (es decir, un comando
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    emitido mediante
    <link xlink:href="&url.mongodb.sdam;">monitoreo de servidor</link>) falla.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre el fallo de latido de servidor.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatstarted.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatstarted.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverheartbeatstarted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverHeartbeatStarted</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando un latido de servidor (es decir, un comando
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    emitido a través de
    <link xlink:href="&url.mongodb.sdam;">monitoreo de servidor</link>) es enviado
    al servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre el latido de servidor iniciado.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -38,9 +38,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatsucceeded.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serverheartbeatsucceeded.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serverheartbeatsucceeded" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverHeartbeatSucceeded</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando un latido de servidor (es decir, una comando
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    emitido a través de
    <link xlink:href="&url.mongodb.sdam;">monitoreo de servidor</link>) tiene éxito.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre el latido de servidor exitoso.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serveropening.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serveropening.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.serveropening" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::serverOpening</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\ServerOpeningEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando un servidor existente
    es retirado de la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\ServerOpeningEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre el servidor abierto.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologychanged.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologychanged.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.topologychanged" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::topologyChanged</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\TopologyChangedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando una
    descripción de topología cambia. Por ejemplo, el descubrimiento de un nuevo primario en un conjunto de réplicas
    resultaría en un cambio de la descripción de la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\TopologyChangedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre la descripción de
       topología modificada.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyclosed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyclosed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.topologyclosed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::topologyClosed</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\TopologyClosedEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando una
    topología es cerrada.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Debido al comportamiento del controlador
@@ -34,9 +34,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\TopologyClosedEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre la topología cerrada.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyopening.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyopening.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.topologyopening" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::topologyOpening</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\TopologyOpeningEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observador está registrado, este método es llamado cuando una
    topología es abierta.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Debido al comportamiento del controlador
@@ -34,9 +34,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\TopologyOpeningEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto de evento que encapsula información sobre la topología abierta.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre del host del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getnewdescription.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getnewdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.getnewdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la nueva <classname>MongoDB\Driver\ServerDescription</classname>
    del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto en el que este servidor está escuchando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getpreviousdescription.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getpreviousdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.getpreviousdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la <classname>MongoDB\Driver\ServerDescription</classname> anterior
    del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el ID de topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverclosedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de host del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverclosedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto en el que este servidor escucha.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverclosedevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el ID de topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/getdurationmicros.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/getdurationmicros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.getdurationmicros" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent::getDurationMicros</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    La duración del latido es un valor calculado que incluye el tiempo
    para enviar el mensaje y recibir la respuesta del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la duración del latido en microsegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/geterror.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/geterror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.geterror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la <classname>Exception</classname> asociada al fallo del latido periódico.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de host del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto en el que este servidor escucha.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/isawaited.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/isawaited.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.isawaited" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent::isAwaited</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Indica si el latido periódico ha utilizado un protocolo de difusión de flujo.
    La extensión no utiliza el protocolo de difusión de flujo para la supervisión, por lo tanto, este método siempre devolverá
    &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre del host del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto en el que este servidor está escuchando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/isawaited.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/isawaited.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.isawaited" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent::isAwaited</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Indica si el latido periódico ha utilizado un protocolo de difusión de flujo.
    La extensión no utiliza el protocolo de difusión de flujo para la monitorización, por lo que este método siempre devolverá
    &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getdurationmicros.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getdurationmicros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.getdurationmicros" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent::getDurationMicros</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    La duración del latido es un valor calculado que incluye el tiempo
    para enviar el mensaje y recibir la respuesta del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la duración del latido en microsegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de host del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto en el que este servidor escucha.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getreply.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getreply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.getreply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent::getReply</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    El documento de respuesta será convertido de BSON a PHP utilizando las reglas de
    <link linkend="mongodb.persistence.deserialization">deserialización</link>
    por omisión (por ejemplo, los documentos BSON serán convertidos en <type>stdClass</type>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el documento de respuesta del heartbeat en forma de un objeto
    <classname>stdClass</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/isawaited.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/isawaited.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.isawaited" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent::isAwaited</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Indica si el latido periódico ha utilizado un protocolo de difusión de flujo.
    La extensión no utiliza el protocolo de difusión de flujo para la supervisión, por lo que este método siempre devolverá
    &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serveropeningevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de host del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serveropeningevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto en el que este servidor está escuchando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-serveropeningevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el ID de topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/subscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/subscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-monitoring-subscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La interfaz MongoDB\Driver\Monitoring\Subscriber</title>
@@ -10,12 +10,12 @@
 <!-- {{{ MongoDB\Driver\Monitoring\Subscriber intro -->
   <section xml:id="mongodb-driver-monitoring-subscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La interfaz base para los observadores de eventos. Es utilizada como tipo de argumento en las funciones
     <function>MongoDB\Driver\Monitoring\addSubscriber</function> y
     <function>MongoDB\Driver\Monitoring\removeSubscriber</function> y no debe
     ser implementada directamente.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -37,10 +37,10 @@
    </classsynopsis>
 <!-- }}} -->
 
-   <para>
+   <simpara>
     Esta interfaz no tiene métodos. Su único propósito es ser la interfaz base
     para todos los observadores de eventos.
-   </para>
+   </simpara>
 
   </section>
 

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/getnewdescription.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/getnewdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-topologychangedevent.getnewdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la nueva <classname>MongoDB\Driver\TopologyDescription</classname>
    para la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/getpreviousdescription.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/getpreviousdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-topologychangedevent.getpreviousdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la descripción anterior <classname>MongoDB\Driver\TopologyDescription</classname>
    para la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-topologychangedevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-topologyclosedevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-monitoring-topologyopeningevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-query.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,12 +14,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>queryOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construye un nuevo objeto <classname>MongoDB\Driver\Query</classname>, que es un objeto
    de valor inmutable que representa una consulta de base de datos. La consulta puede
    luego ser ejecutada con
    <methodname>MongoDB\Driver\Manager::executeQuery</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -56,14 +56,14 @@
           <entry>allowPartialResults</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Para las consultas en una colección fragmentada, devuelve resultados parciales del mongos si algunos fragmentos no están
             disponibles en lugar de generar un error.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"partial"</literal> si no
             se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -80,16 +80,16 @@
           <entry>batchSize</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             El número de documentos a devolver en el primer lote. Por omisión a
             101. Un tamaño de lote de 0 significa que el cursor será establecido, pero
             ningún documento será devuelto en el primer lote.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             En las versiones de MongoDB anteriores a 3.2, donde las consultas
             utilizan el protocolo de filaire heredado OP_QUERY, un tamaño de lote
             de 1 cerrará el cursor independientemente del número de documentos.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.collation;
@@ -97,73 +97,73 @@
           <entry>comment</entry>
           <entry><type>mixed</type></entry>
           <entry>
-           <para>
+           <simpara>
             Un comentario arbitrario para ayudar a rastrear la operación a través
             del perfil de la base de datos, la salida currentOp y los registros.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             El comentario puede ser cualquier tipo BSON válido para MongoDB
             4.4+. Las versiones de servidor anteriores solo admiten
             valores de cadena.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"$comment"</literal> si no
             se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>exhaust</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             El flujo de datos aguas abajo a plena potencia en varios paquetes
             "more", asumiendo que el cliente leerá completamente todos los datos
             consultados. Más rápido cuando se extraen muchos datos y
             se sabe que se quiere extraer todo. Nota: el cliente no está autorizado
             a no leer todos los datos a menos que cierre la conexión.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opción no es admitida por el comando find en MongoDB
             3.2+ y forzará al controlador a utilizar la versión del protocolo de filaire
             heredado (es decir, OP_QUERY).
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>explain</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Si &true; el cursor <classname>MongoDB\Driver\Cursor</classname> devuelto
             contendrá un solo documento que describe el proceso y los índices utilizados
             para devolver la consulta.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"$explain"</literal> si no
             se especifica.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opción no es admitida por el comando find en MongoDB
             3.2+ y solo será respetada al utilizar la versión del protocolo de filaire
             heredado (es decir, OP_QUERY). El comando
             <link xlink:href="&url.mongodb.docs;reference/command/explain/">explain</link>
             debe ser utilizado en MongoDB 3.0+.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Especificación del índice. Especifique el nombre del índice como
             cadena, o el patrón de clave de índice. Si se especifica, el sistema de consulta
             solo considerará los planes que utilicen el índice sugerido.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"hint"</literal> si no se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.let;
@@ -171,64 +171,64 @@
           <entry>limit</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             El número máximo de documentos a devolver. Si no se especifica, entonces
             por omisión a ningún límite. Un límite de 0 es equivalente a no establecer
             un límite.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>max</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             El límite superior <emphasis>exclusivo</emphasis> para un índice específico.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"$max"</literal> si no
             se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxAwaitTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Entero positivo que indica el límite de tiempo en milisegundos para que el
             servidor bloquee una operación getMore si no hay datos disponibles. Esta opción solo debe
             ser utilizada en conjunción con las opciones <literal>"tailable"</literal> y
             <literal>"awaitData"</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             El límite de tiempo acumulativo en milisegundos para el procesamiento de
             las operaciones en el cursor. MongoDB detiene la operación en el primer punto
             de interrupción más cercano.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"$maxTimeMS"</literal> si no
             se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>min</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             El límite inferior <emphasis>inclusivo</emphasis> para un índice específico.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"$min"</literal> si no
             se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -243,11 +243,11 @@
           <entry>projection</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Las <link xlink:href="&url.mongodb.docs;tutorial/project-fields-from-query-results/">especificaciones de proyección</link>
             para determinar qué campos incluir en los documentos devueltos.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Si se utiliza la
             <link linkend="mongodb.persistence.deserialization">funcionalidad ODM</link>
             para deserializar los documentos como su clase PHP original,
@@ -255,54 +255,54 @@
             proyección. Esto es necesario para que la deserialización funcione
             y sin ello, la extensión devolverá (por omisión) un objeto
             <classname>stdClass</classname> en su lugar.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>readConcern</entry>
           <entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
           <entry>
-           <para>
+           <simpara>
             Un read concern a aplicar a la operación. Por omisión, el read concern
             de la <link linkend="mongodb-driver-manager.construct-uri">URI
             de conexión MongoDB</link>
             será utilizado.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opción está disponible en MongoDB 3.2+ y provocará una
             excepción en el momento de la ejecución si se especifica para una
             versión de servidor más antigua.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>returnKey</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Si &true;, solo devuelve las claves de índice en los documentos
             resultantes. El valor por omisión es &false;. Si &true; y la
             comando find no utiliza un índice, los documentos devueltos estarán vacíos.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"$returnKey"</literal> si no
             se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>showRecordId</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Determina si el identificador de registro debe ser devuelto para
             cada documento. Si &true;, añade un campo <literal>"$recordId"</literal>
             de primer nivel a los documentos devueltos.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"$showDiskLoc"</literal> si no
             se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -322,11 +322,11 @@
           <entry>sort</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>La especificación de clasificación para el ordenamiento de los resultados.</para>
-           <para>
+           <simpara>La especificación de clasificación para el ordenamiento de los resultados.</simpara>
+           <simpara>
             Retoma la opción deprecada <literal>"$orderby"</literal> si no
             se especifica.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -369,91 +369,91 @@
          La opción <literal>"partial"</literal> ha sido eliminada. Utilice
          <literal>"allowPartialResults"</literal> en su lugar.
         </para>
-        <para>
+        <simpara>
          La opción <literal>"maxScan"</literal> ha sido eliminada. El soporte
          para esta opción ha sido eliminado en MongoDB 4.2.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          La opción <literal>"modifiers"</literal> ha sido eliminada. Esta opción era
          utilizada para los modificadores de consulta antigua, que están todos deprecados.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          La opción <literal>"oplogReplay"</literal> ha sido eliminada. Esto es ignorado
          en MongoDB 4.4 y versiones más recientes.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          La opción <literal>"snapshot"</literal> ha sido eliminada. Su soporte ha sido
          eliminado en MongoDB 4.0.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Un valor negativo para la opción <literal>"limit"</literal> ya no implica &true; para la opción
          <literal>"singleBatch"</literal>. Para recibir solo un lote de resultados, combine un valor positivo
          <literal>"limit"</literal> con la opción
          <literal>"singleBatch"</literal>.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.14.0</entry>
        <entry>
-        <para>
+        <simpara>
          Añadida la opción <literal>"let"</literal>. La opción
          <literal>"comment"</literal> ahora acepta cualquier tipo.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.8.0</entry>
        <entry>
-        <para>
+        <simpara>
          Añadida la opción <literal>"allowDiskUse"</literal>.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          La opción <literal>"oplogReplay"</literal> está deprecada.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.5.0</entry>
        <entry>
-        <para>
+        <simpara>
          Las opciones <literal>"maxScan"</literal> y <literal>"snapshot"</literal>
          están deprecadas.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.3.0</entry>
        <entry>
-        <para>
+        <simpara>
          Añadida la opción <literal>"maxAwaitTimeMS"</literal>
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
        <entry>PECL mongodb 1.2.0</entry>
        <entry>
-        <para>
+        <simpara>
          Añadidas las opciones <literal>"allowPartialResults"</literal>,
          <literal>"collation"</literal>, <literal>"comment"</literal>,
          <literal>"hint"</literal>, <literal>"max"</literal>,
          <literal>"maxScan"</literal>, <literal>"maxTimeMS"</literal>,
          <literal>"min"</literal>, <literal>"returnKey"</literal>,
          <literal>"showRecordId"</literal>, y <literal>"snapshot"</literal>.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Renombrada la opción <literal>"partial"</literal> a
          <literal>"allowPartialResults"</literal>. Por compatibilidad ascendente,
          <literal>"partial"</literal> será siempre leído si
          <literal>"allowPartialResults"</literal> no está especificado.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Eliminada la opción <literal>"secondaryOk"</literal> obsoleta. Para las
          consultas que utilizan el protocolo de filaire heredado OP_QUERY, el controlador
          establecerá el bit <literal>secondaryOk</literal> según sea necesario
          conforme a la
          <link xlink:href="&url.mongodb.serverselection;">Especificación de selección del servidor</link>.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>

--- a/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5eca06ae7725b4c35eefecbb0d722a3e198ff21 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readconcern.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un objeto para la serialización del ReadConcern en BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readconcern.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ReadConcern::__construct</methodname>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>level</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construye un nuevo <classname>MongoDB\Driver\ReadConcern</classname>, que es
    un objeto de valor inmutable.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,11 +25,11 @@
    <varlistentry>
     <term><parameter>level</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       El <link xlink:href="&url.mongodb.docs.readconcern;#read-concern-levels">nivel del read concern</link>.
       Se puede utilizar, pero no se limita a, una de las
       <link linkend="mongodb-driver-readconcern.constants">constantes de clase</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/mongodb/driver/readconcern/getlevel.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/getlevel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readconcern.getlevel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "level" del ReadConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readconcern.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\ReadConcern::isDefault</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve si es el read concern por omisión (es decir, sin opciones especificadas). Este método está principalmente destinado a ser utilizado en conjunción con
    <methodname>MongoDB\Driver\Manager::getReadConcern</methodname> para determinar si el Manager ha sido construido sin ninguna opción de read concern.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    El controlador no incluirá un read concern por omisión en sus operaciones de lectura (por ejemplo <methodname>MongoDB\Driver\Manager::executeQuery</methodname>) para permitir que el servidor aplique su propio valor por omisión. Las bibliotecas que acceden al read concern del Manager para incluirlo en sus propios comandos de lectura deberían utilizar este método para asegurarse de que los read concerns por omisión se dejan sin definir.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si es el read concern por omisión y &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readpreference.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un objeto para la serialización de la ReadPreference en BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-readpreference.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,9 +16,9 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>tagSets</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construye un nuevo <classname>MongoDB\Driver\ReadPreference</classname>, que es un objeto de valor inmutable.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -51,34 +51,34 @@
          <row>
           <entry><literal>"primaryPreferred"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             En la mayoría de las situaciones, las operaciones son leídas desde el
             primario, pero si no está disponible, las operaciones son leídas desde un miembro secundario.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"secondary"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Todas las operaciones son leídas desde los miembros secundarios del conjunto de réplicas.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"secondaryPreferred"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             En la mayoría de los casos, las operaciones son leídas por miembros secundarios, pero si ningún miembro secundario está disponible, las operaciones son leídas desde el primario.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"nearest"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Operaciones leídas desde el miembro del conjunto de réplicas con la latencia de red más baja, independientemente del tipo de miembro.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -90,12 +90,12 @@
    <varlistentry>
     <term><parameter>tagSets</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Los conjuntos de etiquetas permiten dirigir las operaciones de lectura a miembros específicos de un conjunto de réplicas. Este parámetro debe ser un array de arrays asociativos, que contienen cada uno cero o más pares clave/valor. Al seleccionar un servidor para una operación de lectura, el controlador intenta seleccionar un nodo que contenga todas las etiquetas de un conjunto (es decir, el array asociativo de pares clave/valor). Si la selección falla, el controlador intentará con los siguientes conjuntos. Un conjunto de etiquetas vacío (<literal>array()</literal>) corresponde a cualquier nodo y puede ser utilizado como respaldo.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Las etiquetas no son compatibles con el modo <literal>"primary"</literal> y, en general, solo se aplican cuando se selecciona un miembro secundario de un conjunto para una operación de lectura. Sin embargo, el modo <literal>"nearest"</literal>, cuando se combina con un conjunto de etiquetas, selecciona el miembro correspondiente con la latencia de red más baja. Este miembro puede ser primario o secundario.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -118,27 +118,27 @@
           <entry><type class="union"><type>object</type><type>array</type></type></entry>
           <entry>
            <para>Especifica si se debe utilizar o no <link xlink:href="&url.mongodb.docs;core/sharded-cluster-query-router/#mongos-hedged-reads">las lecturas cruzadas</link>, que son soportadas desde MongoDB 4.4+ para las consultas compartidas.</para>
-           <para>
+           <simpara>
             El servidor de lecturas cruzadas está disponible para todas las lecturas de referencias no primarias, y está activado por omisión al utilizar el modo <literal>"nearest"</literal>. Esta opción permite activar explícitamente el servidor de lecturas cruzadas para las lecturas de referencias no primarias especificando <literal>['enabled' => true]</literal>, o desactivar explícitamente el servidor de lecturas cruzadas para las lecturas de referencias <literal>"nearest"</literal> especificando <literal>['enabled' => false]</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxStalenessSeconds</entry>
           <entry>&integer;</entry>
           <entry>
-           <para>
+           <simpara>
             Especifica un desfase de replicación máximo, o "obsolescencia", para las lecturas de los secundarios. Cuando la obsolescencia estimada de un secundario supera este valor, el controlador deja de utilizarlo para las operaciones de lectura.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Si se especifica, la obsolescencia máxima debe ser un entero signado de 32 bits mayor o igual a <constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Por omisión, <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>, lo que significa que el controlador no tendrá en cuenta el desfase de un secundario al elegir dónde dirigir una operación de lectura.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Esta opción no es compatible con el modo <literal>"primary"</literal>. La especificación de una obsolescencia máxima requiere asimismo que todas las instancias de MongoDB del despliegue utilicen MongoDB 3.4+. Se lanzará una excepción en tiempo de ejecución si todas las instancias de MongoDB en el despliegue son de una versión de servidor más antigua.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -201,9 +201,9 @@
       <row>
        <entry>PECL mongodb 1.2.0</entry>
        <entry>
-        <para>
+        <simpara>
          Añadido un tercer argumento de <parameter>options</parameter>, que soporta la opción <literal>"maxStalenessSeconds"</literal>.
-        </para>
+        </simpara>
        </entry>
       </row>
      </tbody>

--- a/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readpreference.gethedge" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "hedge" del ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/getmaxstalenessseconds.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmaxstalenessseconds.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readpreference.getmaxstalenessseconds" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "maxStalenessSeconds" del ReadPreference. Si no se ha especificado ningún tiempo máximo,
    <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant> será
    devuelto.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/getmode.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readpreference.getmode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,11 +9,11 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Esta función ha sido <emphasis>DEPRECADA</emphasis> desde la versión 1.20.0 de la extensión
     y ha sido eliminada en la versión 2.0. Las aplicaciones deberían utilizar
     <methodname>MongoDB\Driver\ReadPreference::getModeString</methodname> en su lugar.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "mode" del ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -46,8 +46,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -60,7 +59,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/readpreference/getmodestring.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmodestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readpreference.getmodestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "mode" del ReadPreference como string.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/gettagsets.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gettagsets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readpreference.gettagsets" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "tagSets" de ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/construct.xml
+++ b/reference/mongodb/mongodb/driver/server/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dcfd0933c0adfb15d1efafa5c553b2e57c03d3a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,13 +15,13 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Server::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
     Los objetos <classname>MongoDB\Driver\Server</classname> son creados internamente
    por <classname>MongoDB\Driver\Manager</classname> cuando se establece una conexión de base de
    datos y pueden ser devueltos por
    <function>MongoDB\Driver\Manager::getServers</function> y
    <function>MongoDB\Driver\Manager::selectServer</function>.
-  </para>
+  </simpara>
 
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,21 +16,21 @@
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta una o varias operaciones de escritura en este servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Un objeto <classname>MongoDB\Driver\BulkWrite</classname> puede ser construido con
    una o varias operaciones de diferentes tipos (i.e. actualización, eliminación,
    e inserción). El driver intentará enviar las operaciones del mismo tipo al
    servidor en un mínimo de solicitudes posibles para optimizar los viajes de ida y vuelta.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    El valor por omisión para la opción <literal>"writeConcern"</literal> será
    deducido de una transacción activa (indicada por la opción
    <literal>"session"</literal>), luego por el
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -84,7 +84,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -136,7 +136,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,22 +15,22 @@
    <methodparam><type>MongoDB\Driver\BulkWriteCommand</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta una o varias operaciones de escritura en el servidor primario utilizando el
    comando <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
    introducido en MongoDB 8.0.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Una <classname>MongoDB\Driver\BulkWriteCommand</classname> puede ser construida
    con una o varias operaciones de escritura de tipos variados (por ejemplo, inserciones, actualizaciones
    y eliminaciones). Cada operación de escritura puede apuntar a una colección diferente.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    El valor por omisión para la opción <literal>"writeConcern"</literal> será
    deducido de una transacción activa (indicada por la opción
    <literal>"session"</literal>), seguida de
    <link linkend="mongodb-driver-manager.construct-uri">la URI de conexión</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,15 +16,15 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta un comando en este servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método no aplica ninguna lógica especial al comando. Los valores por omisión para las opciones <literal>"readPreference"</literal>, <literal>"readConcern"</literal> y <literal>"writeConcern"</literal> serán deducidos de una transacción activa (indicada por la opción <literal>"session"</literal>). Si no hay una transacción activa, se utilizará una preferencia de lectura primaria para la selección del servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Los valores por omisión <emphasis>no</emphasis> serán deducidos de la <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>. Por lo tanto, se recomienda a los usuarios utilizar métodos de comando de lectura y/o escritura específicos si es posible.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 
@@ -79,7 +79,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -116,7 +116,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,14 +16,14 @@
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta la consulta en este servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Los valores por omisión para la opción <literal>"readPreference"</literal> y
    la opción <literal>"readConcern"</literal> de la consulta se deducirán de una transacción activa
    (indicada por la opción <literal>"session"</literal>), luego por la <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 
@@ -74,7 +74,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -109,7 +109,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/server/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,18 +15,18 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta el comando en este servidor, independientemente de la opción
    <literal>"readPreference"</literal>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará una lógica específica a los comandos de lectura (por ejemplo
    <link xlink:href="&url.mongodb.docs;reference/command/distinct/">distinct</link>).
    Los valores por omisión para las opciones <literal>"readPreference"</literal> y
    <literal>"readConcern"</literal> serán deducidos de una transacción activa (indicada por
    la opción <literal>"session"</literal>), seguida de la
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,17 +15,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta el comando en este servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará una lógica específica a los comandos de lectura y escritura
    (por ejemplo <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
    Los valores por omisión para las opciones <literal>"readConcern"</literal> y
    <literal>"writeConcern"</literal> serán deducidos de una transacción activa (indicada por
    la opción <literal>"session"</literal>), seguida de la
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -78,7 +78,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -99,7 +99,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,16 +15,16 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta el comando en este servidor.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Este método aplicará una lógica específica a los comandos que escriben (por ejemplo
    <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
    El valor por omisión para la opción <literal>"writeConcern"</literal> será deducido de una transacción activa (indicada por
    la opción <literal>"session"</literal>), seguida de la
    <link linkend="mongodb-driver-manager.construct-uri">URI de conexión</link>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Este método no está destinado a ser utilizado para ejecutar
@@ -87,7 +87,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -108,7 +108,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/gethost.xml
+++ b/reference/mongodb/mongodb/driver/server/gethost.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Server::getHost</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el nombre del host del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre del host del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/server/getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,19 +13,19 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Server::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve un array de información que describe el servidor. Este array se deriva
    de la respuesta más reciente a la comando <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    obtenida por la <link xlink:href="&url.mongodb.sdam;">supervisión del servidor</link>.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Cuando el controlador está conectado a un balanceador de carga, este método devuelve
     la respuesta al comando <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
     del servidor de respaldo durante el apretón de manos inicial de la conexión.
     Esto contrasta con otros métodos (por ejemplo, <function>MongoDB\Driver\Server::getType</function>),
     que devolverán información sobre el balanceador de carga mismo.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un array de información que describe este servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -201,8 +201,7 @@ array(23) {
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -222,7 +221,6 @@ array(23) {
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/server/getlatency.xml
+++ b/reference/mongodb/mongodb/driver/server/getlatency.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getlatency" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>integer</type><type>null</type></type><methodname>MongoDB\Driver\Server::getLatency</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve la latencia de este servidor en milisegundos. Es la medida del cliente del tiempo de
    <link xlink:href="&url.mongodb.sdam;#round-trip-time">ida y vuelta</link>
    de un comando <literal>hello</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la latencia del servidor en milisegundos,
    o &null; si no se ha medido ninguna latencia (por ejemplo, el cliente está conectado a un balanceador de carga).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,8 +42,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -63,7 +62,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/server/getport.xml
+++ b/reference/mongodb/mongodb/driver/server/getport.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Server::getPort</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el puerto en el que el servidor está escuchando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto en el que el servidor está escuchando.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/getserverdescription.xml
+++ b/reference/mongodb/mongodb/driver/server/getserverdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getserverdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ServerDescription</type><methodname>MongoDB\Driver\Server::getServerDescription</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve una <classname>MongoDB\Driver\ServerDescription</classname> para este
    servidor. Es un objeto de valor inmutable que describirá el servidor en el momento
    en que se llame a este método.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve una <classname>MongoDB\Driver\ServerDescription</classname> para este
    servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/gettags.xml
+++ b/reference/mongodb/mongodb/driver/server/gettags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.gettags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Server::getTags</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve un <type>array</type> de
    <link xlink:href="&url.mongodb.glossary;#term-tag">tags</link> utilizados para
    describir este servidor en un conjunto de réplicas. El array contendrá cero o más
    pares clave y valor de tipo <type>string</type>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un <type>array</type> de tags utilizados para describir este servidor en un
    conjunto de réplicas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/gettype.xml
+++ b/reference/mongodb/mongodb/driver/server/gettype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,10 +14,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Server::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve un &integer; que representa el tipo del servidor. El valor
    corresponderá a una constante <classname>MongoDB\Driver\Server</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un &integer; que representa el tipo del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/isarbiter.xml
+++ b/reference/mongodb/mongodb/driver/server/isarbiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.isarbiter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isArbiter</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve si este servidor es un
    <link xlink:href="&url.mongodb.glossary;#term-arbiter">miembro árbitro</link>
    de un conjunto de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si este servidor es un miembro árbitro de un conjunto de réplicas, y
    &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/ishidden.xml
+++ b/reference/mongodb/mongodb/driver/server/ishidden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.ishidden" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isHidden</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Indica si este servidor es un
    <link xlink:href="&url.mongodb.glossary;#term-hidden-member">miembro oculto</link>
    de un conjunto de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si este servidor es un miembro oculto de un conjunto de réplicas, y
    &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/ispassive.xml
+++ b/reference/mongodb/mongodb/driver/server/ispassive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.ispassive" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,11 +15,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isPassive</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve si el servidor es un
    <link xlink:href="&url.mongodb.glossary;#term-passive-member">miembro pasivo</link>
     de un conjunto de réplicas (i.e. su prioridad es <literal>0</literal>).
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,10 +30,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si el servidor es un miembro pasivo de un conjunto de réplicas,
     y &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/isprimary.xml
+++ b/reference/mongodb/mongodb/driver/server/isprimary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.isprimary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isPrimary</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve si este servidor es un
    <link xlink:href="&url.mongodb.glossary;#term-primary">miembro principal</link>
    de un conjunto de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si este servidor es un miembro principal de un conjunto de réplicas, y
    &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/issecondary.xml
+++ b/reference/mongodb/mongodb/driver/server/issecondary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.issecondary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isSecondary</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve si este servidor es un
    <link xlink:href="&url.mongodb.glossary;#term-secondary">miembro secundario</link>
    de un conjunto de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si este servidor es un miembro secundario de un conjunto de réplicas, y
    &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eaee72c33fe65d1d4648cd8a30bbec0aeb76c960 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-serverapi.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un objeto para la serialización del ServerApi en BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverapi/construct.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7b808a875840b8850631210ef2190d681b6edfa Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-serverapi.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,11 +16,11 @@
    <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>deprecationErrors</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Crear una nueva instancia de <classname>MongoDB\Driver\ServerApi</classname> utilizada para
    declarar una versión de API al crear un
    <classname>MongoDB\Driver\Manager</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,36 +29,36 @@
    <varlistentry xml:id="mongodb-driver-serverapi.construct-version">
     <term><parameter>version</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Una versión de API de servidor.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Las versiones de API admitidas se proporcionan como constantes
       en <classname>MongoDB\Driver\ServerApi</classname>. La única versión de API
       admitida es <constant>MongoDB\Driver\ServerApi::V1</constant>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="mongodb-driver-manager.construct-strict">
     <term><parameter>strict</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Si el parámetro <parameter>strict</parameter> se establece en &true;, el
       servidor devolverá un error para cualquier comando que no forme parte de la
       versión de API especificada. Si no se proporciona ningún valor, se utiliza el valor predeterminado del servidor
       (&false;).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="mongodb-driver-manager.construct-deprecationErrors">
     <term><parameter>deprecationErrors</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Si el parámetro <parameter>deprecationErrors</parameter> se establece en &true;,
       el servidor devolverá un error al utilizar un comando que está obsoleto en
       la versión de API especificada. Si no se proporciona ningún valor, se utiliza el valor predeterminado del servidor
       (&false;).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/mongodb/driver/serverdescription/gethelloresponse.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gethelloresponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-serverdescription.gethelloresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,21 +13,21 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\ServerDescription::getHelloResponse</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve un array de información que describe el servidor. Este array se deriva de la respuesta
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    más reciente (en el momento en que la
    <classname>MongoDB\Driver\ServerDescription</classname> fue construida) obtenida a través de
    <link xlink:href="&url.mongodb.sdam;">la supervisión del servidor</link>.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Cuando el controlador está conectado a un balanceador de carga, este método devolverá
     un array vacío porque los balanceadores de carga no son supervisados. Esto contrasta con
     <function>MongoDB\Driver\Server::getInfo</function>, que devolvería la respuesta del
     <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
     de la comando de apretón de manos de conexión inicial del servidor base.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -38,9 +38,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un array de información que describe este servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/gethost.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-serverdescription.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\ServerDescription::getHost</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el nombre de host de este servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el nombre de host de este servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getlastupdatetime.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getlastupdatetime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-serverdescription.getlastupdatetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\ServerDescription::getLastUpdateTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve la hora de la última actualización del servidor en microsegundos.
-  </para>
+  </simpara>
   <note>
    <simpara>
     El valor devuelto es un timestamp monotónico, que comienza en un punto arbitrario.
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la hora de la última actualización del servidor en microsegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getport.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-serverdescription.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\ServerDescription::getPort</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el puerto en el que este servidor escucha.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el puerto en el que este servidor escucha.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getroundtriptime.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getroundtriptime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-serverdescription.getroundtriptime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\ServerDescription::getRoundTripTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el tiempo de ida y vuelta del servidor en milisegundos. Se trata de
    la medida del cliente de la duración de una
    comando
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el tiempo de ida y vuelta del servidor en milisegundos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/gettype.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-serverdescription.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\ServerDescription::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve un <type>string</type> que indica el tipo de este servidor. El valor
    estará correlacionado con una constante
    <classname>MongoDB\Driver\ServerDescription</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un <type>string</type> que indica el tipo de este servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/aborttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/aborttransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f1e951b988e8aafe49b33bdf2f7812740c66c2d2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.aborttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::abortTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Termina la transacción multi-documento y anula todas las modificaciones de datos
    realizadas por las operaciones en la transacción. Es decir, la transacción se termina
    sin guardar ninguna de las modificaciones realizadas por las operaciones en la transacción.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.advanceclustertime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,17 +13,17 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceClusterTime</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>clusterTime</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Avance el tiempo del cluster para esta sesión. Si el tiempo del cluster es inferior o igual
    al tiempo del cluster actual de la sesión, esta función no hace nada.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Al utilizar este método en conjunción con
    <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> para copiar
    los tiempos del cluster y de las operaciones de otra sesión
    se puede asegurar que las operaciones en esta sesión sean coherentes
    con la última operación en la otra sesión.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,12 +32,12 @@
    <varlistentry>
     <term><parameter>clusterTime</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       El tiempo del cluster es un documento que contiene un horodatage lógico y una firma de servidor.
       Típicamente, este valor se obtendrá llamando a
       <methodname>MongoDB\Driver\Session::getClusterTime</methodname> en otro
       objeto de sesión.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.advanceoperationtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,17 +13,17 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceOperationTime</methodname>
    <methodparam><type>MongoDB\BSON\TimestampInterface</type><parameter>operationTime</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Avance el tiempo de operación para esta sesión. Si el tiempo de operación es inferior o igual
    al tiempo de operación actual de la sesión, esta función no hace nada.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Al utilizar este método en conjunción con
    <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> para copiar
    los tiempos de operación y de cluster de otra sesión
    se puede asegurar que las operaciones en esta sesión sean coherentes
    con la última operación en la otra sesión.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,12 +32,12 @@
    <varlistentry>
     <term><parameter>operationTime</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       La operación es un timestamp lógico. Típicamente, este valor
       será obtenido llamando a
       <methodname>MongoDB\Driver\Session::getOperationTime</methodname> en
       otro objeto de sesión.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/committransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/committransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63fc2906221a3cdb9bc086aba6f05ee407d2c13b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.committransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::commitTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Guarda los cambios realizados por las operaciones en la transacción
    multi-documento y finaliza la transacción. Hasta la validación, ninguno de
    los cambios de datos realizados por las operaciones en la transacción
    es visible fuera de la transacción.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/construct.xml
+++ b/reference/mongodb/mongodb/driver/session/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Session::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Los objetos <classname>MongoDB\Driver\Session</classname> son devueltos por
    <methodname>MongoDB\Driver\Manager::startSession</methodname> y no pueden ser
    construidos directamente.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/session/endsession.xml
+++ b/reference/mongodb/mongodb/driver/session/endsession.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 69b7314dc644c27289de76afc93684a98428ad05 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.endsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::endSession</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Este método cierra una sesión existente. Si una transacción estaba asociada
    a esta sesión, la transacción será anulada. Después de llamar a este
    método, las aplicaciones no deben invocar otros métodos en la sesión.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Las sesiones también se cierran durante la recolección de basura. No debería ser
@@ -33,9 +33,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/getclustertime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.getclustertime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Session::getClusterTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el tiempo del cluster para esta sesión. Si la sesión no ha sido utilizada
    para una operación y
    <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> no ha
    sido llamado, el tiempo del cluster será &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el tiempo del cluster para esta sesión, o &null; si la sesión no tiene
    tiempo del cluster.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getlogicalsessionid.xml
+++ b/reference/mongodb/mongodb/driver/session/getlogicalsessionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.getlogicalsessionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Session::getLogicalSessionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el identificador de sesión lógica para esta sesión, que puede ser utilizado para
    identificar las operaciones de esta sesión en el servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el identificador de sesión lógica para esta sesión.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/getoperationtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.getoperationtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Timestamp</type><type>null</type></type><methodname>MongoDB\Driver\Session::getOperationTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el tiempo de operación para esta sesión. Si la sesión no ha sido utilizada
    para una operación y
    <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> no ha
    sido llamado, el tiempo de operación será &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el tiempo de operación para esta sesión, o &null; si la sesión no tiene
    tiempo de operación.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getserver.xml
+++ b/reference/mongodb/mongodb/driver/session/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,18 +13,18 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\Server</type><type>null</type></type><methodname>MongoDB\Driver\Session::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> al que esta sesión
    está fijada. Si la sesión no está fijada a un servidor, &null;
    será devuelto.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    La fijación de la sesión se utiliza principalmente para las transacciones
    distribuidas, ya que todas las órdenes en una transacción distribuida deben
    ser enviadas a la misma instancia mongos. Este método está destinado a ser
    utilizado por bibliotecas construidas sobre la extensión para permitir el uso
    de un servidor fijado en lugar de invocar la selección del servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -34,10 +34,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> al que esta sesión
    está fijada, o &null; si la sesión no está fijada a un servidor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.gettransactionoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>MongoDB\Driver\Session::getTransactionOptions</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve las opciones para la transacción en curso.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un <type>array</type> que contiene las opciones de transacción actuales, o
    &null; si no hay ninguna transacción en curso.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/gettransactionstate.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionstate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a8482dea2af701e5aef299fda555ddc9e1587184 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.gettransactionstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Session::getTransactionState</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el estado de la transacción para esta sesión.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el estado de la transacción actual para esta sesión.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/isdirty.xml
+++ b/reference/mongodb/mongodb/driver/session/isdirty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d5127e772887addc6553066a33b31af086cd93b1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.isdirty" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Session::isDirty</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Indica si la sesión ha sido marcada como sucia (es decir, que ha sido utilizada
    con un comando que ha encontrado un error de red).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Indica si la sesión ha sido marcada como sucia.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/isintransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/isintransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.isintransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Session::isInTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Indica si una transacción multi-documento está actualmente en curso para
    esta sesión. Una transacción se considera "en curso" si ha sido
    iniciada pero no ha sido confirmada o anulada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si una transacción está actualmente en curso para esta sesión,
    y &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-session.starttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,21 +13,21 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::startTransaction</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Inicia una transacción multi-documento asociada a la sesión. En un momento dado,
    solo se puede tener una transacción abierta para una sesión. Después de iniciar una transacción, el objeto de sesión debe ser pasado a cada operación a través
    de la opción <literal>"session"</literal> (por ejemplo
    <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>) para asociar
    esta operación a la transacción.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Las transacciones pueden ser confirmadas a través de
    <methodname>MongoDB\Driver\Session::commitTransaction</methodname>, y
    anuladas con
    <methodname>MongoDB\Driver\Session::abortTransaction</methodname>.
    Las transacciones también se anulan automáticamente cuando la sesión se cierra por la recolección de basura o al llamar explícitamente a
    <methodname>MongoDB\Driver\Session::endSession</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -36,13 +36,13 @@
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Las opciones pueden ser pasadas como argumento a este método. Cada elemento de este
       array de opciones reemplaza la opción correspondiente de la opción
       <literal>"defaultTransactionOptions"</literal>, si se define al
       iniciar la sesión con
       <methodname>MongoDB\Driver\Manager::startSession</methodname>.
-     </para>
+     </simpara>
      <para>
       <table>
        <title>options</title>
@@ -70,9 +70,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/getservers.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/getservers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-topologydescription.getservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\TopologyDescription::getServers</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve un array de objetos <classname>MongoDB\Driver\ServerDescription</classname>
    correspondiente a los servidores conocidos en la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un array de objetos <classname>MongoDB\Driver\ServerDescription</classname>
    correspondiente a los servidores conocidos en la topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/gettype.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-topologydescription.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\TopologyDescription::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve un <type>string</type> que denota el tipo de esta topología. El valor
    estará correlacionado con una constante de
    <classname>MongoDB\Driver\TopologyDescription</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un <type>string</type> que denota el tipo de esta topología.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/hasreadableserver.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/hasreadableserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-topologydescription.hasreadableserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\TopologyDescription::hasReadableServer</methodname>
    <methodparam choice="opt"><type class="union"><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>readPreference</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Indica si la topología tiene un servidor legible o, si
    <parameter>readPreference</parameter> está especificado, un servidor que corresponde a
    la preferencia de lectura especificada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,11 +27,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Indica si la topología tiene un servidor legible o, si
    <parameter>readPreference</parameter> está especificado, un servidor que corresponde a
    la preferencia de lectura especificada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/haswritableserver.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/haswritableserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-topologydescription.haswritableserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\TopologyDescription::hasWritableServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Indica si la topología dispone de un servidor en escritura.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Indica si la topología dispone de un servidor en escritura.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5eca06ae7725b4c35eefecbb0d722a3e198ff21 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-writeconcern.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un objeto para la serialización del WriteConcern en BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeconcern.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,9 +17,9 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>wtimeout</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>journal</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construye un nuevo <classname>MongoDB\Driver\WriteConcern</classname>, que es un objeto de valor inmutable.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -69,10 +69,10 @@
             propagado a la mayoría de los nodos votantes, incluyendo el principal, y
             han sido escritas en el journal en disco para esos nodos.
            </para>
-           <para>
+           <simpara>
             Antes de MongoDB 3.0, es la mayoría de los miembros del conjunto de
             réplicas (y no solo de los nodos votantes).
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -92,21 +92,21 @@
    <varlistentry>
     <term><parameter>wtimeout</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Tiempo máximo de espera (en milisegundos) antes de que los secundarios
       fallen.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       <literal>wtimeout</literal> hará que las operaciones de escritura devuelvan
       un error (<classname>WriteConcernError</classname>) después del
       tiempo especificado. Cuando estas operaciones de escritura devuelvan, MongoDB
       no cancelará los datos modificados antes de que las preocupaciones
       de escritura alcancen el tiempo límite <literal>wtimeout</literal>.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Si se especifica, <literal>wtimeout</literal> debe ser un entero con signo de 64 bits
       mayor o igual a cero.
-     </para>
+     </simpara>
      <para>
       <table>
        <title>Tiempo máximo de espera de las preocupaciones de escritura</title>
@@ -137,9 +137,9 @@
    <varlistentry>
     <term><parameter>journal</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Espera antes de que mongod aplique la escritura al journal.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -155,7 +155,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
+
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -174,7 +174,7 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
+
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeconcern/getjournal.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getjournal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-writeconcern.getjournal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "journal" del WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/getw.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-writeconcern.getw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "w" del WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-writeconcern.getwtimeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve la opción "wtimeout" del WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -36,8 +36,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -57,7 +56,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeconcern/isdefault.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/isdefault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-writeconcern.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,19 +13,19 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\WriteConcern::isDefault</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve si es el WriteConcern por omisión (es decir, sin opciones especificadas). Este método está principalmente destinado a ser utilizado en conjunción con
    <methodname>MongoDB\Driver\Manager::getWriteConcern</methodname> para determinar
    si el Manager ha sido construido sin ninguna opción de WriteConcern.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    El controlador no incluirá un WriteConcern por omisión en sus operaciones de escritura
    (por ejemplo <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>) para permitir que el servidor aplique su propio WriteConcern por omisión, que puede haber sido
    <link xlink:href="&url.mongodb.docs;core/replica-set-write-concern/#modify-default-write-concern">modificado</link>.
    Las bibliotecas que acceden al WriteConcern del Manager para incluirlo en sus propios
    comandos de escritura deberían utilizar este método para asegurarse de que los WriteConcern por omisión
    no están definidos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si es el WriteConcern por omisión y &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getcode.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getcode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteConcernError::getCode</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el código de error de WriteConcernError
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\WriteConcernError::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
     Devuelve el documento de metadatos para WriteConcernError, o &null;
    si no hay metadatos disponibles.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getmessage.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getmessage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getmessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\WriteConcernError::getMessage</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el mensaje de error del WriteConcernError
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getcode.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getcode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeerror.getcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteError::getCode</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el código de error de WriteError
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getindex.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getindex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeerror.getindex" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteError::getIndex</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el índice de la operación de escritura (a partir de
    <classname>MongoDBDriverBulkWrite</classname>) correspondiente a este WriteError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeerror.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\WriteError::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el documento de metadatos para WriteError, o &null; si
    no hay metadatos disponibles.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getmessage.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getmessage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 697b3c9468124f58cc13901057bec0b813f6197f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeerror.getmessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\WriteError::getMessage</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el mensaje de error del WriteError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getdeletedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getdeletedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getdeletedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getDeletedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el número de documentos eliminados.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,8 +42,7 @@
 
   <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -56,7 +55,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getinsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getInsertedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el número de documentos insertados (excepto Upserts permitidos).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,8 +42,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -56,7 +55,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getmatchedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmatchedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getmatchedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,12 +14,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getMatchedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Si la operación de actualización no resulta en ninguna modificación del documento
    (por ejemplo, al establecer el valor de un campo en su valor actual),
    el número correspondiente puede ser mayor que el valor devuelto por
    <methodname>MongoDB\Driver\WriteResult::getModifiedCount</methodname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el número de documentos seleccionados para la actualización.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -45,8 +45,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -59,7 +58,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getmodifiedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,12 +14,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getModifiedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
     Si la operación de actualización no resulta en ninguna modificación del documento
    (por ejemplo, al establecer el valor de un campo en su valor actual),
    el número modificado puede ser inferior al valor devuelto por
    <methodname>MongoDB\Driver\WriteResult::getMatchedCount</methodname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el número de documentos existentes actualizados.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -45,8 +45,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -59,7 +58,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getserver.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getserver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\WriteResult::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> asociado a este resultado de escritura. Se trata del servidor que ejecutó el <classname>MongoDB\Driver\BulkWrite</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el <classname>MongoDB\Driver\Server</classname> asociado a este resultado de escritura.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getupsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getupsertedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getupsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getUpsertedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve el número de documentos insertados por un upsert.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,8 +42,7 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
+     <informaltable>
     <tgroup cols="2">
      <thead>
       <row>
@@ -56,7 +55,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getupsertedids.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getupsertedids.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2c423ff085531b5a614c7b10c2d8cf957cdda808 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getupsertedids" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\WriteResult::getUpsertedIds</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un array de identificadores (por ejemplo, el valor del campo <literal> "_id"</literal>) para los documentos upserted. Las claves del array corresponden al índice de la operación de escritura (desde <classname>MongoDBDriverBulkWrite</classname>) responsable del upsert.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getwriteconcernerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\WriteConcernError</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getWriteConcernError</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un <classname>MongoDBDriverWriteConcernError</classname> si se encontró un error de preocupación de escritura durante la operación de escritura, y &null; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteerrors.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteerrors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 61f9e84aa71378ccf3958a6c20d3a8017392562c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getwriteerrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\WriteResult::getWriteErrors</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,11 +28,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un array de objetos <classname>MongoDBDriverWriteError</classname>
    para todos los errores de escritura encontrados durante la operación
    de escritura. El array estará vacío si no se ha producido ningún error de escritura.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/isacknowledged.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/isacknowledged.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.isacknowledged" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,10 +14,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\WriteResult::isAcknowledged</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Si la escritura ha sido reconocida, otros campos de conteo estarán disponibles
    para el objeto <classname>MongoDB\Driver\WriteResult</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve &true; si la escritura ha sido reconocida, y &false; en caso contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Monitoreo del rendimiento de la aplicación (Application Performance Monitoring - APM)</title>
 
- <para>
+ <simpara>
   La extensión contiene una API de observaciones de eventos, que permite a las aplicaciones
   monitorear las órdenes y las actividades internas relacionadas con la
   <link xlink:href="&url.mongodb.sdam;">Especificación de descubrimiento y monitoreo del servidor</link>.
   Este tutorial demostrará el monitoreo de las órdenes utilizando la interfaz
   <classname>MongoDB\Driver\Monitoring\CommandSubscriber</classname>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   La interfaz
   <classname>MongoDB\Driver\Monitoring\CommandSubscriber</classname>
   define tres métodos: <literal>commandStarted</literal>,
@@ -21,19 +21,19 @@
   de una clase específica para el evento respectivo. Por ejemplo, el argumento
   <parameter>$event</parameter> de <literal>commandSucceeded</literal>
   es un objeto <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   En este tutorial, se implementará un observador que crea una lista de todos
   los perfiles de solicitud y el tiempo promedio que han tomado.
- </para>
+ </simpara>
 
  <section>
   <title>Estructura de las clases de observaciones</title>
 
-  <para>
+  <simpara>
    Se comienza con el marco del observador:
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[
@@ -62,13 +62,13 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
  <section>
   <title>Registro del observador</title>
 
-  <para>
+  <simpara>
    Una vez que un objeto observador es instanciado, debe ser registrado con el
    sistema de monitoreo de la extensión. Esto se hace llamando a
    <methodname>MongoDB\Driver\Monitoring\addSubscriber</methodname> o
    <methodname>MongoDB\Driver\Manager::addSubscriber</methodname> para registrar
    el observador globalmente o con un Manager específico, respectivamente.
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[
@@ -84,27 +84,27 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
  <section>
   <title>Implementar la lógica</title>
 
-  <para>
+  <simpara>
    Con el objeto registrado, la única cosa que queda es implementar la lógica
    en la clase observadora. Para correlacionar los dos eventos que componen una
    orden ejecutada con éxito (commandStarted y commandSucceeded), cada
    objeto de evento expone un campo <literal>requestId</literal>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Para registrar el tiempo promedio por forma de solicitud, se comenzará verificando
    una orden <literal>find</literal> en el evento commandStarted. Luego, se añadirá un elemento a la propiedad <literal>pendingCommands</literal> indexado por su
    <literal>requestId</literal> y con su valor representando la forma de solicitud.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si se recibe un evento commandSucceeded correspondiente con el mismo
    <literal>requestId</literal>, se añade la duración del evento (desde
    <literal>durationMicros</literal>) al tiempo total e incrementa el
    contador de operaciones.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si se encuentra un evento commandFailed correspondiente, simplemente se elimina
    la entrada de la propiedad <literal>pendingCommands</literal>.
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Utilizar la biblioteca PHP para MongoDB (PHPLIB)</title>
 
- <para>
+ <simpara>
   Después de la configuración inicial de la extensión, se continuará explicando cómo comenzar
   con la biblioteca de usuario correspondiente para escribir nuestro primer proyecto.
- </para>
+ </simpara>
 
  <section>
   <title>Instalar la biblioteca PHP con Composer</title>
 
-  <para>
+  <simpara>
    La última cosa que se debe instalar para comenzar la aplicación
    en sí es la biblioteca PHP.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    La biblioteca debe ser instalada con
    <link xlink:href="&url.mongodb.composer;">Composer</link>, un gestor de
    paquetes para PHP. Las instrucciones para instalar Composer en diferentes
    plataformas pueden encontrarse en su sitio web.
-   </para>
+   </simpara>
 
    <para>
     Instalar la biblioteca ejecutando:
@@ -50,11 +50,11 @@ Generating autoload files
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Composer creará varios ficheros: <code>composer.json</code>,
     <code>composer.lock</code>, y un directorio <code>vendor</code> que
     contendrá la biblioteca y todas las otras dependencias que su proyecto podría necesitar.
-   </para>
+   </simpara>
   </section>
 
   <section>
@@ -73,13 +73,13 @@ require 'vendor/autoload.php';
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Con esto hecho, ahora puede utilizar cualquier
     funcionalidad como se describe en la
     <link xlink:href="&url.mongodb.library.docs;">documentación de la biblioteca</link>.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Si ha utilizado controladores MongoDB en otros lenguajes, la API de la
     biblioteca debería resultarle familiar. Contiene una clase
     <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBClient/">Client</link>
@@ -90,7 +90,7 @@ require 'vendor/autoload.php';
     <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBCollection">Collection</link>
     para las operaciones a nivel de la colección (por ejemplo, los métodos
     <link xlink:href="&url.mongodb.wiki.crud;">CRUD</link>, la gestión de los índices).
-   </para>
+   </simpara>
 
    <para>
     Como ejemplo, aquí se muestra cómo insertar un documento en la colección
@@ -111,12 +111,12 @@ echo "Inserted with Object ID '{$result->getInsertedId()}'";
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Dado que el documento insertado no contenía un campo <code>_id</code>, la extensión
     generará un <classname>MongoDB\BSON\ObjectId</classname> para que el servidor
     lo utilice como <code>_id</code>. Este valor también está disponible para
     el llamador a través del objeto de resultado devuelto por el método <code>insertOne</code>.
-   </para>
+   </simpara>
 
    <para>
     Después de la inserción, se pueden consultar los datos que acaba de insertar. Para ello, se utiliza el método <code>find</code>, que devuelve un cursor
@@ -139,7 +139,7 @@ foreach ($result as $entry) {
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Aunque los ejemplos no lo muestran, los documentos BSON y los arrays
     son deserializados como clases especiales en la biblioteca por defecto. Estas clases extienden <classname>ArrayObject</classname> para facilidad de uso
     e implementan las interfaces <interfacename>MongoDB\BSON\Serializable</interfacename>
@@ -147,7 +147,7 @@ foreach ($result as $entry) {
     donde los arrays podrían convertirse en documentos, y viceversa. Ver la
     especificación <xref linkend="mongodb.persistence"/> para más información sobre
     cómo se convierten los valores entre PHP y BSON.
-   </para>
+   </simpara>
   </section>
 </section>
 <!-- Keep this comment at the end of the file

--- a/reference/mysql_xdevapi/ini.xml
+++ b/reference/mysql_xdevapi/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40667918dcff1d5c9f7ecdc88b5caca24ba0686c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="mysql-xdevapi.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/mysql_xdevapi/mysql-xdevapi.baseresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.baseresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-baseresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.collection.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-collection" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.collectionadd.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collectionadd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-collectionadd" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.collectionfind.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collectionfind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-collectionfind" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.collectionmodify.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collectionmodify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-collectionmodify" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.collectionremove.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collectionremove.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-collectionremove" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.columnresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.columnresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-columnresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.crudoperationbindable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.crudoperationbindable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-crudoperationbindable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.crudoperationlimitable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.crudoperationlimitable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-crudoperationlimitable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.crudoperationskippable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.crudoperationskippable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-crudoperationskippable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.crudoperationsortable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.crudoperationsortable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-crudoperationsortable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.databaseobject.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.databaseobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-databaseobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.docresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.docresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-docresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.exception.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.executable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.executable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-executable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.executionstatus.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.executionstatus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-executionstatus" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.expression.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.expression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-expression" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.fieldmetadata.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.fieldmetadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-fieldmetadata" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.result.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-result" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.rowresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.rowresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-rowresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.schema.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-schema" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.schemaobject.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.schemaobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-schemaobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.session.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.session.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-session" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.sqlstatementresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.sqlstatementresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-sqlstatementresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.table.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.table.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-table" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.tabledelete.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tabledelete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-tabledelete" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.tableinsert.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tableinsert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-tableinsert" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.tableselect.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tableselect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-tableselect" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.tableupdate.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tableupdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-tableupdate" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/mysql_xdevapi/mysql-xdevapi.warning.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.warning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mysql-xdevapi-warning" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/parallel/parallel.events.event.type.xml
+++ b/reference/parallel/parallel.events.event.type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d9ecfba6ad07e4e0b1b13ed1f0592f09d2e2f5c9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.parallel-events-event-type" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/parle/constants.xml
+++ b/reference/parle/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 33f884b5175a00a6d16654f018611ffb42890a0d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <appendix xml:id="parle.constants" xmlns="http://docbook.org/ns/docbook">

--- a/reference/parle/parle.errorinfo.xml
+++ b/reference/parle/parle.errorinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.parle-errorinfo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/parle/parle.lexerexception.xml
+++ b/reference/parle/parle.lexerexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6add79a3e1df186de8007bc60e9949e7fa961f8d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.parle-lexerexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/parle/parle.parserexception.xml
+++ b/reference/parle/parle.parserexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6add79a3e1df186de8007bc60e9949e7fa961f8d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.parle-parserexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/pdo_odbc/ini.xml
+++ b/reference/pdo_odbc/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: aab33d644359aba597e810e2fc0c0caa0d347c9c Maintainer: seros Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: julionc -->
 
 <section xml:id="pdo-odbc.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/ps/constants.xml
+++ b/reference/ps/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 39b8a62079764f93296887ba43d7a42274f11115 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: f82120f1dc58c812cf7afdbb26f663e525cd4777 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <appendix xml:id="ps.constants" xmlns="http://docbook.org/ns/docbook">

--- a/reference/pspell/constants.xml
+++ b/reference/pspell/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5e9500ddad6dbc2f1b01d7da8b53379c8b7c386c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <appendix xml:id="pspell.constants" xmlns="http://docbook.org/ns/docbook">

--- a/reference/pspell/pspell.config.xml
+++ b/reference/pspell/pspell.config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pspell-config" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>La clase PSpell\Config</title>

--- a/reference/pspell/pspell.dictionary.xml
+++ b/reference/pspell/pspell.dictionary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pspell-dictionary" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>La clase PSpell\Dictionary</title>

--- a/reference/solr/solrclient.xml
+++ b/reference/solr/solrclient.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.solrclient" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrclientexception.xml
+++ b/reference/solr/solrclientexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 38e65393c58b006a923c5bb7878aee5c73e21b20 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrclientexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrcollapsefunction.xml
+++ b/reference/solr/solrcollapsefunction.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7bade7dc0cb3fdfe81d7db2225f27be1698f470d Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 
 <reference xml:id="class.solrcollapsefunction" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrdismaxquery.xml
+++ b/reference/solr/solrdismaxquery.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrdismaxquery" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrdocumentfield.xml
+++ b/reference/solr/solrdocumentfield.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.solrdocumentfield" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrexception.xml
+++ b/reference/solr/solrexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrgenericresponse.xml
+++ b/reference/solr/solrgenericresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrgenericresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrillegalargumentexception.xml
+++ b/reference/solr/solrillegalargumentexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b7fc1cdcf2682e481669db5f07dcfeefea0ee555 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: andresdzphp -->
 
 <reference xml:id="class.solrillegalargumentexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrillegaloperationexception.xml
+++ b/reference/solr/solrillegaloperationexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 38e65393c58b006a923c5bb7878aee5c73e21b20 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrillegaloperationexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrinputdocument.xml
+++ b/reference/solr/solrinputdocument.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 
 <reference xml:id="class.solrinputdocument" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/solr/solrmissingmandatoryparameterexception.xml
+++ b/reference/solr/solrmissingmandatoryparameterexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dde9fdb53318cd3f299f100447f021c901497adb Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 
 <reference xml:id="class.solrmissingmandatoryparameterexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrmodifiableparams.xml
+++ b/reference/solr/solrmodifiableparams.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 
 <reference xml:id="class.solrmodifiableparams" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/solr/solrobject.xml
+++ b/reference/solr/solrobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 
 <reference xml:id="class.solrobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/solr/solrparams.xml
+++ b/reference/solr/solrparams.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 79930e5bd33c2f11c2e9bda5fb5557ee41909a7d Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 
 <reference xml:id="class.solrparams" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/solr/solrpingresponse.xml
+++ b/reference/solr/solrpingresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 
 <reference xml:id="class.solrpingresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/solr/solrquery.xml
+++ b/reference/solr/solrquery.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrquery" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrqueryresponse.xml
+++ b/reference/solr/solrqueryresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrqueryresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrresponse.xml
+++ b/reference/solr/solrresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 
 <reference xml:id="class.solrresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/solr/solrserverexception.xml
+++ b/reference/solr/solrserverexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: andresdzphp -->
 
 <reference xml:id="class.solrserverexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrupdateresponse.xml
+++ b/reference/solr/solrupdateresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrupdateresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrutils.xml
+++ b/reference/solr/solrutils.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734ddd27ada5fdc8fbd2724e4c9e08881649dec1 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 
 <reference xml:id="class.solrutils" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/ssh2/constants.xml
+++ b/reference/ssh2/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 37323ead9517a89b21bd17913c4fa04a9d713f16 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b3c45f0731b6c3a31215c8216f403ff50f4c95b7 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="ssh2.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;

--- a/reference/swoole/swoole/channel/push.xml
+++ b/reference/swoole/swoole/channel/push.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 97d52b78f1cc109bb272d4a844f9f498a74ecf03 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-channel.push" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/swoole/swoole/connection/iterator/offsetexists.xml
+++ b/reference/swoole/swoole/connection/iterator/offsetexists.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 97d52b78f1cc109bb272d4a844f9f498a74ecf03 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-connection-iterator.offsetexists" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/swoole/swoole/lock/destruct.xml
+++ b/reference/swoole/swoole/lock/destruct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 97d52b78f1cc109bb272d4a844f9f498a74ecf03 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-lock.destruct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/swoole/swoole/mysql/destruct.xml
+++ b/reference/swoole/swoole/mysql/destruct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 97d52b78f1cc109bb272d4a844f9f498a74ecf03 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-mysql.destruct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/swoole/swoole/server/port/destruct.xml
+++ b/reference/swoole/swoole/server/port/destruct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 97d52b78f1cc109bb272d4a844f9f498a74ecf03 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-server-port.destruct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/swoole/swoole/server/resume.xml
+++ b/reference/swoole/swoole/server/resume.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 97d52b78f1cc109bb272d4a844f9f498a74ecf03 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-server.resume" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/trader/ini.xml
+++ b/reference/trader/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: seros Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="trader.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/uopz/constants.xml
+++ b/reference/uopz/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <appendix xml:id="uopz.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-backup.xml
+++ b/reference/uopz/functions/uopz-backup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-backup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-compose.xml
+++ b/reference/uopz/functions/uopz-compose.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ad6817fb4d2dba632df881eb8ab9aec5bd6544e5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-compose" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-copy.xml
+++ b/reference/uopz/functions/uopz-copy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-copy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-delete.xml
+++ b/reference/uopz/functions/uopz-delete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-extend.xml
+++ b/reference/uopz/functions/uopz-extend.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c724a01a192e135bf165399d9b25caf6099482a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-extend" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-flags.xml
+++ b/reference/uopz/functions/uopz-flags.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a733bff5ff4a008364f0a90d7443b6b945b6cc18 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-flags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-function.xml
+++ b/reference/uopz/functions/uopz-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-function" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-get-mock.xml
+++ b/reference/uopz/functions/uopz-get-mock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad6817fb4d2dba632df881eb8ab9aec5bd6544e5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.uopz-get-mock" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/uopz/functions/uopz-get-return.xml
+++ b/reference/uopz/functions/uopz-get-return.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.uopz-get-return" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/uopz/functions/uopz-implement.xml
+++ b/reference/uopz/functions/uopz-implement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c724a01a192e135bf165399d9b25caf6099482a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.uopz-implement" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-overload.xml
+++ b/reference/uopz/functions/uopz-overload.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ad6817fb4d2dba632df881eb8ab9aec5bd6544e5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-overload" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-redefine.xml
+++ b/reference/uopz/functions/uopz-redefine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-redefine" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-rename.xml
+++ b/reference/uopz/functions/uopz-rename.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-rename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-restore.xml
+++ b/reference/uopz/functions/uopz-restore.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.uopz-restore" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/uopz/functions/uopz-undefine.xml
+++ b/reference/uopz/functions/uopz-undefine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3fe33df9be38d0a1bc0d0d8fca794762278d4ea Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.uopz-undefine" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/uopz/functions/uopz-unset-mock.xml
+++ b/reference/uopz/functions/uopz-unset-mock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f47136fc2b68ada92f44fb59e1083c68355d15bf Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.uopz-unset-mock" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/uopz/setup.xml
+++ b/reference/uopz/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9a157412627e3f6dbadd76daaf20fb4011393a10 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c9490d424ec11a4fe92f07f08cff95c85c7d22df Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <chapter xml:id="uopz.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;

--- a/reference/v8js/ini.xml
+++ b/reference/v8js/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: jorgeeolayap Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: jorgeeolayap Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="v8js.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/v8js/v8js.xml
+++ b/reference/v8js/v8js.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.v8js" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -82,7 +82,7 @@
     <varlistentry xml:id="v8js.constants.flag-none">
      <term><constant>V8Js::FLAG_NONE</constant></term>
      <listitem>
-      <para>No flags.</para>
+      <para>Ningún flag.</para>
      </listitem>
     </varlistentry>
 

--- a/reference/v8js/v8jsexception.xml
+++ b/reference/v8js/v8jsexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 38e65393c58b006a923c5bb7878aee5c73e21b20 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.v8jsexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/varnish/varnishadmin.xml
+++ b/reference/varnish/varnishadmin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 816c55b8e18c5c286e5baa4570109622a0128c37 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.varnishadmin" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/varnish/varnishexception.xml
+++ b/reference/varnish/varnishexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 38e65393c58b006a923c5bb7878aee5c73e21b20 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.varnishexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/varnish/varnishlog.xml
+++ b/reference/varnish/varnishlog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.varnishlog" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/varnish/varnishstat.xml
+++ b/reference/varnish/varnishstat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 816c55b8e18c5c286e5baa4570109622a0128c37 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.varnishstat" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/wincache/ini.xml
+++ b/reference/wincache/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: seros Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="wincache.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/wkhtmltox/wkhtmltox.image.converter.xml
+++ b/reference/wkhtmltox/wkhtmltox.image.converter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f75f75dcf86e42bc79d5753836fee49ea6a97be Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.wkhtmltox-image-converter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/wkhtmltox/wkhtmltox.pdf.converter.xml
+++ b/reference/wkhtmltox/wkhtmltox.pdf.converter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f75f75dcf86e42bc79d5753836fee49ea6a97be Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.wkhtmltox-pdf-converter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/wkhtmltox/wkhtmltox.pdf.object.xml
+++ b/reference/wkhtmltox/wkhtmltox.pdf.object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f75f75dcf86e42bc79d5753836fee49ea6a97be Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.wkhtmltox-pdf-object" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/xhprof/ini.xml
+++ b/reference/xhprof/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f052ac1bd73549125c3fc3dc68a36d4b0608a16d Maintainer: jorgeolaya Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: jorgeolaya Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <section xml:id="xhprof.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/xmldiff/xmldiff.base.xml
+++ b/reference/xmldiff/xmldiff.base.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c44e9cb68b9b65771f9c45db2c07a06c63d71359 Maintainer: bng5 Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: bng5 Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.xmldiff-base" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/xmldiff/xmldiff.dom.xml
+++ b/reference/xmldiff/xmldiff.dom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: bng5 Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: bng5 Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.xmldiff-dom" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/xmldiff/xmldiff.exception.xml
+++ b/reference/xmldiff/xmldiff.exception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: bng5 Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: bng5 Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.xmldiff-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/xmldiff/xmldiff.file.xml
+++ b/reference/xmldiff/xmldiff.file.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: bng5 Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: bng5 Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.xmldiff-file" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/xmldiff/xmldiff.memory.xml
+++ b/reference/xmldiff/xmldiff.memory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: bng5 Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: bng5 Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.xmldiff-memory" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yac/yac.xml
+++ b/reference/yac/yac.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a523ff9cb9e46d86edea06f275c66f9d4c1db791 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yac" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaconf/ini.xml
+++ b/reference/yaconf/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="yaconf.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/yaconf/yaconf.xml
+++ b/reference/yaconf/yaconf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9cfadc46e7d5a27ae5cc17430f3aa5fc5dc27a04 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaconf" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-bootstrap-abstract.xml
+++ b/reference/yaf/yaf-bootstrap-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40ec84c3b39ae43075e2f98238907ae72cbd4bf8 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.yaf-bootstrap-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-config-abstract.xml
+++ b/reference/yaf/yaf-config-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d762a76c7171fc7babbe5719ebe7ca8ae9a13737 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-config-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-config-ini.xml
+++ b/reference/yaf/yaf-config-ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-config-ini" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-config-simple.xml
+++ b/reference/yaf/yaf-config-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-config-simple" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-dispatcher.xml
+++ b/reference/yaf/yaf-dispatcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-dispatcher" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-dispatchfailed.xml
+++ b/reference/yaf/yaf-exception-dispatchfailed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-dispatchfailed" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-loadfailed-action.xml
+++ b/reference/yaf/yaf-exception-loadfailed-action.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-loadfailed-action" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-loadfailed-controller.xml
+++ b/reference/yaf/yaf-exception-loadfailed-controller.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-loadfailed-controller" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-loadfailed-module.xml
+++ b/reference/yaf/yaf-exception-loadfailed-module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-loadfailed-module" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-loadfailed-view.xml
+++ b/reference/yaf/yaf-exception-loadfailed-view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-loadfailed-view" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-loadfailed.xml
+++ b/reference/yaf/yaf-exception-loadfailed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-loadfailed" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-routerfailed.xml
+++ b/reference/yaf/yaf-exception-routerfailed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-routerfailed" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-startuperror.xml
+++ b/reference/yaf/yaf-exception-startuperror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-startuperror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception-typeerror.xml
+++ b/reference/yaf/yaf-exception-typeerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception-typeerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-exception.xml
+++ b/reference/yaf/yaf-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-plugin-abstract.xml
+++ b/reference/yaf/yaf-plugin-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40ec84c3b39ae43075e2f98238907ae72cbd4bf8 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.yaf-plugin-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-registry.xml
+++ b/reference/yaf/yaf-registry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-registry" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-request-http.xml
+++ b/reference/yaf/yaf-request-http.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.yaf-request-http" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-response-cli.xml
+++ b/reference/yaf/yaf-response-cli.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1f71c647dd6e32a7e4f03c33bac449c69ed2135b Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-response-cli" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-response-http.xml
+++ b/reference/yaf/yaf-response-http.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1f71c647dd6e32a7e4f03c33bac449c69ed2135b Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-response-http" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-route-interface.xml
+++ b/reference/yaf/yaf-route-interface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e434bf67baea73fa96b65c9b1021e30b97abacd3 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-route-interface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-route-map.xml
+++ b/reference/yaf/yaf-route-map.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.yaf-route-map" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-route-regex.xml
+++ b/reference/yaf/yaf-route-regex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-route-regex" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-route-rewrite.xml
+++ b/reference/yaf/yaf-route-rewrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-route-rewrite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-route-simple.xml
+++ b/reference/yaf/yaf-route-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: aeoris Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: aeoris Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-route-simple" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-route-supervar.xml
+++ b/reference/yaf/yaf-route-supervar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-route-supervar" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-router.xml
+++ b/reference/yaf/yaf-router.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.yaf-router" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-session.xml
+++ b/reference/yaf/yaf-session.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-session" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-view-interface.xml
+++ b/reference/yaf/yaf-view-interface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40ec84c3b39ae43075e2f98238907ae72cbd4bf8 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <reference xml:id="class.yaf-view-interface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-view-simple.xml
+++ b/reference/yaf/yaf-view-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-view-simple" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4966eedcbc8d5ae4dd7043ee14cec170e321406b Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <appendix xml:id="yar.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yar/ini.xml
+++ b/reference/yar/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: seros Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <section xml:id="yar.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/yar/yar-client-exception.xml
+++ b/reference/yar/yar-client-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-client-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-client-packager-exception.xml
+++ b/reference/yar/yar-client-packager-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-client-packager-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-client-protocol-exception.xml
+++ b/reference/yar/yar-client-protocol-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-client-protocol-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-client-transport-exception.xml
+++ b/reference/yar/yar-client-transport-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-client-transport-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-client.xml
+++ b/reference/yar/yar-client.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-concurrent-client.xml
+++ b/reference/yar/yar-concurrent-client.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-concurrent-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-server-exception.xml
+++ b/reference/yar/yar-server-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-server-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-server-output-exception.xml
+++ b/reference/yar/yar-server-output-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-server-output-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-server-packager-exception.xml
+++ b/reference/yar/yar-server-packager-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-server-packager-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-server-protocol-exception.xml
+++ b/reference/yar/yar-server-protocol-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-server-protocol-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-server-request-exception.xml
+++ b/reference/yar/yar-server-request-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-server-request-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yar/yar-server.xml
+++ b/reference/yar/yar-server.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yar-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/zookeeper/zookeeperauthenticationexception.xml
+++ b/reference/zookeeper/zookeeperauthenticationexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeeperauthenticationexception"

--- a/reference/zookeeper/zookeeperconfig.xml
+++ b/reference/zookeeper/zookeeperconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6c496422f00c59985b8d233cfa2e43d9ba2b3053 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeeperconfig"

--- a/reference/zookeeper/zookeeperconnectionexception.xml
+++ b/reference/zookeeper/zookeeperconnectionexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeeperconnectionexception"

--- a/reference/zookeeper/zookeeperexception.xml
+++ b/reference/zookeeper/zookeeperexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeeperexception"

--- a/reference/zookeeper/zookeepermarshallingexception.xml
+++ b/reference/zookeeper/zookeepermarshallingexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeepermarshallingexception"

--- a/reference/zookeeper/zookeepernonodeexception.xml
+++ b/reference/zookeeper/zookeepernonodeexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeepernonodeexception"

--- a/reference/zookeeper/zookeeperoperationtimeoutexception.xml
+++ b/reference/zookeeper/zookeeperoperationtimeoutexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeeperoperationtimeoutexception"

--- a/reference/zookeeper/zookeepersessionexception.xml
+++ b/reference/zookeeper/zookeepersessionexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeepersessionexception"


### PR DESCRIPTION
Actualiza el hash EN-Revision de 351 ficheros para alinearlos con doc-en master.

Cambios estructurales sin modificación del contenido traducido:

- `phpdoc:classref` → `<reference role="class">` (renombrado de etiqueta DocBook)
- `<para>...</para>` → `<simpara>...</simpara>` cuando solo contiene texto inline
- Eliminación del envoltorio `<para>` alrededor de `<informaltable>`
- Orden de union types en `methodsynopsis` (string|null en vez de null|string)
- `PHP_INI_X` → `<constant>INI_X</constant>` en tablas de configuración
- `Constants` → `&Constants;` en `classsynopsisinfo role="comment"`

Complemento de #602 (traducción de residuos EN/FR), separado para facilitar la revisión.