### PR TITLE
[Sync EN] proc_close: clarify termination status in regard to proc_get_status

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 350d95443aeb0ea8751d71f262aac56d3ad48f83 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ef623ccf442df416da4e5bc254b4c5d4f6df9475 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
@@ -52,7 +52,29 @@
   </para>
   &note.sigchild;
  </refsect1>
-
+  <refsect1 role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        <function>proc_close</function> ahora devuelve el código de salida correcto
+        incluso cuando se ha llamado previamente a <function>proc_get_status</function>.
+        Anteriormente se devolvía <literal>-1</literal> en ese caso.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Sync de php/doc-en#5483.

Fixes #606