### PR TITLE
[Sync EN] hash: Fix changelog to mention E_WARNING

### DIFF
--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.hash-hmac-file" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -112,7 +112,7 @@
         Levanta una excepción <classname>ValueError</classname> a partir de ahora si
         el parámetro <parameter>algo</parameter> es desconocido o no es
         una función de hash criptográfica; previamente, &false;
-        era devuelto en su lugar.
+        era devuelto y se emitía un mensaje <constant>E_WARNING</constant>.
        </entry>
       </row>
      </tbody>

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.hash-hmac" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -103,7 +103,8 @@
         <function>hash_hmac</function> ahora levanta una excepción
         <classname>ValueError</classname> si el <parameter>algo</parameter>
         es desconocido o no es una función de hash criptográfica ;
-        anteriormente, &false; era retornado en su lugar.
+        anteriormente, &false; era retornado y se emitía un mensaje
+        <constant>E_WARNING</constant>.
        </entry>
       </row>
       <row>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.hash" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -72,6 +72,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lanza una excepción <exceptionname>ValueError</exceptionname> si
+   <parameter>algo</parameter> es desconocido.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -91,9 +99,9 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        <function>hash</function> ahora lanza una excepción
-        <classname>ValueError</classname> si el <parameter>algo</parameter>
-        es desconocido; anteriormente, &false; era devuelto en su lugar.
+        Ahora lanza una excepción <exceptionname>ValueError</exceptionname>
+        si <parameter>algo</parameter> es desconocido; anteriormente, &false;
+        era devuelto y se emitía un mensaje <constant>E_WARNING</constant>.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Sync with php/doc-en#5271.

Fixes #617