### PR TITLE
[Sync EN] IntlChar::digit: add literal tags, amend example

### DIFF
--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e166139c786f6fd72a5f856c14027a3c22a8ce7a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlchar.digit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -18,14 +18,32 @@
    Devuelve el valor decimal del punto de código en la base de numeración especificada.
   </para>
   <para>
-   Si la base de numeración no está en el rango <literal>2&lt;=radix&lt;=36</literal> o si el valor de <parameter>codepoint</parameter>
+   Si la base de numeración no está en el rango <literal>2 &lt;= radix &lt;= 36</literal> o
+   si el valor de <parameter>codepoint</parameter>
    no es un dígito válido en la base especificada, &false; es devuelto.
    Un carácter es un dígito válido si al menos una de las condiciones siguientes es verdadera:
    <simplelist>
-    <member>El carácter tiene un valor de dígito decimal. Estos caracteres tienen la categoría general "Nd" (dígitos decimales) y un Numeric_Type de Decimal. En este caso, el valor es el valor de dígito decimal del carácter.</member>
-    <member>El carácter es una de las letras latinas mayúsculas 'A' a 'Z'. En este caso, el valor es c-'A'+10.</member>
-    <member>El carácter es una de las letras latinas minúsculas 'a' a 'z'. En este caso, el valor es c-'a'+10.</member>
-    <member>Las letras latinas del rango ASCII (0061..007A, 0041..005A) así como del rango ASCII de ancho completo (FF41..FF5A, FF21..FF3A) son reconocidas.</member>
+    <member>
+     El carácter tiene un valor de dígito decimal. Estos caracteres tienen
+     la categoría general "Nd" (dígitos decimales) y un Numeric_Type de "Decimal".
+     En este caso, el valor es el valor de dígito decimal del carácter.
+    </member>
+    <member>
+     El carácter es una de las letras latinas
+     mayúsculas <literal>'A'</literal> a <literal>'Z'</literal>.
+     En este caso, el valor es <literal>codepoint - 'A' + 10</literal>.
+    </member>
+    <member>
+     El carácter es una de las letras latinas
+     minúsculas <literal>'a'</literal> a <literal>'z'</literal>.
+     En este caso, el valor es <literal>codepoint - 'a' + 10</literal>.
+    </member>
+    <member>
+     Las letras latinas del rango ASCII (<literal>0061..007A</literal>,
+     <literal>0041..005A</literal>) así como
+     del rango ASCII de ancho completo (<literal>FF41..FF5A</literal>,
+     <literal>FF21..FF3A</literal>) son reconocidas.
+    </member>
    </simplelist>
   </para>
  </refsect1>
@@ -66,10 +84,13 @@
    <programlisting role="php">
     <![CDATA[
 <?php
+
 var_dump(IntlChar::digit("0"));
 var_dump(IntlChar::digit("3"));
-var_dump(IntlChar::digit("A"));
+
 var_dump(IntlChar::digit("A", 16));
+var_dump(IntlChar::digit("A"));
+
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
Sync with https://github.com/php/doc-en/pull/3595.

Fixes #628