### PR TITLE
[Sync EN] Closure: mention non-serializability of Closure objects

### DIFF
--- a/language/predefined/closure.xml
+++ b/language/predefined/closure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d74f3573b3831b2db8f31f774cff32eb8560ba6e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: a97672ab04d97f510faee2abe8d961014f77f96d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: PhilDaiguille -->
 <reference xml:id="class.closure" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -72,6 +72,17 @@
      </tbody>
     </tgroup>
    </informaltable>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   <note>
+    <simpara>
+     Los objetos <classname>Closure</classname> no pueden ser serializados,
+     ya que los cierres pueden contener variables vinculadas y un contexto de ejecución específico.
+     Intentar serializar un cierre lanzará una <exceptionname>Exception</exceptionname>.
+    </simpara>
+   </note>
   </section>
 
  </partintro>


### PR DESCRIPTION
Sync with https://github.com/php/doc-en/pull/5363.

Fixes #630