### PR TITLE
[Sync EN] ext/reflection: Remove incorrect null in canbepassedbyvalue / gettraits

### DIFF
--- a/reference/reflection/reflectionclass/gettraits.xml
+++ b/reference/reflection/reflectionclass/gettraits.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ca840c9a6d665e60a7de48b57a5b6440c0d3b0c1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 93906cd3b6cf8f7217503dba4d994a1ebd32d4ac Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionclass.gettraits" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
+++ b/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 93906cd3b6cf8f7217503dba4d994a1ebd32d4ac Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionparameter.canbepassedbyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Sync de doc-en@93906cd3 (php/doc-en#5563). Les fichiers ES étaient déjà au format cible (simpara, sans la mention "null"), seul le hash EN-Revision et le Maintainer sont mis à jour.

Fixes #635