### PR TITLE
[Sync EN] pdo_cubrid: fix typo in connection notes

### DIFF
--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 59ce48edd7eb51e3f9bc19828386ce053dd95690 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e3654dc683c7a5b73df80549057ddbfceea00266 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="ref.pdo-cubrid"><?phpdoc extension-membership="pecl" ?>
  <title>Funciones del controlador PDO CUBRID (PDO_CUBRID)</title>


### PR DESCRIPTION
Sync the EN-Revision hash for `reference/pdo_cubrid/reference.xml` to pick up the typo fix from php/doc-en#3360. The Spanish translation already used the correct verb, so only the hash bump is needed.

Fixes #638