### PR TITLE
[Sync EN] Add PHP 8.5.0 deprecation changelog entries (#5369)

### DIFF
--- a/reference/fileinfo/functions/finfo-buffer.xml
+++ b/reference/fileinfo/functions/finfo-buffer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 82ddd2ec8ad195035dcb57dd8f97d27b83ddc126 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.finfo-buffer">
  <refnamediv>
@@ -84,6 +84,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       El parámetro <parameter>context</parameter> ha quedado obsoleto
+       puesto que es ignorado.
+      </entry>
+     </row>
      &fileinfo.changelog.finfo-object;
      <row>
       <entry>8.0.0</entry>

--- a/reference/reflection/reflectionclass/getconstant.xml
+++ b/reference/reflection/reflectionclass/getconstant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionclass.getconstant" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -40,6 +40,29 @@
    Valor de la constante con el nombre <parameter>name</parameter>.
    Devuelve &false; si la constante no ha sido encontrada en la clase.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       La llamada a <methodname>ReflectionClass::getConstant</methodname>
+       para constantes que no existen ha quedado obsoleta.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionmethod/setaccessible.xml
+++ b/reference/reflection/reflectionmethod/setaccessible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="reflectionmethod.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -50,6 +50,35 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Este método ha quedado obsoleto, ya que no tiene efecto.
+      </entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       La llamada a este método no tiene ningún efecto; todos los métodos
+       son invocables por defecto.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f89eee340331eb13a38a95ea64f47dfe866d46e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionproperty.getdefaultvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -31,6 +31,29 @@
    un &null; por defecto de una propiedad tipada no inicializada.
    Utilizar <methodname>ReflectionProperty::hasDefaultValue</methodname> para detectar la diferencia.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       La llamada a <methodname>ReflectionProperty::getDefaultValue</methodname>
+       para propiedades sin valor por defecto ha quedado obsoleta.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionproperty/setaccessible.xml
+++ b/reference/reflection/reflectionproperty/setaccessible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="reflectionproperty.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,6 +51,35 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Este método ha quedado obsoleto, ya que no tiene efecto.
+      </entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       La llamada a este método no tiene ningún efecto; todas las propiedades
+       son accesibles por omisión.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/functions/spl-autoload-unregister.xml
+++ b/reference/spl/functions/spl-autoload-unregister.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 60809ebcf7d0c261b2f00e093e4fab70326ffc7b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.spl-autoload-unregister" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -47,6 +47,32 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Pasar la función <function>spl_autoload_call</function> como
+       argumento callback para desregistrar todos los autoloaders ha
+       quedado obsoleto. En su lugar, iterar sobre el valor de retorno
+       de <function>spl_autoload_functions</function> y llamar a
+       <function>spl_autoload_unregister</function> para cada valor.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a0d62151102e4bf83e2bb4068782757d20ba086d Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.attach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -57,6 +57,29 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Este método ha quedado obsoleto en favor de
+       <methodname>SplObjectStorage::offsetSet</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/splobjectstorage/contains.xml
+++ b/reference/spl/splobjectstorage/contains.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,6 +44,29 @@
   <para>
    Devuelve &true; si el <type>object</type> está en el almacenamiento, en caso contrario &false;.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Este método ha quedado obsoleto en favor de
+       <methodname>SplObjectStorage::offsetExists</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/splobjectstorage/detach.xml
+++ b/reference/spl/splobjectstorage/detach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.detach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,6 +44,29 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Este método ha quedado obsoleto en favor de
+       <methodname>SplObjectStorage::offsetUnset</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/strings/functions/chr.xml
+++ b/reference/strings/functions/chr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.chr">
  <refnamediv>
@@ -77,6 +77,13 @@ $bytevalue %= 256;
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Pasar enteros fuera del intervalo <literal>[0, 255]</literal>
+       ha quedado obsoleto.
+      </entry>
+     </row>
      <row>
       <entry>7.4.0</entry>
       <entry>

--- a/reference/strings/functions/ord.xml
+++ b/reference/strings/functions/ord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.ord">
  <refnamediv>
@@ -51,6 +51,28 @@
   <para>
    Un &integer; entre 0 y 255.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Pasar un string que no sea un único byte ha quedado obsoleto.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Sync the 8.5.0 deprecation changelog entries from php/doc-en#5369: `finfo_buffer` `\$context` parameter, `ReflectionClass::getConstant`, `ReflectionMethod::setAccessible`, `ReflectionProperty::setAccessible`, `ReflectionProperty::getDefaultValue`, `SplObjectStorage::attach`/`contains`/`detach`, `spl_autoload_unregister`, `chr` and `ord`.

Fixes #639