### PR TITLE
[Sync EN] SAPI: Document 8.5 CLI SAPI changes (#5077)

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -271,7 +271,6 @@ Uso: php [opciones] [-f] <archivo> [--] [args...]
   -s               Salida de sintaxis HTML resaltada.
   -v               Número de versión
   -w               Salida de código fuente con comentarios y espacios en blanco eliminados.
-  -z <archivo>     Cargar la extensión Zend <archivo>.
 
   args...          Argumentos pasados al script. Usar -- args cuando el primer argumento
                    comienza con - o el script se lee desde stdin
@@ -686,20 +685,13 @@ Zend Engine v2.3.0, Copyright (c) 1998-2009 Zend Technologies
        </entry>
       </row>
       <row>
-       <entry>-z</entry>
-       <entry>--zend-extension</entry>
-       <entry>
-        <para>
-         Carga una extensión Zend. Si y solo si se proporciona un archivo, PHP intentará cargar esta extensión en el directorio predeterminado de las bibliotecas en su sistema (generalmente especificado con <filename>/etc/ld.so.conf</filename> en Linux, por ejemplo). Pasar un nombre de archivo con la ruta completa hará que PHP use este archivo, sin buscar en los directorios habituales. Una ruta de directorio relativa, que incluya información sobre el directorio, indicará a PHP que debe buscar las extensiones solo en ese directorio.
-        </para>
-       </entry>
-      </row>
-      <row>
        <entry></entry>
        <entry>--ini</entry>
        <entry>
         <para>
          Muestra los nombres de los archivos de configuración y los directorios analizados.
+         Opcionalmente, pasar <literal>--ini=diff</literal> para mostrar las diferencias
+         entre los archivos de configuración cargados y la configuración por omisión.
          <example>
           <title>Ejemplo con <literal>--ini</literal></title>
           <programlisting role="shell">
@@ -712,6 +704,11 @@ Additional .ini files parsed:      (none)
 ]]>
           </programlisting>
          </example>
+         <note>
+          <simpara>
+           La opción <literal>--ini=diff</literal> no está disponible antes de PHP 8.5.0.
+          </simpara>
+         </note>
         </para>
        </entry>
       </row>

--- a/reference/info/functions/cli-get-process-title.xml
+++ b/reference/info/functions/cli-get-process-title.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a331ac8a86bb5929b79be9a369fac1e3af516241 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.cli-get-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/info/functions/cli-set-process-title.xml
+++ b/reference/info/functions/cli-set-process-title.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2df224f44552cfc88fad705cca33c4cdb01d62ed Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.cli-set-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,12 +16,12 @@
    <methodparam><type>string</type><parameter>title</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Define el título del proceso visible con herramientas como
    <command>top</command> y <command>ps</command>. Esta función
    solo está disponible en modo
    <link linkend="features.commandline">CLI</link>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -31,9 +31,9 @@
    <varlistentry>
     <term><parameter>title</parameter></term>
     <listitem>
-     <para>
-      El nuevo título
-     </para>
+     <simpara>
+      El nuevo título.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -41,26 +41,48 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
 
-  <para>
+  <simpara>
    Se generará una alerta de nivel <constant>E_WARNING</constant> si el sistema
    subyacente no es compatible.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <function>cli_set_process_title</function> ahora emite una
+       alerta <constant>E_WARNING</constant> al definir un título de
+       proceso demasiado largo; antes el título era truncado.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Ejemplo con <function>cli_set_process_title</function></title>
-    <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $title = "Mi super script PHP";
@@ -75,18 +97,15 @@ if (!cli_set_process_title($title)) {
 }
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </informalexample>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>cli_get_process_title</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>cli_get_process_title</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Sync CLI SAPI documentation for PHP 8.5 from php/doc-en#5077: drop removed `-z/--zend-extension` option, document the new `--ini=diff` flag and add the `cli_set_process_title` truncation warning changelog entry.

Fixes #640