### PR TITLE
[Sync EN] IntlChar::digit: fix example output (#5566)

### DIFF
--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e166139c786f6fd72a5f856c14027a3c22a8ce7a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: fe67f9ad47e7f04f50c4ec1366bdbcbd8ab940f2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlchar.digit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -99,8 +99,8 @@ var_dump(IntlChar::digit("A"));
     <![CDATA[
 int(0)
 int(3)
-bool(false)
 int(10)
+bool(false)
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
Sync the corrected output ordering from php/doc-en#5566 for `IntlChar::digit`.

Fixes #641