### PR TITLE
[Sync EN] ini/display_errors: clarify possible values and bundled INI defaults

### DIFF
--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e5ff446c832aded712d45c885609ffdd277e6a49 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -212,16 +212,34 @@
      <para>
       Esta directiva determina si los errores deben ser
       mostrados en pantalla o no.
+      <itemizedlist>
+       <listitem>
+        <simpara>
+         <literal>Off</literal> : no mostrar ningún error.
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>On</literal> o <literal>stdout</literal> : mostrar los errores a <literal>stdout</literal>. Es el valor por omisión.
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>stderr</literal> : mostrar los errores a <literal>stderr</literal>. Solamente efectivo en las SAPIs <literal>CLI</literal>, <literal>phpdbg</literal> y <literal>CGI</literal>.
+        </simpara>
+       </listitem>
+      </itemizedlist>
      </para>
-     <para>
-      El valor <literal>"stderr"</literal> envía los errores a <literal>stderr</literal>
-      en lugar de a <literal>stdout</literal>.
-     </para>
+     <simpara>
+      El <literal>php.ini-development</literal> empaquetado lo define en
+      <literal>On</literal>; <literal>php.ini-production</literal> lo
+      define en <literal>Off</literal>.
+     </simpara>
      <note>
-      <para>
+      <simpara>
        Es una directiva necesaria en desarrollo, pero que nunca debe ser utilizada
        en un sistema en producción. (ej. sistemas conectados a Internet).
-      </para>
+      </simpara>
      </note>
      <note>
       <para>


### PR DESCRIPTION
Sync `reference/errorfunc/ini.xml` to the state after php/doc-en#5486 and the two related listitem/para fixes: list the possible values for `display_errors`, mention what the bundled `php.ini-development` and `php.ini-production` set, and align the note structure with EN.

Fixes #642
Fixes #643
Fixes #644