### PR TITLE
Sync EN: mención de LiteSpeed SAPI en funciones de Apache y migración 7.4 (#4922)

### DIFF
--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 90242f8793566eb87ee35a989912310a7c7c132b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration74.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Otros cambios</title>
@@ -195,7 +195,7 @@
    </listitem>
 
    <listitem>
-    <simpara>Litespeed:</simpara>
+    <simpara>LiteSpeed:</simpara>
     <itemizedlist>
      <listitem>
       <simpara>

--- a/reference/apache/book.xml
+++ b/reference/apache/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 46a9cdd2dbef4ec89bf65fad9930e2feb78bbb98 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -10,9 +10,11 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.apache">
   &reftitle.intro;
-  <para>
-   Estas funciones sólo están disponibles cuando se ejecuta PHP como módulo de Apache.
-  </para>
+  <simpara>
+   Estas funciones están disponibles cuando se ejecuta PHP como módulo de Apache.
+   Algunas funciones pueden estar disponibles al ejecutarse con las API de otros
+   servidores web. Consulte la documentación de cada función para más detalles.
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68e52ef14de33f6752a8fdda1ae83c861c5babdb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.apache-request-headers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <type>array</type><methodname>apache_request_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Recupera todos los encabezados HTTP de la petición actual.
-   Funciona con los servidores web Apache, FastCGI, CLI, y FPM.
-  </para>
+   Funciona con los servidores web Apache, LiteSpeed, FastCGI, CLI, y FPM.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un array asociativo con todos los encabezados HTTP de la petición actual.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -90,13 +90,13 @@ Connection: Keep-Alive
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     También pueden obtenerse los valores de las variables <acronym>CGI</acronym> comunes
     leyéndolas en el entorno, lo cual funciona, ya sea en módulo <productname>Apache</productname>
     o no. Utilice la función <function>phpinfo</function> para conocer la lista de
     <link linkend="language.variables.predefined">variables de entorno</link>
     disponibles.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/apache/functions/apache-response-headers.xml
+++ b/reference/apache/functions/apache-response-headers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68e52ef14de33f6752a8fdda1ae83c861c5babdb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.apache-response-headers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,10 +14,10 @@
    <type>array</type><methodname>apache_response_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Recupera todos los encabezados de respuesta HTTP.
-   Funciona con los servidores web Apache, FastCGI, CLI y FPM.
-  </para>
+   Funciona con los servidores web Apache, LiteSpeed, FastCGI, CLI y FPM.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un array de todos los encabezados de respuesta de Apache en caso de éxito.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Sincronización con php/doc-en#4922 (parte portable a ES): apache_request_headers/apache_response_headers ahora mencionan LiteSpeed, se actualiza la descripción de book.xml y la grafía «LiteSpeed» en migration74; para -> simpara. Los nuevos archivos de la extensión litespeed (book/funciones/setup) y appendices/extensions.xml no entran en esta sincronización.

Fixes #653