### PR TITLE
Sync EN: grapheme_strlen documenta el retorno null en caso de fallo (#5568)

### DIFF
--- a/reference/intl/grapheme/grapheme-strlen.xml
+++ b/reference/intl/grapheme/grapheme-strlen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b548fc8e5592b577d29aabf9cf2e79d5385ae549 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e7d502fecc2e84d4c57e6451b16f68bec1295ba8 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.grapheme-strlen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -39,9 +39,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   La longitud de la cadena en caso de éxito, &return.falseforfailure;.
-  </para>
+  <simpara>
+   La longitud de la cadena en caso de éxito, &null; o &false; en caso de fallo.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Sincronización con php/doc-en#5568 : el valor de retorno aclara que <function>grapheme_strlen</function> devuelve &null; o &false; en caso de fallo; para -> simpara.

Fixes #652