### PR TITLE
Sync EN: imagecopyresampled añade la entrada de changelog 8.5.0 del tipo de retorno (#5291)

### DIFF
--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 16b6c3466bb70f2300b236273003f509638ebb90 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagecopyresampled" xmlns="http://docbook.org/ns/docbook">
@@ -146,6 +146,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       El tipo de retorno es ahora &true;; anteriormente, era <type>bool</type>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Sincronización con php/doc-en#5291. Añade la fila de changelog 8.5.0 (el tipo de retorno ahora es &true;).

Fixes #657