### PR TITLE
Sync EN: referencia el atributo DelayedTargetValidation en attributes.xml (#5457)

### DIFF
--- a/language/predefined/attributes.xml
+++ b/language/predefined/attributes.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: efda0bb311990257715bd3a41ab2b04769ce2e4e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <part xml:id="reserved.attributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Atributos predefinidos</title>
 
  <partintro>
-  <para>
+  <simpara>
    PHP proporciona atributos predefinidos que pueden ser utilizados.
-  </para>
+  </simpara>
  </partintro>
 
  &language.predefined.attributes.attribute;
  &language.predefined.attributes.allowdynamicproperties;
+ &language.predefined.attributes.delayedtargetvalidation;
  &language.predefined.attributes.deprecated;
  &language.predefined.attributes.nodiscard;
  &language.predefined.attributes.override;


### PR DESCRIPTION
Sincronización con php/doc-en#5457. Añade la referencia a la entidad del nuevo atributo DelayedTargetValidation (PHP 8.5) y sigue el cambio para->simpara del EN. El archivo delayedtargetvalidation.xml queda sin traducir (recae en EN), fuera del alcance de esta sincronización.

Fixes #656