### PR TITLE
[Sync EN] intl: getBestPattern returns an ICU date/time pattern for IntlDateFormatter

### DIFF
--- a/reference/intl/intldatepatterngenerator/getbestpattern.xml
+++ b/reference/intl/intldatepatterngenerator/getbestpattern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5b6663923676dd3f48bdc916a6a2de651fd959b2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intldatepatterngenerator.getbestpattern" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve un formato, aceptado por <methodname>DateTimeInterface::format</methodname> en caso de éxito, &return.falseforfailure;.
-  </para>
+  <simpara>
+   Devuelve un patrón de fecha/hora ICU aceptado por <classname>IntlDateFormatter</classname> en caso de éxito, &return.falseforfailure;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
php/doc-en#5567

Fixes #668