### PR TITLE
[Sync EN] intl: add IntlTimeZone::getIanaID translation (PHP 8.4)

### DIFF
--- a/reference/intl/intltimezone/getianaid.xml
+++ b/reference/intl/intltimezone/getianaid.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3f1722ae51abab1a1ee5fde3ada01fe5cbb87f36 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="intltimezone.getianaid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlTimeZone::getIanaID</refname>
+  <refname>intltz_get_iana_id</refname>
+  <refpurpose>Traduce un identificador de zona horaria a su equivalente IANA</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>&style.oop; (método):</simpara>
+  <methodsynopsis role="IntlTimeZone">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlTimeZone::getIanaID</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>&style.procedural;:</simpara>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_iana_id</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Traduce un identificador de zona horaria a su equivalente IANA. Por ejemplo,
+   <literal>"GMT"</literal> devuelve <literal>"Etc/GMT"</literal>, y
+   <literal>"US/Eastern"</literal> devuelve <literal>"America/New_York"</literal>.
+  </simpara>
+  <note>
+   <simpara>
+    Esta función requiere ICU versión &gt;= 74.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+ <variablelist>
+  <varlistentry>
+   <term><parameter>timezoneId</parameter></term>
+   <listitem>
+    <simpara>
+     El identificador de la zona horaria a traducir.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el identificador de zona horaria IANA como &string;, o &false; en caso de fallo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+ <simplelist>
+  <member><function>intltz_get_id_for_windows_id</function></member>
+  <member><function>intltz_get_windows_id</function></member>
+  <member><function>intltz_create_time_zone</function></member>
+ </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
php/doc-en#5353

Fixes #667