### PR TITLE
[Sync EN] Fix spelling typos across the manual

### DIFF
--- a/chmonly/integration.xml
+++ b/chmonly/integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lboshell Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lboshell Status: ready -->
  <chapter xml:id="chm.integration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Integración del manual de PHP</title>
 
@@ -36,7 +36,7 @@
    contenido de la ayuda es almacenado en archivos HTML, puede desplegar páginas del CHM
    en Internet Explorer.
   </para>
-  <para>
+  <simpara>
    Asumiendo que usted colocó su archivo <filename>php_manual_en.chm</filename> en
    <filename>c:\phpmanual</filename>, el archivo índice del manual (aquel
    que ve la primera vez) puede ser consultado con la siguiente URL:
@@ -46,7 +46,7 @@
    ruta completa. La parte <filename>/_index.html</filename> es la ruta al
    archivo índice dentro del CHM y <literal>::</literal> es simplemente lo que necesita
    colocar entre la ruta CHM y ésta ruta de archivo.
-  </para>
+  </simpara>
   <para>
    <note>
     <para>

--- a/reference/cmark/commonmark.cql.xml
+++ b/reference/cmark/commonmark.cql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 876a6a393125efc9d771cebdae1c02fec37c8ef7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.commonmark-cql" role="class">
 

--- a/reference/dom/domdocument/getelementbyid.xml
+++ b/reference/dom/domdocument/getelementbyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="domdocument.getelementbyid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -17,7 +17,7 @@
    <xref linkend="domdocument.getelementsbytagname"/>
    pero busca un elemento con un identificador dado.
   </para>
-  <para>
+  <simpara>
    Para que esta función funcione, es necesario definir los atributos ID
    con <xref linkend="domelement.setidattribute"/>
    o definir una DTD que defina un atributo que debe ser de tipo ID.
@@ -25,7 +25,7 @@
    <xref linkend="domdocument.validate"/>
    o <link linkend="domdocument.props.validateonparse">DOMDocument::$validateOnParse</link>
    antes de utilizar esta función.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/dom/domnode/removechild.xml
+++ b/reference/dom/domnode/removechild.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d5c74c9a561dc63be999694ee65195bef1550a0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="domnode.removechild" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <modifier>public</modifier> <type class="union"><type>DOMNode</type><type>false</type></type><methodname>DOMNode::removeChild</methodname>
    <methodparam><type>DOMNode</type><parameter>child</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Esta función elimina un hijo de la lista de hijos.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/ds/ds/deque/contains.xml
+++ b/reference/ds/ds/deque/contains.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-deque.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/ds/ds/deque/rotate.xml
+++ b/reference/ds/ds/deque/rotate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-deque.rotate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/ds/ds/sequence/contains.xml
+++ b/reference/ds/ds/sequence/contains.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-sequence.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/ds/ds/sequence/rotate.xml
+++ b/reference/ds/ds/sequence/rotate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-sequence.rotate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/ds/ds/vector/contains.xml
+++ b/reference/ds/ds/vector/contains.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-vector.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -59,7 +59,7 @@ var_dump($vector->contains(...['c', 'b', 'a'])); // true
 var_dump($vector->contains(1));                  // true
 var_dump($vector->contains('1'));                // false
 
-var_dump($sequece->contains(...[]));               // true
+var_dump($vector->contains(...[]));               // true
 ?>
 ]]>
    </programlisting>

--- a/reference/ds/ds/vector/rotate.xml
+++ b/reference/ds/ds/vector/rotate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-vector.rotate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/ev/ev/feedsignal.xml
+++ b/reference/ev/ev/feedsignal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.feedsignal">
  <refnamediv>

--- a/reference/ev/ev/now.xml
+++ b/reference/ev/ev/now.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.now">
  <refnamediv>

--- a/reference/ev/ev/resume.xml
+++ b/reference/ev/ev/resume.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.resume">
  <refnamediv>

--- a/reference/ev/ev/suspend.xml
+++ b/reference/ev/ev/suspend.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.suspend">
  <refnamediv>

--- a/reference/ev/evprepare/createstopped.xml
+++ b/reference/ev/evprepare/createstopped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evprepare.createstopped">
  <refnamediv>

--- a/reference/ev/evsignal/createstopped.xml
+++ b/reference/ev/evsignal/createstopped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evsignal.createstopped">
  <refnamediv>

--- a/reference/ev/watcher-callbacks.xml
+++ b/reference/ev/watcher-callbacks.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.watcher-callbacks">
  <title>Las funciones de retrollamada de un Watcher</title>
@@ -59,7 +59,7 @@
   función de retrollamada para varios watchers. La máscara de eventos
   se nombra según el tipo, es decir,
   <classname>EvChild</classname> (o <methodname>EvLoop::child</methodname>) define
-  <constant>EV::CHILD</constant>, <classname>EvPrepare</classname> (o
+  <constant>Ev::CHILD</constant>, <classname>EvPrepare</classname> (o
   <methodname>EvLoop::prepare</methodname>) define <constant>Ev::PREPARE</constant>,
   <classname>EvPeriodic</classname> (o <methodname>EvLoop::periodic</methodname>)
   define <constant>Ev::PERIODIC</constant> y así sucesivamente, con la excepción de los

--- a/reference/event/eventbuffer/pullup.xml
+++ b/reference/event/eventbuffer/pullup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbuffer.pullup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/event/eventbufferevent/sslerror.xml
+++ b/reference/event/eventbufferevent/sslerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9ee27f088aefb55de20529000792c4deefc0226b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbufferevent.sslerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/event/eventdnsbase.xml
+++ b/reference/event/eventdnsbase.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.eventdnsbase" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -10,11 +10,11 @@
 <!-- {{{ EventDnsBase intro -->
   <section xml:id="eventdnsbase.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Representa la estructura base DNS de Libevent. Utilizada para
     resolver DNS de forma asíncrona, para analizar ficheros
     de configuración como resolv.conf etc.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
   <section xml:id="eventdnsbase.synopsis">

--- a/reference/event/eventhttprequest/senderror.xml
+++ b/reference/event/eventhttprequest/senderror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 59a1bbcb6f7a1e74a640d7ec2890cc6a12f19b52 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventhttprequest.senderror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -47,9 +47,9 @@
      <parameter>reason</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Una breve explicación del error. Si es &null;, se utilizará el significado estándar del código de error.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="event.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/fann/functions/fann-get-cascade-output-change-fraction.xml
+++ b/reference/fann/functions/fann-get-cascade-output-change-fraction.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: seros Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-cascade-output-change-fraction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -30,9 +30,9 @@
    Si la fracción de cambio de salida en cascada es baja, las conexiones de salida serán entrenadas más, y si la fracción es alta,
    serán entrenadas menos.
   </para>
-  <para>
+  <simpara>
    La fracción de cambio de salida en cascada predeterminada es 0.01, que es equivalente a un cambio del 1% en el ECM.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/fann/functions/fann-get-layer-array.xml
+++ b/reference/fann/functions/fann-get-layer-array.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ea7caabb165509dbf6796bbf07d697f871c462c2 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-layer-array" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un array de números de neuronas en cada capa.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/fann/functions/fann-get-num-layers.xml
+++ b/reference/fann/functions/fann-get-num-layers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: seros Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-num-layers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El número de capas de la red neuronal, o &false; en caso de error.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/imagick/imagick/forwardfouriertransformimage.xml
+++ b/reference/imagick/imagick/forwardfouriertransformimage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="imagick.forwardfouriertransformimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/intl/intlcalendar/getleastmaximum.xml
+++ b/reference/intl/intlcalendar/getleastmaximum.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlcalendar.getleastmaximum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -24,13 +24,13 @@
    <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
    <methodparam><type>int</type><parameter>field</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Devuelve el mínimo máximo local para un campo. Esto debería ser un valor
    menor o igual al devuelto por
-   <function>IntlCalendar::getActualMaxmimum</function>, que a su vez
+   <function>IntlCalendar::getActualMaximum</function>, que a su vez
    es menor o igual al devuelto por
    <function>IntlCalendar::getMaximum</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2a8768782512db2b95e5da2f032dd0347806d203 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <chapter xml:id="outcontrol.user-level-output-buffers" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Búferes de salida a nivel de usuario</title>
@@ -169,7 +169,7 @@
 
  <section xml:id="outcontrol.operations-on-buffers">
   <title>Operaciones permitidas en los búferes</title>
-  <para>
+  <simpara>
    Las operaciones permitidas en los búferes pueden controlarse
    pasando uno de los
    <link linkend="outcontrol.constants.buffer-control-flags">flags de control de búfer</link>
@@ -178,7 +178,7 @@
    Si se usa <literal>0</literal> en su lugar,
    el búfer no puede vaciarse, limpiarse ni desactivarse
    pero su contenido puede recuperarse.
-  </para>
+  </simpara>
   <para>
    <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant> permite a
    <function>ob_clean</function> limpiar el contenido del búfer.

--- a/reference/ps/functions/ps-hyphenate.xml
+++ b/reference/ps/functions/ps-hyphenate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 61374bbe228e8e9c55a24aba59a1e2bb2a871148 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.ps-hyphenate" xmlns="http://docbook.org/ns/docbook">
@@ -45,12 +45,12 @@
     <varlistentry>
      <term><parameter>text</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        <parameter>text</parameter> no debería contener caracteres no
        alfabéticos. Las posiciones posibles para los cortes son devueltas en un
        array de números enteros. Cada número es la posición del carácter
        en <parameter>text</parameter> después de que la unión pueda tener lugar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/yaf/yaf_view_simple/assignref.xml
+++ b/reference/yaf/yaf_view_simple/assignref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4a211b7c8fb2b4410851d06c6f90f751d1f670d0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="yaf-view-simple.assignref" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -27,9 +27,9 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un nombre como cadena que será usado para acceder al valor de la plantilla.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.zookeeper"
@@ -578,7 +578,7 @@
      <varlistentry xml:id="zookeeper.constants.child-event">
       <term><constant>Zookeeper::CHILD_EVENT</constant></term>
       <listitem>
-       <para>Un cambio como el ocurrido en la lista de hijos</para>
+       <simpara>Un cambio como el ocurrido en la lista de hijos</simpara>
        <para>Esto sólo se genera por los relojes en la lista de hijos de un nodo. Estos relojes se ajustan usando Zookeeper::getChildren.</para>
       </listitem>
      </varlistentry>

--- a/reference/zookeeper/zookeeper/addauth.xml
+++ b/reference/zookeeper/zookeeper/addauth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.addauth" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -68,9 +68,9 @@
    Este método emite un error/advertencia PHP cuando el número de parámetros o los tipos son incorrectos o cuando la operación falla.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método emite <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/close.xml
+++ b/reference/zookeeper/zookeeper/close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.close" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -30,9 +30,9 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Este método lanza <classname>ZookeeperException</classname> y sus derivados al cerrar una instancia no inicializada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -67,9 +67,9 @@
    Este método emite un error/advertencia de PHP si el número de parámetros o tipos es incorrecto o si la instancia no ha podido ser inicializada.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/construct.xml
+++ b/reference/zookeeper/zookeeper/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c44e9cb68b9b65771f9c45db2c07a06c63d71359 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -57,9 +57,9 @@
    Este método emite un error/advertencia de PHP si el número de parámetros o tipos es incorrecto o si la instancia no ha podido ser inicializada.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/create.xml
+++ b/reference/zookeeper/zookeeper/create.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.create" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -76,9 +76,9 @@
    Este método emite un error/advertencia de PHP si el número de parámetros o tipos es incorrecto o si la creación del nodo ha fallado.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 
@@ -92,7 +92,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $aclArray = array(
   array(
     'perms'  => Zookeeper::PERM_ALL,

--- a/reference/zookeeper/zookeeper/delete.xml
+++ b/reference/zookeeper/zookeeper/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -52,9 +52,9 @@
   <para>
    Este método emite un error/advertencia de PHP si el número de parámetros o los tipos son incorrectos o si la eliminación del nodo ha fallado.  </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 
@@ -68,7 +68,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $path = '/path/to/node';
 $r = $zookeeper->delete($path);
 if ($r)

--- a/reference/zookeeper/zookeeper/exists.xml
+++ b/reference/zookeeper/zookeeper/exists.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a20b7f936b03d76e8a3ddcadbfa1699f3e2bd1b6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.exists" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,9 +53,9 @@
    Este método emite un error/advertencia de PHP cuando el número de parámetros o los tipos son incorrectos o la comprobación de existencia del nodo ha fallado.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 
@@ -69,7 +69,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $path = '/path/to/node';
 $r = $zookeeper->exists($path);
 if ($r)

--- a/reference/zookeeper/zookeeper/get.xml
+++ b/reference/zookeeper/zookeeper/get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bde4b64a45645d6f83f0f056f5d8517f44157006 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -71,9 +71,9 @@
    o si la recuperación de datos ha fallado.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 
@@ -87,7 +87,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $path = '/path/to/node';
 $value = 'nodevalue';
 $zookeeper->set($path, $value);

--- a/reference/zookeeper/zookeeper/getacl.xml
+++ b/reference/zookeeper/zookeeper/getacl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.getacl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,9 +44,9 @@
    o si no se han podido recuperar las ACL del nodo.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 
@@ -60,7 +60,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $aclArray = array(
   array(
     'perms'  => Zookeeper::PERM_ALL,

--- a/reference/zookeeper/zookeeper/getchildren.xml
+++ b/reference/zookeeper/zookeeper/getchildren.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.getchildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -52,9 +52,9 @@
    Este método emite un error/advertencia PHP cuando el número de parámetros o tipos son incorrectos, o cuando la lista de hijos de un nodo ha fallado.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getclientid.xml
+++ b/reference/zookeeper/zookeeper/getclientid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.getclientid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,9 +34,9 @@
    Este método emite un error/advertencia de PHP cuando el cliente no ha podido obtener el identificador de sesión.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getrecvtimeout.xml
+++ b/reference/zookeeper/zookeeper/getrecvtimeout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.getrecvtimeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,9 +34,9 @@
    Este método emite un error/advertencia PHP cuando la operación falla.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/getstate.xml
+++ b/reference/zookeeper/zookeeper/getstate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.getstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,9 +34,9 @@
    Este método emite un error/advertencia PHP cuando no se puede obtener el estado de la conexión zookeeper.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.isrecoverable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -37,9 +37,9 @@
    Este método emite un error/advertencia PHP cuando la operación falla.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/set.xml
+++ b/reference/zookeeper/zookeeper/set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8758b0605e80c4e3610137b7502a6abeea5c69b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -72,9 +72,9 @@
    o cuando guardar el valor en el nodo ha fallado.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 
@@ -88,7 +88,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $path = '/path/to/node';
 $value = 'nodevalue';
 $r = $zookeeper->set($path, $value);

--- a/reference/zookeeper/zookeeper/setacl.xml
+++ b/reference/zookeeper/zookeeper/setacl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.setacl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -61,9 +61,9 @@
    Este método emite un error/advertencia de PHP cuando el número de parámetros o los tipos son incorrectos o no se ha podido definir la ACL para un nodo.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 
@@ -77,7 +77,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $aclArray = array(
   array(
     'perms'  => Zookeeper::PERM_ALL,

--- a/reference/zookeeper/zookeeper/setdebuglevel.xml
+++ b/reference/zookeeper/zookeeper/setdebuglevel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.setdebuglevel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -45,9 +45,9 @@
    o no definen el nivel de depuración.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
+++ b/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63cfa87a784c175a5360f18be7c4cb5550cc1d66 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.setdeterministicconnorder" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -50,9 +50,9 @@
    Este método emite un error/advertencia de PHP cuando el número de parámetros o tipos es incorrecto o la operación falla.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/setlogstream.xml
+++ b/reference/zookeeper/zookeeper/setlogstream.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.setlogstream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,9 +47,9 @@
    Este método emite un error/advertencia de PHP cuando el número de parámetros o tipos es incorrecto o la operación falla.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/setwatcher.xml
+++ b/reference/zookeeper/zookeeper/setwatcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.setwatcher" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,9 +44,9 @@
    o es imposible cambiar el observador.
   </para>
   <caution>
-    <para>
+    <simpara>
       Desde la versión 0.3.0, este método lanza <classname>ZookeeperException</classname> y sus derivados.
-    </para>
+    </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeperconfig/add.xml
+++ b/reference/zookeeper/zookeeperconfig/add.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeperconfig.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -58,9 +58,9 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Este método lanza <classname>ZookeeperException</classname> y sus derivados cuando el número o tipo de parámetros es incorrecto o el valor no se puede guardar en el nodo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zookeeper/zookeeperconfig/get.xml
+++ b/reference/zookeeper/zookeeperconfig/get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14aa757e611f871de23801655074cc28f7f3fa0f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeperconfig.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -48,9 +48,9 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Este método lanza <classname>ZookeeperException</classname> y sus derivados cuando el número o tipo de parámetros es incorrecto o si falla la recuperación de la configuración.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zookeeper/zookeeperconfig/remove.xml
+++ b/reference/zookeeper/zookeeperconfig/remove.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeperconfig.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -58,9 +58,9 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Este método lanza <classname>ZookeeperException</classname> y sus derivados cuando el número o el tipo de los parámetros es incorrecto o si la eliminación del valor del nodo falla.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zookeeper/zookeeperconfig/set.xml
+++ b/reference/zookeeper/zookeeperconfig/set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeperconfig.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -58,10 +58,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Este método lanza <classname>ZookeeperException</classname> y sus derivados cuando el número
    o tipo de parámetros es incorrecto o si guardar el valor en el nodo falla.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
php/doc-en#5574

Fixes #666