### PR TITLE
[Sync EN] Fix spelling typos across the manual

### DIFF
--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -40,8 +40,8 @@ class Operator {
 
     /**
      * Protected methods will not be exposed
-     * @param interge
-     * @return interge
+     * @param integer
+     * @return integer
      */
     protected function _add($a, $b) {
         return $a + $b;

--- a/reference/zookeeper/ini.xml
+++ b/reference/zookeeper/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 373591548f2bb7cc35e46242ea4faa0adcf7febc Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="zookeeper.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -81,12 +81,12 @@
      <type>int</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Tiempo de espera en microsegundos para los intentos de bloqueo de la sesión PHP.
       Se debe tener precaución al definir este valor. Los valores válidos son enteros,
       donde 0 se interpreta como el valor predeterminado.
       Los valores negativos provocan un bloqueo reducido a un intento de bloqueo.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 


### PR DESCRIPTION
php/doc-en#5571

Fixes #665