### PR TITLE
[Sync EN] ldap: document ldap_exop_sync and deprecate 4+ params for ldap_exop (PHP 8.4)

### DIFF
--- a/reference/ldap/functions/ldap-exop-sync.xml
+++ b/reference/ldap/functions/ldap-exop-sync.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: db22a7cfcbc3af221f67e228336ac3e2d62aaf2c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.ldap-exop-sync" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,84 +18,95 @@
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>
+   Efectúa una operación extendida en el <parameter>ldap</parameter> especificado con
+   <parameter>request_oid</parameter> el <acronym>OID</acronym> de la operación y
+   <parameter>request_data</parameter> los datos.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>ldap</parameter></term>
-     <listitem>
-      <para>
-       &ldap.parameter.ldap;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>request_oid</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>request_data</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>controls</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>response_data</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>response_oid</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ldap</parameter></term>
+    <listitem>
+     <simpara>
+      &ldap.parameter.ldap;
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_oid</parameter></term>
+    <listitem>
+     <simpara>
+      El <acronym>OID</acronym> de la petición de operación extendida.
+      Puede ser una de las constantes
+      <constant>LDAP_EXOP_<replaceable>*</replaceable></constant>,
+      o una cadena con el <acronym>OID</acronym> de la operación.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_data</parameter></term>
+    <listitem>
+     <simpara>
+      Los datos de la petición de operación extendida.
+      Puede ser &null; para algunas operaciones como <constant>LDAP_EXOP_WHO_AM_I</constant>,
+      y también puede necesitar estar codificado en <acronym>BER</acronym>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>controls</parameter></term>
+    <listitem>
+     <simpara>
+      Un array de <link linkend="ldap.controls">controles LDAP</link> a enviar con la solicitud.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_data</parameter></term>
+    <listitem>
+     <simpara>
+      Será rellenado con los datos de respuesta de la operación extendida si se proporcionan.
+      Si no se proporcionan, puede utilizarse <function>ldap_parse_exop</function> en el objeto
+      resultado posteriormente para obtener estos datos.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_oid</parameter></term>
+    <listitem>
+     <simpara>
+      Será rellenado con el <acronym>OID</acronym> de respuesta si se proporciona,
+      generalmente igual al <acronym>OID</acronym> de la solicitud.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Al utilizarse con <parameter>response_data</parameter>,
+   devuelve &true; en caso de éxito o &false; en caso de error.
+   Al utilizarse sin <parameter>response_data</parameter>,
+   devuelve un identificador de resultado o &false; en caso de error.
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>ldap_exop</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>ldap_exop</function></member>
+   <member><function>ldap_exop_whoami</function></member>
+   <member><function>ldap_exop_refresh</function></member>
+   <member><function>ldap_exop_passwd</function></member>
+   <member><function>ldap_parse_result</function></member>
+   <member><function>ldap_parse_exop</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b37727abaf0e731a05c516fd85b44e86f4bf5c75 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.ldap-exop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -18,11 +18,17 @@
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Realiza una operación extendida en el <parameter>ldap</parameter> especificado con
-   <parameter>request_oid</parameter> el OID de la operación y
+   <parameter>request_oid</parameter> el <acronym>OID</acronym> de la operación y
    <parameter>request_data</parameter> los datos.
-  </para>
+  </simpara>
+  <warning>
+   <simpara>
+    El uso de más de 4 parámetros ha quedado obsoleto,
+    use <function>ldap_exop_sync</function> en su lugar.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -31,51 +37,55 @@
    <varlistentry>
     <term><parameter>ldap</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       &ldap.parameter.ldap;
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>request_oid</parameter></term>
     <listitem>
-     <para>
-       El OID de la operación extendida. Puede utilizarse <constant>LDAP_EXOP_START_TLS</constant>, <constant>LDAP_EXOP_MODIFY_PASSWD</constant>, <constant>LDAP_EXOP_REFRESH</constant>, <constant>LDAP_EXOP_WHO_AM_I</constant>, <constant>LDAP_EXOP_TURN</constant>, o una cadena con el OID de la operación que se desea enviar.
-     </para>
+     <simpara>
+      El <acronym>OID</acronym> de la petición de operación extendida.
+      Puede ser una de las constantes
+      <constant>LDAP_EXOP_<replaceable>*</replaceable></constant>,
+      o una cadena con el <acronym>OID</acronym> de la operación.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>request_data</parameter></term>
     <listitem>
-     <para>
-       La operación extendida requiere datos. Puede ser NULL para ciertas operaciones como <constant>LDAP_EXOP_WHO_AM_I</constant>, puede requerir asimismo un codificación BER.
-     </para>
+     <simpara>
+       La operación extendida requiere datos. Puede ser NULL para ciertas operaciones como
+      <constant>LDAP_EXOP_WHO_AM_I</constant>, puede requerir asimismo un codificación <acronym>BER</acronym>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>controls</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un array de <link linkend="ldap.controls">controles LDAP</link> a enviar con la solicitud.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>response_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
        Será rellenado con los datos de respuesta de la operación extendida si se proporcionan.
-       Si no se proporcionan, puede utilizarse ldap_parse_exop en el objeto resultado
+       Si no se proporcionan, puede utilizarse <function>ldap_parse_exop</function> en el objeto resultado
        posteriormente para obtener estos datos.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>response_oid</parameter></term>
     <listitem>
-     <para>
-       Será rellenado con el OID de respuesta si se proporciona, generalmente igual al OID de la solicitud.
-     </para>
+     <simpara>
+       Será rellenado con el <acronym>OID</acronym> de respuesta si se proporciona, generalmente igual al <acronym>OID</acronym> de la solicitud.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -83,41 +93,45 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Al utilizarse con <parameter>response_data</parameter>, devuelve &true; en caso de éxito o &false; en caso de error.
    Al utilizarse sin <parameter>response_data</parameter>, devuelve un identificador de resultado o &false; en caso de error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &ldap.changelog.ldap-object;
-      <row>
-       <entry>7.3.0</entry>
-       <entry>
-        Se ha añadido el soporte para <parameter>controls</parameter>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       El uso de más de 4 parámetros ha quedado obsoleto,
+       use <function>ldap_exop_sync</function> en su lugar.
+      </entry>
+     </row>
+     &ldap.changelog.ldap-object;
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Se ha añadido el soporte para <parameter>controls</parameter>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
+  <example>
     <title>Operación extendida WHOAMI</title>
     <programlisting role="php">
 <![CDATA[
@@ -149,20 +163,18 @@ if ($ds) {
 ]]>
     </programlisting>
    </example>
-  </para>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>ldap_parse_result</function></member>
-    <member><function>ldap_parse_exop</function></member>
-    <member><function>ldap_exop_whoami</function></member>
-    <member><function>ldap_exop_refresh</function></member>
-    <member><function>ldap_exop_passwd</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>ldap_exop_sync</function></member>
+   <member><function>ldap_exop_whoami</function></member>
+   <member><function>ldap_exop_refresh</function></member>
+   <member><function>ldap_exop_passwd</function></member>
+   <member><function>ldap_parse_result</function></member>
+   <member><function>ldap_parse_exop</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 


### PR DESCRIPTION
php/doc-en#4066

Fixes #662