### PR TITLE
[Sync EN] Fix typos and spelling mistakes

### DIFF
--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration74.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Otros cambios</title>
@@ -34,10 +34,10 @@
    <link linkend="ini.zend.exception-ignore-args">zend.exception_ignore_args</link>
    es una nueva directiva INI para incluir o excluir los argumentos de las trazas de pila generadas por las excepciones.
   </para>
-  <para>
+  <simpara>
    <link linkend="ini.opcache.preload-user">opcache.preload_user</link> es una
    nueva directiva INI que permite especificar la cuenta de usuario que tiene el rol de ejecutar el código precargado (el usuario root no está permitido por razones de seguridad).
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration74.other-changes.pkg-config">

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: No Maintainer: Marqitos -->
 <sect1 xml:id="migration83.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nuevas características</title>
@@ -68,10 +68,10 @@
   <sect3 xml:id="migration83.new-features.core.static-variable-initializers">
    <title>Inicializadores de variables estáticas</title>
 
-   <para>
+   <simpara>
     Los inicializadores de variables estáticas ahora pueden contener expresiones arbitrarias.
-    <!-- RFC: RFC: https://wiki.php.net/rfc/arbitrary_static_variable_initializers -->
-   </para>
+    <!-- RFC: https://wiki.php.net/rfc/arbitrary_static_variable_initializers -->
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.new-features.core.fallback-value-syntax-for-php-ini">

--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2871f7103c7cfcfd95db64eb0930085965fd9330 Maintainer: jorgeolaya Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: jorgeolaya Status: ready -->
 <!-- Reviewed: yes Maintainer: julionc -->
 
 <sect1 xml:id="install.windows.apache2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,14 +16,14 @@
   </para>
  </note>
 
- <para>
+ <simpara>
   Se recomienda consultar la
   <link xlink:href="&url.apache2.docs;">Documentación de Apache</link>
   para obtener un conocimiento básico del servidor Apache 2.x.
   También considere leer las
   <link xlink:href="&url.apache2.windows;">notas específicas para Windows</link>
   para Apache 2.x antes de seguir leyendo.
- </para>
+ </simpara>
 
  <para>
   Descargue la versión más reciente de

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8bc832a464e33122e8129f5a623bd845b69fa7e0 Maintainer: chuso Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: chuso Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="wrappers.expect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
@@ -11,11 +11,11 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <para>
+  <simpara>
    Los flujos que se hayan abierto con la envoltura <filename>expect://</filename>, darán
-   acceso a stdio, stdout y stderr (entrada, salida y errores estándar respectivamente)
+   acceso a stdin, stdout y stderr (entrada, salida y errores estándar respectivamente)
    de los procesos, vía PTY.
-  </para>
+  </simpara>
   <note>
    <title>Esta envoltura no está habilitada por omisión</title>
    <simpara>

--- a/reference/event/eventbuffer/write.xml
+++ b/reference/event/eventbuffer/write.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbuffer.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -36,9 +36,9 @@
      <parameter>fd</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Recurso de socket, flujo, o un descriptor numérico de fichero asociado con un socket.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/gearman/gearmanclient/setdata.xml
+++ b/reference/gearman/gearmanclient/setdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cf0a919c126e45b5df583d188e77fa62015b714a Maintainer: tatai Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: tatai Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanclient.setdata">
  <refnamediv>
   <refname>GearmanClient::setData</refname>
@@ -19,7 +19,7 @@
   </simpara>
   <note>
    <simpara>
-    Este método ha sido reemplazado por <methodname>GearmanCient::setContext</methodname>
+    Este método ha sido reemplazado por <methodname>GearmanClient::setContext</methodname>
     en la versión 0.6.0 de la extensión Gearman.
    </simpara>
   </note>

--- a/reference/gmp/functions/gmp-add.xml
+++ b/reference/gmp/functions/gmp-add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.gmp-add" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -27,9 +27,9 @@
     <varlistentry>
      <term><parameter>num1</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El primer operando (augend).
-      </para>
+      </simpara>
       &gmp.parameter;
      </listitem>
     </varlistentry>

--- a/reference/gnupg/reference.xml
+++ b/reference/gnupg/reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a148eb08b658eafa139f8996ad92d860e023da3f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ref.gnupg">
  <title>&Functions; GnuPG</title>
@@ -9,7 +9,7 @@
    &reftitle.notes;
    <simpara>
     Esta extensión utiliza el trousseau del usuario actual. Este trousseau se
-    encuentra normalmente en ~./.gnupg/.
+    encuentra normalmente en ~/.gnupg/.
     Para especificar una ubicación diferente, registrar la ruta del trousseau en la variable de entorno GNUPGHOME. Ver
     <link linkend="function.putenv">putenv</link> para más información sobre cómo realizar esto.
    </simpara>

--- a/reference/ibm_db2/functions/db2-fetch-row.xml
+++ b/reference/ibm_db2/functions/db2-fetch-row.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-fetch-row">
  <refnamediv>
@@ -115,7 +115,7 @@ cabra Rickety Ride
      En general
      <function>db2_fetch_row</function>/<function>db2_result</function> tiene más
      problemas con tipos de columna variados en la traducción de
-     <literal>EBCIDIC</literal> a <literal>ASCII</literal>, incluyendo posible
+     <literal>EBCDIC</literal> a <literal>ASCII</literal>, incluyendo posible
      truncamiento en aplicaciones <literal>DBCS</literal>.
      También podría encontrar una mejor performance utilizando
      <function>db2_fetch_both</function>, <function>db2_fetch_array</function>

--- a/reference/info/functions/assert-options.xml
+++ b/reference/info/functions/assert-options.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ada1d79de35239334b68d0120b011530e31244ff Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.assert-options" xmlns="http://docbook.org/ns/docbook">
@@ -196,7 +196,7 @@
       <row>
        <entry>8.3.0</entry>
        <entry>
-        <function>assert_option</function> ahora está obsoleto.
+        <function>assert_options</function> ahora está obsoleto.
        </entry>
       </row>
       <row>

--- a/reference/intl/intlcalendar/getkeywordvaluesforlocale.xml
+++ b/reference/intl/intlcalendar/getkeywordvaluesforlocale.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlcalendar.getkeywordvaluesforlocale" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -81,7 +81,7 @@
   &reftitle.examples;
   <para>
    <example>
-   <title><function>IntlCalendar::getKeyworkValuesForLocale</function></title>
+   <title><function>IntlCalendar::getKeywordValuesForLocale</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ps/functions/ps-rect.xml
+++ b/reference/ps/functions/ps-rect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 <!-- splitted from ./en/functions/ps.xml, last change in rev 1.12 -->
 <refentry xml:id="function.ps-rect" xmlns="http://docbook.org/ns/docbook">
@@ -90,7 +90,7 @@
   <para>
    <simplelist>
     <member><function>ps_arc</function></member>
-    <member><function>ps_cirle</function></member>
+    <member><function>ps_circle</function></member>
     <member><function>ps_lineto</function></member>
    </simplelist>
   </para>

--- a/reference/spl/recursivecallbackfilteriterator/construct.xml
+++ b/reference/spl/recursivecallbackfilteriterator/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="recursivecallbackfilteriterator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -57,7 +57,7 @@
    <simplelist>
     <member><link linkend="recursivecallbackfilteriterator.examples">Ejemplos RecursiveCallbackFilterIterator</link></member>
     <member><methodname>RecursiveCallbackFilterIterator::getChildren</methodname></member>
-    <member><methodname>RecursiveCallbackFilteriterator::hasChildren</methodname></member>
+    <member><methodname>RecursiveCallbackFilterIterator::hasChildren</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/spl/recursivecallbackfilteriterator/getchildren.xml
+++ b/reference/spl/recursivecallbackfilteriterator/getchildren.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="recursivecallbackfilteriterator.getchildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -42,7 +42,7 @@
    <simplelist>
     <member><link linkend="recursivecallbackfilteriterator.examples">Ejemplos con RecursiveCallbackFilterIterator</link></member>
     <member><methodname>RecursiveCallbackFilterIterator::__construct</methodname></member>
-    <member><methodname>RecursiveCallbackFilteriterator::hasChildren</methodname></member>
+    <member><methodname>RecursiveCallbackFilterIterator::hasChildren</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/spl/recursivecallbackfilteriterator/haschildren.xml
+++ b/reference/spl/recursivecallbackfilteriterator/haschildren.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="recursivecallbackfilteriterator.haschildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -68,7 +68,7 @@ $files = new RecursiveCallbackFilterIterator($dir, function ($current, $key, $it
    <simplelist>
     <member><link linkend="recursivecallbackfilteriterator.examples">Ejemplos con RecursiveCallbackFilterIterator</link></member>
     <member><methodname>RecursiveCallbackFilterIterator::__construct</methodname></member>
-    <member><methodname>RecursiveCallbackFilteriterator::getChildren</methodname></member>
+    <member><methodname>RecursiveCallbackFilterIterator::getChildren</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/svm/svm.xml
+++ b/reference/svm/svm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1ca2d4af9471f44743281e6949cb53b8afcaefb8 Maintainer: pablorr85 Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: pablorr85 Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.svm" role="class">
 
@@ -119,7 +119,7 @@
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="svm.constants.opt-probability">SVM::OPT_PROPABILITY</varname>
+     <varname linkend="svm.constants.opt-probability">SVM::OPT_PROBABILITY</varname>
      <initializer>105</initializer>
     </fieldsynopsis>
     <fieldsynopsis>

--- a/reference/swoole/swoole/buffer/read.xml
+++ b/reference/swoole/swoole/buffer/read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-buffer.read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Los datos leídos del búfer de memoria.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/swoole/swoole/buffer/substr.xml
+++ b/reference/swoole/swoole/buffer/substr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-buffer.substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -54,9 +54,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Los datos leídos del búfer de memoria.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/swoole/swoole/channel/push.xml
+++ b/reference/swoole/swoole/channel/push.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 97d52b78f1cc109bb272d4a844f9f498a74ecf03 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-channel.push" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -41,9 +41,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Si los datos son empujados en el canal Swoole.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/swoole/swoole/lock/construct.xml
+++ b/reference/swoole/swoole/lock/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-lock.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam choice="opt"><type>string</type><parameter>type</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>file_lock_location</parameter></methodparam>
   </constructorsynopsis>
-  <para>
+  <simpara>
     Un bloqueo Swoole se utiliza para la sincronización de datos entre varios hilos o procesos.
-  </para>
+  </simpara>
 
  </refsect1>
 

--- a/reference/ui/ui/controls/form/delete.xml
+++ b/reference/ui/ui/controls/form/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be295015d068095fc92880baef4e47038646adbd Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ui-controls-form.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Indicación de éxito
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/ui/ui/controls/separator/construct.xml
+++ b/reference/ui/ui/controls/separator/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be295015d068095fc92880baef4e47038646adbd Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ui-controls-separator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -25,9 +25,9 @@
    <varlistentry>
     <term><parameter>type</parameter></term>
     <listitem>
-     <para>
-      Separator::Horizonal o Separator::Vertical
-     </para>
+     <simpara>
+      Separator::Horizontal o Separator::Vertical
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/ui/ui/draw/brush.gradient/addstop.xml
+++ b/reference/ui/ui/draw/brush.gradient/addstop.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ui-draw-brush-gradient.addstop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -19,9 +19,9 @@
    <methodparam><type>float</type><parameter>position</parameter></methodparam>
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Añade un tope en la posición dada con el color dado
-  </para>
+  </simpara>
 
  </refsect1>
 

--- a/reference/ui/ui/window/isfullscreen.xml
+++ b/reference/ui/ui/window/isfullscreen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2735ac5fada61995f5a07e9a4ad01ba9a400b69b Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="ui-window.isfullscreen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>UI\Window::isFullScreen</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Detectará si esta ventana se utiliza toda la pantalla
-  </para>
+  </simpara>
 
  </refsect1>
 

--- a/reference/uopz/functions/uopz-get-static.xml
+++ b/reference/uopz/functions/uopz-get-static.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b5e484908859c4d96e212fb4ec6f5af2526db288 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.uopz-get-static" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,11 +51,11 @@
    Devuelve un <type>array</type> asociativo de nombres de variables mapeados a sus
    valores actuales en caso de éxito, o &null; si la función o método no existe.
   </para>
-  <para>
+  <simpara>
    Desde PHP 8.3.0, los inicializadores estáticos se calculan ya sea durante la compilación,
    o si no es posible, solo cuando la función o método se ejecuta por primera vez, en cuyo caso
    el valor de la variable estática se reporta como &null; antes de la primera invocación.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/win32service/functions/win32-query-service-status.xml
+++ b/reference/win32service/functions/win32-query-service-status.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95fe2d7de6477ae5e28ae2e6f11eb4025f427b4f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.win32-query-service-status" xmlns="http://docbook.org/ns/docbook">
@@ -90,13 +90,13 @@
     <varlistentry>
      <term><parameter>Win32ExitCode</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si el servicio termina, el código de retorno del proceso. Este valor es igual
        a <constant>WIN32_ERROR_SERVICE_SPECIFIC_ERROR</constant> si el modo de salida no es
        correcto. Consulte
        <link linkend="win32service.constants.errors">códigos de error Win32Service</link>
        y <function>win32_set_service_exit_mode</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/win32service/functions/win32-set-service-exit-mode.xml
+++ b/reference/win32service/functions/win32-set-service-exit-mode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 05568582247276cc2ee7b2b87f7df7d602e566c0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="function.win32-set-service-exit-mode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,11 +15,11 @@
    <type>bool</type><methodname>win32_set_service_exit_mode</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>gracefulMode</parameter><initializer>true</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si se proporciona el argumento <parameter>gracefulMode</parameter>, se modifica el modo de
    salida. Cuando el modo de salida no es correcto, el código de salida utilizado puede ser definido con la función
    <function>win32_set_service_exit_code</function>.
-  </para>
+  </simpara>
 
   <caution>
    <para>

--- a/reference/yaconf/yaconf.xml
+++ b/reference/yaconf/yaconf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaconf" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -13,12 +13,12 @@
 <!-- {{{ Yaconf intro -->
   <section xml:id="yaconf.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Yaconf es un contenedor de configuraciones,
     analiza los archivos del INI, almacena el resultado en
     cuando PHP se inicia, el resultado vive
     con todo el ciclo de vida de PHP.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/yaf/yaf-loader.xml
+++ b/reference/yaf/yaf-loader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7541512acf899391b68c3b6bae66a4fcc65e6c4e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <reference xml:id="class.yaf-loader" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -25,7 +25,7 @@
    <para>
     <classname>Yaf_Loader</classname> intenta cargar una clase sólo una vez, y si
     falla, dependiendo de <link
-    linkend="ini.yaf.use-spl-autoload">yaf.use_spl_auload</link>, si esta configuración
+    linkend="ini.yaf.use-spl-autoload">yaf.use_spl_autoload</link>, si esta configuración
     es "On" <methodname>Yaf_Loader::autoload</methodname> devolverá
     &false;, y así dará otra oportunidad a otra función de autocarga; si es "Off"
     (por omisión), <methodname>Yaf_Loader::autoload</methodname> devolverá

--- a/reference/yaf/yaf_application/construct.xml
+++ b/reference/yaf/yaf_application/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7541512acf899391b68c3b6bae66a4fcc65e6c4e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="yaf-application.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -13,7 +13,7 @@
   <constructorsynopsis>
    <modifier>public</modifier> <methodname>Yaf_Application::__construct</methodname>
    <methodparam><type>mixed</type><parameter>config</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>envrion</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>environ</parameter></methodparam>
   </constructorsynopsis>
   <para>
    Instancia un objeto de la clase <classname>Yaf_Application</classname>.
@@ -81,7 +81,7 @@ ap.modules=Index
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>envrion</parameter></term>
+    <term><parameter>environ</parameter></term>
     <listitem>
      <para>
       Qué sección se cargará como configuración final

--- a/reference/yaf/yaf_route_rewrite/construct.xml
+++ b/reference/yaf/yaf_route_rewrite/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b37bddfde36975bf6bf06ce98867e62d489d49c5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <refentry xml:id="yaf-route-rewrite.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -82,7 +82,7 @@
     * Añadir una ruta de reescritura a la pila de rutas de Yaf_Router
     */
     Yaf_Dispatcher::getInstance()->getRouter()->addRoute("name",
-        new Yaf_Route_rewrite(
+        new Yaf_Route_Rewrite(
            "/product/:name/:id/*", //match request uri leading "/product"
            array(
                'controller' => "product",  //route to product controller,


### PR DESCRIPTION
Sync de upstream php/doc-en, corrige typos et bumpe les fichiers ES concernés (identifiants, littéraux, mirror para→simpara). Les typos qui n'étaient que de la prose anglaise déjà bien traduite en espagnol ont été laissés tels quels.

Fixes #692