### PR TITLE
[Sync EN] array: Updated notes for example 10

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3061900171d4ae84d532571bfd6eda823726dad4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: bfdd82f3f6cde571a61de3fcea28a03145374dda Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.array">
  <title>Arrays</title>
@@ -530,12 +530,12 @@ var_dump($arr);
    </example>
 
    <note>
-    <para>
-     Como se mencionó anteriormente, si no se especifica ninguna clave, se toma el máximo de los
-     índices <type>int</type> existentes, y la nueva clave será ese valor máximo
-     más 1 (pero al menos 0). Si no existen índices <type>int</type> aún, la clave será
-     <literal>0</literal> (cero).
-    </para>
+    <simpara>
+     Si no se especifica ninguna clave, la clave será el
+     índice entero máximo existente + <literal>1</literal>. Si el array no tiene índices
+     enteros positivos, la clave será <literal>0</literal>.
+     A partir de PHP 8.3.0, también puede ser un entero negativo.
+    </simpara>
 
     <para>
      Tenga en cuenta que el índice entero máximo usado para esto <emphasis>no


### PR DESCRIPTION
Sync de upstream php/doc-en : reformulation de la note d'auto-incrémentation de clé, avec mention du support des entiers négatifs depuis PHP 8.3.0. Mirror `<para>` → `<simpara>`.

Fixes #691