### PR TITLE
[Sync EN] Fix copy-pasted descriptions referencing the wrong function

### DIFF
--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-cache-info">
  <refnamediv>
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>limited</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Recupera la información almacenada y los metadatos del almacén de datos de la APC.
+   Recupera la información almacenada y los metadatos del almacén de datos de la APCu.
   </simpara>
  </refsect1>
 
@@ -44,7 +44,7 @@
   <note>
    <simpara>
     <function>apcu_cache_info</function> hará una advertencia si no puede recuperar
-    los datos de la caché del APC. Esto suele ocurrir cuando el APC no está activado.
+    los datos de la caché del APCu. Esto suele ocurrir cuando el APCu no está activado.
    </simpara>
   </note>
  </refsect1>

--- a/reference/apcu/functions/apcu-key-info.xml
+++ b/reference/apcu/functions/apcu-key-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos-->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-key-info">
  <refnamediv>

--- a/reference/cubrid/functions/cubrid-lob2-import.xml
+++ b/reference/cubrid/functions/cubrid-lob2-import.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-lob2-import">
  <refnamediv>

--- a/reference/cubrid/functions/cubrid-pconnect.xml
+++ b/reference/cubrid/functions/cubrid-pconnect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-pconnect">
  <refnamediv>
@@ -100,7 +100,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo con <function>cubrid_connect</function></title>
+   <title>Ejemplo con <function>cubrid_pconnect</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/cubrid/functions/cubrid-seq-insert.xml
+++ b/reference/cubrid/functions/cubrid-seq-insert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-seq-insert">
  <refnamediv>
@@ -19,7 +19,7 @@
    <methodparam><type>string</type><parameter>seq_element</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   La función <function>cubrid_col_insert</function> se utiliza para
+   La función <function>cubrid_seq_insert</function> se utiliza para
    insertar un elemento en una secuencia de tipos de atributos.
   </simpara>
  </refsect1>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-chown">
  <refnamediv>
   <refname>eio_chown</refname>
-  <refpurpose>Cambiar los permisos de un fichero/directorio</refpurpose>
+  <refpurpose>Cambiar el propietario de un fichero/directorio</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -19,7 +19,9 @@
    <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Cambia los permisos de un fichero o directorio.
+   <function>eio_chown</function> cambia el propietario de un fichero o directorio.
+   El nuevo propietario es especificado por <parameter>uid</parameter>, y el grupo
+   por <parameter>gid</parameter>.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fchown">
  <refnamediv>
@@ -79,7 +79,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_fdatasync</function> devuelve un recurso de petición en caso de éxito,&return.falseforfailure;.
+   <function>eio_fchown</function> devuelve un recurso de petición en caso de éxito,&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fstat">
  <refnamediv>
@@ -61,14 +61,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_busy</function> devuelve un recurso de petición en caso de éxito,&return.falseforfailure;.
+   <function>eio_fstat</function> devuelve un recurso de petición en caso de éxito,&return.falseforfailure;.
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo de <function>eio_lstat</function></title>
+   <title>Ejemplo de <function>eio_fstat</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/eio/functions/eio-nready.xml
+++ b/reference/eio/functions/eio-nready.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-nready">
  <refnamediv>
@@ -36,7 +36,6 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>eio_nreqs</function></member>
-   <member><function>eio_nready</function></member>
    <member><function>eio_nthreads</function></member>
   </simplelist>
  </refsect1>

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-truncate">
  <refnamediv>
@@ -70,7 +70,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_busy</function> devuelve un recurso de petición en caso de éxito,&return.falseforfailure;.
+   <function>eio_truncate</function> devuelve un recurso de petición en caso de éxito,&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-suggest">
  <refnamediv>
   <refname>enchant_dict_suggest</refname>
-  <refpurpose>Devolverá una lista de valores si no se cumplen alguna de las precondiciones</refpurpose>
+  <refpurpose>Sugerir ortografías para una palabra</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ev/evchild/createstopped.xml
+++ b/reference/ev/evchild/createstopped.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evchild.createstopped">
  <refnamediv>
   <refname>EvChild::createStopped</refname>
-  <refpurpose>Crea una instancia del observador detenido EvCheck</refpurpose>
+  <refpurpose>Crea una instancia del observador detenido EvChild</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ev/evsignal/construct.xml
+++ b/reference/ev/evsignal/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evsignal.construct">
  <refnamediv>
@@ -32,7 +32,7 @@
   </constructorsynopsis>
   <simpara>
    Construye un objeto watcher EvSignal y lo inicia automáticamente.
-   Para un watcher periódico detenido, utilice en su lugar el método
+   Para un watcher de señal detenido, utilice en su lugar el método
    <methodname>EvSignal::createStopped</methodname>.
   </simpara>
  </refsect1>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 23ea6be076881a34e1d454e9680968ece085f7f6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.event" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -159,11 +159,11 @@
       <constant>Event::WRITE</constant>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Este flag indica que un evento se vuelve activo cuando el descriptor
        de fichero proporcionado (normalmente, un recurso de flujo o un socket)
        está listo para una escritura.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="event.constants.signal">

--- a/reference/event/eventhttprequest/getbufferevent.xml
+++ b/reference/event/eventhttprequest/getbufferevent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5d7cfa894ddb7d30f5b63ef272f33e80e1c63f3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventhttprequest.getbufferevent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -13,7 +13,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <type>EventBufferEvent</type>
-   <methodname>EventHttpRequest::closeConnection</methodname>
+   <methodname>EventHttpRequest::getBufferEvent</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/fann/functions/fann-get-activation-function.xml
+++ b/reference/fann/functions/fann-get-activation-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: seros Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-activation-function" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -59,10 +59,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Una constante de <link linkend="constants.fann-train">funciones de aprendizaje</link> o -1
+  <simpara>
+   Una constante de <link linkend="constants.fann-activation-funcs">funciones de activación</link> o -1
    si la neurona no está definida en la red neuronal, o &false; en caso de error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-get-rprop-decrease-factor.xml
+++ b/reference/fann/functions/fann-get-rprop-decrease-factor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: seros Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-rprop-decrease-factor" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: be295015d068095fc92880baef4e47038646adbd Maintainer: seros Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="zmqdevice.settimercallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -32,22 +32,22 @@
    <varlistentry>
     <term><parameter>cb_func</parameter></term>
     <listitem>
-     <para>
-      Función de retrollamada a invocar cuando el dispositivo está inactivo. La devolución de false
+     <simpara>
+      Función de retrollamada a invocar cuando se dispara el temporizador. La devolución de false
       o de un valor que se evalú como false por parte de esta función causará la detención
       del dispositivo.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timeout</parameter></term>
     <listitem>
-     <para>
-      Frecuencia con la que se invoca la retrollamada de inactividad en milisegundos. La retrollamada de inactividad se invoca
-      periódicamente cuando no hay actividad en el dispositivo.
+     <simpara>
+      Frecuencia con la que se invoca la retrollamada del temporizador en milisegundos. La retrollamada del temporizador se invoca
+      periódicamente.
       El valor del tiempo de espera garantiza que haya al menos dicha cantidad de milisegundos entre
       invocaciones a la función de retrollamada.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
Sync de upstream php/doc-en : corrige les descriptions, refpurposes, identifiants et titres d'exemples qui pointaient vers la mauvaise fonction (copies-pastes oubliés). Mirror `<para>` → `<simpara>` quand applicable.

Fixes #690