### PR TITLE
[Sync EN] eio/constants.xml: add dots at the ends of sentences

### DIFF
--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 2132501990f8e139a75021165634830f1f6a90e1 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eio.constants">
  &reftitle.constants;
@@ -15,7 +15,7 @@
     </term>
     <listitem>
      <simpara>
-      Prioridad de petición mínima
+      Prioridad de petición mínima.
      </simpara>
     </listitem>
    </varlistentry>
@@ -26,7 +26,7 @@
     </term>
     <listitem>
      <simpara>
-      Prioridad de petición predeterminada
+      Prioridad de petición predeterminada.
      </simpara>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
     </term>
     <listitem>
      <simpara>
-      Prioridad de petición máxima
+      Prioridad de petición máxima.
      </simpara>
     </listitem>
    </varlistentry>
@@ -104,7 +104,7 @@
       <literal>'type'</literal> - una de las constantes
       <emphasis>EIO_DT_*</emphasis>;
       <literal>'inode'</literal> - el número de inodo, si está disponible, de otro modo
-      sin especificar;
+      sin especificar.
      </simpara>
     </listitem>
    </varlistentry>
@@ -156,7 +156,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo desconocido(muy común). Se necistan más estadísticas (<function>stat</function>).
+      Tipo de nodo desconocido (muy común). Se necistan más estadísticas (<function>stat</function>).
      </simpara>
     </listitem>
    </varlistentry>
@@ -167,7 +167,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo FIFO
+      Tipo de nodo FIFO.
      </simpara>
     </listitem>
    </varlistentry>
@@ -178,7 +178,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo
+      Tipo de nodo.
      </simpara>
     </listitem>
    </varlistentry>
@@ -189,7 +189,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo de dispositivo de caracteres multiplexado (v7+coherent)
+      Tipo de nodo de dispositivo de caracteres multiplexado (v7+coherent).
      </simpara>
     </listitem>
    </varlistentry>
@@ -200,7 +200,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo de directorio
+      Tipo de nodo de directorio.
      </simpara>
     </listitem>
    </varlistentry>
@@ -211,7 +211,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo de fichero Xenix nominado especial
+      Tipo de nodo de fichero Xenix nominado especial.
      </simpara>
     </listitem>
    </varlistentry>
@@ -222,7 +222,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo
+      Tipo de nodo.
      </simpara>
     </listitem>
    </varlistentry>
@@ -233,7 +233,7 @@
     </term>
     <listitem>
      <simpara>
-      Dispositivo de bloqueo multiplexado (v7+coherent)
+      Dispositivo de bloqueo multiplexado (v7+coherent).
      </simpara>
     </listitem>
    </varlistentry>
@@ -244,7 +244,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo
+      Tipo de nodo.
      </simpara>
     </listitem>
    </varlistentry>
@@ -265,7 +265,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de noto especial de red HP-UX
+      Tipo de nodo especial de red HP-UX.
      </simpara>
     </listitem>
    </varlistentry>
@@ -276,7 +276,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo de vínculo
+      Tipo de nodo de vínculo.
      </simpara>
     </listitem>
    </varlistentry>
@@ -287,7 +287,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo socket
+      Tipo de nodo socket.
      </simpara>
     </listitem>
    </varlistentry>
@@ -298,7 +298,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo de puerta de Solaris
+      Tipo de nodo de puerta de Solaris.
      </simpara>
     </listitem>
    </varlistentry>
@@ -309,7 +309,7 @@
     </term>
     <listitem>
      <simpara>
-      Tipo de nodo
+      Tipo de nodo.
      </simpara>
     </listitem>
    </varlistentry>
@@ -320,7 +320,7 @@
     </term>
     <listitem>
      <simpara>
-      Valor de tipo de nodo más alto
+      Valor de tipo de nodo más alto.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Sync de upstream php/doc-en : ajoute les points de fin de phrase manquants sur les descriptions de constantes eio (et ajoute l'espace manquant avant la parenthèse de « desconocido (muy común) »).

Fixes #689