### PR TITLE
[Sync EN] fiber/throw.xml: add an example

### DIFF
--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b3a0b9924ba577a3abf246c1bd1a6cf5c4bf14dc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="fiber.throw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -41,6 +41,40 @@
    El valor proporcionado en la próxima llamada a <methodname>Fiber::suspend</methodname> o &null; si la fibra retorna.
    Si la fibra lanza una excepción antes de suspenderse, será emitida al llamar a este método.
   </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$fiber = new Fiber(function () {
+   try {
+       // Suspende la ejecución de la fibra declarando un punto de interrupción
+       Fiber::suspend();
+   } catch (Throwable $e) {
+       echo $e->getMessage();
+   }
+});
+
+$fiber->start();
+
+// Reanuda la ejecución de la fibra pasando
+// la Excepción a lanzar en el punto de interrupción
+$fiber->throw(new Exception('Mensaje de una excepción lanzada en el punto de interrupción actual'));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Mensaje de una excepción lanzada en el punto de interrupción actual
+]]>
+   </screen>
+  </informalexample>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Sync de upstream php/doc-en : ajoute un exemple de code montrant l'utilisation de `Fiber::throw` pour relancer la fibre avec une exception lancée au point d'interruption. Code conservé en PHP, commentaires et chaînes traduits en espagnol.

Fixes #688