### PR TITLE
[Sync EN] exit: add changelog and warning about updated exit code behaviour since PHP 8.4.0

### DIFF
--- a/reference/funchand/functions/register-shutdown-function.xml
+++ b/reference/funchand/functions/register-shutdown-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b412bbd26214f7281ac7dd858710e09952a275f2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 2312f826e5fdedbef87c6288c2c20f9f904b4d0b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.register-shutdown-function" xmlns="http://docbook.org/ns/docbook">
@@ -29,6 +29,14 @@
    durante una de las funciones de cierre, el proceso será definitivamente
    detenido, sin que las otras funciones sean llamadas.
   </para>
+  <caution>
+   <simpara>
+    Desde PHP 8.4.0, una llamada a <function>exit</function> sin parámetros dentro
+    de una función de cierre registrada restablece el código de salida a
+    <literal>0</literal>. Llamar a <function>exit</function> con un estado
+    explícito sobrescribe el código de salida anterior en todas las versiones.
+   </simpara>
+  </caution>
   <para>
    Las funciones de cierre pueden también llamar a la función
    <function>register_shutdown_function</function> ellas mismas para añadir una

--- a/reference/misc/functions/exit.xml
+++ b/reference/misc/functions/exit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2aaaf1967f2510471b694daf8e41a419fc98b751 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 2312f826e5fdedbef87c6288c2c20f9f904b4d0b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.exit" xmlns="http://docbook.org/ns/docbook">
@@ -109,6 +109,17 @@
        <link linkend="language.types.declarations.strict"><literal>strict_types</literal></link>,
        puede ser llamada con argumentos nombrados y ser utilizada
        como una <link linkend="functions.variable-functions">función variable</link>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Una llamada a <function>exit</function> sin parámetros dentro de
+       <link linkend="function.register-shutdown-function">funciones de cierre</link>
+       o de <link linkend="language.oop5.decon.destructor">destructores de objetos</link>
+       restablece ahora el código de salida a <literal>0</literal>; anteriormente
+       se conservaba el código de salida establecido por una llamada anterior a
+       <function>exit</function>.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Sync de upstream php/doc-en : ajoute un avertissement sur `register_shutdown_function` et une entrée de changelog dans `exit` documentant qu'un appel à `exit` sans paramètre dans une fonction de cierre ou un destructeur réinitialise désormais le code de sortie à 0 depuis PHP 8.4.0.

Fixes #687