### PR TITLE
[Sync EN] sscanf/fscanf: Clarify negative -1 return value (#5580)

### DIFF
--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.fscanf" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,67 +15,69 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    La función <function>fscanf</function> es similar a la función
    <function>sscanf</function>, excepto que toma un archivo como entrada,
    representado por el recurso <parameter>stream</parameter> e interpreta
    la entrada según el formato <parameter>format</parameter> especificado.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Todos los caracteres en blanco de la cadena de formato corresponden
    a tantos espacios en el flujo de entrada. Esto significa que una tabulación
    (<literal>\t</literal>) en la cadena de formato puede reemplazar
    un espacio simple en el flujo de entrada.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Cada llamada a la función <function>fscanf</function> lee una línea del archivo.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>stream</parameter></term>
-     <listitem>
-      &fs.file.pointer;
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Los valores opcionales a asignar.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     &fs.file.pointer;
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Los valores opcionales a asignar.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Si solo se pasan 2 argumentos a la función, el valor analizado
-   será devuelto en forma de un array. Si se pasan argumentos opcionales,
+   será devuelto como un <type>array</type>. Si se pasan argumentos opcionales,
    la función devolverá el número de valores asignados.
    Los argumentos opcionales deben ser pasados por referencia.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si se esperan más subcadenas en el <parameter>format</parameter>
    de las disponibles en <parameter>string</parameter>,
    &null; será devuelto. En otros casos de error, &false; será devuelto.
-  </para>
+  </simpara>
+  <simpara>
+   Cuando se usan parámetros opcionales y se alcanza el final de la entrada
+   leída de <parameter>stream</parameter> antes de que se haya analizado
+   ningún valor, se devuelve <literal>-1</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Ejemplo con <function>fscanf</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Ejemplo con <function>fscanf</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $handle = fopen("users.txt", "r");
@@ -87,36 +88,31 @@ while ($userinfo = fscanf($handle, "%s\t%s\t%s\n")) {
 fclose($handle);
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Contenido del archivo users.txt</title>
-    <programlisting role="txt">
+   </programlisting>
+  </example>
+  <example>
+   <title>Contenido del archivo users.txt</title>
+   <programlisting role="txt">
 <![CDATA[
 javier  argonaut        pe
 hiroshi sculptor        jp
 robert  slacker us
 luigi   florist it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fread</function></member>
-    <member><function>fgets</function></member>
-    <member><function>fgetss</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fread</function></member>
+   <member><function>fgets</function></member>
+   <member><function>fgetss</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/fscanf.xml
+++ b/reference/spl/splfileobject/fscanf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splfileobject.fscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,82 +14,84 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Lee una línea de el fichero e interpreta este de acuerdo a el <parameter>format</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Cualquier espacio en blanco en el <parameter>format</parameter> string coincide con cualquier espacio en blanco en la línea de
    el fichero. Esto significa que incluso un (<literal>\t</literal>) en el formato string puede coincidir con un sólo caracter de
    espacio en la secuencia de entrada.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Los valores opcionales asignados.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Los valores opcionales asignados.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Si sólo se pasa un parámetro a este método, los valores analizados serán devueltos
-   como un array. De lo contrario, si se paran los parámetros opcionales, la función
-   devolverá el número de valores asignados. Los parámetros opcionales deben ser pasados
-   por referencia.
-  </para>
+   como un <type>array</type>. De lo contrario, si se pasan los parámetros opcionales,
+   el método devolverá el número de valores asignados. Los parámetros opcionales deben
+   ser pasados por referencia.
+  </simpara>
+  <simpara>
+   Si se esperan más subcadenas en el <parameter>format</parameter> de las disponibles
+   en la línea leída del fichero, se devuelve &null;.
+  </simpara>
+  <simpara>
+   Cuando se usan parámetros opcionales y se alcanza el final de la línea leída del
+   fichero antes de que se haya analizado ningún valor, se devuelve <literal>-1</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Ejemplo de <methodname>SplFileObject::fscanf</methodname></title>
-    <programlisting role="php">
+  <example>
+   <title>Ejemplo de <methodname>SplFileObject::fscanf</methodname></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $file = new SplFileObject("usuarios.txt");
 while ($usuarioinfo = $file->fscanf("%s %s %s")) {
-    list ($nombre, $profesion, $codigopais) = $usuarioinfo;
-    // Operar con  $name $profession $countrycode
+   list ($nombre, $profesion, $codigopais) = $usuarioinfo;
+   // Operar con  $name $profession $countrycode
 }
 ?>
 ]]>
-    </programlisting>
-    <para>Contenido de usuarios.txt</para>
-    <programlisting role="txt">
+   </programlisting>
+   <simpara>Contenido de usuarios.txt</simpara>
+   <programlisting role="txt">
 <![CDATA[
 javier   argonaut    pe
 hiroshi  sculptor    jp
 robert   slacker     us
 luigi    florist     it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fscanf</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fscanf</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/strings/functions/sscanf.xml
+++ b/reference/strings/functions/sscanf.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.sscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,68 +15,69 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>sscanf</function> es la función inversa de
    <function>printf</function>. <function>sscanf</function> lee
    datos de la cadena <parameter>string</parameter> e
    los interpreta según el formato <parameter>format</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Todos los caracteres en blanco en la cadena <parameter>format</parameter> corresponden
    a un carácter en blanco en la cadena <parameter>string</parameter>. Esto significa que
    incluso una tabulación (<literal>\t</literal>) en la cadena de formato puede corresponder a
    un simple espacio en la cadena <parameter>str</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>string</parameter></term>
-     <listitem>
-      <para>
-       La cadena a analizar.
-      </para>
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Opcionalmente, se pueden pasar variables en este parámetro,
-       por referencia que contendrán los valores del análisis.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      La cadena a analizar.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Opcionalmente, se pueden pasar variables en este parámetro,
+      por referencia que contendrán los valores del análisis.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Si solo se proporcionan dos parámetros, los valores encontrados
-   se devolverán como un array. De lo contrario, si se proporcionan los parámetros
-   opcionales, la función devolverá el número de
-   valores asignados. El parámetro opcional debe pasarse por
-   referencia.
-  </para>
-  <para>
+   se devolverán como un <type>array</type>. De lo contrario, si se proporcionan
+   los parámetros opcionales, la función devolverá el número de
+   valores asignados. El parámetro opcional debe pasarse por referencia.
+  </simpara>
+  <simpara>
    Si hay más subcadenas esperadas en el parámetro
    <parameter>format</parameter> que las disponibles en
    <parameter>string</parameter>, entonces &null; será devuelto.
-  </para>
+  </simpara>
+  <simpara>
+   Cuando se usan parámetros opcionales y se alcanza el final de la cadena
+   de entrada <parameter>string</parameter> antes de que se haya analizado
+   ningún valor, se devuelve <literal>-1</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Ejemplo con <function>sscanf</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Ejemplo con <function>sscanf</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // Lectura de un número de serie
@@ -88,17 +88,15 @@ list($month, $day, $year) = sscanf($mandate, "%s %d %d");
 echo "El producto $serial fue fabricado el: $year-" . substr($month, 0, 3) . "-$day\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
    Si se pasan parámetros opcionales, <function>sscanf</function> devolverá
    el número de valores asignados.
-  </para>
-  <para>
-   <example>
-    <title><function>sscanf</function> - uso de parámetros opcionales</title>
-    <programlisting role="php">
+  </simpara>
+  <example>
+   <title><function>sscanf</function> - uso de parámetros opcionales</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // lee la información del autor y genera una entrada DocBook
@@ -110,26 +108,23 @@ echo "<author id='$id'>
 </author>\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-    <member><function>fprintf</function></member>
-    <member><function>vprintf</function></member>
-    <member><function>vsprintf</function></member>
-    <member><function>vfprintf</function></member>
-    <member><function>fscanf</function></member>
-    <member><function>number_format</function></member>
-    <member><function>date</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+   <member><function>fprintf</function></member>
+   <member><function>vprintf</function></member>
+   <member><function>vsprintf</function></member>
+   <member><function>vfprintf</function></member>
+   <member><function>fscanf</function></member>
+   <member><function>number_format</function></member>
+   <member><function>date</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Apply upstream PR #5580 to doc-es: new `-1` return value paragraph on the three files (`fscanf`, `sscanf`, `SplFileObject::fscanf`). Inline `<para>` → `<simpara>` and wrappers around `<variablelist>` / `<example>` / `<simplelist>` removed to mirror EN structure. Existing Maintainers (PhilDaiguille, seros) kept; `<!-- $Revision$ -->` dropped on touched files.

Closes #703.