### PR TITLE
[Sync EN] ibase: Update ibase_trans method parameters in XML (#5587)

### DIFF
--- a/reference/ibase/functions/ibase-trans.xml
+++ b/reference/ibase/functions/ibase-trans.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 17b3531ad4a8ccb3f98656e5300fba45020f0e71 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 2d8dcd319217fa3e6140bfc976d98e03a2c6ae37 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ibase-trans">
  <refnamediv>
@@ -18,7 +17,6 @@
   <methodsynopsis>
    <type>resource</type><methodname>ibase_trans</methodname>
    <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>trans_args</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    Prepara una transacción interBase.


### PR DESCRIPTION
Apply upstream PR #5587 to doc-es: drop the obsolete `trans_args` parameter from the second `<methodsynopsis>` of `ibase_trans` (first signature unchanged). `<!-- $Revision$ -->` dropped, Maintainer `PhilDaiguille` kept.

Closes #704.