### PR TITLE
[Sync EN] Fix various class method signatures to match stub

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -878,6 +878,13 @@ buscado en <link xmlns="http://docbook.org/ns/docbook" linkend="ini.include-path
  </entry>
 </row>'>
 
+ <!ENTITY return.type.true.84 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  El tipo de retorno es ahora &true;, anteriormente era <type>bool</type>.
+ </entry>
+</row>'>
+
  <!ENTITY return.falseforfailure ' o &false; si ocurre un error'>
  <!ENTITY return.falseforfailure.style.procedural '&style.procedural; retorna &false; en caso de error.'>
 

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4756524479423ee3118adec1effa89171a9ffda Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdostatement.setfetchmode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,25 +12,25 @@
   &reftitle.description;
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_COLUMN</initializer></methodparam>
    <methodparam><type>int</type><parameter>colno</parameter></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_CLASS</initializer></methodparam>
    <methodparam><type>string</type><parameter>class</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>null</type></type><parameter>constructorArgs</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_INTO</initializer></methodparam>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -87,9 +87,26 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.84;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/phar/Phar/setStub.xml
+++ b/reference/phar/Phar/setStub.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phar.setstub">
  <refnamediv>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="Phar">
-   <modifier>public</modifier> <type>bool</type><methodname>Phar::setStub</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>Phar::setStub</methodname>
    <methodparam><type class="union"><type>resource</type><type>string</type></type><parameter>stub</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
@@ -71,9 +71,9 @@ include 'phar://monphar.phar/unfchier.php';
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -98,6 +98,7 @@ include 'phar://monphar.phar/unfchier.php';
      </row>
     </thead>
     <tbody>
+     &return.type.true.84;
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phardata.setstub">
  <refnamediv>
@@ -9,9 +9,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="PharData">
-   <modifier>public</modifier> <type>bool</type><methodname>PharData::setStub</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PharData::setStub</methodname>
    <methodparam><type>string</type><parameter>stub</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
 
   <para>
@@ -34,7 +34,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>len</parameter></term>
+     <term><parameter>length</parameter></term>
      <listitem>
       <para>
 
@@ -48,9 +48,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -58,6 +58,23 @@
   <para>
    Genera una excepción <classname>PharException</classname> en cualquier llamada al método
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.84;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/reflection/reflectionclass/getstaticpropertyvalue.xml
+++ b/reference/reflection/reflectionclass/getstaticpropertyvalue.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="reflectionclass.getstaticpropertyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,7 +13,7 @@
   <methodsynopsis role="ReflectionClass">
    <modifier>public</modifier> <type>mixed</type><methodname>ReflectionClass::getStaticPropertyValue</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">def_value</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter role="reference">default</parameter></methodparam>
   </methodsynopsis>
   <para>
    Obtiene el valor de una propiedad estática de esta clase.
@@ -35,7 +34,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>def_value</parameter></term>
+     <term><parameter>default</parameter></term>
      <listitem>
       <para>
        Un valor predeterminado a devolver en caso de que la clase no declare propiedades


### PR DESCRIPTION
Sincronización ES con el commit EN 8a910daa: firmas alineadas con los stubs (tipo de retorno `true`, renombrado de parámetros `def_value` → `default` y `len` → `length`), `return.success` cambiado a `return.true.always` y entradas de changelog 8.4.0 añadidas.

Fixes #707