### PR TITLE
[Sync EN] image: Fix examples and description

### DIFF
--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagedashedline" xmlns="http://docbook.org/ns/docbook">
@@ -21,7 +21,8 @@
   <para>
    <function>imagedashedline</function> está obsoleto. Se recomienda utilizar
    una combinación de las funciones <function>imagesetstyle</function> y
-   <function>imageline</function>.
+   <function>imageline</function>. El punto 0, 0 es la esquina superior
+   izquierda de la imagen.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -33,7 +34,7 @@
      <term><parameter>x1</parameter></term>
      <listitem>
       <para>
-       Coordenada en X: En la parte superior, a la izquierda.
+       Coordenada x del primer punto.
       </para>
      </listitem>
     </varlistentry>
@@ -41,8 +42,7 @@
      <term><parameter>y1</parameter></term>
      <listitem>
       <para>
-       Coordenada en Y: En la parte superior, a la izquierda. 0 es la esquina superior izquierda
-       de la imagen.
+       Coordenada y del primer punto.
       </para>
      </listitem>
     </varlistentry>
@@ -50,7 +50,7 @@
      <term><parameter>x2</parameter></term>
      <listitem>
       <para>
-       Coordenada en X: En la parte inferior, a la derecha.
+       Coordenada x del segundo punto.
       </para>
      </listitem>
     </varlistentry>
@@ -58,7 +58,7 @@
      <term><parameter>y2</parameter></term>
      <listitem>
       <para>
-       Coordenada en Y: En la parte inferior, a la derecha.
+       Coordenada y del segundo punto.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagerectangle" xmlns="http://docbook.org/ns/docbook">
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <para>
    <function>imagerectangle</function> dibuja un rectángulo en las coordenadas
-   especificadas.
+   especificadas. El punto 0, 0 es la esquina superior izquierda de la imagen.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -41,7 +41,6 @@
      <listitem>
       <para>
        Y: coordenada de la esquina superior izquierda.
-       0, 0 es la esquina superior izquierda de la imagen.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagesetbrush" xmlns="http://docbook.org/ns/docbook">
@@ -89,6 +89,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Carga un mini-logo PHP
 $php = imagecreatefrompng('./php.png');
 
@@ -97,7 +98,7 @@ $im = imagecreatetruecolor(100, 100);
 
 // Define el fondo en blanco
 $white = imagecolorallocate($im, 255, 255, 255);
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 99, 99, $white);
 
 // Define el pincel
 imagesetbrush($im, $php);

--- a/reference/image/functions/imagesetthickness.xml
+++ b/reference/image/functions/imagesetthickness.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagesetthickness" xmlns="http://docbook.org/ns/docbook">
@@ -72,13 +72,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Creación de una imagen de 200x100
 $im = imagecreatetruecolor(200, 100);
 $white = imagecolorallocate($im, 0xFF, 0xFF, 0xFF);
 $black = imagecolorallocate($im, 0x00, 0x00, 0x00);
 
 // Establece el fondo en blanco
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 199, 99, $white);
 
 // Establece el grosor de la línea a 5
 imagesetthickness($im, 5);


### PR DESCRIPTION
Sincronización ES con el commit EN d56953fc: descripciones de parámetros de `imagedashedline`/`imagerectangle` aclaradas, y corrección de coordenadas en los ejemplos de `imagesetbrush` e `imagesetthickness`.

Fixes #708