### PR TITLE
[Sync EN] phar/PharData::setStub: tipo del parámetro stub

### DIFF
--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4c394e560dac163a0be9098de27153a9f98ef490 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phardata.setstub">
  <refnamediv>
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis role="PharData">
    <modifier>public</modifier> <type>true</type><methodname>PharData::setStub</methodname>
-   <methodparam><type>string</type><parameter>stub</parameter></methodparam>
+   <methodparam><type class="union"><type>resource</type><type>string</type></type><parameter>stub</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
 


### PR DESCRIPTION
El tipo del parámetro stub pasa a resource|string para coincidir con el stub.

Fixes #712
