### PR TITLE
[Sync EN] appendix 8.4 property hooks: improve terminology

### DIFF
--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d7efc67559999c1dda0f65c90617b60c6872a61b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.new-features">
  <title>Nuevas características</title>
@@ -53,6 +53,8 @@ $p->firstName = 'peter';
 print $p->firstName; // Imprime "Peter"
 $p->lastName = 'Peterson';
 print $p->fullName; // Imprime "Peter Peterson"
+
+$p->fullName = "Peter 'Pete' Peterson"; // Lanza Error: "Property Person::$fullName is read-only"
 ]]>
     </programlisting>
    </informalexample>


### PR DESCRIPTION
Sincroniza el ejemplo de property hooks con el cambio EN: añade la línea que muestra el Error al escribir en una propiedad virtual de solo lectura.

Fixes #717