### PR TITLE
[Sync EN] reflection: ReflectionFunction::__construct() example expects bool param

### DIFF
--- a/reference/reflection/reflectionfunction/construct.xml
+++ b/reference/reflection/reflectionfunction/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 629dfc9ec496d66c49b626dfc72a4981e74d6250 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionfunction.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -89,12 +89,12 @@ function dumpReflectionFunction($func)
     );
 
     // Muestra los comentarios de documentación
-    printf("---> Documentación:\n %s\n", var_export($func->getDocComment(), 1));
+    printf("---> Documentación:\n %s\n", var_export($func->getDocComment(), true));
 
     // Muestra las variables estáticas existentes
     if ($statics = $func->getStaticVariables())
     {
-        printf("---> Variables estáticas: %s\n", var_export($statics, 1));
+        printf("---> Variables estáticas: %s\n", var_export($statics, true));
     }
 }
 


### PR DESCRIPTION
Sincroniza el ejemplo con el cambio EN: usa `true` en lugar de `1` como segundo argumento de `var_export()`.

Fixes #718