### PR TITLE
[Sync EN] enumerations: Amend the CS of the code examples

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1eb67bea30f61f7d9cdfd371146911a0ba07bbd2 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 4c158f4a34c8f869a43f9f0bd5a4897fb35cec89 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Enumeraciones</title>
@@ -38,6 +38,7 @@
    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -60,6 +61,7 @@ enum Suit
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -106,6 +108,7 @@ pick_a_card('Spades');
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -156,6 +159,7 @@ if ($a !== 'Spades') {
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -194,6 +198,7 @@ print Suit::Spades->name;
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -236,6 +241,7 @@ enum Suit: string
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -259,6 +265,7 @@ print Suit::Clubs->value;
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -308,6 +315,7 @@ $ref = &$suit->value;
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -353,6 +361,7 @@ print $suit->value . "\n";
    <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -368,7 +377,7 @@ enum Suit implements Colorful
     // Cumple con el contrato de la interfaz.
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -406,6 +415,7 @@ print Suit::Diamonds->shape(); // imprime "Rectangle"
   <programlisting role="php" annotations="non-interactive">
    <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -421,7 +431,7 @@ enum Suit: string implements Colorful
     // Cumple con el contrato de la interfaz.
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -454,6 +464,7 @@ enum Suit: string implements Colorful
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -470,7 +481,7 @@ final class Suit implements UnitEnum, Colorful
 
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -509,6 +520,7 @@ final class Suit implements UnitEnum, Colorful
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -517,7 +529,7 @@ enum Size
 
     public static function fromLength(int $cm): self
     {
-        return match(true) {
+        return match (true) {
             $cm < 50 => self::Small,
             $cm < 100 => self::Medium,
             default => self::Large,
@@ -551,6 +563,7 @@ var_dump(Size::fromLength(50));
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -578,6 +591,7 @@ var_dump(Size::Huge);
    <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -585,7 +599,8 @@ interface Colorful
 
 trait Rectangle
 {
-    public function shape(): string {
+    public function shape(): string
+    {
         return "Rectangle";
     }
 }
@@ -601,7 +616,7 @@ enum Suit implements Colorful
 
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -636,6 +651,7 @@ var_dump($suit->shape());
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 // Esta es una definición de Enumeración completamente legal.
 enum Direction implements ArrayAccess
 {
@@ -734,6 +750,7 @@ $foo = new Foo();
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 $clovers = new Suit();
 // Error: No se puede instanciar la enumeración Suit
 
@@ -757,6 +774,7 @@ $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor(
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -796,6 +814,7 @@ var_dump(SuitBacked::cases());
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -832,11 +851,14 @@ print serialize(Suit::Hearts);
    <programlisting role="php">
 <![CDATA[
 <?php
-enum Foo {
+
+enum Foo
+{
     case Bar;
 }
 
-enum Baz: int {
+enum Baz: int
+{
     case Beep = 5;
 }
 
@@ -869,12 +891,14 @@ Baz Enum:int {
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 class A {}
 class B extends A {}
 
 function foo(A $a) {}
 
-function bar(B $b) {
+function bar(B $b)
+{
     foo($b);
 }
 ]]>
@@ -893,7 +917,9 @@ function bar(B $b) {
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-enum ErrorCode {
+
+enum ErrorCode
+{
     case SOMETHING_BROKE;
 }
 
@@ -920,13 +946,16 @@ function quux(ErrorCode $errorCode)
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 // Código de experimento mental donde las enumeraciones no son finales.
 // Nota: esto no funcionará realmente en PHP.
-enum MoreErrorCode extends ErrorCode {
+enum MoreErrorCode extends ErrorCode
+{
     case PEBKAC;
 }
 
-function fot(MoreErrorCode $errorCode) {
+function fot(MoreErrorCode $errorCode)
+{
     quux($errorCode);
 }
 
@@ -958,6 +987,7 @@ fot(MoreErrorCode::PEBKAC);
     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum SortOrder
 {
     case Asc;
@@ -987,6 +1017,7 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -996,7 +1027,7 @@ enum UserStatus: string
 
     public function label(): string
     {
-        return match($this) {
+        return match ($this) {
             self::Pending => 'Pending',
             self::Active => 'Active',
             self::Suspended => 'Suspended',
@@ -1026,6 +1057,7 @@ var_dump($status->label());
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -1035,7 +1067,7 @@ enum UserStatus: string
 
     public function label(): string
     {
-        return match($this) {
+        return match ($this) {
             self::Pending => 'Pending',
             self::Active => 'Active',
             self::Suspended => 'Suspended',


### PR DESCRIPTION
Sincroniza el estilo de código de los ejemplos con el cambio EN: línea en blanco tras `<?php`, espacio en `match (`, y llave de apertura en línea propia.

Fixes #719