### PR TITLE
[Sync EN] mysqli: A deprecation notice for mysqli_execute

### DIFF
--- a/reference/mysqli/functions/mysqli-execute.xml
+++ b/reference/mysqli/functions/mysqli-execute.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d7a97693b4683a8c116ac4ba2e25731f5dcb8890 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.mysqli-execute" xmlns="http://docbook.org/ns/docbook">
@@ -9,21 +8,15 @@
   <refpurpose>&Alias; <function>mysqli_stmt_execute</function></refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
    &info.function.alias; <function>mysqli_stmt_execute</function>.
   </para>
- </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    <function>mysqli_execute</function> está fuertemente desaconsejada y debería
-    ser eliminada próximamente.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Sincroniza con el cambio EN: mueve el aviso de obsolescencia a `<refsynopsisdiv>` con la entidad `&warn.deprecated.function-8-5-0;` y elimina el bloque de notas.

Fixes #720