### PR TITLE
[Sync EN] Cubrid: Fix the broken cubrid_prepare description

### DIFF
--- a/reference/cubrid/functions/cubrid-prepare.xml
+++ b/reference/cubrid/functions/cubrid-prepare.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5acad2fc911ee95b2293ece98dfb45a64b91ae14 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-prepare">
  <refnamediv>
@@ -17,17 +16,18 @@
    <methodparam choice="opt"><type>int</type><parameter>option</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   La función <function>cubrid_prepare</function> prepara una consulta SQL para un
-   gestor de conexión proporcionado. Esta consulta SQL precompilada será incluida en
-   la función <function>cubrid_prepare</function>.
+   La función <function>cubrid_prepare</function> compila una consulta SQL para un
+   gestor de conexión dado y devuelve un gestor que representa la consulta precompilada.
   </simpara>
   <simpara>
-   Asimismo, esta consulta puede ser utilizada varias veces o para procesar grandes
-   volúmenes de datos. Una única consulta puede ser utilizada y se pueden insertar
-   variables. La adición de una variable se realiza cuando se desea vincular un valor
-   en la cláusula VALUES o WHERE de una consulta. Tenga en cuenta que solo es
-   permitido vincular un valor a una variable (?) utilizando la función
-   <function>cubrid_bind</function>.
+   Una consulta preparada puede ser ejecutada varias veces, lo cual resulta eficiente
+   para la ejecución repetida o para el procesamiento de grandes volúmenes de datos.
+   Solo se puede utilizar una única consulta, y un parámetro puede marcarse con un
+   signo de interrogación (<literal>?</literal>) en el lugar apropiado de la consulta
+   SQL. Se añade un parámetro al vincular un valor en la cláusula <literal>VALUES</literal>
+   de una sentencia <literal>INSERT</literal> o en la cláusula <literal>WHERE</literal>.
+   Tenga en cuenta que un valor solo puede ser vinculado a un parámetro utilizando la
+   función <function>cubrid_bind</function>.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Sincroniza con el cambio EN: reescribe la descripción de <function>cubrid_prepare</function> para aclararla y añade el marcado <literal> en los términos SQL.

Fixes #721