### PR TITLE
Sync EN: add PHP 8.4.0 changelog entries for SPL, Standard, and Filesystem pages

### DIFF
--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d1cacac75c04a115ee9b464015ce8e7782bd1517 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.tempnam" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -72,6 +72,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       El nombre de los archivos creados por <function>tempnam</function>
+       ahora es 13 bytes más largo. La longitud total sigue dependiendo
+       de la plataforma.
+      </entry>
+     </row>
      <row>
       <entry>7.1.0</entry>
       <entry>

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <reference xml:id="class.splfixedarray" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase SplFixedArray</title>
@@ -68,6 +68,18 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Los accesos fuera de los límites en <classname>SplFixedArray</classname>
+        ahora lanzan excepciones de tipo
+        <exceptionname>OutOfBoundsException</exceptionname> en lugar de
+        <exceptionname>RuntimeException</exceptionname>.
+        Dado que <exceptionname>OutOfBoundsException</exceptionname> es una clase
+        hija de <exceptionname>RuntimeException</exceptionname>, no se produce
+        ningún cambio de comportamiento al intentar capturar esas excepciones.
+       </entry>
+      </row>
       <row>
        <entry>8.2.0</entry>
        <entry>

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2a5223230bf6177c225003ca30c63f48ef266cc0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.debug-zval-dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,6 +47,30 @@
    &return.void;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>debug_zval_dump</function> ahora indica si un
+       array está empaquetado.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a9e47cecca7d5834de43b7641baf5d86828bb153 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -171,6 +171,14 @@
         Ahora lanza <exceptionname>TypeError</exceptionname> y
         <exceptionname>ValueError</exceptionname> si el elemento <literal>allowed_classes</literal>
         de <parameter>options</parameter> no es un <type>array</type> de nombres de clases.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Deserializar cadenas usando la etiqueta <literal>"S"</literal> en mayúscula
+        ahora está obsoleto; en su lugar, utilice la etiqueta <literal>"s"</literal>
+        en minúscula.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Sincroniza con upstream las entradas de changelog de PHP 8.4.0 para `tempnam`, `SplFixedArray`, `debug_zval_dump` y `unserialize`. Réplica tag a tag del EN, se conservan los Maintainer existentes.

Fixes #728