### PR TITLE
Sync EN: add PHP 8.4.0 changelog entries for Intl and MBString pages

### DIFF
--- a/reference/intl/idn/idn-to-ascii.xml
+++ b/reference/intl/idn/idn-to-ascii.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e908bfda98eb9fe16fb2c1b5773f312e5c684ee3  Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699  Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
@@ -94,6 +94,21 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Ahora lanza un <exceptionname>ValueError</exceptionname>
+        si el parámetro <parameter>domain</parameter> está vacío.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Ahora lanza un <exceptionname>ValueError</exceptionname>
+        si el parámetro <parameter>variant</parameter> no es
+        <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/intl/idn/idn-to-utf8.xml
+++ b/reference/intl/idn/idn-to-utf8.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d6aee4a5004f7d532f24c06ea2ab2ac0b91b8664 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
@@ -97,6 +97,21 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Ahora lanza un <exceptionname>ValueError</exceptionname>
+        si el parámetro <parameter>domain</parameter> está vacío.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Ahora lanza un <exceptionname>ValueError</exceptionname>
+        si el parámetro <parameter>variant</parameter> no es
+        <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.mb-strcut" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -112,6 +112,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       El comportamiento ahora es más consistente con las cadenas <literal>UTF-8</literal> y <literal>UTF-16</literal> inválidas.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.mb-substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -99,6 +99,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       En cadenas inválidas (aquellas con errores de codificación),
+       los índices de caracteres ahora se interpretan de la misma manera que la mayoría
+       de las otras funciones de mbstring. Esto significa que los índices de caracteres devueltos
+       por <function>mb_strpos</function> pueden pasarse directamente.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Sincroniza con upstream las entradas de changelog de PHP 8.4.0 para `idn_to_ascii`, `idn_to_utf8`, `mb_strcut` y `mb_substr`. Réplica tag a tag del EN, se conservan los Maintainer existentes.

Fixes #727