### PR TITLE
[Sync EN] unserialization: allowed_classes no afecta a las enumeraciones

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4c158f4a34c8f869a43f9f0bd5a4897fb35cec89 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Enumeraciones</title>
@@ -835,6 +835,12 @@ print serialize(Suit::Hearts);
    Al deserializar, si no se puede encontrar una enumeración y un caso para coincidir con un valor serializado,
    se emitirá una advertencia y se devolverá &false;.
   </para>
+
+  <simpara>
+   La opción <literal>allowed_classes</literal> de
+   <function>unserialize</function> no afecta a las
+   <link linkend="language.enumerations">Enumeraciones</link>.
+  </simpara>
 
   <para>
    Si una Enumeración Pura se serializa a JSON, se lanzará un error. Si una Enumeración Respaldada

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -102,6 +102,9 @@
            <simpara>
             Omitir esta opción equivale a definirla como &true;:
             PHP intentará instanciar objetos de cualquier clase.
+           </simpara>
+           <simpara>
+            Esta opción no afecta a las <link linkend="language.enumerations">Enumeraciones</link>.
            </simpara>
           </entry>
          </row>


### PR DESCRIPTION
Sync EN (commit 8af3521). Fixes #736