### PR TITLE
[Sync EN] PDO: tipo de constantes de int a bool (PHP 8.4.0)

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7e384b24f7e37c6b4caf735f3601179cc65ef8f9 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="pdo.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -230,12 +230,16 @@
    <varlistentry xml:id="pdo.constants.attr-autocommit">
     <term>
      <constant>PDO::ATTR_AUTOCOMMIT</constant>
-     (<type>int</type>)
+     (<type>bool</type>)
     </term>
     <listitem>
      <simpara>
       Si el valor es &false;, PDO intenta desactivar la validación automática
       cuando la conexión comienza una transacción.
+     </simpara>
+     <simpara>
+      A partir de PHP 8.4.0 esta constante es de tipo <type>bool</type>;
+      anteriormente, era de tipo <type>int</type>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -488,11 +492,19 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
    <varlistentry xml:id="pdo.constants.attr-emulate-prepares">
     <term>
      <constant>PDO::ATTR_EMULATE_PREPARES</constant>
-     (<type>int</type>)
+     (<type>bool</type>)
     </term>
     <listitem>
      <simpara>
-
+      Indica si se debe activar o desactivar la emulación de las sentencias
+      preparadas. Algunos controladores no soportan las sentencias preparadas
+      nativas o solo tienen un soporte limitado de ellas. Cuando se define a
+      &true;, PDO siempre emula las sentencias preparadas; cuando se define a
+      &false;, utiliza las sentencias preparadas nativas del controlador.
+     </simpara>
+     <simpara>
+      A partir de PHP 8.4.0 esta constante es de tipo <type>bool</type>;
+      anteriormente, era de tipo <type>int</type>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 608815b2f52cc7dae75eb02e27f457aad1e5e977 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-dblib" role="class">
  <title>La clase Pdo\Dblib</title>
@@ -54,7 +54,7 @@
      <fieldsynopsis>
       <modifier>public</modifier>
       <modifier>const</modifier>
-      <type>int</type>
+      <type>bool</type>
       <varname linkend="pdo-dblib.constants.attr-stringify-uniqueidentifier">Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</varname>
      </fieldsynopsis>
      <fieldsynopsis>
@@ -78,7 +78,7 @@
      <fieldsynopsis>
       <modifier>public</modifier>
       <modifier>const</modifier>
-      <type>int</type>
+      <type>bool</type>
       <varname linkend="pdo-dblib.constants.attr-datetime-convert">Pdo\Dblib::ATTR_DATETIME_CONVERT</varname>
      </fieldsynopsis>
 
@@ -116,6 +116,8 @@
      <term><constant>Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</constant></term>
      <listitem>
       <simpara>
+       A partir de PHP 8.4.0 esta constante es de tipo <type>bool</type>;
+       anteriormente, era de tipo <type>int</type>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -152,6 +154,10 @@
        por el usuario o por la configuración regional, según se especifica en
        el archivo <filename>locales.conf</filename> de FreeTDS. Por defecto,
        este atributo es &false;.
+      </simpara>
+      <simpara>
+       A partir de PHP 8.4.0 esta constante es de tipo <type>bool</type>;
+       anteriormente, era de tipo <type>int</type>.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b2a7a5fab7231fa8634096f111ae0fa0dc60bcfe Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="ref.pdo-mysql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -87,11 +87,15 @@
   <varlistentry xml:id="pdo.constants.mysql-attr-direct-query">
    <term>
     <constant>PDO::MYSQL_ATTR_DIRECT_QUERY</constant>
-    (<type>int</type>)
+    (<type>bool</type>)
    </term>
    <listitem>
     <simpara>
      &Alias; <constant>PDO::ATTR_EMULATE_PREPARES</constant>
+    </simpara>
+    <simpara>
+     A partir de PHP 8.4.0 esta constante es de tipo <type>bool</type>;
+     anteriormente, era de tipo <type>int</type>.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Sync EN (commit 5d8e96f). Fixes #733