### PR TITLE
[Sync EN] readline: entradas de registro de cambios de PHP 8.5

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -885,6 +885,13 @@ buscado en <link xmlns="http://docbook.org/ns/docbook" linkend="ini.include-path
  </entry>
 </row>'>
 
+ <!ENTITY return.type.true.85 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.5.0</entry>
+ <entry>
+  El tipo de retorno ahora es &true;; anteriormente era <type>bool</type>.
+ </entry>
+</row>'>
+
  <!ENTITY return.falseforfailure ' o &false; si ocurre un error'>
  <!ENTITY return.falseforfailure.style.procedural '&style.procedural; retorna &false; en caso de error.'>
 

--- a/reference/readline/functions/readline-add-history.xml
+++ b/reference/readline/functions/readline-add-history.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-add-history">
  <refnamediv>
@@ -39,6 +38,24 @@
    &return.true.always;
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-callback-handler-install">
  <refnamediv>
@@ -58,6 +57,23 @@
   <simpara>
    &return.true.always;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/readline/functions/readline-clear-history.xml
+++ b/reference/readline/functions/readline-clear-history.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-clear-history">
  <refnamediv>
@@ -30,6 +29,24 @@
    &return.true.always;
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Sincroniza las páginas de readline con la fuente EN: añade las entradas de registro de cambios de PHP 8.5 (el tipo de retorno ahora es true). Se añade la entidad return.type.true.85 a language-snippets.ent.