### PR TITLE
[Sync EN] Sincronización de revisión (correcciones de erratas, #5582): lote B

### DIFF
--- a/reference/gearman/gearmanworker/timeout.xml
+++ b/reference/gearman/gearmanworker/timeout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cf0a919c126e45b5df583d188e77fa62015b714a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanworker.timeout">
  <refnamediv>

--- a/reference/gmp/functions/gmp-init.xml
+++ b/reference/gmp/functions/gmp-init.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c75f19c74fa3b64abfafd7a35aaa652b07834a5a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.gmp-init" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/gnupg/functions/gnupg-getengineinfo.xml
+++ b/reference/gnupg/functions/gnupg-getengineinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a148eb08b658eafa139f8996ad92d860e023da3f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.gnupg-getengineinfo">
  <refnamediv>

--- a/reference/intl/intlcalendar/getleastmaximum.xml
+++ b/reference/intl/intlcalendar/getleastmaximum.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlcalendar.getleastmaximum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-manager.startsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-readconcern.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/server.xml
+++ b/reference/mongodb/mongodb/driver/server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql_xdevapi/columnresult/isnumbersigned.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/columnresult/isnumbersigned.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee52285714f7f7371364a3e5233d2ca2da078706 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysql-xdevapi-columnresult.isnumbersigned" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &true; si una columna dada es de tipo signado.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli_stmt/error-list.xml
+++ b/reference/mysqli/mysqli_stmt/error-list.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d31ab6f26d3bb116298aed86cf1daba2bfb78b6b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli-stmt.error-list" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo_cubrid/constants.xml
+++ b/reference/pdo_cubrid/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 10eade765ad63d4e660a5a06709a9ca876f2d411 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="pdo-cubrid.constants" xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
Sincroniza un lote de archivos con la revisión EN tras correcciones de erratas en inglés. La mayoría solo requiere actualizar el hash; se ajusta el código/estructura donde la errata afectaba a contenido compartido.