### PR TITLE
[Sync EN] Sincronización de revisión (correcciones de erratas, #5582) — lote A

### DIFF
--- a/appendices/examples.xml
+++ b/appendices/examples.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bce2cb849721c70737eb32ce958131e22677770c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="examples" xmlns="http://docbook.org/ns/docbook">
  <title>Acerca de los ejemplos del manual</title>

--- a/reference/cubrid/setup.xml
+++ b/reference/cubrid/setup.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: seros Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="cubrid.setup">
  &reftitle.setup;

--- a/reference/enchant/functions/enchant-dict-store-replacement.xml
+++ b/reference/enchant/functions/enchant-dict-store-replacement.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-store-replacement">
  <refnamediv>

--- a/reference/exif/functions/exif-read-data.xml
+++ b/reference/exif/functions/exif-read-data.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6a08181be1706dfebdb3ad6e45620bceb08019ba Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.exif-read-data">
  <refnamediv>

--- a/reference/fdf/functions/fdf-get-attachment.xml
+++ b/reference/fdf/functions/fdf-get-attachment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: f86fd7b1ce74d1ea3a6a2e3e40757590b14a3e7e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-get-attachment">
  <refnamediv>

--- a/reference/fdf/functions/fdf-set-file.xml
+++ b/reference/fdf/functions/fdf-set-file.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: f86fd7b1ce74d1ea3a6a2e3e40757590b14a3e7e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-set-file">
  <refnamediv>

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0a3648a71895f35f570573d31ca9e003786aa993 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.fgetcsv" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/gearman/gearmanclient/jobstatus.xml
+++ b/reference/gearman/gearmanclient/jobstatus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cf0a919c126e45b5df583d188e77fa62015b714a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanclient.jobstatus">
  <refnamediv>

--- a/reference/gearman/gearmanjob/sendstatus.xml
+++ b/reference/gearman/gearmanjob/sendstatus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cf0a919c126e45b5df583d188e77fa62015b714a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanjob.sendstatus">
  <refnamediv>

--- a/reference/gearman/gearmanjob/status.xml
+++ b/reference/gearman/gearmanjob/status.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: cf0a919c126e45b5df583d188e77fa62015b714a Maintainer: tatai Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: tatai Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanjob.status">
  <refnamediv>
   <refname>GearmanJob::status</refname>


### PR DESCRIPTION
Sincronización con la revisión EN que corrige erratas ortográficas. Como las coquillas están en prosa inglesa ya traducida, solo se actualiza el hash EN-Revision (lote A).