### PR TITLE
Sync EN: fix bpftrace note about environment variable

### DIFF
--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 939350f9b52be4b91e04ec1a5d41995e63aa5150 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7c966c94fde8a9bb4e52975b559dc0bb0cb2ef72 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <chapter xml:id="features.dtrace" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Rastreo dinámico de DTrace</title>
@@ -593,7 +593,7 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
     o conéctese por PID con <literal>-p</literal> según sea necesario.
    </simpara>
    <simpara>
-    Asegúrese de que el binario objetivo esté construido con DTrace y de que el entorno esté configurado correctamente.
+    Asegúrese de que el binario objetivo esté construido con DTrace y de que la variable de entorno esté configurada correctamente.
     Consulte <link linkend="features.dtrace.install">Configurar PHP para las sondas estáticas de DTrace</link> para más detalles.
    </simpara>
    <para>


### PR DESCRIPTION
Alinea la nota de bpftrace con el texto EN: es la variable de entorno (no el entorno) la que debe estar configurada correctamente.

Fixes #758