### PR TITLE
Sync EN: make the boolean example executable

### DIFF
--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4657c1173e6b3852cdc8db4fc64f380d10ebae0c Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ee66d210fb1dd5799fbca9881c6ac2560a19579d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.boolean">
  <title>Booleano</title>
@@ -18,7 +18,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $foo = true; // asigna el valor TRUE a $foo
+
+var_dump($foo); // bool(true)
 ?>
 ]]>
    </programlisting>
@@ -32,6 +35,7 @@ $foo = true; // asigna el valor TRUE a $foo
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $action = "show_version";
 $show_separators = true;
 


### PR DESCRIPTION
Hace ejecutable el primer ejemplo de la página de booleanos añadiendo un var_dump, en espejo del texto EN.

Fixes #753