### PR TITLE
Sync EN: proc_close espera al proceso, corrección gramatical en los valores devueltos

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ef623ccf442df416da4e5bc254b4c5d4f6df9475 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 970d3aa7fdf5c714b584cbe67ebf9e32a1e8b0d3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>proc_close</refname>
   <refpurpose>
-   Cierra un proceso abierto por <function>proc_open</function>
+   Cierra los pipes hacia un proceso abierto por <function>proc_open</function>,
+   espera a que termine y devuelve su código de salida
   </refpurpose>
  </refnamediv>
 
@@ -47,9 +48,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve el código de salida del proceso o <literal>-1</literal> en caso de error.
-  </para>
+  <simpara>
+   Devuelve el estado de terminación del proceso que se ejecutó. En caso de
+   error, se devuelve <literal>-1</literal>.
+  </simpara>
   &note.sigchild;
  </refsect1>
   <refsect1 role="changelog">


### PR DESCRIPTION
Alinea el refpurpose de proc_close con el texto EN (cierra los pipes y espera a que el proceso termine, no lo cierra) y convierte el bloque de valores devueltos en simpara.

Fixes #754