### PR TITLE
Sync EN: documenta el elemento de modo de fichero de los descriptores de proc_open

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6667724b8a42ba501172bc874dd1644a6744be0f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: f50098447455250c9f92eed119248aaa30920100 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.proc-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -80,11 +80,12 @@
        <simplelist>
         <member>
          Un array que describe el pipe a pasar al proceso. El primer elemento
-         es el tipo del descriptor y el segundo es una opción para el tipo dado.
+         es el tipo del descriptor y los elementos siguientes son opciones para el tipo dado.
          Los tipos válidos son <literal>pipe</literal> (el segundo elemento es
          <literal>r</literal> para pasar el extremo de lectura del pipe al proceso, o
          <literal>w</literal> para pasar el extremo de escritura) y
-         <literal>file</literal> (el segundo elemento es el nombre de fichero).
+         <literal>file</literal> (el segundo elemento es el nombre de fichero, y el tercer
+         elemento es el modo de apertura del fichero, igual que <function>fopen</function>).
          Se debe notar que cualquier otro elemento diferente de <literal>w</literal> es tratado como <literal>r</literal>.
         </member>
         <member>


### PR DESCRIPTION
Alinea la descripción de los descriptores de proc_open con el texto EN: un descriptor file acepta un tercer elemento, el modo de apertura del fichero (como fopen).

Fixes #755