### PR TITLE
Sync EN: documenta la directiva INI fatal_error_backtraces

### DIFF
--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6b48f364497107ae46f926bfc99a4e3d9d546316 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.other-changes">
  <title>Otros cambios</title>
@@ -403,8 +403,9 @@
    <title>Núcleo</title>
 
    <simpara>
-    Añadido fatal_error_backtraces para controlar si los errores fatales deben incluir
-    un seguimiento de pila.
+    Añadido <link
+    linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link> para
+    controlar si los errores fatales deben incluir un seguimiento de pila.
     <!-- RFC: https://wiki.php.net/rfc/error_backtraces_v2 -->
    </simpara>
 

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5ff446c832aded712d45c885609ffdd277e6a49 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -24,6 +24,14 @@
      <entry>NULL</entry>
      <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
+    </row>
+    <row>
+     <entry><link linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link></entry>
+     <entry>"1"</entry>
+     <entry><constant>INI_ALL</constant></entry>
+     <entry>
+      Disponible a partir de PHP 8.5.0
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.display-errors">display_errors</link></entry>
@@ -200,6 +208,23 @@
        los errores de tipo <constant>E_ALL</constant>).
       </para>
      </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.fatal-error-backtraces">
+    <term>
+     <parameter>fatal_error_backtraces</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Controla si los errores fatales deben incluir un seguimiento de pila.
+      Los errores fatales son <constant>E_ERROR</constant>,
+      <constant>E_CORE_ERROR</constant>, <constant>E_COMPILE_ERROR</constant>,
+      <constant>E_USER_ERROR</constant>,
+      <constant>E_RECOVERABLE_ERROR</constant>, y
+      <constant>E_PARSE</constant>.
+     </simpara>
     </listitem>
    </varlistentry>
 


### PR DESCRIPTION
Documenta la directiva fatal_error_backtraces (añadida en PHP 8.5) en la lista de directivas INI de errorfunc, y añade el enlace en los cambios de migración 8.5.

Fixes #756