### PR TITLE
Sync EN: añade StreamBucket al sumario de stream y corrige el ancla dataLength

### DIFF
--- a/reference/stream/book.xml
+++ b/reference/stream/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98d4a70aac9e7e3663282507f2f9ce014227e39d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 564bdc2db8f4c01ba36f64e24356756442b74bc5 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <book xml:id="book.stream" xmlns="http://docbook.org/ns/docbook">
@@ -74,6 +74,7 @@
  &reference.stream.examples;
  &reference.stream.php-user-filter;
  &reference.stream.streamwrapper;
+ &reference.stream.streambucket;
  &reference.stream.reference;
 
 </book>

--- a/reference/stream/streambucket.xml
+++ b/reference/stream/streambucket.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7be7e9abb82bfd0c69ea341d74fb9456e93f6f6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 564bdc2db8f4c01ba36f64e24356756442b74bc5 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <reference xml:id="class.streambucket" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase StreamBucket</title>
@@ -75,7 +75,7 @@
       </simpara>
      </listitem>
     </varlistentry>
-    <varlistentry xml:id="streambucket.props.dataLength">
+    <varlistentry xml:id="streambucket.props.datalength">
      <term>int <varname>dataLength</varname></term>
      <listitem>
       <simpara>La longitud del string en el cubo.</simpara>
@@ -95,8 +95,6 @@
   </section>
 
  </partintro>
-
- &reference.stream.entities.streambucket;
 
 </reference>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Añade la referencia StreamBucket que faltaba en el book.xml de la extensión stream, y alinea el ancla de la propiedad dataLength con su mayúsculas/minúsculas EN.

Fixes #757