### PR TITLE
[Sync EN] Documentar nuevas funciones pgsql de PHP 8.4 (#765)

### DIFF
--- a/reference/pgsql/functions/pg-change-password.xml
+++ b/reference/pgsql/functions/pg-change-password.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-change-password" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_change_password</refname>
+  <refpurpose>Cambia la contraseña de un usuario de PostgreSQL</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pg_change_password</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>user</parameter></methodparam>
+   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pg_change_password</function> cambia la contraseña de un
+   usuario de PostgreSQL. Esta función utiliza la función de libpq
+   <literal>PQchangePassword</literal>, que gestiona el cifrado de la
+   contraseña automáticamente según la configuración del servidor.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>user</parameter></term>
+    <listitem>
+     <simpara>
+      El nombre del usuario de PostgreSQL cuya contraseña se va a cambiar.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <simpara>
+      La nueva contraseña.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-jit.xml
+++ b/reference/pgsql/functions/pg-jit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-jit" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_jit</refname>
+  <refpurpose>Devuelve la información JIT del servidor</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>pg_jit</methodname>
+   <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pg_jit</function> devuelve un array con la información JIT
+   (compilación Just-In-Time) del servidor PostgreSQL.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection-with-nullable-default;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve un &array; que contiene la información JIT del servidor.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_version</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-data.xml
+++ b/reference/pgsql/functions/pg-put-copy-data.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-put-copy-data" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_data</refname>
+  <refpurpose>Envía datos al servidor durante una operación COPY</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_data</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cmd</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Envía datos al servidor durante una operación
+   <literal>COPY FROM STDIN</literal>. Se debe haber emitido un comando
+   <literal>COPY</literal> mediante <function>pg_query</function> antes
+   de llamar a esta función.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cmd</parameter></term>
+    <listitem>
+     <simpara>
+      Los datos a enviar al servidor. Se añade automáticamente un salto
+      de línea final si no está presente. Los datos deben tener el
+      formato correspondiente al formato del comando
+      <literal>COPY</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve <literal>1</literal> en caso de éxito, <literal>0</literal>
+   si los datos no se pudieron poner en cola (solo en modo no
+   bloqueante), o <literal>-1</literal> en caso de error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_end</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-end.xml
+++ b/reference/pgsql/functions/pg-put-copy-end.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-put-copy-end" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_end</refname>
+  <refpurpose>Indica al servidor la finalización de una operación COPY</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_end</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>error</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Envía una indicación de fin de datos al servidor durante una
+   operación <literal>COPY FROM STDIN</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>error</parameter></term>
+    <listitem>
+     <simpara>
+      Si no es &null;, la operación <literal>COPY</literal> se fuerza a
+      fallar con el mensaje de error indicado.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve <literal>1</literal> en caso de éxito, <literal>0</literal>
+   si los datos no se pudieron poner en cola (solo en modo no
+   bloqueante), o <literal>-1</literal> en caso de error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_data</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-socket-poll.xml
+++ b/reference/pgsql/functions/pg-socket-poll.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-socket-poll" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_socket_poll</refname>
+  <refpurpose>Sondea un socket de conexión PostgreSQL para comprobar si está listo para lectura/escritura</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_socket_poll</methodname>
+   <methodparam><type>resource</type><parameter>socket</parameter></methodparam>
+   <methodparam><type>int</type><parameter>read</parameter></methodparam>
+   <methodparam><type>int</type><parameter>write</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sondea un socket de conexión PostgreSQL para comprobar si está listo
+   para lectura y/o escritura. El socket puede obtenerse mediante
+   <function>pg_socket</function>. Esta función es útil para implementar
+   flujos de trabajo de consultas no bloqueantes y asíncronos.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>socket</parameter></term>
+    <listitem>
+     <simpara>
+      Un recurso de socket obtenido de <function>pg_socket</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>read</parameter></term>
+    <listitem>
+     <simpara>
+      Indica si se debe comprobar si está listo para lectura. Pase
+      <literal>1</literal> para comprobarlo, <literal>0</literal> para
+      omitirlo.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>write</parameter></term>
+    <listitem>
+     <simpara>
+      Indica si se debe comprobar si está listo para escritura. Pase
+      <literal>1</literal> para comprobarlo, <literal>0</literal> para
+      omitirlo.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>timeout</parameter></term>
+    <listitem>
+     <simpara>
+      El número máximo de milisegundos a esperar. Pase
+      <literal>-1</literal> para esperar indefinidamente, o
+      <literal>0</literal> para no esperar en absoluto.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve un valor positivo si el socket está listo,
+   <literal>0</literal> si se alcanzó el tiempo de espera, o
+   <literal>-1</literal> en caso de error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_socket</function></member>
+   <member><function>pg_consume_input</function></member>
+   <member><function>pg_send_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Traduce al español las nuevas funciones de pgsql añadidas en PHP 8.4: pg_change_password, pg_jit, pg_put_copy_data, pg_put_copy_end y pg_socket_poll.

Fixes #765