### PR TITLE
[Sync EN] Documentar IntlDateFormatter::parseToCalendar y Spoofchecker::setAllowedChars (PHP 8.4) (#769)

### DIFF
--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="intldateformatter.parsetocalendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlDateFormatter::parseToCalendar</refname>
+  <refpurpose>Analiza una cadena hacia un timestamp, actualizando un calendario abierto</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlDateFormatter">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type><type>false</type></type><methodname>IntlDateFormatter::parseToCalendar</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Convierte <parameter>string</parameter> en un valor de tiempo incremental, comenzando
+   en <parameter>offset</parameter> y leyendo tantos caracteres del valor de entrada como sea posible.
+  </simpara>
+  <simpara>
+   Este método se comporta como <methodname>IntlDateFormatter::parse</methodname>, salvo
+   que la zona horaria del formateador se actualiza según la información de zona horaria
+   contenida en la cadena <parameter>string</parameter> analizada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      La cadena a convertir en un tiempo.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      Posición en la que comenzar el análisis en <parameter>string</parameter> (basada en cero).
+      Si no ocurre ningún error antes de que <parameter>string</parameter> sea consumida,
+      <parameter>offset</parameter> contendrá -1; de lo contrario contendrá la posición
+      en la que el análisis terminó (y se produjo el error).
+      Esta variable contendrá la posición final si el análisis falla.
+      Si <parameter>offset</parameter> &gt; <code>strlen($string)</code>, el análisis falla inmediatamente.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   El timestamp del valor analizado, o &false; si el valor no se puede analizar.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>IntlDateFormatter::parseToCalendar</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlDateFormatter(
+    'en_US',
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    'America/Los_Angeles',
+    IntlDateFormatter::GREGORIAN
+);
+echo $fmt->parseToCalendar('Wednesday, December 20, 1989 at 4:00:00 PM Pacific Standard Time');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+630201600
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlDateFormatter::parse</methodname></member>
+   <member><methodname>IntlDateFormatter::format</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorCode</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorMessage</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/spoofchecker/setallowedchars.xml
+++ b/reference/intl/spoofchecker/setallowedchars.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="spoofchecker.setallowedchars" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Spoofchecker::setAllowedChars</refname>
+  <refpurpose>Define el conjunto de caracteres permitidos al ejecutar las comprobaciones</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Spoofchecker">
+   <modifier>public</modifier> <type>void</type><methodname>Spoofchecker::setAllowedChars</methodname>
+   <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>patternOptions</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Restringe los caracteres que las comprobaciones posteriores consideran aceptables al
+   conjunto descrito por <parameter>pattern</parameter>. Cualquier carácter fuera de este conjunto
+   provoca que <methodname>Spoofchecker::isSuspicious</methodname> reporte un resultado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>pattern</parameter></term>
+    <listitem>
+     <simpara>
+      Un conjunto de caracteres descrito como un patrón <literal>UnicodeSet</literal>, es decir,
+      una clase de caracteres al estilo de las expresiones regulares. Debe comenzar con <literal>[</literal>
+      y terminar con <literal>]</literal>, por ejemplo <literal>[a-z0-9]</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>patternOptions</parameter></term>
+    <listitem>
+     <simpara>
+      Una máscara de bits que controla cómo se interpreta <parameter>pattern</parameter>. Debe ser
+      <literal>0</literal>, o <constant>Spoofchecker::IGNORE_SPACE</constant> por sí solo
+      o combinado con exactamente uno de <constant>Spoofchecker::CASE_INSENSITIVE</constant>,
+      <constant>Spoofchecker::ADD_CASE_MAPPINGS</constant> o
+      <constant>Spoofchecker::SIMPLE_CASE_INSENSITIVE</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   No se devuelve ningún valor.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lanza un <exceptionname>ValueError</exceptionname> si <parameter>pattern</parameter> no
+   es un patrón de conjunto de caracteres válido, o si <parameter>patternOptions</parameter> no
+   es una combinación de opciones válida.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Spoofchecker::setAllowedChars</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$checker = new Spoofchecker();
+$checker->setAllowedChars('[a-z0-9]');
+
+var_dump($checker->isSuspicious('hello'));
+var_dump($checker->isSuspicious('héllo'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Spoofchecker::setAllowedLocales</methodname></member>
+   <member><methodname>Spoofchecker::isSuspicious</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Traduce al español las dos nuevas páginas de PHP 8.4: `IntlDateFormatter::parseToCalendar` y `Spoofchecker::setAllowedChars`, espejo de la estructura de doc-en.

Fixes #769