### PR TITLE
[Sync EN] Añadir entradas de registro de cambios de PHP 8.4.0 para Session y LDAP (#768)

### DIFF
--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 57c38af2b053068ad0f1dfdead8128b957ccf4f0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.ldap-connect" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -106,6 +106,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Llamar a <function>ldap_connect</function> con más de
+       dos argumentos está ahora obsoleto.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/session/functions/session-set-save-handler.xml
+++ b/reference/session/functions/session-set-save-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-set-save-handler" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -292,6 +292,30 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Llamar a <function>session_set_save_handler</function> con más
+       de dos argumentos está ahora obsoleto.
+       En su lugar, use la firma de dos argumentos.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Sincroniza las entradas de registro de cambios de PHP 8.4.0 para `ldap_connect` y `session_set_save_handler` (firma con más de dos argumentos ahora obsoleta).

Fixes #768