### PR TITLE
[Sync EN] Documentar constantes y obsolescencias de PHP 8.4.0 que faltan (#767)

### DIFF
--- a/reference/session/constants.xml
+++ b/reference/session/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7c4e8d8219e9a65553cfc378bb46405bf6b2ed53 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <appendix xml:id="session.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -20,6 +20,11 @@
      Es el mismo valor que el devuelto por la función
      <function>session_id</function>.
     </simpara>
+    <warning>
+     <simpara>
+      Esta constante ha quedado obsoleta a partir de PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.php-session-disabled">

--- a/reference/soap/constants.xml
+++ b/reference/soap/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7c4e8d8219e9a65553cfc378bb46405bf6b2ed53 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <appendix xml:id="soap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -68,7 +68,9 @@
       (<type>int</type>)
      </entry>
      <entry>999</entry>
-     <entry/>
+     <entry>
+      Obsoleta a partir de PHP 8.4.0.
+     </entry>
     </row>
     <row xml:id="constant.soap-encoded">
      <entry>


### PR DESCRIPTION
Sincroniza Session y SOAP con PHP 8.4.0: `SID` y `SOAP_FUNCTIONS_ALL` quedan obsoletas.

Las constantes de LDAP y OpenSSL de la issue van en #778 (para no duplicar los mismos `xml:id`).

Fixes #767