### PR TITLE
[Sync EN] PHP 8.4: documentar algunos cambios en ext/date (#772)

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -80,6 +80,11 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Ahora tiene un tipo de retorno tentativo de <type>DateInterval</type>.
+       Anteriormente era <type class="union"><type>DateInterval</type><type>false</type></type>.
+      </entry>
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> ahora lanza

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0cf48a5a4869bd8b42f84e7032076756cde6a474 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="dateperiod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -33,8 +33,8 @@
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    En su lugar, debería utilizarse el constructor virtual (factory method) estático
-    <methodname>DatePeriod::createFromISO8601String</methodname>.
+    Esta variante del constructor ha quedado obsoleta a partir de PHP 8.4.0,
+    utiliza <methodname>DatePeriod::createFromISO8601String</methodname> en su lugar.
    </simpara>
   </warning>
   <para>
@@ -164,6 +164,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        La firma que utiliza <parameter>isostr</parameter> ha quedado obsoleta,
+        utiliza <methodname>DatePeriod::createFromISO8601String</methodname> en su lugar.
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -68,6 +68,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Ahora tiene un tipo de retorno tentativo de <type>DateTime</type>.
+       Anteriormente era <type class="union"><type>DateTime</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>


### PR DESCRIPTION
Sincroniza `ext/date` con PHP 8.4: tipos de retorno tentativos y obsolescencia de la firma `isostr` de `DatePeriod::__construct()`.

El cambio de `DateTimeImmutable::modify()` va en #780.

Fixes #772