### PR TITLE
[Sync EN] Añadir nuevas funciones de DateTime de PHP 8.4 (#771)

### DIFF
--- a/reference/datetime/datetime/createfromtimestamp.xml
+++ b/reference/datetime/datetime/createfromtimestamp.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: lacatoire Status: ready -->
+<refentry xml:id="datetime.createfromtimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTime::createFromTimestamp</refname>
+  <refpurpose>Crea una instancia a partir de una marca de tiempo Unix</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <modifier>static</modifier> <type>static</type><methodname>DateTime::createFromTimestamp</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Crea una instancia a partir de una marca de tiempo Unix.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timestamp</parameter></term>
+    <listitem>
+     <simpara>
+      Marca de tiempo Unix que representa la fecha.
+      También se acepta un valor &float;, lo que permite una precisión de microsegundos.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve una nueva instancia de <classname>DateTime</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si <parameter>timestamp</parameter> está fuera del rango [<constant>PHP_INT_MIN</constant>, <constant>PHP_INT_MAX</constant>],
+   se lanza una <exceptionname>DateRangeError</exceptionname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetime.createfromtimestamp.example.basic">
+   <title>Ejemplo de <methodname>DateTime::createFromTimestamp</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTime::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetime/setmicrosecond.xml
+++ b/reference/datetime/datetime/setmicrosecond.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: lacatoire Status: ready -->
+<refentry xml:id="datetime.setmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTime::setMicrosecond</refname>
+  <refpurpose>Establece la parte de microsegundos de la hora</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <type>static</type><methodname>DateTime::setMicrosecond</methodname>
+   <methodparam><type>int</type><parameter>microsecond</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Establece la parte de microsegundos de la hora.
+  </simpara>
+  <simpara>
+   Igual que <methodname>DateTimeImmutable::setMicrosecond</methodname> pero funciona con
+   <classname>DateTime</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>microsecond</parameter></term>
+    <listitem>
+     <simpara>
+      El valor de microsegundos a establecer (de <literal>0</literal> a <literal>999999</literal>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &date.datetime.return.modifiedobject;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si <parameter>microsecond</parameter> está fuera del rango [<literal>0</literal>, <literal>999999</literal>],
+   se lanza una <exceptionname>DateRangeError</exceptionname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetime.setmicrosecond.example.basic">
+   <title>Ejemplo de <methodname>DateTime::setMicrosecond</methodname></title>
+
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTime::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+$date->setMicrosecond(987654);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+1970-01-01 00:02:03.987654
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getMicrosecond</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetime/settimestamp.xml
+++ b/reference/datetime/datetime/settimestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <refentry xml:id="datetime.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -63,6 +63,7 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>DateTimeImmutable::setTimestamp</function></member>
+   <member><function>DateTime::setMicrosecond</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/datetime/datetimeimmutable/add.xml
+++ b/reference/datetime/datetimeimmutable/add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42d5fb01e01e9ab1fdb47612833dd13d9003df6a Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::add() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::add</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/createfromtimestamp.xml
+++ b/reference/datetime/datetimeimmutable/createfromtimestamp.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: lacatoire Status: ready -->
+<refentry xml:id="datetimeimmutable.createfromtimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeImmutable::createFromTimestamp</refname>
+  <refpurpose>Crea una instancia a partir de una marca de tiempo Unix</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier>public</modifier> <modifier>static</modifier> <type>static</type><methodname>DateTimeImmutable::createFromTimestamp</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Crea una instancia a partir de una marca de tiempo Unix.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timestamp</parameter></term>
+    <listitem>
+     <simpara>
+      Marca de tiempo Unix que representa la fecha.
+      También se acepta un valor &float;, lo que permite una precisión de microsegundos.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve una nueva instancia de <classname>DateTimeImmutable</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si <parameter>timestamp</parameter> está fuera del rango [<constant>PHP_INT_MIN</constant>, <constant>PHP_INT_MAX</constant>],
+   se lanza una <exceptionname>DateRangeError</exceptionname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeimmutable.createfromtimestamp.example.basic">
+   <title>Ejemplo de <methodname>DateTimeImmutable::createFromTimestamp</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTimeImmutable::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::modify() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::modify</methodname>
    <methodparam><type>string</type><parameter>modifier</parameter></methodparam>
   </methodsynopsis>
@@ -61,6 +61,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Ahora tiene un tipo de retorno tentativo de <type>DateTimeImmutable</type>.
+       Anteriormente era <type class="union"><type>DateTimeImmutable</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/datetime/datetimeimmutable/setdate.xml
+++ b/reference/datetime/datetimeimmutable/setdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.setdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setDate() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setDate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>month</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.setisodate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setISODate() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setISODate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>week</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/setmicrosecond.xml
+++ b/reference/datetime/datetimeimmutable/setmicrosecond.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: lacatoire Status: ready -->
+<refentry xml:id="datetimeimmutable.setmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeImmutable::setMicrosecond</refname>
+  <refpurpose>Establece la parte de microsegundos de la hora</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setMicrosecond() does not modify the object itself")]</modifier>
+   <modifier>public</modifier> <type>static</type><methodname>DateTimeImmutable::setMicrosecond</methodname>
+   <methodparam><type>int</type><parameter>microsecond</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Devuelve un nuevo objeto <type>DateTimeImmutable</type> construido a partir del
+   antiguo, con la parte de microsegundos modificada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>microsecond</parameter></term>
+    <listitem>
+     <simpara>
+      El valor de microsegundos a establecer (de <literal>0</literal> a <literal>999999</literal>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &date.datetimeimmutable.return.modifiedobject;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si <parameter>microsecond</parameter> está fuera del rango [<literal>0</literal>, <literal>999999</literal>],
+   se lanza una <exceptionname>DateRangeError</exceptionname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeimmutable.setmicrosecond.example.basic">
+   <title>Ejemplo de <methodname>DateTimeImmutable::setMicrosecond</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTimeImmutable::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+$date = $date->setMicrosecond(987654);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+1970-01-01 00:02:03.987654
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getMicrosecond</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeimmutable/settime.xml
+++ b/reference/datetime/datetimeimmutable/settime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTime() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTime</methodname>
    <methodparam><type>int</type><parameter>hour</parameter></methodparam>
    <methodparam><type>int</type><parameter>minute</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTimestamp() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimestamp</methodname>
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>
@@ -73,6 +73,7 @@ echo $newDate->format('U = Y-m-d H:i:s') . "\n";
   &reftitle.seealso;
   <simplelist>
    <member><function>DateTimeImmutable::getTimestamp</function></member>
+   <member><function>DateTimeImmutable::setMicrosecond</function></member>
   </simplelist>
  </refsect1>
 

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTimezone() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimezone</methodname>
    <methodparam><type>DateTimeZone</type><parameter>timezone</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.sub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::sub() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::sub</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeinterface/getmicrosecond.xml
+++ b/reference/datetime/datetimeinterface/getmicrosecond.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: lacatoire Status: ready -->
+<refentry xml:id="datetimeinterface.getmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeInterface::getMicrosecond</refname>
+  <refname>DateTimeImmutable::getMicrosecond</refname>
+  <refname>DateTime::getMicrosecond</refname>
+  <refpurpose>Obtiene la parte de microsegundos de la marca de tiempo Unix</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeInterface">
+   <modifier>public</modifier> <type>int</type><methodname>DateTimeInterface::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier>public</modifier> <type>int</type><methodname>DateTimeImmutable::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <type>int</type><methodname>DateTime::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Obtiene la parte de microsegundos de la marca de tiempo Unix.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la parte de microsegundos de la marca de tiempo Unix que representa la fecha.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeinterface.getmicrosecond.example.basic">
+   <title>Ejemplo de <methodname>DateTimeInterface::getMicrosecond</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = new DateTimeImmutable('2024-01-01 12:34:56.789123');
+var_dump($date->format('u'));
+var_dump($date->getMicrosecond());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(6) "789123"
+int(789123)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getTimestamp</methodname></member>
+   <member><methodname>DateTimeInterface::format</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="datetime.gettimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -155,6 +155,7 @@ echo $milli, "\n", $micro, "\n";
    <member><function>DateTime::setTimestamp</function></member>
    <member><function>DateTimeImmutable::setTimestamp</function></member>
    <member><function>DateTimeInterface::format</function></member>
+   <member><function>DateTimeInterface::getMicrosecond</function></member>
   </simplelist>
  </refsect1>
 


### PR DESCRIPTION
Sincroniza la documentación de DateTime con las nuevas funciones de PHP 8.4: `DateTime::createFromTimestamp`, `DateTime::setMicrosecond`, `DateTimeImmutable::createFromTimestamp`, `DateTimeImmutable::setMicrosecond` y `DateTimeInterface::getMicrosecond`.

Crea los 5 ficheros nuevos y actualiza los 10 existentes (mensaje de `#[\NoDiscard]` y enlaces de "ver también").

Fixes #771