### PR TITLE
[Sync EN] Fix changelog row markup in DateInterval::createFromDateString

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 82f00c8d4d4f09fa5a363bc0c6f48e0c80eea72d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -85,6 +85,8 @@
        Ahora tiene un tipo de retorno tentativo de <type>DateInterval</type>.
        Anteriormente era <type class="union"><type>DateInterval</type><type>false</type></type>.
       </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> ahora lanza


### PR DESCRIPTION
Sincroniza el marcado de la fila del changelog para separar las entradas 8.4.0 y 8.3.0 en filas distintas.

Fixes #781