### PR TITLE
[Sync EN] reflection: Delete outdated paragraph in hasreturntype.xml

### DIFF
--- a/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c3485c8f1c57caa8ea0fc2924050a175bbc7686d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionfunctionabstract.hasreturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -39,7 +39,8 @@
 <![CDATA[
 <?php
 
-function to_int($param) : int {
+function to_int($param): int
+{
     return (int) $param;
 }
 
@@ -73,11 +74,6 @@ bool(false)
 ]]>
     </screen>
    </example>
-  </para>
-  <para>
-   Esto ocurre porque muchas funciones internas no definen un tipo para
-   sus argumentos o sus valores de retorno. Por lo tanto, se recomienda evitar el uso
-   de este método con funciones integradas.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Elimina el párrafo obsoleto y actualiza el formato del ejemplo, en sincronía con el inglés.

Fixes #785