### PR TITLE
[Sync EN] ReturnTypeWillChange: Add warning about future strict return type

### DIFF
--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 0019a7e201442447fd746c2852d28ba839ed15ae Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos-->
 <reference xml:id="class.returntypewillchange" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>El atributo ReturnTypeWillChange</title>
@@ -9,12 +9,26 @@
 
   <section xml:id="returntypewillchange.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La mayoría de los métodos internos no finales requieren ahora que los métodos sobrescritos declaren
     un tipo de retorno compatible, de lo contrario se emite un aviso de deprecación durante la validación de herencia.
+    Esto introduce una fase de tipo de retorno tentativo: el motor emite un aviso de deprecación
+    en lugar de un error fatal cuando los tipos de retorno son incompatibles, antes de que se vuelvan
+    obligatorios en una versión futura.
     En caso de que el tipo de retorno no pueda declararse para un método sobrescrito debido a preocupaciones de compatibilidad entre versiones de PHP,
     se puede añadir un atributo <code>#[\ReturnTypeWillChange]</code> para silenciar el aviso de deprecación.
-   </para>
+   </simpara>
+
+   <warning>
+    <simpara>
+     El atributo <classname>ReturnTypeWillChange</classname> suprime los avisos de deprecación
+     <emphasis>únicamente</emphasis> durante la fase de tipo de retorno tentativo.
+     No tiene efecto al sobrescribir métodos definidos en clases definidas por el usuario.
+     Una vez que los métodos internos adopten tipos estrictos, las discrepancias en las firmas de los
+     métodos sobrescritos provocarán un error fatal y este atributo dejará de tener efecto.
+    </simpara>
+   </warning>
+
   </section>
 
   <section xml:id="returntypewillchange.synopsis">


### PR DESCRIPTION
Añade la advertencia sobre el tipo de retorno estricto futuro y convierte el párrafo de introducción en simpara, en sincronía con el inglés.

Fixes #783