### PR TITLE
Sync EN: fix example outputs inconsistent with code

### DIFF
--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f94d903985119d3ac00f4528551df947f57b667f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.inheritance" xmlns="http://docbook.org/ns/docbook">
  <title>Herencia</title>
@@ -86,7 +86,7 @@ class Foo
 
     public function printPHP()
     {
-        echo 'PHP es genial' . PHP_EOL;
+        echo 'PHP es genial.' . PHP_EOL;
     }
 }
 
@@ -101,9 +101,9 @@ class Bar extends Foo
 $foo = new Foo();
 $bar = new Bar();
 $foo->printItem('baz'); // Muestra: 'Foo: baz'
-$foo->printPHP();       // Muestra: 'PHP es genial'
+$foo->printPHP();       // Muestra: 'PHP es genial.'
 $bar->printItem('baz'); // Muestra: 'Bar: baz'
-$bar->printPHP();       // Muestra: 'PHP es genial'
+$bar->printPHP();       // Muestra: 'PHP es genial.'
 
 ?>
 ]]>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -255,11 +255,11 @@ print date('c', $nextyear) . "\n";
   <para>
    <example>
     <title>El último día del mes</title>
-    <para>
+    <simpara>
      El último día de cualquier mes dado se puede expresar como el día "0"
      del mes siguiente, no el día -1. Los dos ejemplos siguientes
      producirán la cadena "El último día en Feb 2000 es: 29".
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/dom/domelement/construct.xml
+++ b/reference/dom/domelement/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4f5e2b22575131fa5e9c3004b1c874e1acb06573 Maintainer: chuso Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: chuso Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="domelement.construct" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -69,7 +69,7 @@ $dom = new DOMDocument('1.0', 'iso-8859-1');
 $element = $dom->appendChild(new DOMElement('root'));
 $element_ns = new DOMElement('pr:node1', 'thisvalue', 'http://xyz');
 $element->appendChild($element_ns);
-echo $dom->saveXML(); /* <?xml version="1.0" encoding="utf-8"?>
+echo $dom->saveXML(); /* <?xml version="1.0" encoding="iso-8859-1"?>
 <root><pr:node1 xmlns:pr="http://xyz">thisvalue</pr:node1></root> */
 
 ?>

--- a/reference/ds/ds/map/ksort.xml
+++ b/reference/ds/ds/map/ksort.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2226ad08fd93e3979efbba47c5ae3545eec97d25 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-map.ksort" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,9 +15,9 @@
    <modifier>public</modifier> <type>void</type><methodname>Ds\Map::ksort</methodname>
    <methodparam choice="opt"><type>callable</type><parameter>comparator</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Ordena el mapa en el lugar por clave, utilizando una función <parameter>comparator</parameter> opcional.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
     &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -100,7 +100,6 @@ print_r($map);
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Ds\Map Object
 Ds\Map Object
 (
     [0] => Ds\Pair Object

--- a/reference/ds/ds/map/ksorted.xml
+++ b/reference/ds/ds/map/ksorted.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2226ad08fd93e3979efbba47c5ae3545eec97d25 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-map.ksorted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>Ds\Map</type><methodname>Ds\Map::ksorted</methodname>
    <methodparam choice="opt"><type>callable</type><parameter>comparator</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Devuelve una copia ordenada por clave, utilizando una función <parameter>comparator</parameter> opcional.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -33,9 +33,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
     Devuelve una copia del mapa, ordenada por clave.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -54,7 +54,6 @@ print_r($map->ksorted());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Ds\Map Object
 Ds\Map Object
 (
     [0] => Ds\Pair Object
@@ -98,7 +97,6 @@ print_r($sorted);
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Ds\Map Object
 Ds\Map Object
 (
     [0] => Ds\Pair Object

--- a/reference/ds/ds/map/pairs.xml
+++ b/reference/ds/ds/map/pairs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-map.pairs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,7 +47,7 @@ var_dump($map->pairs());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-object(Ds\Map)#8 (3) {
+object(Ds\Vector)#8 (3) {
   [0]=>
   object(Ds\Pair)#5 (2) {
     ["key"]=>
@@ -70,7 +70,6 @@ object(Ds\Map)#8 (3) {
     int(3)
   }
 }
-p
 ]]>
    </screen>
   </example>

--- a/reference/ds/ds/pair/clear.xml
+++ b/reference/ds/ds/pair/clear.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-pair.clear" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -50,9 +50,8 @@ print_r($pair);
 <![CDATA[
 Ds\Pair Object
 (
-    [0] => 1
-    [1] => 2
-    [2] => 3
+    [key] => a
+    [value] => 1
 )
 Ds\Pair Object
 (

--- a/reference/ds/ds/vector/join.xml
+++ b/reference/ds/ds/vector/join.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ds-vector.join" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -73,7 +73,7 @@ var_dump($vector->join());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-string(11) "abc123"
+string(6) "abc123"
 ]]>
    </screen>
   </example>

--- a/reference/memcached/memcached/fetch.xml
+++ b/reference/memcached/memcached/fetch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1d8068ecb070fdc360d750e0c1f3f15796e61ec0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="memcached.fetch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/functions/bson/fromphp.xml
+++ b/reference/mongodb/functions/bson/fromphp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.mongodb.bson-fromphp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -100,7 +100,7 @@ echo bin2hex($bson), "\n";
    &example.outputs;
    <screen>
 <![CDATA[
-0e00000010666f6f000100000000cat
+0e00000010666f6f000100000000
 ]]>
    </screen>
   </example>

--- a/reference/mongodb/mongodb/driver/cursor.xml
+++ b/reference/mongodb/mongodb/driver/cursor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mongodb-driver-cursor" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -145,7 +145,7 @@ stdClass Object
     [name] => Vesta
     [size] => 525
     [distance] => 2.362
-}
+)
 ]]>
     </screen>
    </example>

--- a/reference/spl/splobjectstorage/rewind.xml
+++ b/reference/spl/splobjectstorage/rewind.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6d29533483657c036e49edb5ea88c7103d126681 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -62,8 +62,12 @@ while($s->valid()) {
     &example.outputs.similar;
     <screen>
 <![CDATA[
-int(1)
-int(0)
+object(stdClass)#2 (0) {
+}
+string(2) "d1"
+object(stdClass)#3 (0) {
+}
+string(2) "d2"
 ]]>
     </screen>
    </example>

--- a/reference/uri/uri/whatwg/url/getquery.xml
+++ b/reference/uri/uri/whatwg/url/getquery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-whatwg-url.getquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::getQuery</refname>
@@ -45,7 +45,7 @@ echo $url->getQuery();
    &example.outputs;
    <screen>
 <![CDATA[
-foo=bar
+foo/bar
 ]]>
    </screen>
   </example>

--- a/reference/wincache/functions/wincache-ucache-delete.xml
+++ b/reference/wincache/functions/wincache-ucache-delete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ed710737ea7ce93f1289809cf89170c6d48b72a6 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.wincache-ucache-delete" xmlns="http://docbook.org/ns/docbook">
@@ -88,7 +88,7 @@ var_dump(wincache_ucache_delete($array2));
     <screen>
 <![CDATA[
 array(4) { [0]=> string(5) "green"
-           [1]=> string(4) "Blue"
+           [1]=> string(4) "blue"
            [2]=> string(6) "yellow"
            [3]=> string(4) "cyan" }
 ]]>

--- a/reference/yaf/yaf-config-ini.xml
+++ b/reference/yaf/yaf-config-ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.yaf-config-ini" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -153,7 +153,7 @@ var_dump($config->get("database.params.username"));
 <![CDATA[
 string(15) "dev.example.com"
 string(6) "dbname"
-string(7) "devuser
+string(7) "devuser"
 ]]>
     </screen>
    </example>

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: seros Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: seros Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -80,7 +80,7 @@ var_dump($cliente->add(1, 2));
 var_dump($cliente->call("add", array(3, 2)));
 
 
-/* __add no puede ser llamado */
+/* _add no puede ser llamado */
 var_dump($cliente->_add(1, 2));
 ?>
 ]]>


### PR DESCRIPTION
Syncs the ES manual with the EN fixes from upstream doc-en PR `5600`: example `<screen>` outputs that did not match their code (stray characters, wrong type names, missing quotes, etc.), plus the related `para` to `simpara` changes. EN-Revision bumped on all 16 files, maintainers kept.

Fixes #792