### PR TITLE
Sync radius_get_vendor_attr return type hint

### DIFF
--- a/reference/radius/functions/radius-get-vendor-attr.xml
+++ b/reference/radius/functions/radius-get-vendor-attr.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9ac4d06c0bddbbb1b87ba93d1591ef1707d30420 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4047ef2a8b552d69909e1cee259fcad65d2510c7 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.radius-get-vendor-attr">
+<refentry xml:id="function.radius-get-vendor-attr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>radius_get_vendor_attr</refname>
   <refpurpose>Extrae un atributo específico del proveedor</refpurpose>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>radius_get_vendor_attr</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>radius_get_vendor_attr</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <simpara>


### PR DESCRIPTION
Sincroniza el tipo de retorno de radius_get_vendor_attr (array|false).

Fixes #795