### PR TITLE
Sync new cURL constants (PHP 8.5)

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dec90c90d3662c5433f7c3972f8557321da7b11d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="curl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -207,6 +207,52 @@
      para forzar a libcurl a verificar la autenticación no restringida y si no,
      solo este algoritmo de autenticación es aceptable.
      Disponible a partir de cURL 7.21.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-all">
+   <term>
+    <constant>CURLFOLLOW_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valor para <constant>CURLOPT_FOLLOWLOCATION</constant> que activa el seguimiento
+     de las redirecciones y mantiene en uso un método de solicitud personalizado definido
+     con <constant>CURLOPT_CUSTOMREQUEST</constant> para todas las solicitudes, incluso
+     después de las redirecciones.
+     Disponible a partir de PHP 8.5.0 y cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-obeycode">
+   <term>
+    <constant>CURLFOLLOW_OBEYCODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valor para <constant>CURLOPT_FOLLOWLOCATION</constant> que activa el seguimiento
+     de las redirecciones respetando el código de respuesta HTTP: un método de solicitud
+     personalizado definido con <constant>CURLOPT_CUSTOMREQUEST</constant> se mantiene,
+     salvo que se cambia a <literal>GET</literal> en los códigos de estado de redirección
+     que lo requieren (como 301, 302 y 303).
+     Disponible a partir de PHP 8.5.0 y cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-firstonly">
+   <term>
+    <constant>CURLFOLLOW_FIRSTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valor para <constant>CURLOPT_FOLLOWLOCATION</constant> que activa el seguimiento
+     de las redirecciones pero utiliza un método de solicitud personalizado definido con
+     <constant>CURLOPT_CUSTOMREQUEST</constant> solo para la primera solicitud;
+     las solicitudes siguientes siguen el método dictado por el código de respuesta de redirección.
+     Disponible a partir de PHP 8.5.0 y cURL 8.13.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f34918d8b2761af5b596b1b762753ee825c19cd8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <variablelist xml:id="constant.curl-getinfo.constants" role="constant_list">
  <title><function>curl_getinfo</function></title>
@@ -69,6 +69,18 @@
   <listitem>
    <simpara>
     Información sobre la condición temporal no cumplida.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-conn-id">
+  <term>
+   <constant>CURLINFO_CONN_ID</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    El ID de la última conexión utilizada por la transferencia. El ID de conexión es único entre todas las conexiones que usan la misma caché de conexiones y resulta útil para distinguir la reutilización de conexiones.
+    Disponible a partir de PHP 8.5.0 y cURL 8.2.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -250,6 +262,18 @@
   <listitem>
    <simpara>
     La máscara de bits que indica el método de autenticación disponible(s) según la respuesta anterior.
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-httpauth-used">
+  <term>
+   <constant>CURLINFO_HTTPAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Máscara de bits que indica el o los métodos de autenticación HTTP realmente utilizados en la solicitud anterior.
+    Disponible a partir de PHP 8.5.0 y cURL 8.12.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -445,6 +469,18 @@
    </simpara>
   </listitem>
  </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-proxyauth-used">
+  <term>
+   <constant>CURLINFO_PROXYAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Máscara de bits que indica el o los métodos de autenticación del proxy realmente utilizados en la solicitud anterior.
+    Disponible a partir de PHP 8.5.0 y cURL 8.12.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
  <varlistentry xml:id="constant.curlinfo-proxy-error">
   <term>
    <constant>CURLINFO_PROXY_ERROR</constant>
@@ -466,6 +502,18 @@
    <simpara>
     El resultado de la verificación del certificado que ha sido solicitada (usando la opción <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Utilizado únicamente para proxies HTTPS.
     Disponible a partir de PHP 7.3.0 y cURL 7.52.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-queue-time-t">
+  <term>
+   <constant>CURLINFO_QUEUE_TIME_T</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    El tiempo, en microsegundos, durante el cual la transferencia estuvo retenida en una cola de espera antes de comenzar, debido a los límites establecidos con <constant>CURLMOPT_MAX_TOTAL_CONNECTIONS</constant> u opciones similares.
+    Disponible a partir de PHP 8.5.0 y cURL 8.6.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -774,6 +822,18 @@
    <simpara>
     El tiempo total en microsegundos para la última transferencia, incluyendo la resolución de nombre, la conexión TCP, etc.
     Disponible a partir de PHP 7.3.0 y cURL 7.61.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-used-proxy">
+  <term>
+   <constant>CURLINFO_USED_PROXY</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Indica si la transferencia anterior utilizó un proxy; devuelve <literal>1</literal> si se utilizó un proxy y <literal>0</literal> en caso contrario.
+    Disponible a partir de PHP 8.5.0 y cURL 8.7.0.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e7e81a179eabc75e1b37947c7696afd557cef656 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <variablelist role="constant_list">
  <title><function>curl_setopt</function></title>
@@ -1464,6 +1464,21 @@
     Esta opción acepta cualquier valor que pueda convertirse en un <type>int</type> válido.
     Disponible a partir de cURL 7.1.0.
    </para>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlopt-infilesize-large">
+  <term>
+   <constant>CURLOPT_INFILESIZE_LARGE</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    El tamaño esperado, en bytes, del fichero al enviar un fichero
+    a un sitio remoto. Es la variante de 64 bits de
+    <constant>CURLOPT_INFILESIZE</constant>, que permite especificar tamaños
+    superiores a 2 GB.
+    Disponible a partir de PHP 8.5.0.
+   </simpara>
   </listitem>
  </varlistentry>
  <varlistentry xml:id="constant.curlopt-interface">


### PR DESCRIPTION
Sincroniza las nuevas constantes cURL de PHP 8.5: CURLFOLLOW_*, varias CURLINFO_* y CURLOPT_INFILESIZE_LARGE. El fichero constants_curl_setopt.xml queda alineado con el estado final EN (simpara).

Fixes #798
Fixes #797