### PR TITLE
Sync new OpenSSL constants (PHP 8.5)

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6eadfc4332ac3ba482aef3ebf3eab10e02e007ca Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <appendix xml:id="openssl.constants" xmlns="http://docbook.org/ns/docbook">
@@ -157,6 +157,18 @@
     <listitem>
      <simpara>
 
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.openssl-pkcs1-pss-padding">
+    <term>
+     <constant>OPENSSL_PKCS1_PSS_PADDING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Relleno RSA-PSS.
+      Disponible a partir de PHP 8.5.0.
      </simpara>
     </listitem>
    </varlistentry>
@@ -393,6 +405,46 @@
         Disponible a partir de PHP 8.3.0.
         Establece el encabezado HTTP Content-Type en <literal>application/pkcs7-mime</literal> en lugar de
         <literal>application/x-pkcs7-mime</literal> para cifrar un mensaje.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-nosmimecap">
+       <entry>
+        <constant>PKCS7_NOSMIMECAP</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Disponible a partir de PHP 8.5.0.
+        No incluye las capacidades S/MIME (SMIMECapabilities) en la firma.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-crlfeol">
+       <entry>
+        <constant>PKCS7_CRLFEOL</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Disponible a partir de PHP 8.5.0.
+        Utiliza <literal>CRLF</literal> como fin de línea en la salida.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-nocrl">
+       <entry>
+        <constant>PKCS7_NOCRL</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Disponible a partir de PHP 8.5.0.
+        No incluye las CRL en la estructura PKCS7.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-no-dual-content">
+       <entry>
+        <constant>PKCS7_NO_DUAL_CONTENT</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Disponible a partir de PHP 8.5.0.
+        No incluye el contenido duplicado, evitando la duplicación del contenido firmado.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Sincroniza las nuevas constantes OpenSSL de PHP 8.5: OPENSSL_PKCS1_PSS_PADDING y los flags PKCS7 (NOSMIMECAP, CRLFEOL, NOCRL, NO_DUAL_CONTENT).

Fixes #799