### PR TITLE
[Sync EN] nodiscard.xml: comportamiento en interfaces, métodos abstractos y sobrescrituras

### DIFF
--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 30bda33771e1c8fa8fc8a5ee7559fd7fa189caa0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e7f89579e2abcecad5a62dd96f11a4926df62e13 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.nodiscard" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>El atributo NoDiscard</title>
@@ -31,6 +31,20 @@
      Para suprimir la advertencia sin usar <code>(void)</code>,
      que no es soportado antes de PHP 8.5,
      considere usar una variable como <code>$_</code>.
+    </simpara>
+   </note>
+   <note>
+    <simpara>
+     <code>#[\NoDiscard]</code> se aplica a la declaración de función o método
+     específica sobre la que está escrito, y la advertencia se emite en función
+     de la declaración que realmente se llama. Como resultado, añadir
+     <code>#[\NoDiscard]</code> a un método de interfaz o a un método abstracto
+     no emite ninguna advertencia, porque el método que se invoca es el método
+     de implementación o de sobrescritura. Del mismo modo, un método que
+     sobrescribe un método <code>#[\NoDiscard]</code> no emite la advertencia a
+     menos que esté marcado él mismo con el atributo. Por el contrario, un
+     método importado desde un trait conserva el atributo, porque el método del
+     trait se copia en la clase que lo usa como si estuviera declarado allí.
     </simpara>
    </note>
   </section>


### PR DESCRIPTION
Sync EN de `language/predefined/attributes/nodiscard.xml`.

Traduce la nota añadida en upstream: comportamiento de `#[\NoDiscard]` en métodos de interfaz, abstractos y sobrescritos, y el caso de los traits.

Fixes #805