### PR TITLE
[Sync EN] precedence.xml: prioridad unaria/instanceof y asignación en operadores prefijos

### DIFF
--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7428462fea1c0387cf5e8473b4c48c3c8ac8c2c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 80dfa568e602649eb13585bf59a7b6239eddaac3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.operators.precedence">
  <title>La prioridad de los operadores</title>
@@ -295,6 +295,18 @@
    </tgroup>
   </table>
  </para>
+ <note>
+  <simpara>
+   Los operadores unarios que comparten la fila con los operadores de conversión
+   (<literal>~</literal>, <literal>@</literal>, y <literal>+</literal>/<literal>-</literal>
+   unarios) tienen mayor prioridad que <literal>instanceof</literal>, mientras que
+   <literal>!</literal> tiene menor prioridad. En consecuencia,
+   <literal>(int) $x instanceof Foo</literal> se agrupa como
+   <literal>((int) $x) instanceof Foo</literal>, mientras que
+   <literal>!$x instanceof Foo</literal> se agrupa como
+   <literal>!($x instanceof Foo)</literal>.
+  </simpara>
+ </note>
  <para>
   <example>
    <title>Asociatividad</title>
@@ -409,6 +421,15 @@ x menos uno es igual 3, en todo caso espero
    Aunque <literal>=</literal> tiene prioridad sobre la mayoría de los operadores, PHP ejecutará expresiones como: <literal>if (!$a = foo())</literal>.
    En esta situación, el resultado de <literal>foo()</literal> será colocado en la variable <varname>$a</varname>.
   </para>
+  <simpara>
+   Esto es posible porque el lado izquierdo de una asignación debe ser una
+   variable, por lo que la asignación se agrupa con esa variable en lugar de con
+   el operador prefijo circundante de mayor prioridad. Lo mismo se aplica a los
+   demás operadores prefijos que toman una expresión como operando, como
+   <literal>clone</literal>, los operadores de conversión, <literal>@</literal> y
+   <literal>~</literal>: por ejemplo, <literal>clone $a = $b</literal> se agrupa
+   como <literal>clone ($a = $b)</literal>, no como <literal>(clone $a) = $b</literal>.
+  </simpara>
  </note>
  <sect2 role="changelog">
   &reftitle.changelog;


### PR DESCRIPTION
Sync EN de `language/operators/precedence.xml`.

Traduce las dos notas añadidas en upstream: prioridad de los operadores unarios frente a `instanceof`, y agrupamiento de la asignación dentro de los operadores prefijos.

Fixes #804