### PR TITLE
[Sync EN] pdo_pgsql: deprecaciones 8.5, ATTR_PREFETCH, ejemplos (#5626, #5629)

### DIFF
--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0f1d7fba407bd1385616508a1e42e31fe009bff2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.other-changes">
  <title>Otros cambios</title>
@@ -249,7 +249,7 @@
    </simpara>
 
    <simpara>
-    Se ha añadido una nueva constante <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>
+    Se ha añadido una nueva constante <constant>Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</constant>
     para recuperar el uso de memoria de los resultados de consulta con
     <methodname>PDO::getAttribute</methodname> para los controladores que lo soportan.
    </simpara>
@@ -326,7 +326,7 @@
 
    <simpara>
     Soporte para recuperar el uso de memoria de consultas para
-    <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>.
+    <constant>Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</constant>.
    </simpara>
 
    <simpara>

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="pdo.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -254,6 +254,13 @@
       de una aplicación. No todas las combinaciones bases de datos / controladores soportan
       la configuración del tamaño de precarga. Un mayor tamaño de precarga resulta en un
       mayor rendimiento a costa de un mayor uso de memoria.
+     </simpara>
+     <simpara>
+      El controlador PDO_PGSQL, en cambio, trata este atributo como un conmutador: a partir de
+      PHP 8.5.0, un valor de <literal>0</literal> habilita la obtención perezosa (fila a fila);
+      véase la
+      <link linkend="pdo-pgsql.constants.attr-prefetch">documentación del controlador PDO_PGSQL</link>
+      para más detalles.
      </simpara>
     </listitem>
    </varlistentry>
@@ -732,6 +739,12 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
      (<type>int</type>)
     </term>
     <listitem>
+     <warning>
+      <simpara>
+       Esta constante está <emphasis>OBSOLETA</emphasis> a partir de PHP 8.5.0.
+       Utilice <constant>Pdo\Sqlite::DETERMINISTIC</constant> en su lugar.
+      </simpara>
+     </warning>
      <simpara>
       Especifica que una función creada con <methodname>PDO::PDO::sqliteCreateFunction</methodname>
       es determinista, es decir, siempre devuelve el mismo resultado

--- a/reference/pdo_pgsql/constants.xml
+++ b/reference/pdo_pgsql/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b69a8dcce47d6619d6459914e784627cbb02a5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <section xml:id="ref.pdo-pgsql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -14,6 +14,67 @@
    <listitem>
     <simpara>
      &Alias; <constant>Pdo\Pgsql::ATTR_DISABLE_PREPARES</constant>.
+     A partir de PHP 8.5.0, esta constante está obsoleta.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-idle">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_IDLE</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalente a <constant>Pdo\Pgsql::TRANSACTION_IDLE</constant>.
+     A partir de PHP 8.5.0, esta constante está obsoleta, ya que no tiene efecto.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-active">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_ACTIVE</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalente a <constant>Pdo\Pgsql::TRANSACTION_ACTIVE</constant>.
+     A partir de PHP 8.5.0, esta constante está obsoleta, ya que no tiene efecto.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-intrans">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_INTRANS</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalente a <constant>Pdo\Pgsql::TRANSACTION_INTRANS</constant>.
+     A partir de PHP 8.5.0, esta constante está obsoleta, ya que no tiene efecto.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-inerror">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_INERROR</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalente a <constant>Pdo\Pgsql::TRANSACTION_INERROR</constant>.
+     A partir de PHP 8.5.0, esta constante está obsoleta, ya que no tiene efecto.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-unknown">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_UNKNOWN</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalente a <constant>Pdo\Pgsql::TRANSACTION_UNKNOWN</constant>.
+     A partir de PHP 8.5.0, esta constante está obsoleta, ya que no tiene efecto.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 205c3b8ad9af665e2b49dcc6020005bb479217a3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
-<reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-pgsql" role="class">
+<reference xml:id="class.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" role="class">
  <title>La clase Pdo\Pgsql</title>
  <titleabbrev>Pdo\Pgsql</titleabbrev>
 
@@ -157,39 +157,81 @@
       </simpara>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="pdo-pgsql.constants.attr-prefetch">
+     <term><constant>PDO::ATTR_PREFETCH</constant></term>
+     <listitem>
+      <simpara>
+       A partir de PHP 8.5.0, asignar el valor <literal>0</literal> a este
+       atributo activa la obtención perezosa (fila a fila): las filas se
+       recuperan del servidor de una en una a medida que se obtienen, en lugar
+       de almacenar en memoria todo el conjunto de resultados antes de la
+       primera llamada a <methodname>PDOStatement::fetch</methodname>. Esto
+       reduce el uso de memoria para conjuntos de resultados grandes. Cualquier
+       otro valor mantiene el comportamiento almacenado en búfer por omisión.
+      </simpara>
+      <simpara>
+       Puede establecerse por conexión con
+       <methodname>PDO::setAttribute</methodname>, o por sentencia mediante
+       las opciones de controlador de <methodname>PDO::prepare</methodname> o
+       <methodname>PDO::query</methodname>.
+      </simpara>
+      <caution>
+       <simpara>
+        En modo perezoso, una conexión sólo puede tener una sentencia activa a
+        la vez. Ejecutar otra sentencia descarta de forma silenciosa las filas
+        no leídas de la anterior; no se genera ningún error.
+       </simpara>
+      </caution>
+     </listitem>
+    </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-idle">
      <term><constant>Pdo\Pgsql::TRANSACTION_IDLE</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Esta constante no tiene efecto y está obsoleta a partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-active">
      <term><constant>Pdo\Pgsql::TRANSACTION_ACTIVE</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Esta constante no tiene efecto y está obsoleta a partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-intrans">
      <term><constant>Pdo\Pgsql::TRANSACTION_INTRANS</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Esta constante no tiene efecto y está obsoleta a partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-inerror">
      <term><constant>Pdo\Pgsql::TRANSACTION_INERROR</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Esta constante no tiene efecto y está obsoleta a partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-unknown">
      <term><constant>Pdo\Pgsql::TRANSACTION_UNKNOWN</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Esta constante no tiene efecto y está obsoleta a partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b69a8dcce47d6619d6459914e784627cbb02a5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 205c3b8ad9af665e2b49dcc6020005bb479217a3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo-pgsql.copyfromarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,7 +12,7 @@
   <methodsynopsis role="Pdo\\Pgsql">
    <modifier>public</modifier> <type>bool</type><methodname>Pdo\Pgsql::copyFromArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
-   <methodparam><type>array</type><parameter>rows</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>Traversable</type></type><parameter>rows</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>nullAs</parameter><initializer>"\\\\N"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>fields</parameter><initializer>&null;</initializer></methodparam>
@@ -39,8 +39,9 @@
     <term><parameter>rows</parameter></term>
     <listitem>
      <simpara>
-      Un <type>array</type> indexado de <type>string</type>s con los campos
-      separados por <parameter>separator</parameter>.
+      Un <type>array</type> indexado (o <type>Traversable</type>) de
+      <type>string</type>s con los campos separados por
+      <parameter>separator</parameter>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -77,6 +78,69 @@
   <simpara>
    &return.success;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>rows</parameter> ahora también acepta un
+       <classname>Traversable</classname>; anteriormente sólo se aceptaba un
+       <type>array</type>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-pgsql.copyfromarray.example.basic">
+   <title>Ejemplo de <methodname>Pdo\Pgsql::copyFromArray</methodname></title>
+   <simpara>
+    Cada elemento de <parameter>rows</parameter> es un registro cuyos campos se
+    unen mediante <parameter>separator</parameter> (un tabulador por omisión).
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+
+$rows = [
+    "1\tapple\t10",
+    "2\tbanana\t20",
+    "3\tcherry\t30",
+];
+$db->copyFromArray('fruits', $rows);
+
+foreach ($db->query('SELECT * FROM fruits ORDER BY id') as $row) {
+    echo "{$row['id']} {$row['name']} {$row['qty']}\n";
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 apple 10
+2 banana 20
+3 cherry 30
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b69a8dcce47d6619d6459914e784627cbb02a5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo-pgsql.copyfromfile" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -55,6 +55,48 @@
   <simpara>
    &return.success;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si <parameter>filename</parameter> no puede abrirse para lectura, el fallo
+   se notifica a través del manejo de errores de la conexión
+   (véase <constant>PDO::ATTR_ERRMODE</constant>); con
+   <constant>PDO::ERRMODE_EXCEPTION</constant> se lanza una
+   <exceptionname>PDOException</exceptionname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-pgsql.copyfromfile.example.basic">
+   <title>Ejemplo de <methodname>Pdo\Pgsql::copyFromFile</methodname></title>
+   <simpara>
+    El fichero contiene un registro por línea, con los campos unidos por
+    <parameter>separator</parameter> (un tabulador por defecto).
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+
+file_put_contents('/tmp/fruits.tsv', "1\tapple\t10\n2\tbanana\t20\n");
+$db->copyFromFile('fruits', '/tmp/fruits.tsv');
+
+echo $db->query('SELECT count(*) FROM fruits')->fetchColumn(), "\n";
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9ec2c28f9400490fe1b70fb88e50e23de97905f1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo-pgsql.copytoarray" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -49,6 +49,41 @@
   <simpara>
    Devuelve un array de filas, &return.falseforfailure;.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-pgsql.copytoarray.example.basic">
+   <title>Ejemplo de <methodname>Pdo\Pgsql::copyToArray</methodname></title>
+   <simpara>
+    Cada elemento devuelto es un registro, con los campos unidos por
+    <parameter>separator</parameter> y un salto de línea final.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+$db->exec("INSERT INTO fruits VALUES (1, 'apple', 10), (2, 'banana', 20)");
+
+$rows = $db->copyToArray('fruits');
+var_export($rows);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array (
+  0 => '1	apple	10
+',
+  1 => '2	banana	20
+',
+)
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b69a8dcce47d6619d6459914e784627cbb02a5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo-pgsql.copytofile" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -60,6 +60,48 @@
   <simpara>
    &return.success;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si <parameter>filename</parameter> no puede abrirse para escritura, o no
+   puede escribirse en él, el fallo se notifica a través del manejo de errores
+   de la conexión (ver <constant>PDO::ATTR_ERRMODE</constant>); con
+   <constant>PDO::ERRMODE_EXCEPTION</constant> se lanza una
+   <exceptionname>PDOException</exceptionname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-pgsql.copytofile.example.basic">
+   <title>Ejemplo de <methodname>Pdo\Pgsql::copyToFile</methodname></title>
+   <simpara>
+    La tabla se escribe en <parameter>filename</parameter>, un registro por
+    línea, con los campos unidos por <parameter>separator</parameter>.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+$db->exec("INSERT INTO fruits VALUES (1, 'apple', 10), (2, 'banana', 20)");
+
+$db->copyToFile('fruits', '/tmp/fruits.tsv');
+echo file_get_contents('/tmp/fruits.tsv');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1	apple	10
+2	banana	20
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pdo_pgsql/pdo/pgsql/getnotify.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/getnotify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="pdo-pgsql.getnotify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -51,9 +51,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Si una o varias notificaciones están pendientes, devuelve una sola fila,
-   con los campos <literal>message</literal> y <literal>pid</literal>,
-   en caso contrario devuelve &false;.
+   Si una notificación está pendiente, devuelve una sola fila, en caso
+   contrario devuelve &false;. La fila tiene un campo
+   <literal>message</literal> (el nombre del canal) y un campo
+   <literal>pid</literal> (el identificador de proceso (PID) del backend
+   notificador). Si la notificación lleva una carga útil (payload) no vacía,
+   la fila tiene además un campo <literal>payload</literal>. Con
+   <constant>PDO::FETCH_NUM</constant>, estos campos están en los índices
+   <literal>0</literal>, <literal>1</literal> y <literal>2</literal>.
   </simpara>
  </refsect1>
 
@@ -75,6 +80,41 @@
    que puede contener un entero firmado de 32 bits, en cuyo caso será
    el valor máximo de un entero firmado de 32 bits.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-pgsql.getnotify.example.basic">
+   <title>Ejemplo de <methodname>Pdo\Pgsql::getNotify</methodname></title>
+   <simpara>
+    Suscribirse a un canal con <literal>LISTEN</literal>, luego leer la
+    siguiente notificación pendiente con un tiempo de espera de un segundo.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$db->exec('LISTEN messages');
+$db->exec("NOTIFY messages, 'hello'");
+
+$notification = $db->getNotify(PDO::FETCH_ASSOC, 1000);
+var_export($notification);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array (
+  'message' => 'messages',
+  'pid' => 1928,
+  'payload' => 'hello',
+)
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pdo_pgsql/pdo/pgsql/getpid.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/getpid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02b075821852f44e97742ba6f586cc2fa3272806 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo-pgsql.getpid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -30,6 +30,34 @@
   <simpara>
    Devuelve el PID en forma de un <type>int</type>.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-pgsql.getpid.example.basic">
+   <title>Ejemplo de <methodname>Pdo\Pgsql::getPid</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+echo $db->getPid();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+12345
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_get_pid</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4bf27edcd6c317ea311e68117bb2fa20dacb8e57 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo-pgsql.lobopen" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -41,8 +41,11 @@
     <term><parameter>mode</parameter></term>
     <listitem>
      <simpara>
-      Si el modo es <literal>r</literal>, abre el flujo en lectura.
-      Si el modo es <literal>w</literal>, abre el flujo en escritura.
+      El modo de acceso. Si <parameter>mode</parameter> contiene
+      <literal>w</literal> o <literal>+</literal>, el flujo se abre para
+      lectura y escritura; en caso contrario, se abre solo para lectura. Un
+      indicador <literal>b</literal> (binario) no tiene efecto. El valor
+      predeterminado <literal>"rb"</literal> abre el flujo para lectura.
      </simpara>
     </listitem>
    </varlistentry>
@@ -72,10 +75,10 @@ $db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->beginTransaction();
 $stmt = $db->prepare("SELECT oid FROM BLOBS WHERE ident = ?");
-$stmt->execute(array($some_id));
+$stmt->execute([$some_id]);
 $stmt->bindColumn('oid', $oid, PDO::PARAM_STR);
 $stmt->fetch(PDO::FETCH_BOUND);
-$stream = $db->pgsqlLOBOpen($oid, 'r');
+$stream = $db->lobOpen($oid, 'r');
 header("Content-type: application/octet-stream");
 fpassthru($stream);
 ?>

--- a/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02b075821852f44e97742ba6f586cc2fa3272806 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo-pgsql.lobunlink" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -47,20 +47,20 @@
   <example xml:id="pdo-pgsql.lobunlink.example.basic">
    <title>Ejemplo de <methodname>Pdo\Pgsql::lobUnlink</methodname></title>
    <simpara>
-    Este ejemplo elimina un objeto grande de la base de datos antes de eliminar
-    la fila que lo referencia en la tabla blobs. Se utiliza en los ejemplos de
+    Este ejemplo desvincula un objeto grande de la base de datos antes de eliminar
+    la fila que lo referencia. Utiliza la tabla blobs de los ejemplos de
     <methodname>Pdo\Pgsql::lobCreate</methodname> y
     <methodname>Pdo\Pgsql::lobOpen</methodname>.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-$db = new PDO('pgsql:dbname=test host=localhost', $user, $pass);
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->beginTransaction();
-$db->pgsqlLOBUnlink($oid);
+$db->lobUnlink($oid);
 $stmt = $db->prepare("DELETE FROM BLOBS where ident = ?");
-$stmt->execute(array($some_id));
+$stmt->execute([$some_id]);
 $db->commit();
 ?>
 ]]>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlcopyfromarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,12 +8,17 @@
    &Alias; <methodname>Pdo\Pgsql::copyFromArray</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyFromArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
-   <methodparam><type>array</type><parameter>rows</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>Traversable</type></type><parameter>rows</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>nullAs</parameter><initializer>"\\\\N"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>fields</parameter><initializer>&null;</initializer></methodparam>
@@ -21,6 +26,30 @@
   <simpara>
    &info.method.alias; <methodname>Pdo\Pgsql::copyFromArray</methodname>.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       El parámetro <parameter>rows</parameter> ahora también acepta un
+       <classname>Traversable</classname>; anteriormente sólo se aceptaba un
+       <type>array</type>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlcopyfromfile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,9 +8,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyFromFile</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyFromFile</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlcopytoarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,9 +8,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyToArray</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>PDO::pgsqlCopyToArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlcopytofile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,9 +8,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyToFile</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyToFile</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlgetnotify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,9 +8,14 @@
    &Alias; <methodname>Pdo\Pgsql::getNotify</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>PDO::pgsqlGetNotify</methodname>
    <methodparam choice="opt"><type>int</type><parameter>fetchMode</parameter><initializer>PDO::FETCH_DEFAULT</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>timeoutMilliseconds</parameter><initializer>0</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetPid.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetPid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlgetpid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,9 +8,14 @@
    &Alias; <methodname>Pdo\Pgsql::getPid</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>int</type><methodname>PDO::pgsqlGetPid</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBCreate.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBCreate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqllobcreate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,9 +8,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobCreate</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>string</type><methodname>PDO::pgsqlLOBCreate</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBOpen.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBOpen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqllobopen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,9 +8,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobOpen</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>PDO::pgsqlLOBOpen</methodname>
    <methodparam><type>string</type><parameter>oid</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>mode</parameter><initializer>"rb"</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBUnlink.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBUnlink.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqllobunlink" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,9 +8,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobUnlink</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlLOBUnlink</methodname>
    <methodparam><type>string</type><parameter>oid</parameter></methodparam>
   </methodsynopsis>

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3c1bec9d700807df36994cf368ba291214cd424d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="ref.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
@@ -19,10 +19,10 @@
 
    <section xml:id="ref.pdo-pgsql.resources">
     &reftitle.resources;
-    <para>
+    <simpara>
      Esta extensión define un recurso de flujo, devuelto
-     por la función <function>PDO::pgsqlLOBOpen</function>.
-    </para>
+     por <methodname>Pdo\Pgsql::lobOpen</methodname>.
+    </simpara>
    </section>
 
    &reference.pdo-pgsql.configure;
@@ -31,9 +31,11 @@
    <section xml:id="ref.pdo-pgsql.general-notes">
     <title>Notas generales</title>
     <note>
-     <para>
-      Los campos <literal>bytea</literal> se devuelven en forma de flujo.
-     </para>
+     <simpara>
+      Las columnas <literal>bytea</literal> se devuelven como recursos de flujo. Véase
+      <link linkend="pdo.lobs">Objetos grandes (LOBs)</link> para saber cómo leer estos
+      valores y cómo vincular datos con <constant>PDO::PARAM_LOB</constant>.
+     </simpara>
     </note>
    </section>
 
@@ -106,10 +108,15 @@
       <varlistentry>
        <term><literal>sslmode</literal></term>
        <listitem>
-        <para>
-         El modo SSL. Los valores admitidos y su significado se listan en
-         la sección <link xlink:href="&url.pgsql.manual;">Documentación PostgreSQL</link>.
-        </para>
+        <simpara>
+         El modo SSL. Los valores aceptados son <literal>disable</literal>,
+         <literal>allow</literal>, <literal>prefer</literal>,
+         <literal>require</literal>, <literal>verify-ca</literal> y
+         <literal>verify-full</literal>; su significado se describe en
+         la <link xlink:href="&url.pgsql.manual;">Documentación PostgreSQL</link>.
+         Muchos servicios PostgreSQL alojados requieren una conexión cifrada, por lo que
+         se necesita <literal>require</literal> o más estricto para conectarse a ellos.
+        </simpara>
        </listitem>
       </varlistentry>
 


### PR DESCRIPTION
Sincronización de la extensión pdo_pgsql con php/doc-en#5626 y php/doc-en#5629.

- Deprecaciones de PHP 8.5.0: constantes de transacción, alias `PDO::pgsql*` (`#[\Deprecated]`), `PDO::PGSQL_TRANSACTION_*`.
- Documenta `PDO::ATTR_PREFETCH` (obtención perezosa fila a fila) y la firma de `copyFromArray` con `Traversable`.
- Añade ejemplos y `changelog` a los métodos copy*/getNotify/getPid, y mejora notas (sslmode, bytea/LOBs).

Cada fichero queda al nivel del último commit EN que lo modifica; Maintainer conservado.

Fixes #808
Fixes #809