### PR TITLE
Sync EN: PDO 8.5.0 deprecations in constants and methods (#815)

### DIFF
--- a/reference/pdo_firebird/constants.xml
+++ b/reference/pdo_firebird/constants.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b9cf1a2e7307131913ac3c16c2fb67ed9ad38527 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: PhilDaiguille Status: ready -->
 
 <section xml:id="ref.pdo-firebird.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
+ <warning>
+  <simpara>
+   Las constantes listadas a continuación están <emphasis>OBSOLETAS</emphasis>
+   a partir de PHP 8.5.0. Utilice las constantes correspondientes de
+   <classname>Pdo\Firebird</classname> en su lugar.
+  </simpara>
+ </warning>
  <variablelist>
   <varlistentry xml:id="pdo.constants.fb-attr-date-format">
    <term>
@@ -13,9 +18,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_DATE_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="pdo.constants.fb-attr-time-format">
@@ -24,9 +29,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_TIME_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="pdo.constants.fb-attr-timestamp-format">
@@ -35,9 +40,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_TIMESTAMP_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
  </variablelist>

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: PhilDaiguille Status: ready -->
 <section xml:id="ref.pdo-mysql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
+ <warning>
+  <simpara>
+   Las constantes listadas a continuación están <emphasis>OBSOLETAS</emphasis>
+   a partir de PHP 8.5.0. Utilice las constantes correspondientes de
+   <classname>Pdo\Mysql</classname> en su lugar.
+  </simpara>
+ </warning>
  <variablelist>
   <varlistentry xml:id="pdo.constants.mysql-attr-use-buffered-query">
    <term>

--- a/reference/pdo_odbc/constants.xml
+++ b/reference/pdo_odbc/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 220e1d0ef80ba8f68254db56ee9f2203be4cd8e6 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: PhilDaiguille Status: ready -->
 <section xml:id="pdo-odbc.global.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
@@ -11,11 +10,22 @@
     (<type>string</type>)
    </term>
    <listitem>
-    <para>
-
-    </para>
+    <simpara>
+     Describe la biblioteca ODBC enlazada con la extensión PDO_ODBC.
+     Los valores posibles incluyen <literal>unixODBC</literal>,
+     <literal>iODBC</literal> o <literal>generic</literal>.
+    </simpara>
    </listitem>
   </varlistentry>
+ </variablelist>
+ <warning>
+  <simpara>
+   Las constantes listadas a continuación están <emphasis>OBSOLETAS</emphasis>
+   a partir de PHP 8.5.0. Utilice las constantes correspondientes de
+   <classname>Pdo\Odbc</classname> en su lugar.
+  </simpara>
+ </warning>
+ <variablelist>
   <varlistentry xml:id="pdo.constants.odbc-attr-use-cursor-library">
    <term>
     <constant>PDO::ODBC_ATTR_USE_CURSOR_LIBRARY</constant>

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateAggregate.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateAggregate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdo.sqlitecreateaggregate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::sqliteCreateAggregate</refname>
@@ -8,6 +7,10 @@
    &Alias; <methodname>Pdo\Sqlite::createAggregate</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateCollation.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateCollation.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdo.sqlitecreatecollation" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::sqliteCreateCollation</refname>
@@ -8,6 +7,10 @@
    &Alias; <methodname>Pdo\Sqlite::createCollation</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateFunction.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateFunction.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdo.sqlitecreatefunction" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::sqliteCreateFunction</refname>
@@ -8,6 +7,10 @@
    &Alias; <methodname>Pdo\Sqlite::createFunction</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;


### PR DESCRIPTION
Closes #815

Documenta las deprecaciones de PHP 8.5.0 en las constantes y métodos PDO (avisos de obsolescencia en pdo_firebird, pdo_mysql, pdo_odbc; &warn.deprecated.function-8-5-0; en los métodos sqliteCreate* de pdo_sqlite).

`reference/pdo/constants.xml` ya estaba sincronizado.