### PR TITLE
Sync ext/operator language reference link

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2946c8a267734a9e8696e1764f7436e6caa8909c Maintainer: Marqitos Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: Marqitos Status: ready -->
 <chapter xml:id="language.operators" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Los operadores</title>
  <simpara>
@@ -30,6 +29,11 @@
   que indican exactamente cómo se evalúan las expresiones que contienen varios
   operadores diferentes.
  </para>
+ <simpara>
+  Existe una extensión PECL que permite la sobrecarga de algunos operadores para
+  objetos. Para más información, véase la sección de
+  <link linkend="book.operator">Sobrecarga de operadores para objetos</link>.
+ </simpara>
 
  &language.operators.precedence;
  &language.operators.arithmetic;


### PR DESCRIPTION
Closes #812

Añade el enlace a la sección de sobrecarga de operadores en `language/operators.xml`.

Los nuevos archivos EN (`reference/operator/*`, `appendices/extensions.xml`) quedan fuera del alcance de la sincronización (fallback a EN), conforme a la convención doc-es.