### PR TITLE
Sync codespell typo fixes in PECL extensions

### DIFF
--- a/reference/gearman/gearmantask/create.xml
+++ b/reference/gearman/gearmantask/create.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: cf0a919c126e45b5df583d188e77fa62015b714a Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmantask.create">
  <refnamediv>
   <refname>GearmanTask::create</refname>

--- a/reference/ibm_db2/functions/db2-escape-string.xml
+++ b/reference/ibm_db2/functions/db2-escape-string.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: tardeenfamenor Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: tardeenfamenor Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-escape-string">
  <refnamediv>
   <refname>db2_escape_string</refname>

--- a/reference/imagick/examples.xml
+++ b/reference/imagick/examples.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 3739933b8c796d45aad74410caebb2734dc00aa7 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: seros Status: ready -->
 
 <chapter xml:id="imagick.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;

--- a/reference/imagick/imagick/brightnesscontrastimage.xml
+++ b/reference/imagick/imagick/brightnesscontrastimage.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="imagick.brightnesscontrastimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::brightnessContrastImage</refname>
@@ -15,9 +14,9 @@
    <methodparam><type>float</type><parameter>contrast</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cambia el brillo y/o el contraste de una imagen. Convierte los parámetros de brillo y contraste en pendiente e intercepción y llama a una función polinómica para aplicarla a la imagen.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/imagick/imagick/distortimage.xml
+++ b/reference/imagick/imagick/distortimage.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: seros Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.distortimage">
  <refnamediv>
   <refname>Imagick::distortImage</refname>

--- a/reference/imagick/imagick/evaluateimage.xml
+++ b/reference/imagick/imagick/evaluateimage.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 65c4446ab35754d2f3cd8abec11302650a150bf9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.evaluateimage">
  <refnamediv>
@@ -17,11 +15,11 @@
    <methodparam><type>float</type><parameter>constant</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Aplica una expresión aritmética, relacional o lógica a una imagen.
    Utilice estos operadores para aclarar u oscurecer una imagen, para
    aumentar o reducir el contraste, o para producir una imagen invertida.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/imagick/imagick/extentimage.xml
+++ b/reference/imagick/imagick/extentimage.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.extentimage">
  <refnamediv>

--- a/reference/imagick/imagick/getimageproperties.xml
+++ b/reference/imagick/imagick/getimageproperties.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.getimageproperties">
  <refnamediv>

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 52d113ac0ae010b8229ac7a7e98b837ff2c755b3 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.sigmoidalcontrastimage" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -59,10 +57,10 @@
     <varlistentry>
      <term><parameter>beta</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Dónde debe situarse el punto medio del gradiente. Este valor debe estar
        en el intervalo 0-1, multiplicado por el valor del quantum para ImageMagick.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/imagick/imagick/trimimage.xml
+++ b/reference/imagick/imagick/trimimage.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: seros Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.trimimage">
  <refnamediv>
   <refname>Imagick::trimImage</refname>

--- a/reference/imagick/imagickdraw/affine.xml
+++ b/reference/imagick/imagickdraw/affine.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 668b6fc28891062b1c96202009ccb70b7147740d Maintainer: seros Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickdraw.affine">
  <refnamediv>
@@ -81,7 +80,7 @@ function affine($strokeColor, $fillColor, $backgroundColor) {
     //Translate (offset) the drawing
     $affineTranslate = array("sx" => 1, "sy" => 1, "rx" => 0, "ry" => 0, "tx" => 30, "ty" => 30);
 
-    //The identiy affine matrix
+    //The identity affine matrix
     $affineIdentity = array("sx" => 1, "sy" => 1, "rx" => 0, "ry" => 0, "tx" => 0, "ty" => 0);
 
     $examples = [$affineScale, $affineShear, $affineRotate, $affineTranslate, $affineIdentity,];

--- a/reference/imagick/imagickpixeliterator/resetiterator.xml
+++ b/reference/imagick/imagickpixeliterator/resetiterator.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fa0c88f1e36a3f28b4fcee0b2d1e188b54e0c44b Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickpixeliterator.resetiterator">
  <refnamediv>

--- a/reference/memcached/memcached/ispersistent.xml
+++ b/reference/memcached/memcached/ispersistent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a996df6b949ae2db2cf19a07e68ce367137d3ecb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="memcached.ispersistent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Memcached::isPersistent</refname>

--- a/reference/mongodb/bson/document/tophp.xml
+++ b/reference/mongodb/bson/document/tophp.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mongodb-bson-document.tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\Document::toPHP</refname>

--- a/reference/mongodb/bson/objectid/tostring.xml
+++ b/reference/mongodb/bson/objectid/tostring.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="mongodb-bson-objectid.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/bson/objectidinterface/tostring.xml
+++ b/reference/mongodb/bson/objectidinterface/tostring.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="mongodb-bson-objectidinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/bson/timestamp/getincrement.xml
+++ b/reference/mongodb/bson/timestamp/getincrement.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="mongodb-bson-timestamp.getincrement" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\Timestamp::getIncrement</refname>

--- a/reference/mongodb/functions/bson/tophp.xml
+++ b/reference/mongodb/functions/bson/tophp.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.mongodb.bson-tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\toPHP</refname>

--- a/reference/mongodb/mongodb/driver/bulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <reference xml:id="class.mongodb-driver-bulkwrite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase MongoDB\Driver\BulkWrite</title>

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="mongodb-driver-manager.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Manager::executeBulkWrite</refname>

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="mongodb-driver-manager.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Manager::executeCommand</refname>

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="mongodb-driver-manager.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Manager::executeQuery</refname>

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xml:id="mongodb-driver-server.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xml:id="mongodb-driver-server.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/session/committransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/committransaction.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="mongodb-driver-session.committransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Session::commitTransaction</refname>

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <chapter xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Seguridad</title>
 

--- a/reference/oci8/functions/oci-get-implicit-resultset.xml
+++ b/reference/oci8/functions/oci-get-implicit-resultset.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ed6de1ae20ce16c0c7be0b3fef282b6065bebfac Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.oci-get-implicit-resultset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>oci_get_implicit_resultset</refname>
@@ -14,7 +12,7 @@
    <type class="union"><type>resource</type><type>false</type></type><methodname>oci_get_implicit_resultset</methodname>
    <methodparam><type>resource</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Utilizado para recuperar juegos recursivos de resultados de consultas
    después de la ejecución de un bloque almacenado o anónimo Oracle PL/SQL donde este bloque
    retorna resultados de consultas con la función
@@ -22,7 +20,7 @@
    Oracle 12 (o posterior).
    Esto permite a los bloques PL/SQL retornar fácilmente resultados
    de consultas.
-  </para>
+  </simpara>
   <para>
    La consulta hija puede ser utilizada con cualquiera de las funciones
    de recuperación OCI8: <function>oci_fetch</function>, <function>oci_fetch_all</function>,

--- a/reference/oci8/ini.xml
+++ b/reference/oci8/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <section xml:id="oci8.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/sqlsrv/constants.xml
+++ b/reference/sqlsrv/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2471b0dc9ba5f9aff8b1b73060515dd9ce41b634 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sqlsrv.constants">
  &reftitle.constants;
  &extension.constants;

--- a/reference/sqlsrv/functions/sqlsrv-close.xml
+++ b/reference/sqlsrv/functions/sqlsrv-close.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c758e862cf7648f657acb9e073bcc657f368a701 Maintainer: regiemix Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: regiemix Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sqlsrv-close">
  <refnamediv>
   <refname>sqlsrv_close</refname>

--- a/reference/sqlsrv/functions/sqlsrv-num-rows.xml
+++ b/reference/sqlsrv/functions/sqlsrv-num-rows.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c758e862cf7648f657acb9e073bcc657f368a701 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sqlsrv-num-rows">
  <refnamediv>
   <refname>sqlsrv_num_rows</refname>

--- a/reference/swoole/constants.xml
+++ b/reference/swoole/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ecc53915a8e9eee17065ce22bef4dca3e42537d1 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <appendix xml:id="swoole.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
@@ -1025,7 +1024,7 @@
     </term>
     <listitem>
      <simpara>
-      SSL no puede utilizar senfile.
+      SSL no puede utilizar sendfile.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/swoole/functions/swoole-async-read.xml
+++ b/reference/swoole/functions/swoole-async-read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.swoole-async-read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,9 +53,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
+         <simpara>
           El contenido leído del flujo de fichero.
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>

--- a/reference/swoole/functions/swoole-last-error.xml
+++ b/reference/swoole/functions/swoole-last-error.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17623bf363758688a477a430af75e05a28661779 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.swoole-last-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/swoole/swoole/async/read.xml
+++ b/reference/swoole/swoole/async/read.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="swoole-async.read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Async::read</refname>
@@ -53,9 +52,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
+         <simpara>
           El contenido leído desde el flujo de fichero.
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>

--- a/reference/swoole/swoole/async/readfile.xml
+++ b/reference/swoole/swoole/async/readfile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="swoole-async.readfile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Async::readFile</refname>
@@ -51,9 +50,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
+         <simpara>
           El contenido leído desde el fichero.
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>


### PR DESCRIPTION
Closes #814

Sincroniza el commit de codespell de php/doc-en (PECL: imagick, swoole, mongodb, oci8, sqlsrv, memcached, gearman, ibm_db2).

La mayoría de las erratas EN estaban en prosa ya traducida al español, por lo que solo se actualiza el hash EN-Revision. Cambios de texto reales: `identiy`→`identity` (comentario de código en imagickdraw/affine) y `senfile`→`sendfile` (swoole/constants). Además, conversiones `para`→`simpara` siguiendo a EN en 7 ficheros.