### PR TITLE
[Sync EN] ext/libxml: advertencia sobre el uso de LIBXML_PARSEHUGE (#5647)

### DIFF
--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 64e1182c986582df32ed7e629e42b4fea204de2e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 77ae1d1908566c7d20972011c2ea067480a4f42e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <appendix xml:id="libxml.constants" xmlns="http://docbook.org/ns/docbook">
@@ -283,6 +283,14 @@
      profundidad máxima de un documento o la recursión de entidades, pero también
      a los límites del tamaño del texto de los nodos.
     </simpara>
+    <caution>
+     <simpara>
+      Dado que esto relaja los límites codificados en el código, solo debería utilizarse
+      con datos de confianza. Eliminar el límite de profundidad sobre datos no confiables
+      puede provocar un consumo excesivo de recursos, como un desbordamiento de pila al
+      procesar un documento profundamente anidado.
+     </simpara>
+    </caution>
     <note>
      <para>
       Disponible únicamente desde Libxml &gt;= 2.7.0 (desde PHP


### PR DESCRIPTION
Sync de php/doc-en#5647 (commit 77ae1d19). Closes #824.