### PR TITLE
[Sync EN] Remove $ sigil from <parameter> names (#5643)

### DIFF
--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration83.deprecated">
  <title>Funcionalidades obsoletas</title>
@@ -41,10 +41,10 @@
  <sect2 xml:id="migration83.deprecated.core.dba">
   <title>DBA</title>
 
-  <para>
-   Llamar a <function>dba_fetch</function> con <parameter>$dba</parameter> como
+  <simpara>
+   Llamar a <function>dba_fetch</function> con <parameter>dba</parameter> como
    tercer argumento está ahora depreciado.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.ffi">
@@ -73,21 +73,21 @@
  <sect2 xml:id="migration83.deprecated.ldap">
   <title>LDAP</title>
 
-  <para>
+  <simpara>
    Llamar a <function>ldap_connect</function> con
-   <parameter>$hostname</parameter> y <parameter>$port</parameter> separados está
+   <parameter>hostname</parameter> y <parameter>port</parameter> separados está
    depreciado.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.mbstring">
   <title>MBString</title>
 
-  <para>
-   Pasar un <parameter>$width</parameter> negativo a
+  <simpara>
+   Pasar un <parameter>width</parameter> negativo a
    <function>mb_strimwidth</function> está ahora depreciado.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.phar">
@@ -95,7 +95,7 @@
 
   <para>
    Llamar a <methodname>Phar::setStub</methodname> con un
-   <type>resource</type> y un <parameter>$length</parameter>
+   <type>resource</type> y un <parameter>length</parameter>
    está ahora depreciado. Estas llamadas deben ser reemplazadas por:
    <code>$phar->setStub(stream_get_contents($resource));</code>
   </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a989e5f21db7902c0028ad51e9adc94024d13216 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration83.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Cambios incompatibles con versiones anteriores</title>
@@ -172,28 +172,28 @@
   <para>
    La función <function>range</function> ha tenido varios cambios:
    <simplelist>
-    <member>Ahora se lanza un <classname>TypeError</classname> cuando se pasan <type>object</type>s,
+    <member>Ahora se lanza un <exceptionname>TypeError</exceptionname> cuando se pasan <type>object</type>s,
     <type>resource</type>s, o <type>array</type>s como entradas de límite.</member>
-    <member>Se lanza un <classname>ValueError</classname> más descriptivo cuando
-    se pasa <literal>0</literal> para <parameter>$step</parameter>.</member>
-    <member>Ahora se lanza un <classname>ValueError</classname> cuando se usa un
-    <parameter>$step</parameter> negativo para rangos crecientes.</member>
-    <member>Si <parameter>$step</parameter> es un float que puede interpretarse
+    <member>Se lanza un <exceptionname>ValueError</exceptionname> más descriptivo cuando
+    se pasa <literal>0</literal> para <parameter>step</parameter>.</member>
+    <member>Ahora se lanza un <exceptionname>ValueError</exceptionname> cuando se usa un
+    <parameter>step</parameter> negativo para rangos crecientes.</member>
+    <member>Si <parameter>step</parameter> es un float que puede interpretarse
     como un int, ahora se hace así.</member>
-    <member>Ahora se lanza un <classname>ValueError</classname> si cualquier argumento
+    <member>Ahora se lanza un <exceptionname>ValueError</exceptionname> si cualquier argumento
     es infinito o NAN.</member>
     <member>Ahora se emite un <constant>E_WARNING</constant> si
-    <parameter>$start</parameter> o <parameter>$end</parameter> es la cadena vacía.
+    <parameter>start</parameter> o <parameter>end</parameter> es la cadena vacía.
     El valor continúa siendo convertido al valor <literal>0</literal>.</member>
     <member>Ahora se emite un <constant>E_WARNING</constant> si
-    <parameter>$start</parameter> o <parameter>$end</parameter> tiene más de
+    <parameter>start</parameter> o <parameter>end</parameter> tiene más de
     un byte, solo si es una cadena no numérica.</member>
     <member>Ahora se emite un <constant>E_WARNING</constant> si
-    <parameter>$start</parameter> o <parameter>$end</parameter> se convierte a un
+    <parameter>start</parameter> o <parameter>end</parameter> se convierte a un
     entero porque la otra entrada de límite es un número.
     (p.ej. <code>range(5, 'z');</code>).</member>
     <member>Ahora se emite un <constant>E_WARNING</constant> si
-    <parameter>$step</parameter> es un float al intentar generar un rango de
+    <parameter>step</parameter> es un float al intentar generar un rango de
     caracteres, excepto si ambas entradas de límite son cadenas numéricas (p.ej.
     <code>range('5', '9', 0.5);</code> no produce una advertencia).</member>
     <member><function>range</function> ahora produce una lista de caracteres si una
@@ -215,9 +215,9 @@ range('9', 'A');  // [9, 8, 7, 6, 5, 4, 3, 2, 1, 0], antes de PHP 8.3.0
 
   <para>
    <function>number_format</function> ahora maneja valores negativos de
-   <parameter>$decimals</parameter> redondeando
-   <parameter>$num</parameter> a <code>abs($decimals)</code> dígitos antes del
-   punto decimal. Anteriormente, los valores negativos de <parameter>$decimals</parameter>
+   <parameter>decimals</parameter> redondeando
+   <parameter>num</parameter> a <code>abs($decimals)</code> dígitos antes del
+   punto decimal. Anteriormente, los valores negativos de <parameter>decimals</parameter>
    eran ignorados.
   </para>
 

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: No Maintainer: Marqitos -->
 <sect1 xml:id="migration83.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nuevas características</title>
@@ -154,10 +154,10 @@ echo $user_ini['listen']; // localhost:9000
  <sect2 xml:id="migration83.new-features.posix">
   <title>POSIX</title>
 
-  <para>
+  <simpara>
    <function>posix_getrlimit</function> ahora toma un argumento opcional
-   <parameter>$resource</parameter> para permitir la recuperación de un solo límite de recurso.
-  </para>
+   <parameter>resource</parameter> para permitir la recuperación de un solo límite de recurso.
+  </simpara>
 
   <para>
    <function>posix_isatty</function> ahora lanza advertencias de tipo para enteros

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration83.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Otros cambios</title>
@@ -178,11 +178,11 @@
   <sect3 xml:id="migration83.other-changes.functions.gd">
    <title>Gd</title>
 
-   <para>
+   <simpara>
     La firma de <function>imagerotate</function> ha cambiado.
-    El parámetro <parameter>$ignore_transparent</parameter> ha sido eliminado,
+    El parámetro <parameter>ignore_transparent</parameter> ha sido eliminado,
     porque ha sido ignorado desde PHP 5.5.0.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.intl">
@@ -262,18 +262,18 @@
   <sect3 xml:id="migration83.other-changes.functions.mysqli">
    <title>mysqli</title>
 
-   <para>
+   <simpara>
     <function>mysqli_fetch_object</function> ahora lanza una
     <classname>ValueError</classname> en lugar de una <classname>Exception</classname>
-    cuando el argumento <parameter>$constructor_args</parameter> no está vacío
+    cuando el argumento <parameter>constructor_args</parameter> no está vacío
     con la clase no teniendo un constructor.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     <function>mysqli_poll</function> ahora lanza una <classname>ValueError</classname>
-    cuando ni el argumento <parameter>$read</parameter>
-    ni el argumento <parameter>$error</parameter> son pasados.
-   </para>
+    cuando ni el argumento <parameter>read</parameter>
+    ni el argumento <parameter>error</parameter> son pasados.
+   </simpara>
 
    <para>
     <function>mysqli_field_seek</function> y
@@ -285,23 +285,23 @@
   <sect3 xml:id="migration83.other-changes.functions.odbc">
    <title>ODBC</title>
 
-   <para>
+   <simpara>
     <function>odbc_autocommit</function> ahora acepta &null; para el
-    parámetro <parameter>$enable</parameter>.
+    parámetro <parameter>enable</parameter>.
     Pasar &null; tiene el mismo comportamiento que pasar un solo parámetro,
     indicando si la funcionalidad autocommit está habilitada o no.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.pgsql">
    <title>PGSQL</title>
 
-   <para>
+   <simpara>
     <function>pg_fetch_object</function> ahora lanza una
     <classname>ValueError</classname> en lugar de una <classname>Exception</classname>
-    cuando el argumento <parameter>$constructor_args</parameter> no está vacío
+    cuando el argumento <parameter>constructor_args</parameter> no está vacío
     con la clase no teniendo un constructor.
-   </para>
+   </simpara>
 
    <para>
     <function>pg_insert</function> ahora lanza una <classname>ValueError</classname>
@@ -315,12 +315,12 @@
     no coincide correctamente con el tipo de PostgreSQL.
    </para>
 
-   <para>
-    El parámetro <parameter>$row</parameter> de
+   <simpara>
+    El parámetro <parameter>row</parameter> de
     <function>pg_fetch_result</function>,
     <function>pg_field_prtlen</function>, y
     <function>pg_field_is_null</function> ahora es nullable.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.random">
@@ -371,27 +371,27 @@
     token no es proporcionado al iniciar la tokenización.
    </para>
 
-   <para>
+   <simpara>
     <function>password_hash</function> ahora encadena la excepción subyacente
-    <classname>Random\RandomException</classname>
-    como <classname>ValueError</classname>'s <parameter>$previous</parameter>
-    <classname>Exception</classname> cuando falla la generación de sal.
-   </para>
+    <exceptionname>Random\RandomException</exceptionname>
+    como <exceptionname>ValueError</exceptionname>'s <parameter>previous</parameter>
+    <exceptionname>Exception</exceptionname> cuando falla la generación de sal.
+   </simpara>
 
-   <para>
-    Si un array es usado como <parameter>$command</parameter> para
+   <simpara>
+    Si un array es usado como <parameter>command</parameter> para
     <function>proc_open</function>, debe tener al menos un elemento
     no vacío. De lo contrario, se lanza una <classname>ValueError</classname>.
-   </para>
+   </simpara>
 
-   <para>
-    <function>proc_open</function> ahora devuelve &false; si el array <parameter>$command</parameter>
+   <simpara>
+    <function>proc_open</function> ahora devuelve &false; si el array <parameter>command</parameter>
     es un comando inválido en lugar de un objeto de recurso que produce una advertencia más tarde.
     Esto ya era el caso para Windows, pero ahora también es el caso si se usa una implementación posix_spawn
     (la mayoría de las plataformas Linux, BSD y MacOS). Sigue habiendo
     algunas plataformas antiguas donde este comportamiento no ha cambiado porque posix_spawn no es
     soportado allí.
-   </para>
+   </simpara>
 
    <para>
     <function>array_sum</function> y <function>array_product</function> ahora emiten
@@ -402,21 +402,21 @@
     <!-- RFC: https://wiki.php.net/rfc/saner-array-sum-product -->
    </para>
 
-   <para>
-    El <parameter>$decimals</parameter> de <function>number_format</function>
+   <simpara>
+    El <parameter>decimals</parameter> de <function>number_format</function>
     ahora maneja enteros negativos.
-    Redondear con un valor negativo para <parameter>$decimals</parameter> significa
-    que <parameter>$num</parameter> es redondeado a <parameter>$decimals</parameter>
+    Redondear con un valor negativo para <parameter>decimals</parameter> significa
+    que <parameter>num</parameter> es redondeado a <parameter>decimals</parameter>
     dígitos significativos antes del separador decimal.
-    Anteriormente, los enteros negativos para <parameter>$decimals</parameter> eran
+    Anteriormente, los enteros negativos para <parameter>decimals</parameter> eran
     silenciosamente ignorados y el número era redondeado a cero decimales.
-   </para>
+   </simpara>
 
-   <para>
-    Se ha añadido un nuevo argumento <parameter>$before_needle</parameter> a
+   <simpara>
+    Se ha añadido un nuevo argumento <parameter>before_needle</parameter> a
     <function>strrchr</function>. Se comporta como su homólogo en las
     funciones <function>strstr</function> o <function>stristr</function>.
-   </para>
+   </simpara>
 
    <para>
     <function>str_getcsv</function> y <function>fgetcsv</function> ahora devuelven

--- a/appendices/migration85/deprecated.xml
+++ b/appendices/migration85/deprecated.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2def8c3cfec11fcc74f153b337301bbc06c16bc9 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.deprecated">
  <title>Funcionalidades obsoletas</title>
@@ -206,7 +206,7 @@
   </simpara>
 
   <simpara>
-   El parámetro <parameter>$context</parameter> de la
+   El parámetro <parameter>context</parameter> de la
    función <function>finfo_buffer</function> ha quedado obsoleto
    ya que se ignora.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_context_parameter_for_finfo_buffer -->
@@ -287,7 +287,7 @@
   <title>OpenSSL</title>
 
   <simpara>
-   El parámetro <parameter>$key_length</parameter> de
+   El parámetro <parameter>key_length</parameter> de
    <function>openssl_pkey_derive</function> ha quedado obsoleto.
    Esto se debe a que se ignora o trunca la clave, lo que puede suponer
    una vulnerabilidad de seguridad.

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f81bbcf9d36c28bf067b5514cffdbc7663357cf3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Cambios incompatibles con versiones anteriores</title>
@@ -157,12 +157,12 @@
 
   <simpara>
    <function>bzcompress</function> ahora lanza un <classname>ValueError</classname>
-   cuando <parameter>$block_size</parameter> no está entre 1 y 9.
+   cuando <parameter>block_size</parameter> no está entre 1 y 9.
   </simpara>
 
   <simpara>
    <function>bzcompress</function> ahora lanza un <classname>ValueError</classname>
-   cuando <parameter>$work_factor</parameter> no está entre 0 y 250.
+   cuando <parameter>work_factor</parameter> no está entre 0 y 250.
   </simpara>
 
  </sect2>
@@ -186,7 +186,7 @@
   <simpara>
    <function>finfo_file</function> y <methodname>finfo::file</methodname>
    ahora lanzan un <exceptionname>ValueError</exceptionname> en lugar de un
-   <exceptionname>TypeError</exceptionname> cuando <parameter>$filename</parameter>
+   <exceptionname>TypeError</exceptionname> cuando <parameter>filename</parameter>
    contiene bytes nulos.
    Esto alinea el tipo de error que se produce para que sea coherente con el resto
    del lenguaje.
@@ -295,12 +295,12 @@
 
   <simpara>
    <function>pcntl_exec</function> ahora lanza <exceptionname>ValueError</exceptionname>
-   cuando las entradas del parámetro <parameter>$args</parameter> contienen bytes nulos.
+   cuando las entradas del parámetro <parameter>args</parameter> contienen bytes nulos.
   </simpara>
 
   <simpara>
    <function>pcntl_exec</function> ahora lanza <exceptionname>ValueError</exceptionname>
-   cuando las entradas o claves del parámetro <parameter>$env_vars</parameter>
+   cuando las entradas o claves del parámetro <parameter>env_vars</parameter>
    contienen bytes nulos.
   </simpara>
 
@@ -487,7 +487,7 @@
 
   <simpara>
    <methodname>SoapClient::__doRequest</methodname> ahora acepta un nuevo
-   parámetro opcional <parameter>$uriParserClass</parameter> que acepta
+   parámetro opcional <parameter>uriParserClass</parameter> que acepta
    argumentos de tipo string o &null;.
    &null; representa el método original basado en
    (<function>parse_url</function>), mientras que los nuevos backends se utilizarán al pasar
@@ -539,7 +539,7 @@
   </simpara>
 
   <simpara>
-   El parámetro <methodname>SplFileObject::fwrite</methodname> <parameter>$length</parameter> ahora admite valores nulos.
+   El parámetro <methodname>SplFileObject::fwrite</methodname> <parameter>length</parameter> ahora admite valores nulos.
    El valor predeterminado cambió de <literal>0</literal> a &null;.
   </simpara>
 

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce397343296708654c8cdac774e23a9ee47ab27d Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nuevas características</title>
@@ -396,7 +396,7 @@ print T1 . PHP_EOL;   // Imprime "0"
   <simpara>
    Por lo tanto, las firmas de <methodname>SoapFault::__construct</methodname> y
    <methodname>SoapServer::fault</methodname>
-   ahora incluyen un parámetro opcional <parameter>$lang</parameter>.
+   ahora incluyen un parámetro opcional <parameter>lang</parameter>.
    Esta compatibilidad resuelve el problema de compatibilidad con los clientes SOAP de .NET.
   </simpara>
 
@@ -455,11 +455,11 @@ print T1 . PHP_EOL;   // Imprime "0"
   <title>XSL</title>
 
   <simpara>
-   El argumento <parameter>$namespace</parameter> de <methodname>XSLTProcessor::getParameter</methodname>,
+   El argumento <parameter>namespace</parameter> de <methodname>XSLTProcessor::getParameter</methodname>,
    <methodname>XSLTProcessor::setParameter</methodname> y
    <methodname>XSLTProcessor::removeParameter</methodname> ahora funciona correctamente
    en lugar de considerarse vacío.
-   Esto solo funciona si el argumento <parameter>$name</parameter> no utiliza la notación Clark ni es un
+   Esto solo funciona si el argumento <parameter>name</parameter> no utiliza la notación Clark ni es un
    QName, ya que en esos casos el espacio de nombres se obtiene del espacio de nombres href o
    prefijo, respectivamente.
   </simpara>

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.other-changes">
  <title>Otros cambios</title>
@@ -90,7 +90,7 @@
 
    <simpara>
     <function>grapheme_extract</function> asigna correctamente el valor de
-    <parameter>$next</parameter> al omitir bytes iniciales no válidos.
+    <parameter>next</parameter> al omitir bytes iniciales no válidos.
     Anteriormente, en ocasiones apuntaba al inicio del
     límite del grafema en lugar de al final.
    </simpara>
@@ -105,7 +105,7 @@
    </simpara>
 
    <simpara>
-    Las siguientes funciones ahora admiten un argumento <parameter>$locale</parameter>:
+    Las siguientes funciones ahora admiten un argumento <parameter>locale</parameter>:
     <function>grapheme_strpos</function>,
     <function>grapheme_stripos</function>,
     <function>grapheme_strrpos</function>,
@@ -145,18 +145,18 @@
    <simpara>
     <function>openssl_public_encrypt</function> y
     <function>openssl_private_decrypt</function> tienen un nuevo parámetro
-    <parameter>$digest_algo</parameter> que permite especificar el algoritmo de
+    <parameter>digest_algo</parameter> que permite especificar el algoritmo de
     resumen hash para el relleno OAEP.
    </simpara>
 
    <simpara>
     <function>openssl_sign</function> y <function>openssl_verify</function>
-    tienen un nuevo parámetro <parameter>$padding</parameter> para permitir el uso
+    tienen un nuevo parámetro <parameter>padding</parameter> para permitir el uso
     de un relleno RSA PSS más seguro.
    </simpara>
 
    <simpara>
-    <function>openssl_cms_encrypt</function> el parámetro <parameter>$cipher_algo</parameter>
+    <function>openssl_cms_encrypt</function> el parámetro <parameter>cipher_algo</parameter>
     puede ser un string con el nombre del algoritmo de cifrado.
     Esto permite usar más algoritmos, incluidos los algoritmos de cifrado AES y GCM, para
     datos cifrados con autenticación.
@@ -272,7 +272,7 @@
    <title>Zlib</title>
 
    <simpara>
-    El argumento <parameter>$use_include_path</parameter> para las funciones
+    El argumento <parameter>use_include_path</parameter> para las funciones
     <function>gzfile</function>, <function>gzopen</function> y
     <function>readgzfile</function> se ha cambiado
     de <type>int</type> a <type>bool</type>.

--- a/appendices/migration85/windows-support.xml
+++ b/appendices/migration85/windows-support.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.windows-support">
  <title>Soporte para Windows</title>
@@ -60,8 +60,8 @@
   <title>Streams</title>
 
   <simpara>
-   Si el array <parameter>$read</parameter> solo contiene pipe streams
-   y los arrays <parameter>$write</parameter> y <parameter>$except</parameter> están vacíos,
+   Si el array <parameter>read</parameter> solo contiene pipe streams
+   y los arrays <parameter>write</parameter> y <parameter>except</parameter> están vacíos,
    <function>stream_select</function> ahora se comporta de forma similar a los sistemas POSIX;
    es decir, la función solo retorna si al menos un pipe está listo para leerse
    o después de que expire el tiempo de espera.

--- a/reference/com/functions/variant-cat.xml
+++ b/reference/com/functions/variant-cat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 31ab1b9a07ee6fdfd09cafaf22efa1cf78b49798 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.variant-cat" xmlns="http://docbook.org/ns/docbook">
@@ -19,10 +19,10 @@
    Une <parameter>left</parameter> con <parameter>right</parameter>
    y devuelve el resultado.
   </para>
-  <para>
+  <simpara>
    Esta función es equivalente a
-   <parameter>$left</parameter> <literal>.</literal> <parameter>$right</parameter>.
-  </para>
+   <parameter>left</parameter> <literal>.</literal> <parameter>right</parameter>.
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8b4c3d8dc5e190fbd5d84eede38a4da13537043d Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <refentry xml:id="datetime.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -32,32 +32,32 @@
     <term><parameter>datetime</parameter></term>
     <listitem>
      <para>&date.formats.parameter;</para>
-     <para>
+     <simpara>
       Introduzca <literal>"now"</literal> aquí para obtener el instante actual cuando se emplee
-      el parámetro <parameter>$timezone</parameter>.
-     </para>
+      el parámetro <parameter>timezone</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timezone</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto <classname>DateTimeZone</classname> que representa la
-      zona horaria de <parameter>$datetime</parameter>.
-     </para>
-     <para>
-      Si se omite <parameter>$timezone</parameter> o
+      zona horaria de <parameter>datetime</parameter>.
+     </simpara>
+     <simpara>
+      Si se omite <parameter>timezone</parameter> o
       es &null;, se usará la zona horaria actual.
-     </para>
+     </simpara>
      <note>
-      <para>
-       El parámetro <parameter>$timezone</parameter>
+      <simpara>
+       El parámetro <parameter>timezone</parameter>
        y la zona horaria actuales se ignoran cuando el
-       parámetro <parameter>$time</parameter>
+       parámetro <parameter>time</parameter>
        es una marca temporal de UNIX (p.ej. <literal>@946684800</literal>)
        o especifica una zona horaria
        (p.ej. <literal>2010-01-28T15:00:00+02:00</literal>).
-      </para>
+      </simpara>
      </note>
     </listitem>
    </varlistentry>

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -35,33 +35,33 @@
     <term><parameter>datetime</parameter></term>
     <listitem>
      <para>&date.formats.parameter;</para>
-     <para>
+     <simpara>
       Introduzca <literal>"now"</literal> aquí para obtener el instante actual cuando se emplee
-      el parámetro <parameter>$timezone</parameter>.
-     </para>
+      el parámetro <parameter>timezone</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timezone</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un objeto <classname>DateTimeZone</classname> que representa la
-      zona horaria de <parameter>$datetime</parameter>.
-     </para>
-     <para>
-      Si se omite <parameter>$timezone</parameter> o
+      zona horaria de <parameter>datetime</parameter>.
+     </simpara>
+     <simpara>
+      Si se omite <parameter>timezone</parameter> o
       es &null;, se usará la zona horaria actual.
-     </para>
+     </simpara>
      <note>
-      <para>
-       El parámetro <parameter>$timezone</parameter>
+      <simpara>
+       El parámetro <parameter>timezone</parameter>
        y la zona horaria actuales se ignoran cuando el
-       parámetro <parameter>$time</parameter>
+       parámetro <parameter>time</parameter>
        es una marca temporal de UNIX (p.ej. <literal>@946684800</literal>)
        o especifica una zona horaria
        (p.ej. <literal>2010-01-28T15:00:00+02:00</literal>, o
        <literal>2010-07-05T06:00:00Z</literal>).
-      </para>
+      </simpara>
      </note>
     </listitem>
    </varlistentry>

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Monitoreo del rendimiento de la aplicación (Application Performance Monitoring - APM)</title>
@@ -19,7 +19,7 @@
   <literal>commandSucceeded</literal>, y <literal>commandFailed</literal>.
   Cada uno de estos tres métodos acepta un solo argumento <parameter>event</parameter>
   de una clase específica para el evento respectivo. Por ejemplo, el argumento
-  <parameter>$event</parameter> de <literal>commandSucceeded</literal>
+  <parameter>event</parameter> de <literal>commandSucceeded</literal>
   es un objeto <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>.
  </simpara>
 

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b731f708be0b9f5c656b81eb6491d04b0d5b19d8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.preg-match-all" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -314,7 +314,7 @@ Array
        <entry>7.2.0</entry>
        <entry>
         <constant>PREG_UNMATCHED_AS_NULL</constant> es ahora soportado para el
-        parámetro <parameter>$flags</parameter>.
+        parámetro <parameter>flags</parameter>.
        </entry>
       </row>
      </tbody>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.preg-match" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -278,7 +278,7 @@ Array
        <entry>7.2.0</entry>
        <entry>
         <constant>PREG_UNMATCHED_AS_NULL</constant> ahora es soportado para el
-        parámetro <parameter>$flags</parameter>.
+        parámetro <parameter>flags</parameter>.
        </entry>
       </row>
      </tbody>

--- a/reference/session/examples.xml
+++ b/reference/session/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <appendix xml:id="session.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -249,12 +249,12 @@ if (empty($_SESSION['count'])) {
   <para>
    Cuando una sesión es destruida, PHP llamará a <parameter>destroy</parameter> con el ID de sesión.
   </para>
-  <para>
+  <simpara>
    PHP llamará a la función de retrollamada <parameter>gc</parameter> de vez en cuando para limpiar
    las sesiones expiradas según su
    tiempo de vida máximo. Esta llamada debería llevar a la destrucción de los registros en
-   el soporte de almacenamiento que no han sido accedidos desde <parameter>$lifetime</parameter>.
-  </para>
+   el soporte de almacenamiento que no han sido accedidos desde <parameter>lifetime</parameter>.
+  </simpara>
  </section>
 </appendix>
 

--- a/reference/session/functions/session-decode.xml
+++ b/reference/session/functions/session-decode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 584c3e8805b728ec0cfde0318bb34e00ebc36324 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-decode">
  <refnamediv>
@@ -14,11 +14,11 @@
    <type>bool</type><methodname>session_decode</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>session_decode</function> decodifica la información de sesión serializada proporcianda en
-   <parameter>$data</parameter>, y rellena la variable superglobal $_SESSION
+   <parameter>data</parameter>, y rellena la variable superglobal $_SESSION
    con el resultado.
-  </para>
+  </simpara>
   <para>
    Por defecto, el método de deserialización usado es interno a PHP, y no es el mismo que <function>unserialize</function>.
    El método de serialización se puede establecer con <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.

--- a/reference/session/sessionhandler/destroy.xml
+++ b/reference/session/sessionhandler/destroy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <refentry xml:id="sessionhandler.destroy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>public</modifier> <type>bool</type><methodname>SessionHandler::destroy</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Destruye una sesión. Llamado internamente por PHP con <function>session_regenerate_id</function> (se asume
-   que <parameter>$destroy</parameter> está establecido a &true;, mediante <function>session_destroy</function> o cuando
+   que <parameter>destroy</parameter> está establecido a &true;, mediante <function>session_destroy</function> o cuando
    <function>session_decode</function> falla.
-  </para>
+  </simpara>
   <para>
    Este método envuelve el gestor de almacenamiento interno de PHP definido en el
    ajuste ini <link linkend="ini.session.save-handler">session.save_handler</link> que fue establecido

--- a/reference/session/sessionhandler/read.xml
+++ b/reference/session/sessionhandler/read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <refentry xml:id="sessionhandler.read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -24,12 +24,12 @@
    ajuste ini <link linkend="ini.session.save-handler">session.save_handler</link> que fue establecido
    antes de que este gestor fuese establecido mediante <function>session_set_save_handler</function>.
   </para>
-  <para>
+  <simpara>
    Si esta clase se extiende por herencia, al llamar al método padre <parameter>read</parameter> invocará a la
    envoltura para este método y así invocará a la llamada de retorno interna asociada. Esto permite que el método sea
-   sobrescrito y/o interceptado y filtrado (por ejemplo, desencriptando el valor de <parameter>$data</parameter>
+   sobrescrito y/o interceptado y filtrado (por ejemplo, desencriptando el valor de <parameter>data</parameter>
    devuelto por el método padre <parameter>read</parameter>).
-  </para>
+  </simpara>
   <para>
    Para más información sobre lo que se espera que haga este método, consulte la documentación de
    <function>SessionHandlerInterface::close</function>.

--- a/reference/session/sessionhandler/write.xml
+++ b/reference/session/sessionhandler/write.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: seros Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <refentry xml:id="sessionhandler.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -24,12 +24,12 @@
    ajuste ini <link linkend="ini.session.save-handler">session.save_handler</link> que fue establecido
    antes de que este gestor fuese establecido mediante <function>session_set_save_handler</function>.
   </para>
-  <para>
+  <simpara>
    Si esta clase se extiende por herencia, al llamar al método padre <parameter>write</parameter> invocará a la
    envoltura para este método y así invocará a la llamada de retorno interna asociada. Esto permite que este método sea
-   sobrescrito y/o interceptado y filtrado (por ejemplo, encriptando el valor de <parameter>$data</parameter>
+   sobrescrito y/o interceptado y filtrado (por ejemplo, encriptando el valor de <parameter>data</parameter>
    antes de enviarlo al método padre <parameter>write</parameter>).
-  </para>
+  </simpara>
   <para>
    Para más información sobre lo que se espera que haga este método, consulte la documentación de
    <function>SessionHandlerInterface::write</function>.

--- a/reference/stream/constants.xml
+++ b/reference/stream/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 561e36d646b8e48dc53a910234ee9f30cba147d0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <appendix xml:id="stream.constants" xmlns="http://docbook.org/ns/docbook">
@@ -1198,7 +1198,7 @@
      <listitem>
       <simpara>
        Valor de retorno que indica que el filtro de usuario
-       ha devuelto cubos en <parameter>$out</parameter>.
+       ha devuelto cubos en <parameter>out</parameter>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -1210,7 +1210,7 @@
      <listitem>
       <simpara>
        Valor de retorno que indica que el filtro de usuario
-       no ha devuelto cubos en <parameter>$out</parameter>.
+       no ha devuelto cubos en <parameter>out</parameter>.
        (es decir, no hay datos disponibles).
       </simpara>
      </listitem>

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8be4b126c545a0b452be29b6b5ce185471814a1 Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -13,7 +13,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::dump</methodname>
-   <methodparam><type>int</type><parameter>$num</parameter></methodparam>
+   <methodparam><type>int</type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
    Volcar valores almacenados en caché


### PR DESCRIPTION
Sync de php/doc-en#5643 (commit 4de6272a). Retrait du sigil $ dans les balises <parameter>, conversions <para>→<simpara> et <classname>→<exceptionname> correspondantes, sur les 22 fichiers concernés. Closes #823.