### PR TITLE
[Sync EN] ext/ssh2: tipo de retorno false en ssh2_sftp_* (#5640)

### DIFF
--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-lstat">
+<refentry xml:id="function.ssh2-sftp-lstat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_lstat</refname>
   <refpurpose>Estado de un enlace simbólico</refpurpose>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>ssh2_sftp_lstat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>ssh2_sftp_lstat</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
@@ -52,6 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
+   Devuelve un array de estadísticas del enlace simbólico dado en caso de éxito&return.falseforfailure;.
    Ver la documentación de la función <function>stat</function>
    para los detalles concernientes a los valores devueltos.
   </simpara>

--- a/reference/ssh2/functions/ssh2-sftp-readlink.xml
+++ b/reference/ssh2/functions/ssh2-sftp-readlink.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-readlink">
+<refentry xml:id="function.ssh2-sftp-readlink" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_readlink</refname>
   <refpurpose>Devuelve el destino de un enlace simbólico</refpurpose>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>ssh2_sftp_readlink</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>ssh2_sftp_readlink</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>link</parameter></methodparam>
   </methodsynopsis>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve el destino del enlace simbólico <parameter>link</parameter>.
+   Devuelve el destino del enlace simbólico <parameter>link</parameter>&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-realpath.xml
+++ b/reference/ssh2/functions/ssh2-sftp-realpath.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-realpath">
+<refentry xml:id="function.ssh2-sftp-realpath" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_realpath</refname>
   <refpurpose>Resuelve la ruta real de una ruta proporcionada</refpurpose>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>ssh2_sftp_realpath</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>ssh2_sftp_realpath</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve la ruta real, en forma de &string;.
+   Devuelve la ruta real, en forma de &string;&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-stat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-stat.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-stat">
+<refentry xml:id="function.ssh2-sftp-stat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_stat</refname>
   <refpurpose>Obtiene el estado de un fichero en un sistema de ficheros remoto</refpurpose>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>ssh2_sftp_stat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>ssh2_sftp_stat</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
@@ -49,6 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
+   Devuelve un array de estadísticas del fichero dado en caso de éxito&return.falseforfailure;.
    Ver la documentación de la función
    <function>stat</function> para los detalles sobre los valores devueltos.
   </simpara>


### PR DESCRIPTION
Sync de php/doc-en#5640 (commit cad275c0). Añade false al tipo de retorno de ssh2_sftp_realpath/readlink/stat/lstat y actualiza los valores de retorno. Closes #821.