### PR TITLE
[Sync EN] ext/libxml: aclarar que LIBXML_PARSEHUGE aumenta los límites en lugar de eliminarlos

### DIFF
--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 77ae1d1908566c7d20972011c2ea067480a4f42e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 7dce5910421f42a97717220587841423ef1fa27a Maintainer: PhilDaiguille Status: ready -->
 
 <appendix xml:id="libxml.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -278,15 +276,15 @@
    </term>
    <listitem>
     <simpara>
-     Afecta al flag XML_PARSE_HUGE. Desactiva cualquier límite del
-     analizador codificado en el código. Esto afecta a límites como la
+     Afecta al flag XML_PARSE_HUGE. Aumenta algunos límites del
+     analizador codificados en el código. Esto afecta a límites como la
      profundidad máxima de un documento o la recursión de entidades, pero también
      a los límites del tamaño del texto de los nodos.
     </simpara>
     <caution>
      <simpara>
-      Dado que esto relaja los límites codificados en el código, solo debería utilizarse
-      con datos de confianza. Eliminar el límite de profundidad sobre datos no confiables
+      Dado que esto aumenta los límites codificados en el código, solo debería utilizarse
+      con datos de confianza. Aumentar el límite de profundidad sobre datos no confiables
       puede provocar un consumo excesivo de recursos, como un desbordamiento de pila al
       procesar un documento profundamente anidado.
      </simpara>


### PR DESCRIPTION
Sincronización con php/doc-en#5649.

Fixes #835