### PR TITLE
[Sync EN] ext/ldap: documentar el valor de retorno de ldap_count_entries()

### DIFF
--- a/reference/ldap/functions/ldap-count-entries.xml
+++ b/reference/ldap/functions/ldap-count-entries.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bc90525a5a5ebcf8412ef34b8355d2de12166fff Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: cf27955fcbad1b75678cd6bb12bfdfa1e2005b63 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ldap-count-entries" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_count_entries</refname>
@@ -47,9 +46,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve el número de entradas en el resultado,&return.falseforfailure;.
-  </para>
+  <simpara>
+   Devuelve el número de entradas en el resultado, o <literal>-1</literal> en caso de error.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Sincronización con php/doc-en#5218.

Fixes #834