### PR TITLE
[Sync EN] ext/intl: corregir el tipo del parámetro de IntlBreakIterator::getPartsIterator()

### DIFF
--- a/reference/intl/intlbreakiterator/getpartsiterator.xml
+++ b/reference/intl/intlbreakiterator/getpartsiterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 0f83ceff02d7f368686fbc55b44c89ee562e3ae7 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="intlbreakiterator.getpartsiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis role="IntlBreakIterator">
    <modifier>public</modifier> <type>IntlPartsIterator</type><methodname>IntlBreakIterator::getPartsIterator</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>type</parameter><initializer><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
 


### PR DESCRIPTION
Sincronización con php/doc-en#5624.

Fixes #833