### PR TITLE
[Sync EN] añadir configuración de Devcontainer

### DIFF
--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+FORMAT="${1:-xhtml}"
+
+case "$FORMAT" in
+  xhtml) OUTDIR="output/php-chunked-xhtml" ;;
+  php)   OUTDIR="output/php-web" ;;
+  *)     echo "Usage: $0 [xhtml|php]" >&2; exit 1 ;;
+esac
+
+ # doc-base invokes `java -jar jing.jar` with no flags, so the only handle on
+ # the JAXP entity-size limit is the JVM env vars. The PHP manual is well past
+ # the 100k default and we have no other way to lift the limit.
+ export _JAVA_OPTIONS='-Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0 -Djdk.xml.maxGeneralEntitySizeLimit=0'
+
+php ../doc-base/configure.php \
+    --disable-libxml-check \
+    --enable-xml-details \
+    --redirect-stderr-to-stdout \
+    --with-lang=es
+
+php -d memory_limit=512M ../phd/render.php \
+    --docbook ../doc-base/.manual.xml \
+    --output ./output \
+    --package PHP \
+    --format "$FORMAT"
+
+pkill -f 'php -S 0.0.0.0:8080' 2>/dev/null || true
+exec php -S 0.0.0.0:8080 -t "$OUTDIR"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/php
+{
+  "name": "PHP",
+  "image": "mcr.microsoft.com/devcontainers/php:8.4-trixie",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "lts",
+      "installGradle": false,
+      "installMaven": false
+    }
+  },
+
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      "extensions": [
+        "editorconfig.editorconfig",
+        "redhat.vscode-xml"
+      ],
+      // Workspace-level launch config
+      "settings": {
+        "launch": {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "name": "Build XHTML & serve",
+              "type": "node-terminal",
+              "request": "launch",
+              "command": ".devcontainer/build.sh xhtml"
+            },
+            {
+              "name": "Build PHP web & serve",
+              "type": "node-terminal",
+              "request": "launch",
+              "command": ".devcontainer/build.sh php"
+            }
+          ]
+        }
+      }
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [
+    8080
+  ],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "sudo .devcontainer/post-create.sh",
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+WORKSPACE="$(cd "$(dirname "$0")/.." && pwd)"
+PARENT="$(dirname "$WORKSPACE")"
+OWNER="$(stat -c '%U' "$WORKSPACE")"
+
+# Clone doc-base and phd as siblings of doc-es
+[ -d "$PARENT/doc-base" ] || sudo -u "$OWNER" git -C "$PARENT" clone --depth 1 https://github.com/php/doc-base.git
+[ -d "$PARENT/phd" ]      || sudo -u "$OWNER" git -C "$PARENT" clone --depth 1 https://github.com/php/phd.git
+
+# doc-base's configure.php looks for the language source as a sibling directory
+[ -e "$PARENT/es" ] || sudo -u "$OWNER" ln -s "$WORKSPACE" "$PARENT/es"
+
+# Xdebug degrades performance and is not needed for the build, so disable it by default.
+rm -f /usr/local/etc/php/conf.d/xdebug.ini
+
+# Pre-create the served directory
+sudo -u "$OWNER" mkdir -p "$WORKSPACE/output/php-chunked-xhtml"
+
+cat <<'EOF'
+
+  Devcontainer ready.
+
+  Build & serve:     F5 > "Build XHTML & serve"   (or "Build PHP web & serve")
+
+  View them:         http://localhost:8080
+
+EOF

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Sincronización con php/doc-en#4793.

Configuración de Devcontainer adaptada a la fuente en español (`--with-lang=es`), más la entrada `devcontainers` en dependabot.

Fixes #790