### PR TITLE
CI: add EN-Revision check and align workflow group names with doc-fr

### DIFF
--- a/.github/workflows/check-en-revision.yml
+++ b/.github/workflows/check-en-revision.yml
@@ -1,0 +1,47 @@
+# https://docs.github.com/en/actions
+# Checks that the EN-Revision comment of the .xml files changed in a PR points to
+# the latest doc-en commit for that file. Emits a ::error annotation and fails if
+# the hash is missing, wrong, from another file, or outdated.
+
+name: "Structure"
+
+on:
+  pull_request:
+    branches: ["master"]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  revision:
+    name: "Check EN-Revision"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout translation"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Checkout php/doc-en"
+        uses: actions/checkout@v4
+        with:
+          path: en
+          repository: php/doc-en
+          fetch-depth: 0
+
+      - name: "Check EN-Revision"
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags --depth=1 origin "$BASE"
+          fail=0
+          while IFS= read -r f; do
+            [ -f "$f" ] && [ -f "en/$f" ] || continue
+            declared=$(grep -oiP 'EN-Revision:\s*\K[0-9a-f]+' "$f" | head -1 || true)
+            latest=$(git -C en log -1 --format=%H -- "$f")
+            if [ "$declared" != "$latest" ]; then
+              echo "::error file=$f::EN-Revision ${declared:-missing} != latest doc-en commit $latest"
+              fail=1
+            fi
+          done < <(git diff --name-only "$BASE"...HEAD -- '*.xml')
+          exit $fail

--- a/.github/workflows/check-whitespace-push.yml
+++ b/.github/workflows/check-whitespace-push.yml
@@ -1,4 +1,4 @@
-name: check-whitespace-push
+name: "Style"
 
 # Get the repository with all commits to ensure that we can analyze
 # all Pushes except in master branch.

--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -1,4 +1,4 @@
-name: check-whitespace
+name: "Style"
 
 # Get the repository with all commits to ensure that we can analyze
 # all of the commits contributed via the Pull Request.

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/actions
 
-name: "Integrate"
+name: "Structure"
 
 on:
   pull_request: null


### PR DESCRIPTION
Two CI changes, aligning doc-es with `php/doc-fr`.

**1) New EN-Revision check.** On every PR, verifies that the `EN-Revision:` comment of the changed .xml files points to the latest doc-en commit for that file. A missing, wrong, mismatched or outdated hash produces a `::error` annotation. Only needs a checkout of doc-en, no doc-base. To make it warn without blocking the PR, change the final `exit $fail` to `exit 0`.

The same check already runs on `php/doc-fr`:
https://github.com/php/doc-fr/blob/master/.github/workflows/check-en-revision.yml

**2) Workflow group names.** Aligns the `name:` grouping with doc-fr:

- `integrate.yaml` (the build): `"Integrate"` to `"Structure"`
- `check-en-revision.yml` (new): `"Structure"`
- `check-whitespace.yml` and `check-whitespace-push.yml`: to `"Style"`
