### PR TITLE
[Review] Sync format and review root translation files

### DIFF
--- a/bookinfo.xml
+++ b/bookinfo.xml
@@ -1,73 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7d2dd02b7bdd1f1c3becbe06444c354f5e6f0e34 Maintainer: yago Status: ready -->
-<!-- Reviewed: yes Maintainer: seros -->
+<!-- EN-Revision: 7d2dd02b7bdd1f1c3becbe06444c354f5e6f0e34 Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
 
-<info xmlns="http://docbook.org/ns/docbook" xml:id="bookinfo">
- &frontpage.authors;
- <pubdate><?dbtimestamp format="Y-m-d"?></pubdate>
- &frontpage.editors;
+ <info xmlns="http://docbook.org/ns/docbook" xml:id="bookinfo">
+  &frontpage.authors;
+  <pubdate><?dbtimestamp format="Y-m-d"?></pubdate>
+  &frontpage.editors;
 
- <authorgroup xml:id="translators">
-  <author>
-   <personname>
-    <firstname>¿Quieres ayudarnos a traducir?</firstname>
-    <surname>Ponte en contacto con: seros[arroba]php.net</surname>
-   </personname>
-  </author>
-  <author>
-   <personname>
-    <firstname>Traduciendo desde Dic-2009. Estado: 80%</firstname>
-    <surname>completo y al día.</surname>
-   </personname>
-  </author>
-  <author>
-   <personname>
-    <firstname></firstname>
-    <surname></surname>
-   </personname>
-  </author>
-  <author>
-   <personname>
-    <firstname>Lista de encargados del mantenimiento y</firstname>
-    <surname>traducción por número de ficheros:</surname>
-   </personname>
-  </author>
-  <author>
-   <personname>
-    <firstname>1. Pedro Antonio</firstname>
-    <surname>Gil Rodríguez 2. Andrés García 3. Yago Ferrer 4. Jesús Ruiz-Ayúcar Vázquez  5. Juan Pablo Berdejo 6. Alexander Garzon 7. Jesús Ruiz García 8. Marta Regina Cano Jiménez 9. Leonardo Boshell 10. Francisco José Naranjo Abad 11. Jesús Rafael
+  <authorgroup xml:id="translators">
+   <author>
+    <personname>
+     <firstname>¿Quieres ayudarnos a traducir?</firstname>
+     <surname>Ponte en contacto con: seros[arroba]php.net</surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname>Traduciendo desde Dic-2009. Estado: 80%</firstname>
+     <surname>completo y al día.</surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname></firstname>
+     <surname></surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname>Lista de encargados del mantenimiento y</firstname>
+     <surname>traducción por número de ficheros:</surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname>1. Pedro Antonio</firstname>
+     <surname>Gil Rodríguez 2. Andrés García 3. Yago Ferrer 4. Jesús Ruiz-Ayúcar Vázquez  5. Juan Pablo Berdejo 6. Alexander Garzon 7. Jesús Ruiz García 8. Marta Regina Cano Jiménez 9. Leonardo Boshell 10. Francisco José Naranjo Abad 11. Jesús Rafael
 Cova Huerta 12. Jorge Eduardo Olaya P. 13. Edwin Cartagena Hdez. 14. Jesús Díez 15. Diego Agulló Falcó 16. Ernesto Mediavilla del Río 17. Carlos Hernández Afan de Ribera 18. Waldo Malqui Silva 19. Braian Iván Monnier 20. José Mercedes Venegas Acevedo</surname>
-   </personname>
-  </author>
-  <author>
-   <personname>
-    <firstname>y</firstname>
-    <surname>muchos más...</surname>
-   </personname>
-  </author>
-  <author>
-   <personname>
-    <firstname></firstname>
-    <surname></surname>
-   </personname>
-  </author>
- </authorgroup>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname>y</firstname>
+     <surname>muchos más...</surname>
+    </personname>
+   </author>
+   <author>
+    <personname>
+     <firstname></firstname>
+     <surname></surname>
+    </personname>
+   </author>
+  </authorgroup>
 
- <legalnotice xml:id="copyright" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <info><title>Copyright</title></info>
-  <simpara>
-   Copyright © 1997 - <?dbtimestamp format="Y"?> por el PHP Documentation Group.
-   Este material puede ser distribuido solamente sujeto a los términos y
-   condiciones establecidos por la licencia de Creative Commons Attribution
-   3.0 o superior. Una copia de la <link linkend="cc.license">Licencia de
-   Commons Attribution 3.0</link> está distribuida con este manual. La
-   versión más reciente está disponible en
-   <link xlink:href="&url.cc.by;">&url.cc.by;</link>.
-  </simpara>
- </legalnotice>
+  <legalnotice xml:id="copyright" xmlns:xlink="http://www.w3.org/1999/xlink">
+   <info><title>Copyright</title></info>
+   <simpara>
+    Copyright © 1997 - <?dbtimestamp format="Y"?> por el PHP Documentation Group.
+    Este material puede ser distribuido únicamente bajo los términos y
+    condiciones establecidos en la licencia Creative Commons Attribution
+    3.0 o posterior. Una copia de la <link linkend="cc.license">licencia
+    Creative Commons Attribution 3.0</link> se distribuye con este manual.
+    La versión más reciente está actualmente disponible en
+    <link xlink:href="&url.cc.by;">&url.cc.by;</link>.
+   </simpara>
+  </legalnotice>
 
-</info>
+ </info>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/extensions.ent
+++ b/extensions.ent
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 067e27db0a6f790ee0faaf99aa1f321f88f82cc9 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes Maintainer: julionc -->
+<!-- EN-Revision: 067e27db0a6f790ee0faaf99aa1f321f88f82cc9 Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
 
 <!--
   Entities for the categorized extension list, so it does not need
   to be translated, and thus it is not going to be outdated.
 -->
 
-<!ENTITY extcat.intro '<title xmlns="http://docbook.org/ns/docbook">Categorización de
-Extensiones</title><simpara xmlns="http://docbook.org/ns/docbook">Este apéndice categoriza más de 150 extensiones
-documentadas en el manual de PHP de acuerdo a varios criterios.</simpara>'>
+<!ENTITY extcat.intro '<title xmlns="http://docbook.org/ns/docbook">Categorización de Extensiones</title><simpara xmlns="http://docbook.org/ns/docbook">Este
+apéndice categoriza más de 150 extensiones documentadas en el Manual de
+PHP según varios criterios.</simpara>'>
 
 <!ENTITY extcat.alphabetical '<title xmlns="http://docbook.org/ns/docbook">Alfabética</title>'>
 
@@ -21,13 +20,13 @@ documentadas en el manual de PHP de acuerdo a varios criterios.</simpara>'>
 <!ENTITY extcat.purpose.basic '<title xmlns="http://docbook.org/ns/docbook">Extensiones PHP básicas</title>'>
 <!ENTITY extcat.purpose.basic.vartype '<title xmlns="http://docbook.org/ns/docbook">Extensiones relacionadas con variables y tipos</title>'>
 <!ENTITY extcat.purpose.basic.text '<title xmlns="http://docbook.org/ns/docbook">Procesamiento de texto</title>'>
-<!ENTITY extcat.purpose.basic.php "<title xmlns='http://docbook.org/ns/docbook'>Afectan el comportamiento de PHP</title>">
+<!ENTITY extcat.purpose.basic.php "<title xmlns='http://docbook.org/ns/docbook'>Extensiones que afectan el comportamiento de PHP</title>">
 <!ENTITY extcat.purpose.basic.session '<title xmlns="http://docbook.org/ns/docbook">Extensiones de sesión</title>'>
 <!ENTITY extcat.purpose.basic.other '<title xmlns="http://docbook.org/ns/docbook">Otras extensiones básicas</title>'>
+
 <!ENTITY extcat.purpose.database '<title xmlns="http://docbook.org/ns/docbook">Extensiones de bases de datos</title>'>
 <!ENTITY extcat.purpose.database.abstract '<title xmlns="http://docbook.org/ns/docbook">Capas de abstracción</title>'>
-<!ENTITY extcat.purpose.database.vendors '<title xmlns="http://docbook.org/ns/docbook">Extensiones de bases de datos de
-proveedores especí­ficos</title>'>
+<!ENTITY extcat.purpose.database.vendors '<title xmlns="http://docbook.org/ns/docbook">Extensiones de bases de datos de proveedores específicos</title>'>
 
 <!ENTITY extcat.purpose.xml '<title xmlns="http://docbook.org/ns/docbook">Manipulación de XML</title>'>
 
@@ -35,12 +34,11 @@ proveedores especí­ficos</title>'>
 
 <!ENTITY extcat.purpose.creditcard '<title xmlns="http://docbook.org/ns/docbook">Procesamiento de tarjetas de crédito</title>'>
 
-<!ENTITY extcat.purpose.mathcrypto '<title xmlns="http://docbook.org/ns/docbook">Matemáticas y criptografí­a</title>'>
+<!ENTITY extcat.purpose.mathcrypto '<title xmlns="http://docbook.org/ns/docbook">Matemáticas y criptografía</title>'>
 <!ENTITY extcat.purpose.mathcrypto.math '<title xmlns="http://docbook.org/ns/docbook">Extensiones matemáticas</title>'>
-<!ENTITY extcat.purpose.mathcrypto.crypto '<title xmlns="http://docbook.org/ns/docbook">Extensiones de criptografí­a</title>'>
+<!ENTITY extcat.purpose.mathcrypto.crypto '<title xmlns="http://docbook.org/ns/docbook">Extensiones de criptografía</title>'>
 
-<!ENTITY extcat.purpose.international '<title xmlns="http://docbook.org/ns/docbook">Soporte de idioma Humano y
-codificación de caracteres</title>'>
+<!ENTITY extcat.purpose.international '<title xmlns="http://docbook.org/ns/docbook">Soporte de idioma humano y codificación de caracteres</title>'>
 
 <!ENTITY extcat.purpose.fileprocess '<title xmlns="http://docbook.org/ns/docbook">Sistema de archivos y control de procesos</title>'>
 <!ENTITY extcat.purpose.fileprocess.file '<title xmlns="http://docbook.org/ns/docbook">Extensiones relacionadas con sistemas de archivos</title>'>
@@ -51,42 +49,48 @@ codificación de caracteres</title>'>
 <!ENTITY extcat.purpose.remote.auth '<title xmlns="http://docbook.org/ns/docbook">Servicios de autenticación</title>'>
 <!ENTITY extcat.purpose.remote.other '<title xmlns="http://docbook.org/ns/docbook">Otros servicios</title>'>
 
-<!ENTITY extcat.purpose.compression '<title xmlns="http://docbook.org/ns/docbook">Extensiones de compresión y paquetes</title>'>
+<!ENTITY extcat.purpose.compression '<title xmlns="http://docbook.org/ns/docbook">Extensiones de compresión y archivo</title>'>
 
-<!ENTITY extcat.purpose.calendar '<title xmlns="http://docbook.org/ns/docbook">Extensiones relacionadas con calendario y eventos</title>'>
+<!ENTITY extcat.purpose.calendar '<title xmlns="http://docbook.org/ns/docbook">Extensiones relacionadas con fecha y hora</title>'>
 
-<!ENTITY extcat.purpose.utilspec '<title xmlns="http://docbook.org/ns/docbook">Extensiones de uso en áreas especí­ficas</title>'>
+<!ENTITY extcat.purpose.utilspec '<title xmlns="http://docbook.org/ns/docbook">Extensiones de uso en áreas específicas</title>'>
 <!ENTITY extcat.purpose.utilspec.nontext '<title xmlns="http://docbook.org/ns/docbook">Salida MIME diferente a texto</title>'>
 <!ENTITY extcat.purpose.utilspec.image '<title xmlns="http://docbook.org/ns/docbook">Procesamiento y generación de imágenes</title>'>
 <!ENTITY extcat.purpose.utilspec.audio '<title xmlns="http://docbook.org/ns/docbook">Manipulación de formatos de audio</title>'>
-<!ENTITY extcat.purpose.utilspec.cmdline '<title xmlns="http://docbook.org/ns/docbook">Extensiones especí­ficas de lí­nea de comandos</title>'>
+<!ENTITY extcat.purpose.utilspec.cmdline '<title xmlns="http://docbook.org/ns/docbook">Extensiones específicas de línea de comandos</title>'>
 <!ENTITY extcat.purpose.utilspec.windows '<title xmlns="http://docbook.org/ns/docbook">Extensiones solo para Windows</title>'>
-<!ENTITY extcat.purpose.utilspec.server '<title xmlns="http://docbook.org/ns/docbook">Extensiones especí­ficas de servidor</title>'>
+<!ENTITY extcat.purpose.utilspec.server '<title xmlns="http://docbook.org/ns/docbook">Extensiones específicas de servidor</title>'>
 
 <!-- ======================================================================= -->
 
-<!ENTITY extcat.membership '<title xmlns="http://docbook.org/ns/docbook">Incorporación</title>'>
+<!ENTITY extcat.membership '<title xmlns="http://docbook.org/ns/docbook">Integración</title>'>
 
-<!ENTITY extcat.membership.core '<title xmlns="http://docbook.org/ns/docbook">Extensiones del núcleo</title><simpara xmlns="http://docbook.org/ns/docbook">No son extensiones realmente. Son parte del núcleo de PHP y no pueden omitirse en un binario de PHP con opciones de
-compilación.</simpara>'>
+<!ENTITY extcat.membership.core '<title xmlns="http://docbook.org/ns/docbook">Extensiones del núcleo</title><simpara xmlns="http://docbook.org/ns/docbook">No
+son extensiones realmente. Son parte del núcleo de PHP y no pueden omitirse
+en un binario de PHP con opciones de compilación.</simpara>'>
 
-<!ENTITY extcat.membership.bundled '<title xmlns="http://docbook.org/ns/docbook">Bundled
-</title><simpara xmlns="http://docbook.org/ns/docbook">Extensiones incorporadas en PHP.</simpara>'>
+<!ENTITY extcat.membership.bundled '<title xmlns="http://docbook.org/ns/docbook">Extensiones incorporadas</title><simpara xmlns="http://docbook.org/ns/docbook">Estas
+extensiones vienen incorporadas con PHP.</simpara>'>
 
-<!ENTITY extcat.membership.external '<title xmlns="http://docbook.org/ns/docbook">Extensiones externas</title><simpara xmlns="http://docbook.org/ns/docbook">Estas extensiones vienen con PHP, pero para poder compilarlas, se requieren bibliotecas externas.</simpara>'>
+<!ENTITY extcat.membership.external '<title xmlns="http://docbook.org/ns/docbook">Extensiones externas</title><simpara xmlns="http://docbook.org/ns/docbook">Estas
+extensiones vienen con PHP, pero para poder compilarlas, se requieren bibliotecas externas.</simpara>'>
 
 <!ENTITY extcat.membership.pecl '<title xmlns="http://docbook.org/ns/docbook">
 Extensiones PECL</title>
 <simpara xmlns="http://docbook.org/ns/docbook">Estas extensiones están disponibles desde
 &link.pecl;. Pueden requerir bibliotecas externas. Existen más extensiones PECL pero
-todavía no están documentadas en el manual de PHP.</simpara>'>
+todavía no están documentadas en el Manual de PHP.</simpara>'>
 
 <!-- ======================================================================= -->
 
-<!ENTITY extcat.state '<title xmlns="http://docbook.org/ns/docbook">Estado</title><simpara xmlns="http://docbook.org/ns/docbook">Esta sección lista las extensiones que no son recomendables para su uso en producción - son demasiado "viejas" (obsoletas) o "nuevas" (experimentales).</simpara>'>
+<!ENTITY extcat.state '<title xmlns="http://docbook.org/ns/docbook">Estado</title><simpara xmlns="http://docbook.org/ns/docbook">Esta sección lista las extensiones que
+no están destinadas para su uso en producción; ya sea porque son demasiado "antiguas" (deprecadas) o
+"nuevas" (experimentales).</simpara>'>
 
-<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Extensiones obsoletas</title><simpara xmlns="http://docbook.org/ns/docbook">Estas extensiones han sido marcadas como obsoletas, por lo general han sido reemplazadas por otras extensiones.</simpara>'>
+<!ENTITY extcat.state.deprecated '<title xmlns="http://docbook.org/ns/docbook">Extensiones obsoletas</title><simpara xmlns="http://docbook.org/ns/docbook">Estas
+extensiones han sido deprecadas, por lo general en favor de otras extensiones.</simpara>'>
 
-<!ENTITY extcat.state.experimental '<title xmlns="http://docbook.org/ns/docbook">Extensiones experimentales</title><simpara xmlns="http://docbook.org/ns/docbook">El comportamiento de estas extensiones - incluyendo los nombres de sus funciones y cualquier otra cosa documentada
-sobre estas extensiones - puede cambiar sin previo aviso en una futura
-versión de PHP. Use estas extensiones bajo su propio riesgo.</simpara>'>
+<!ENTITY extcat.state.experimental '<title xmlns="http://docbook.org/ns/docbook">Extensiones experimentales</title><simpara xmlns="http://docbook.org/ns/docbook">El
+comportamiento de estas extensiones - incluyendo los nombres de sus funciones y cualquier otra
+cosa documentada sobre estas extensiones - puede cambiar sin previo aviso en una futura versión
+de PHP. Use estas extensiones bajo su propio riesgo.</simpara>'>

--- a/language-defs.ent
+++ b/language-defs.ent
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a6621a4baf56fd78a842dfd684f5c981991bddcd Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: julionc -->
+<!-- EN-Revision: a6621a4baf56fd78a842dfd684f5c981991bddcd Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
 
 <!-- Part titles used mostly in manual.xml itself -->
 <!ENTITY PHPManual         "Manual de PHP">
-<!ENTITY Seealso           "Ver también">
+<!ENTITY Seealso           "Véase también">
 <!ENTITY Date              "Fecha:">
 <!ENTITY GettingStarted    "Conceptos básicos">
 <!ENTITY InstallAndConfigure "Instalación y configuración">
@@ -14,13 +13,13 @@
 <!ENTITY Features          "Características">
 <!ENTITY Security          "Seguridad">
 <!ENTITY FunctionReference "Referencia de funciones">
-<!ENTITY VariableandTypeRelatedExtensions         "Extensiones relacionadas con variable y tipo">
+<!ENTITY VariableandTypeRelatedExtensions         "Extensiones relacionadas con variables y tipos">
 <!ENTITY TextProcessing                           "Procesamiento de texto">
-<!ENTITY AffectingPHPsBehaviour                   "Afecta el comportamiento de PHP">
+<!ENTITY AffectingPHPsBehaviour                   "Extensiones que afectan el comportamiento de PHP">
 <!ENTITY SessionExtensions                        "Extensiones de sesiones">
 <!ENTITY OtherBasicExtensions                     "Otras extensiones básicas">
 <!ENTITY DatabaseExtensions                       "Extensiones de bases de datos">
-<!ENTITY AbstractionLayers                        "Capas abstractas">
+<!ENTITY AbstractionLayers                        "Capas de abstracción">
 <!ENTITY VendorSpecificDatabaseExtensions         "Extensiones de bases de datos específicas del proveedor">
 <!ENTITY XMLManipulation                          "Manipulación de XML">
 <!ENTITY WebServices                              "Servicios web">
@@ -30,7 +29,7 @@
 <!ENTITY HumanLanguageandCharacterEncodingSupport "Soporte para lenguaje humano y codificación de caracteres">
 <!ENTITY FileSystemRelatedExtensions              "Extensiones relacionadas con el sistema de ficheros">
 <!ENTITY ProcessControlExtensions                 "Extensiones de control de procesos">
-<!ENTITY MailRelatedExtensions                    "Extensiones relacionadas con Email">
+<!ENTITY MailRelatedExtensions                    "Extensiones relacionadas con correo">
 <!ENTITY AuthenticationServices                   "Servicios de autenticación">
 <!ENTITY OtherServices                            "Otros servicios">
 <!ENTITY CompressionExtensions                    "Extensiones de compresión y archivos">
@@ -42,13 +41,13 @@
 <!ENTITY WindowsOnlyExtensions                    "Extensiones específicas de Windows">
 <!ENTITY ServerSpecificExtensions                 "Extensiones específicas para Servidores">
 <!ENTITY SearchEngineExtensions                   "Extensiones para motores de búsqueda">
-<!ENTITY MiscExtensions                           "Miscelánea de extensiones">
+<!ENTITY MiscExtensions                           "Extensiones diversas">
 <!ENTITY UIExtensions                             "Extensiones de GUI">
 <!ENTITY Appendices        "Apéndices">
 <!ENTITY PEAR              "PEAR: Repositorio de extensiones y aplicaciones de PHP">
 <!ENTITY FAQ               "Preguntas frecuentes">
 <!ENTITY FAQabbrev         "FAQ">
-<!ENTITY Internals         "PHP y partes internas del motor Zend ">
+<!ENTITY Internals         "Funcionamiento interno de PHP y el motor Zend">
 <!ENTITY Internals2        "El núcleo de PHP: Guía del Hacker">
 <!ENTITY ZendAPI           "La API Zend: Hackeando el núcleo de PHP">
 <!ENTITY IndexListing      "Listado de índices">
@@ -57,8 +56,8 @@
 <!ENTITY ExampleListing    "Listado de ejemplos">
 <!ENTITY ExampleListingDescription   "Lista todos los ejemplos del manual">
 <!ENTITY ChangelogListingTitle "Registro de cambios">
-<!ENTITY ChangelogListingDescription "A las clases/funciones/métodos de esta extensión se han realizado los siguientes cambios.">
-<!ENTITY ChangelogListingBundledDescription "A las funciones de las extensiones incluidas se han realizado los siguientes cambios.">
+<!ENTITY ChangelogListingDescription "Se han realizado los siguientes cambios en las clases/funciones/métodos de esta extensión.">
+<!ENTITY ChangelogListingBundledDescription "Se han realizado los siguientes cambios en las funciones de las extensiones incluidas.">
 <!ENTITY CHMEdition        "HTML edición de ayuda">
 <!ENTITY ReservedConstants "Constantes predefinidas">
 <!ENTITY MissingStuff      "Cosas perdidas">
@@ -87,8 +86,8 @@
 supplemental files to mark section titles -->
 <!ENTITY reftitle.changelog    '<title xmlns="http://docbook.org/ns/docbook">&Changelog;</title>'>
 <!ENTITY reftitle.classes      '<title xmlns="http://docbook.org/ns/docbook">Clases predefinidas</title>'>
-<!ENTITY reftitle.classsynopsis '<title xmlns="http://docbook.org/ns/docbook">Sinopsis de la Clase</title>'>
-<!ENTITY reftitle.enumsynopsis '<title xmlns="http://docbook.org/ns/docbook">Sinopsis del Enum</title>'>
+<!ENTITY reftitle.classsynopsis '<title xmlns="http://docbook.org/ns/docbook">Sinopsis de la clase</title>'>
+<!ENTITY reftitle.enumsynopsis '<title xmlns="http://docbook.org/ns/docbook">Sinopsis del enum</title>'>
 <!ENTITY reftitle.constants    '<title xmlns="http://docbook.org/ns/docbook">Constantes predefinidas</title>'>
 <!ENTITY reftitle.constructor  '<title xmlns="http://docbook.org/ns/docbook">Constructor</title>'>
 <!ENTITY reftitle.description  '<title xmlns="http://docbook.org/ns/docbook">Descripción</title>'>
@@ -100,18 +99,18 @@ supplemental files to mark section titles -->
 <!ENTITY reftitle.install      '<title xmlns="http://docbook.org/ns/docbook">Instalación</title>'>
 <!ENTITY reftitle.intro        '<title xmlns="http://docbook.org/ns/docbook">Introducción</title>'>
 <!ENTITY reftitle.indices      '<title xmlns="http://docbook.org/ns/docbook">Índices</title>'>
-<!ENTITY reftitle.interfacesynopsis '<title xmlns="http://docbook.org/ns/docbook">Sinopsis de la Interfaz</title>'>
+<!ENTITY reftitle.interfacesynopsis '<title xmlns="http://docbook.org/ns/docbook">Sinopsis de la interfaz</title>'>
 <!ENTITY reftitle.methods      '<title xmlns="http://docbook.org/ns/docbook">Métodos</title>'>
-<!ENTITY reftitle.mysqlnd      '<title xmlns="http://docbook.org/ns/docbook">Solo Controlador Nativo de MySQL</title>'>
+<!ENTITY reftitle.mysqlnd      '<title xmlns="http://docbook.org/ns/docbook">Solo controlador nativo de MySQL</title>'>
 <!ENTITY reftitle.notes        '<title xmlns="http://docbook.org/ns/docbook">Notas</title>'>
 <!ENTITY reftitle.parameters   '<title xmlns="http://docbook.org/ns/docbook">Parámetros</title>'>
 <!ENTITY reftitle.options      '<title xmlns="http://docbook.org/ns/docbook">Opciones</title>'>
 <!ENTITY reftitle.properties   '<title xmlns="http://docbook.org/ns/docbook">Propiedades</title>'>
-<!ENTITY reftitle.required     '<title xmlns="http://docbook.org/ns/docbook">Requerimientos</title>'>
+<!ENTITY reftitle.required     '<title xmlns="http://docbook.org/ns/docbook">Requisitos</title>'>
 <!ENTITY reftitle.resources    '<title xmlns="http://docbook.org/ns/docbook">Tipos de recursos</title>'>
 <!ENTITY reftitle.runtime      '<title xmlns="http://docbook.org/ns/docbook">Configuración en tiempo de ejecución</title>'>
 <!ENTITY reftitle.returnvalues '<title xmlns="http://docbook.org/ns/docbook">Valores devueltos</title>'>
-<!ENTITY reftitle.seealso      '<title xmlns="http://docbook.org/ns/docbook">Ver también</title>'>
+<!ENTITY reftitle.seealso      '<title xmlns="http://docbook.org/ns/docbook">Véase también</title>'>
 <!ENTITY reftitle.setup        '<title xmlns="http://docbook.org/ns/docbook">Instalación/Configuración</title>'>
 <!ENTITY reftitle.unicode      '<title xmlns="http://docbook.org/ns/docbook">Unicode</title>'>
 <!ENTITY reftitle.usage        '<title xmlns="http://docbook.org/ns/docbook">Uso</title>'>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
 
-<!ENTITY installation.enabled.disable 'Esta extensión está activada por omisión. Puede ser desactivada utilizando la opción de configuración: '>
+<!ENTITY installation.enabled.disable 'Esta extensión está activada por defecto. Puede ser desactivada utilizando la opción de configuración: '>
 
 <!-- Not used in EN anymore -->
 <!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>El generador
@@ -18,189 +18,174 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0. Depender de esta función está
 altamente desaconsejado.</simpara></warning>'>
 
-<!-- Cautions / Precauciones -->
+<!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Esta función no genera valores criptográficamente seguros, y <emphasis>no debe</emphasis>
   ser utilizada con fines criptográficos, o con fines que requieran que los valores devueltos sean indescifrables.
  </simpara>
  <simpara>
-  Si se requiere aleatoriedad criptográficamente segura, el <classname>Random\Randomizer</classname> puede ser utilizado
-  con el motor <classname>Random\Engine\Secure</classname>. Para casos de uso simples, las funciones
-  <function>random_int</function> y <function>random_bytes</function> proporcionan una <acronym>API</acronym>
-   práctica y segura que es soportada por el <acronym>CSPRNG</acronym> del sistema operativo.
+  Si se requiere aleatoriedad criptográficamente segura, el <classname>Random\Randomizer</classname> puede ser
+  utilizado con el motor <classname>Random\Engine\Secure</classname>. Para casos de uso simples, las funciones <function>random_int</function>
+  y <function>random_bytes</function> proporcionan una <acronym>API</acronym> práctica y segura que es
+  soportada por el <acronym>CSPRNG</acronym> del sistema operativo.
  </simpara>
 </caution>'>
 
 <!ENTITY caution.mt19937-global-state '<caution xmlns="http://docbook.org/ns/docbook">
  <simpara>
-    Esta función utiliza la instancia global Mt19937 ("Mersenne Twister") como fuente de aleatoriedad y por lo tanto comparte su estado con todas las demás funciones que usan el Mt19937 global.
-    El uso de cualquiera de estas funciones avanza la secuencia para <emphasis>todas</emphasis> las demás funciones, independientemente del ámbito.
+    Esta función utiliza la instancia global Mt19937 ("Mersenne Twister") como fuente de aleatoriedad y por lo tanto comparte su estado con todas las demás funciones que usan el Mt19937 global. El
+    uso de cualquiera de estas funciones avanza la secuencia para <emphasis>todas</emphasis> las demás funciones, independientemente del ámbito.
   </simpara>
   <simpara>
-    Generar secuencias repetibles sembrando <function>mt_srand</function> o <function>srand</function> con un valor conocido también producirá una salida repetible de esta función.
+    Generar secuencias repetibles inicializando <function>mt_srand</function> o <function>srand</function> con un valor conocido también producirá una salida repetible de esta función.
   </simpara>
   <simpara>
-    Preferir el uso de los métodos de <classname>Random\Randomizer</classname> en todo código nuevo.
+    Prefiera utilizar los métodos de <classname>Random\Randomizer</classname> en todo el código nuevo.
  </simpara>
 </caution>'>
 
 <!ENTITY caution.mt19937-tiny-seed '<caution xmlns="http://docbook.org/ns/docbook">
  <simpara>
-   Dado que el motor Mt19937 ("Mersenne Twister") toma un solo entero de 32 bits como
-   semilla, el número de secuencias aleatorias posibles está limitado a solo 2<superscript>32</superscript>
-   (por ejemplo 4 294 967 296), a pesar de la enorme período de Mt19937 de 2<superscript>19937</superscript>-1.
+  Dado que el motor Mt19937 ("Mersenne Twister") toma un solo entero de 32 bits como
+  semilla, el número de secuencias aleatorias posibles está limitado a solo 2<superscript>32</superscript>
+  (por ejemplo 4 294 967 296), a pesar de la enorme período de Mt19937 de 2<superscript>19937</superscript>-1.
  </simpara>
  <simpara>
-   Cuando se confía en una semilla aleatoria implícita o explícita, las duplicaciones aparecerán
-   mucho antes. Las semillas duplicadas son esperadas con una probabilidad del 50&#37; después de menos de
-   80 000 semillas generadas aleatoriamente según el problema del cumpleaños. Una probabilidad del 10&#37;
-   de una semilla duplicada ocurre después de haber generado aproximadamente 30 000 semillas de manera aleatoria.
+  Cuando se confía en una semilla aleatoria implícita o explícita, las duplicaciones aparecerán mucho antes.
+  Las semillas duplicadas son esperadas con una probabilidad del 50&#37; después de menos de 80
+  000 semillas generadas aleatoriamente según el problema del cumpleaños. Una probabilidad del 10&#37; de una
+  semilla duplicada ocurre después de haber generado aproximadamente 30 000 semillas de manera aleatoria.
  </simpara>
  <simpara>
   Esto hace que Mt19937 sea inadecuado para aplicaciones donde las secuencias duplicadas no deben ocurrir con
-  más que una probabilidad despreciable. Si se requiere una semilla reproducible, tanto el
-  motor <classname>Random\Engine\Xoshiro256StarStar</classname> como <classname>Random\Engine\PcgOneseq128XslRr64</classname>
+  más que una probabilidad despreciable. Si se requiere una semilla reproducible, tanto el motor
+  <classname>Random\Engine\Xoshiro256StarStar</classname> como <classname>Random\Engine\PcgOneseq128XslRr64</classname>
   soportan semillas mucho más grandes que son poco propensas a colisionar aleatoriamente. Si la reproductibilidad
-  no es requerida, el motor <classname>Random\Engine\Secure</classname> proporciona datos aleatorios criptográficamente
-  seguros.
+  no es requerida, el motor <classname>Random\Engine\Secure</classname> proporciona datos aleatorios
+  criptográficamente seguros.
  </simpara>
 </caution>'>
 
 <!-- Notes -->
 
-<!ENTITY note.bin-safe '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función es
-segura para sistemas binarios.</simpara></note>'>
+<!ENTITY note.bin-safe '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función es segura para
+sistemas binarios.</simpara></note>'>
 
-<!ENTITY note.clearstatcache '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los resultados de esta
-función se almacenan en caché. Véase la función <function>clearstatcache</function> para
+<!ENTITY note.clearstatcache '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los resultados de esta función se
+almacenan en caché. Véase la función <function>clearstatcache</function> para
 más detalles.</simpara></note>'>
 
- <!ENTITY note.context-support '<simpara xmlns="http://docbook.org/ns/docbook">Un <type>resource</type> de
- <link linkend="stream.contexts">contexto de flujo</link>.</simpara>'>
+<!ENTITY note.context-support '<simpara xmlns="http://docbook.org/ns/docbook">Un <link linkend="stream.contexts">contexto de flujo</link> de
+tipo <type>resource</type>.</simpara>'>
 
- <!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><simpara>Si un programa es iniciado con esta función
- y se ejecuta en segundo plano, la salida del programa debe
- ser redirigida a un archivo, o a otro flujo de salida. De lo contrario,
- PHP se bloqueará hasta el final de la ejecución del programa.</simpara></note>'>
+<!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><simpara>Si un programa es iniciado con esta
+función y se ejecuta en segundo plano, la salida del programa debe ser
+redirigida a un fichero, o a otro flujo de salida. De lo contrario,
+PHP se bloqueará hasta el final de la ejecución del programa.</simpara></note>'>
 
- <!ENTITY note.exec-bypass-shell '<note xmlns="http://docbook.org/ns/docbook"><simpara>En Windows <function>exec</function>
- iniciará primero cmd.exe para ejecutar el comando. Si se desea iniciar un programa externo sin ejecutar cmd.exe
- utilice <function>proc_open</function> definiendo la opción <parameter>bypass_shell</parameter>.</simpara></note>'>
+<!ENTITY note.exec-bypass-shell '<note xmlns="http://docbook.org/ns/docbook"><simpara>En Windows <function>exec</function>
+iniciará primero cmd.exe para ejecutar el comando. Si se desea iniciar un programa externo sin ejecutar cmd.exe
+utilice <function>proc_open</function> definiendo la opción <parameter>bypass_shell</parameter>.</simpara></note>'>
 
- <!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los sistemas de archivos NTFS de Windows
- no soportan ciertos caracteres en los nombres de archivo, como <literal>&lt;|&gt;*?":</literal>. Los nombres de archivo con un punto
- final no son soportados. A diferencia de algunas herramientas de extracción, este método no reemplaza estos caracteres con
- un guión bajo, sino que falla al extraer tales archivos.</simpara></note>'>
+<!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los sistemas de archivos NTFS de
+Windows no soportan ciertos caracteres en los nombres de fichero, como <literal>&lt;|&gt;*?":</literal>. Los nombres de fichero con un
+punto final no son soportados. A diferencia de algunas herramientas de extracción, este método no reemplaza estos caracteres con
+un guión bajo, sino que falla al extraer tales ficheros.</simpara></note>'>
 
- <!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara> En lugar de un nombre de función, un
- array que contenga una referencia de objeto y un nombre de método también
- puede ser utilizado.</simpara></note>'>
+<!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara> En lugar de un nombre de función, un
+array que contenga una referencia de objeto y un nombre de método también puede ser
+utilizado.</simpara></note>'>
 
- <!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>Las devoluciónes de llamada registradas
- con funciones como <function>call_user_func</function> y <function>call_user_func_array</function> no serán
- llamadas si una excepción no es interceptada cuando ha sido lanzada en una función de devolución de llamada anterior.</simpara></note>'>
+<!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>Las devoluciónes de
+llamada registradas con funciones como <function>call_user_func</function> y <function>call_user_func_array</function> no serán llamadas si
+una excepción no es interceptada cuando ha sido lanzada en una función de devolución de llamada anterior.</simpara></note>'>
 
- <!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>Si los argumentos son pasados por referencia,
- todas sus modificaciones serán reflejadas en los valores devueltos por esta función. A partir de PHP 7,
- los valores actuales también serán devueltos si los argumentos son pasados por su valor.</simpara></note>'>
+<!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>Si los argumentos son pasados por referencia,
+todas sus modificaciones serán reflejadas en los valores devueltos por esta función. A partir de PHP 7, los
+valores actuales también serán devueltos si los argumentos son pasados por su valor.</simpara></note>'>
 
- <!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Dado que esta función depende del ámbito actual para determinar los detalles de los argumentos, estos no
- pueden ser utilizados como argumento de una función en versiones de PHP anteriores a 5.3.0.
- Si este valor debe ser pasado, el resultado debe ser asignado a una variable y esta variable debe ser pasada.
+<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>Dado que esta función depende del ámbito
+actual para determinar los detalles de los argumentos, estos no pueden ser utilizados como
+argumento de una función en versiones de PHP anteriores a 5.3.0. Si este valor debe ser pasado, el resultado debe ser
+asignado a una variable y esta variable debe ser pasada.</simpara></note>'>
+
+<!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara> A partir de PHP 8.0.0, la familia de funciones
+func_*() está diseñada para ser esencialmente transparente con respecto a los argumentos nombrados,
+tratando los argumentos como si fueran todos pasados de manera posicional,
+y los argumentos faltantes son reemplazados con sus valores
+por defecto. Esta función ignora la colección de argumentos variádicos nombrados
+desconocidos. Los argumentos nombrados que son recolectados solo son accesibles a través del parámetro variádico.</simpara></note>'>
+
+<!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara> Si PHP no reconoce correctamente los finales de
+línea al leer ficheros que han sido creados o leídos en un Macintosh, la activación de
+la opción de configuración
+<link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link>
+puede resolver el problema.</simpara></note>'>
+
+<!ENTITY note.no-remote '<note xmlns="http://docbook.org/ns/docbook"><simpara> Esta función no funciona con los
+<link linkend="features.remote-files">archivos remotos</link>, ya que el archivo
+examinado debe ser accesible en el sistema de archivos del servidor.</simpara></note>'>
+
+<!ENTITY note.not-bin-safe '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Esta función no
+es capaz de manejar strings binarios (aún)!</simpara></warning>'>
+
+<!ENTITY note.no-key-association '<note xmlns="http://docbook.org/ns/docbook"><simpara> Esta función
+asigna nuevas claves a los elementos en <parameter>array</parameter>.
+Eliminará todas las claves existentes que hayan podido ser asignadas, en
+lugar de reordenar las claves.</simpara></note>'>
+
+<!ENTITY note.no-windows '<note xmlns="http://docbook.org/ns/docbook"><simpara> Esta función no está
+implementada en las plataformas Windows.</simpara></note>'>
+
+<!ENTITY note.no-windows.extension '<note xmlns="http://docbook.org/ns/docbook"><simpara> Esta extensión no está
+disponible en las plataformas Windows.</simpara></note>'>
+
+<!ENTITY note.no-zts '<note xmlns="http://docbook.org/ns/docbook"><simpara> Esta función no está
+disponible en los intérpretes PHP compilados con ZTS (Zend Thread Safety) activado. Para verificar si su copia de PHP ha sido compilada con ZTS activado, utilice <command>php -i</command> o pruebe la constante incluida <constant>PHP_ZTS</constant>.</simpara></note>'>
+
+<!ENTITY note.randomseed '<note xmlns="http://docbook.org/ns/docbook"><simpara> No es necesario inicializar
+el generador de números aleatorios con <function>srand</function> o
+<function>mt_srand</function>, esto se hace automáticamente.
 </simpara></note>'>
 
- <!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- A partir de PHP 8.0.0, la familia de funciones func_*() está diseñada para ser esencialmente
- transparente con respecto a los argumentos nombrados, tratando los argumentos como si fueran todos pasados
- de manera posicional, y los argumentos faltantes son reemplazados con sus valores por defecto.
- Esta función ignora la colección de argumentos variádicos nombrados desconocidos.
- Los argumentos nombrados que son recolectados solo son accesibles a través del parámetro variádico.
-</simpara></note>'>
-
- <!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Si PHP no reconoce correctamente los finales de línea al leer archivos que han sido creados o leídos en
- un Macintosh, la activación de la opción de configuración
- <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link> puede resolver el problema.
-</simpara></note>'>
-
- <!ENTITY note.no-remote '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función no funciona con los <link linkend="features.remote-files">archivos remotos</link>,
- ya que el archivo examinado debe ser accesible en el sistema de archivos del servidor.
-</simpara></note>'>
-
- <!ENTITY note.not-bin-safe '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función no es capaz de manejar strings binarios !
-</simpara></warning>'>
-
- <!ENTITY note.no-key-association '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función asigna nuevas claves a los elementos en <parameter>array</parameter>.
- Eliminará todas las claves existentes que hayan podido ser asignadas, en lugar de reordenar las claves.
-</simpara></note>'>
-
- <!ENTITY note.no-windows '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función no está implementada en las plataformas Windows.
-</simpara></note>'>
-
- <!ENTITY note.no-windows.extension '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta extensión no está disponible en las plataformas Windows.
-</simpara></note>'>
-
- <!ENTITY note.no-zts '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función no está disponible en los intérpretes PHP compilados con
- ZTS (Zend Thread Safety) activado. Para verificar si su copia de PHP ha sido
- compilada con ZTS activado, utilice <command>php -i</command> o pruebe la
- constante incluida <constant>PHP_ZTS</constant>.
-</simpara></note>'>
-
- <!ENTITY note.randomseed '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- No es necesario inicializar el generador de números aleatorios con
- <function>srand</function> o <function>mt_srand</function>, esto se hace automáticamente.
-</simpara></note>'>
-
- <!ENTITY note.is-superglobal "<note xmlns='http://docbook.org/ns/docbook'><simpara>
- Esto es una 'superglobal', o variable global automática. Esto significa simplemente que esta variable
- está disponible en todos los contextos del script. No es necesario hacer <command>global $variable;</command>
- para acceder a ella en las funciones o los métodos.
+<!ENTITY note.is-superglobal "<note xmlns='http://docbook.org/ns/docbook'><simpara> Esto es una 'superglobal', o
+variable global automática. Esto significa simplemente que esta variable está
+disponible en todos los contextos del script. No es necesario hacer
+<command>global $variable;</command> para acceder a ella en las funciones o los métodos.
 </simpara></note>">
 
- <!ENTITY note.uses-ob '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Cuando el parámetro <parameter>return</parameter> es utilizado, esta función utiliza el buffer
- interno de salida, por lo tanto no puede ser utilizado en la función de devolución de llamada de <function>ob_start</function>.
-</simpara></note>'>
+<!ENTITY note.uses-ob '<note xmlns="http://docbook.org/ns/docbook"><simpara> Cuando el parámetro <parameter>return</parameter> es utilizado,
+esta función utiliza el buffer interno de salida, por lo tanto no puede ser utilizado en la función de devolución de llamada de
+<function>ob_start</function>.</simpara></note>'>
 
- <!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Cuando el parámetro <parameter>return</parameter> es utilizado, esta función
- utilizaba el buffer interno de salida anterior a PHP 7.1.0, y por lo tanto no puede ser
- utilizado en la función de devolución de llamada de <function>ob_start</function>.
-</simpara></note>'>
+<!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><simpara> Cuando el parámetro <parameter>return</parameter> es utilizado,
+esta función utilizaba el buffer interno de salida anterior a PHP 7.1.0, y por lo tanto no puede ser utilizado en la función de devolución de llamada de
+<function>ob_start</function>.</simpara></note>'>
 
- <!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Tenga en cuenta que la precisión temporal puede variar según el sistema de archivos utilizado.
-</simpara></note>'>
+<!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><simpara> Tenga en cuenta que la precisión temporal puede
+variar según el sistema de archivos utilizado.</simpara></note>'>
 
- <!ENTITY note.uses-autoload '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- El uso de esta función utilizará todos los <link linkend="language.oop5.autoload">autoloaders</link>
- registrados si la clase no es conocida aún.
-</simpara></note>'>
+<!ENTITY note.uses-autoload '<note xmlns="http://docbook.org/ns/docbook">
+<simpara> El uso de esta función utilizará todos los
+<link linkend="language.oop5.autoload">autoloaders</link> registrados si la clase no es conocida aún.</simpara></note>'>
 
- <!ENTITY note.network.header.sapi '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY note.network.header.sapi '<note xmlns="http://docbook.org/ns/docbook">
+   <simpara>
+    Los encabezados solo serán accesibles y se mostrarán cuando se utilice un SAPI
+    que los soporte.
+   </simpara>
+  </note>
+'>
+
+<!ENTITY note.sigchild '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  Los encabezados solo serán accesibles y se mostrarán cuando se utilice un SAPI que los soporte.
+  Si PHP ha sido compilado con la opción de configuración --enable-sigchild, el valor devuelto de esta función será indefinido.
  </simpara>
 </note>
 '>
 
- <!ENTITY note.sigchild '<note xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Si PHP ha sido compilado con la opción de configuración --enable-sigchild,
-  el valor devuelto de esta función será indefinido.
- </simpara>
-</note>
-'>
-
- <!ENTITY note.sort-unstable '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY note.sort-unstable '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Si dos miembros se comparan como iguales, mantienen su orden original.
   Anterior a PHP 8.0.0, su orden relativo en el array ordenado no está definido.
@@ -208,163 +193,158 @@ más detalles.</simpara></note>'>
 </note>
 '>
 
- <!ENTITY note.reset-index "<note xmlns='http://docbook.org/ns/docbook'>
- <para>
+<!ENTITY note.reset-index "<note xmlns='http://docbook.org/ns/docbook'>
+ <simpara>
     Reinicia el puntero interno del array al primer elemento.
- </para>
+ </simpara>
 </note>
 ">
 
- <!ENTITY note.resource-migration-8.0-dead-function '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY note.resource-migration-8.0-dead-function '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  Esta función no tiene ningún efecto. Anterior a PHP 8.0.0,
-  esta función era utilizada para cerrar un recurso.
+  Esta función no tiene ningún efecto. Anterior a PHP 8.0.0, esta función era utilizada para cerrar un recurso.
  </simpara>
 </note>
 '>
 
- <!-- Tips / Astuces -->
+<!-- Tips -->
 
- <!ENTITY tip.fopen-wrapper '<tip xmlns="http://docbook.org/ns/docbook"><simpara>
- Puede utilizar una URL como nombre de archivo con esta función, si el
- <link linkend="ini.allow-url-fopen">gestor fopen</link> ha sido activado. Véase <function>fopen</function>
- para más detalles sobre cómo especificar el nombre del archivo. Consulte
- <xref linkend="wrappers"/> para más información sobre las capacidades de los diferentes gestores,
- las notas sobre su uso, así como la información sobre las variables predefinidas que proporcionan.
-</simpara></tip>'>
+<!ENTITY tip.fopen-wrapper '<tip xmlns="http://docbook.org/ns/docbook"><simpara> Puede utilizar una URL como nombre de
+archivo con esta función, si el <link linkend="ini.allow-url-fopen"
+>gestor fopen</link> ha sido activado.
+Véase <function>fopen</function> para más detalles sobre cómo especificar el nombre
+del archivo. Consulte <xref linkend="wrappers"/> para más información sobre
+las capacidades de los diferentes gestores, las notas sobre su uso, así
+como la información sobre las variables predefinidas que
+proporcionan.</simpara></tip>'>
 
- <!ENTITY tip.fopen-wrapper.stat '<tip xmlns="http://docbook.org/ns/docbook"><simpara>
- A partir de PHP 5.0.0, esta función también puede ser utilizada con <emphasis>algunos</emphasis> protocolos url.
- Lea <xref linkend="wrappers"/> para conocer los protocolos que soportan la familia de funcionalidades de
- <function>stat</function>.
-</simpara></tip>'>
+<!ENTITY tip.fopen-wrapper.stat '<tip xmlns="http://docbook.org/ns/docbook"><simpara> A partir de PHP 5.0.0, esta función
+también puede ser utilizada con <emphasis>algunos</emphasis> protocolos url. Lea
+<xref linkend="wrappers"/> para conocer los protocolos que soportan la familia de funcionalidades de
+<function>stat</function>.</simpara></tip>'>
 
- <!ENTITY tip.ob-capture '<tip xmlns="http://docbook.org/ns/docbook"><simpara>
- Al igual que con todas las funciones que muestran directamente resultados al navegador, las
- <link linkend="book.outcontrol">funciones de gestión de salida</link> pueden ser utilizadas para capturar la salida
- de esta función y almacenarla en un string (por ejemplo).
-</simpara></tip>'>
+<!ENTITY tip.ob-capture '<tip xmlns="http://docbook.org/ns/docbook"><simpara>Al igual que con cualquier cosa
+que envíe sus resultados directamente al navegador, las <link
+linkend="book.outcontrol">funciones de control de salida</link> se pueden usar para capturar
+la salida de esta función y guardarla en un
+<type>string</type> (por ejemplo).</simpara></tip>'>
 
- <!ENTITY tip.userlandnaming '<tip xmlns="http://docbook.org/ns/docbook"><simpara>
- Eche un vistazo a <xref linkend="userlandnaming" />.
-</simpara></tip>'>
+<!ENTITY tip.userlandnaming '<tip xmlns="http://docbook.org/ns/docbook"><simpara> Véase también
+<xref linkend="userlandnaming" />.</simpara></tip>'>
 
- <!-- Warnings / Avertissement -->
 
- <!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Si los datos provenientes de los usuarios tienen permiso de ser pasados a esta función, utilice
- <function>escapeshellarg</function> o <function>escapeshellcmd</function> para asegurarse de que los usuarios
- no puedan hacer que el sistema ejecute comandos arbitrarios.
-</simpara></warning>'>
+<!-- Warnings -->
 
- <!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta extensión es <emphasis>EXPERIMENTAL</emphasis>. El comportamiento de esta extensión, los nombres de sus funciones,
- y toda la documentación alrededor de esta extensión puede cambiar sin previo aviso en una próxima versión de PHP.
- Esta extensión debe ser utilizada bajo su propio riesgo.
-</simpara></warning>'>
+<!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Si los datos provenientes de los usuarios tienen permiso
+de ser pasados a esta función, utilice
+<function>escapeshellarg</function> o <function>escapeshellcmd</function>
+para asegurarse de que los usuarios no puedan hacer que el sistema ejecute comandos
+arbitrarios.</simpara></warning>'>
 
- <!ENTITY deprecated.function 'Esta función está obsoleta.'>
- <!ENTITY removed.function 'Esta función ha sido eliminada.'>
+<!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Esta extensión es
+<emphasis>EXPERIMENTAL</emphasis>. El comportamiento de esta extensión, los
+nombres de sus funciones, y toda la documentación alrededor de esta
+extensión puede cambiar sin previo aviso en una próxima versión de PHP.
+Esta extensión debe ser utilizada bajo su propio riesgo.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY deprecated.function 'Esta función está obsoleta.'>
+<!ENTITY removed.function 'Esta función ha sido eliminada.'>
 
- <!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 5.4.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-5-3-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-5-3-0.removed-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 5.4.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido <emphasis>ELIMINADA</emphasis>
+a partir de PHP 5.4.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-5-3-0.removed-5-4-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 5.4.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-5-6-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.6.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-5-5-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.0.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-5-6-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.6.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-7-1-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-7-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.0.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-7-1-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0.
- Depender de esta función está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-7-1-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-7-0-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.0.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0.
- Depender de esta función está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-7-1-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0. Depender de esta función
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-7-1-0.removed-7-2-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.2.0.
- Depender de esta función está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-7-0-0.removed-8-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.0.0 y ha sido
+<emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0. Depender de esta función
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-7-2-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-7-1-0.removed-7-2-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0 y ha sido
+<emphasis>ELIMINADA</emphasis> a partir de PHP 7.2.0. Depender de esta función
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-7-2-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0,
- y <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-7-2-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-7-2-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0.
- Depender de esta función está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-7-2-0.removed-8-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0, y <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-7-2-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-7-2-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0. Depender de esta función
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-7-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-7-2-0.removed-8-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP
+8.0.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-7-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0.
- Depender de esta función está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-7-3-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-7-3-0.removed-8-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0,
- y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0.
- Depender de esta función está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-7-3-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0. Depender de esta función
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-7-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.4.0.
- Depender de esta funcionalidad está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-7-3-0.removed-8-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0, y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0. Depender de esta función
+está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-7-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.4.0.
- Depender de esta función está altamente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-7-4-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.4.0. Depender de esta funcionalidad
+está altamente desaconsejado.</simpara></warning>'>
+
+<!ENTITY warn.deprecated.function-7-4-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 7.4.0. Depender de esta función
+está altamente desaconsejado.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-4-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está
@@ -425,149 +405,140 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 8.5.0. Depender de esta función
 está altamente desaconsejado.</simpara></warning>'>
 
- <!ENTITY removed.php.future 'Esta funcionalidad obsoleta <emphasis xmlns="http://docbook.org/ns/docbook">será</emphasis>
+<!ENTITY removed.php.future 'Esta funcionalidad obsoleta <emphasis xmlns="http://docbook.org/ns/docbook">será</emphasis>
 ciertamente <emphasis xmlns="http://docbook.org/ns/docbook">eliminada</emphasis> en el futuro.'>
 
- <!ENTITY warn.deprecated.function.removed-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 5.3.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function.removed-5-3-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 5.3.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function.removed-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis>, y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 5.5.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function.removed-5-5-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis>, y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 5.5.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.alias-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Este alias está <emphasis>OBSOLETO</emphasis> a partir de PHP 5.3.0.
- Depender de este alias está fuertemente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.alias-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook">
+<simpara>Este alias está <emphasis>OBSOLETO</emphasis> a partir de PHP 5.3.0.
+Depender de este alias está fuertemente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.func-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.4.0.
- Depender de esta función está fuertemente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.func-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
+<simpara>Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.4.0.
+Depender de esta función está fuertemente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Este alias está <emphasis>OBSOLETO</emphasis> a partir de PHP 5.4.0.
- Depender de este alias está fuertemente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
+<simpara>Este alias está <emphasis>OBSOLETO</emphasis> a partir de PHP 5.4.0.
+Depender de este alias está fuertemente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.func-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0.
- Depender de esta función está fuertemente desaconsejado.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.func-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook">
+<simpara>Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0.
+Depender de esta función está fuertemente desaconsejado.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.feature-5-5-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-5-5-0.removed-7-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-5-5-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-5-5-0.removed-7-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-4-1-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 4.1.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-4-1-0.removed-7-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 4.1.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.function-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.function-5-3-0.removed-7-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Este alias está <emphasis>OBSOLETO</emphasis> a partir de PHP 5.4.0. y ha sido
- <emphasis>ELIMINADO</emphasis> a partir de PHP 7.0.0.
-</simpara></warning>'><!ENTITY warn.deprecated.feature-5-6-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.6.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Este alias está
+<emphasis>OBSOLETO</emphasis> a partir de PHP 5.4.0. y ha sido <emphasis>ELIMINADO</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
- <!ENTITY warn.removed.function-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara></warning>'>
+<!ENTITY warn.deprecated.feature-5-6-0.removed-7-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 5.6.0 y ha sido
+<emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
- <!ENTITY warn.removed.function-7-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.4.0.
-</simpara></warning>'>
+<!ENTITY warn.removed.function-7-0-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función ha sido
+<emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.alias-7-2-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Este alias está
+<!ENTITY warn.removed.function-7-4-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara> Esta función ha sido
+<emphasis>ELIMINADA</emphasis> a partir de PHP 7.4.0.</simpara></warning>'>
+
+<!ENTITY warn.deprecated.alias-7-2-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Este alias está
 <emphasis>OBSOLETO</emphasis> en PHP 7.2.0, y <emphasis>ELIMINADO</emphasis> a partir de PHP 8.0.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.alias-7-4-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Este alias está
+<!ENTITY warn.deprecated.alias-7-4-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Este alias está
 <emphasis>OBSOLETO</emphasis> en PHP 7.4.0, y <emphasis>ELIMINADO</emphasis> a partir de PHP 8.0.0.</simpara></warning>'>
 
- <!ENTITY warn.deprecated.alias-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Este alias está
+<!ENTITY warn.deprecated.alias-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Este alias está
 <emphasis>OBSOLETO</emphasis> en PHP 8.0.0.</simpara></warning>'>
 
- <!ENTITY warn.removed.alias-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Este alias está
+<!ENTITY warn.removed.alias-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Este alias está
 <emphasis>ELIMINADO</emphasis> a partir de PHP 8.0.0.</simpara></warning>'>
 
 <!ENTITY warn.removed.feature-8-5-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 <emphasis>ELIMINADA</emphasis> a partir de PHP 8.5.0.</simpara></warning>'>
 
- <!ENTITY warn.experimental.func '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función es <emphasis>EXPERIMENTAL</emphasis>. El comportamiento de esta función, su nombre, y toda la
- documentación alrededor de esta función puede cambiar sin previo aviso en una próxima versión de PHP.
- Esta función debe ser utilizada bajo su propio riesgo.
+<!ENTITY warn.experimental.func '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Esta función es
+<emphasis>EXPERIMENTAL</emphasis>. El comportamiento de esta función, su nombre, y toda la
+documentación alrededor de esta función puede cambiar sin previo aviso en una próxima versión
+de PHP. Esta función debe ser utilizada bajo su propio riesgo.
 </simpara></warning>'>
 
- <!ENTITY warn.imaprecodeyaz '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Las extensiones <link linkend="book.imap">IMAP</link>, <link linkend="book.recode">recode</link> y
- <link linkend="book.yaz">YAZ</link>
- no pueden ser utilizadas simultáneamente ya que utilizan un símbolo interno común.
- Nota: Yaz 2.0 y superior ya no sufre de este problema.
-</simpara></warning>'>
+<!ENTITY warn.imaprecodeyaz '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Las extensiones <link
+linkend="book.imap">IMAP</link>, <link linkend="book.recode">recode</link> y
+<link linkend="book.yaz">YAZ</link>
+no pueden ser utilizadas simultáneamente ya que utilizan
+un símbolo interno común. Nota: Yaz 2.0 y superior ya no sufre de este problema.</simpara></warning>'>
 
- <!ENTITY warn.install.cgi '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Un servidor desplegado en modo CGI se expone a varias vulnerabilidades posibles. Por favor, lea nuestra
- <link linkend="security.cgi-bin">sección sobre la seguridad en modo CGI</link>
- para aprender cómo protegerse contra estos ataques.
-</simpara></warning>'>
+<!ENTITY warn.install.cgi '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Un servidor desplegado en modo CGI se expone a
+varias vulnerabilidades posibles. Por favor, lea nuestra
+<link linkend="security.cgi-bin">sección sobre la seguridad en modo CGI</link> para aprender cómo
+protegerse contra estos ataques.</simpara></warning>'>
 
- <!ENTITY warn.passwordhashing '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>
- No se recomienda utilizar esta función para asegurar contraseñas, debido a la naturaleza
- rápida de este algoritmo de hash. Ver <link linkend="faq.passwords.fasthash">F.A.Q del hash de
- contraseñas</link> para más detalles y las buenas prácticas.
-</simpara>
-</warning>'>
-
- <!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cuando SSL es utilizado, el servidor IIS de Microsoft violará el protocolo al cerrar la conexión sin
- enviar un indicador <literal>close_notify</literal>. PHP lo reportará como "SSL: Fatal Protocol Error"
- cuando se llegue al final de los datos. Para evitar esto, el nivel de la directiva
- <link linkend="ini.error-reporting">error_reporting</link> debe ser bajado para no incluir los avisos.
- PHP puede detectar automáticamente los servidores IIS defectuosos al abrir
- el flujo utilizando <literal>https://</literal> y suprimirá el aviso.
- Al utilizar <function>fsockopen</function> para crear un socket <literal>ssl://</literal>,
- es responsabilidad del desarrollador detectar y suprimir el aviso.
-</simpara></warning>'>
-
- <!ENTITY warn.undocumented.class '
+<!ENTITY warn.passwordhashing '
 <warning xmlns="http://docbook.org/ns/docbook">
-<simpara>
- Esta clase está actualmente no documentada; solo la lista de sus propiedades y métodos está disponible.
-</simpara>
+ <simpara>
+  No se recomienda utilizar esta función para asegurar contraseñas, debido
+  a la naturaleza rápida de este algoritmo de hash. Ver
+  <link linkend="faq.passwords.fasthash">F.A.Q del hash de contraseñas</link>
+  para más detalles y las buenas prácticas.
+ </simpara>
 </warning>
 '>
 
- <!ENTITY warn.undocumented.func '
+<!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Cuando SSL es utilizado, el servidor
+IIS de Microsoft violará el protocolo al cerrar la conexión sin enviar un indicador
+<literal>close_notify</literal>. PHP lo reportará como "SSL: Fatal Protocol
+Error" cuando se llegue al final de los datos. Para evitar esto, el nivel de
+la directiva <link linkend="ini.error-reporting">error_reporting</link> debe ser
+bajado para no incluir los avisos. PHP
+puede detectar automáticamente los servidores IIS defectuosos al abrir
+el flujo utilizando <literal>https://</literal> y suprimirá el aviso.
+Al utilizar <function>fsockopen</function> para crear un socket
+<literal>ssl://</literal>, es responsabilidad del desarrollador detectar
+y suprimir el aviso.</simpara></warning>'>
+
+<!ENTITY warn.undocumented.class '
 <warning xmlns="http://docbook.org/ns/docbook">
-<simpara>
- Esta función está actualmente no documentada; solo la lista de sus argumentos está disponible.
-</simpara>
+ <simpara>
+  Esta clase está actualmente no documentada; solo la lista de sus propiedades y
+  métodos está disponible.
+ </simpara>
 </warning>
 '>
 
- <!-- Deprecation and removal warnings designed for use with a list of
+<!ENTITY warn.undocumented.func '<warning xmlns="http://docbook.org/ns/docbook"> <simpara>Esta función está actualmente
+no documentada; solo la lista de sus argumentos está disponible.
+</simpara></warning>'>
+
+
+<!-- Deprecation and removal warnings designed for use with a list of
      alternatives. See en/reference/regex/functions/ereg.xml and
      en/reference/regex/reference.xml for examples of these in action. -->
 
- <!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
+<!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 4.1.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
@@ -577,7 +548,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 </simpara>
 '>
 
- <!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
+<!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
@@ -587,7 +558,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 </simpara>
 '>
 
- <!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
+<!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
@@ -597,7 +568,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 </simpara>
 '>
 
- <!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
+<!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
@@ -607,7 +578,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 </simpara>
 '>
 
- <!ENTITY warn.removed.feature.7-0-0.alternatives '
+<!ENTITY warn.removed.feature.7-0-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Esta funcionalidad ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
 </simpara>
@@ -616,7 +587,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 </simpara>
 '>
 
- <!ENTITY warn.removed.function.7-0-0.alternatives '
+<!ENTITY warn.removed.function.7-0-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Esta función ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
 </simpara>
@@ -625,7 +596,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 </simpara>
 '>
 
- <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
+<!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.2.0.
@@ -635,7 +606,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 </simpara>
 '>
 
- <!ENTITY warn.deprecated.function.7-1-0.removed.7-2-0.alternatives '
+<!ENTITY warn.deprecated.function.7-1-0.removed.7-2-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0 y ha sido
  <emphasis>ELIMINADA</emphasis> a partir de PHP 7.2.0.
@@ -645,182 +616,184 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta funcionalidad ha sido
 </simpara>
 '>
 
- <!ENTITY warn.deprecated.function-8-1-0.alternatives '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>Esta función
-está <emphasis>OBSOLETA</emphasis> a partir de PHP 8.1.0.
-Se recomienda evitar su uso.</simpara></warning>
+<!ENTITY warn.deprecated.function-8-1-0.alternatives '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está
+<emphasis>OBSOLETA</emphasis> a partir de PHP 8.1.0. Se recomienda
+evitar su uso.</simpara></warning>
 <simpara xmlns="http://docbook.org/ns/docbook">
  Las alternativas a esta función incluyen:
 </simpara>
 '>
 
- <!-- Misc / Divers -->
+<!-- Misc -->
 
- <!ENTITY version.exists.asof 'Existe a partir de PHP '>
+<!ENTITY version.exists.asof 'Existe a partir de PHP '>
 
- <!ENTITY version.trunk.changelog 'Futuro'>
+<!ENTITY version.trunk.changelog 'Futuro'>
 
- <!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">Esta función no contiene ningún parámetro.</simpara>'>
+<!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">Esta función no contiene ningún parámetro.</simpara>'>
 
- <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">El ejemplo anterior mostrará:</simpara>'>
+<!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">El ejemplo anterior mostrará:</simpara>'>
 
- <!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5:</simpara>'>
+<!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5:</simpara>'>
 
- <!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.3:</simpara>'>
+<!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.3:</simpara>'>
 
- <!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.4:</simpara>'>
+<!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.4:</simpara>'>
 
- <!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.5:</simpara>'>
+<!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.5:</simpara>'>
 
- <!ENTITY example.outputs.56 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.6:</simpara>'>
+<!ENTITY example.outputs.56 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.6:</simpara>'>
 
- <!ENTITY example.outputs.7 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7:</simpara>'>
+<!ENTITY example.outputs.7 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7:</simpara>'>
 
- <!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.0:</simpara>'>
+<!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.0:</simpara>'>
 
- <!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.1:</simpara>'>
+<!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.1:</simpara>'>
 
- <!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.2:</simpara>'>
+<!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.2:</simpara>'>
 
- <!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.3:</simpara>'>
+<!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.3:</simpara>'>
 
- <!ENTITY example.outputs.8 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8:</simpara>'>
+<!ENTITY example.outputs.8 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8:</simpara>'>
 
- <!ENTITY example.outputs.8.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8 es similar a:</simpara>'>
+<!ENTITY example.outputs.8.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.80 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.0:</simpara>'>
+<!ENTITY example.outputs.80 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.0:</simpara>'>
 
- <!ENTITY example.outputs.81 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.1:</simpara>'>
+<!ENTITY example.outputs.81 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.1:</simpara>'>
 
- <!ENTITY example.outputs.82 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.2:</simpara>'>
+<!ENTITY example.outputs.82 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.2:</simpara>'>
 
- <!ENTITY example.outputs.82.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.2 es similar a:</simpara>'>
+<!ENTITY example.outputs.82.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.2 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.83 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.3:</simpara>'>
+<!ENTITY example.outputs.83 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.3:</simpara>'>
 
- <!ENTITY example.outputs.83.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.3 es similar a:</simpara>'>
+<!ENTITY example.outputs.83.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 8.3 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.84 '<simpara xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.4:</simpara>'>
+<!ENTITY example.outputs.84 '<simpara xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.4:</simpara>'>
 
- <!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.4 es similar a:</simpara>'>
+<!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.4 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.5:</simpara>'>
+<!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.5:</simpara>'>
 
- <!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.5 es similar a:</simpara>'>
+<!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.5 es similar a:</simpara>'>
 
- <!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 32 bits:</simpara>'>
+<!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 32 bits:</simpara>'>
 
- <!ENTITY example.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 64 bits:</simpara>'>
+<!ENTITY example.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 64 bits:</simpara>'>
 
- <!ENTITY example.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior es similar a:</simpara>'>
+<!ENTITY example.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior
+es similar a:</simpara>'>
 
- <!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán:</simpara>'>
+<!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán:</simpara>'>
 
- <!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 32 bits:</simpara>'>
+<!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 32 bits:</simpara>'>
 
- <!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 64 bits:</simpara>'>
+<!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 64 bits:</simpara>'>
 
- <!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán algo similar a:</simpara>'>
+<!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán
+algo similar a:</simpara>'>
 
- <!ENTITY array.resetspointer '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función reinicia el puntero al inicio del array de entrada (equivalente a <function>reset</function>).
-</simpara></note>'>
+<!ENTITY array.resetspointer '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ejecutará
+<function>reset</function> sobre el puntero del <type>array</type> de entrada después de
+usarlo.</simpara></note>'>
 
- <!ENTITY array.changelog.by-ref '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY array.changelog.by-ref '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  Si <parameter>callback</parameter> espera un parámetro a ser pasado por
-  referencia, esta función emite ahora una <constant>E_WARNING</constant>.
+  Si <parameter>callback</parameter> espera un parámetro a ser pasado
+  por referencia, esta función emite ahora una <constant>E_WARNING</constant>.
  </entry>
 </row>'>
 
- <!ENTITY array.changelog.require-only-one '<row xmlns="http://docbook.org/ns/docbook">
- <entry>8.0.0</entry>
- <entry>
-  Esta función puede ser llamada ahora con un solo parámetro.
-  Anteriormente, al menos dos parámetros eran necesarios.
- </entry>
+<!ENTITY array.changelog.require-only-one '<row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.0.0</entry>
+  <entry>
+  Esta función puede ser llamada ahora con un solo
+  parámetro. Anteriormente, al menos dos parámetros eran necesarios.
+  </entry>
 </row>'>
 
- <!ENTITY seealso.array.sorting 'Las funciones de <link xmlns="http://docbook.org/ns/docbook" linkend="array.sorting">ordenación de arrays</link>'>
+<!ENTITY seealso.array.sorting 'Las funciones de <link xmlns="http://docbook.org/ns/docbook" linkend="array.sorting">ordenación de arrays</link>'>
 
- <!ENTITY sort.flags.parameter '<varlistentry xmlns="http://docbook.org/ns/docbook">
- <term><parameter>flags</parameter></term>
- <listitem>
-  <simpara>
-   El segundo parámetro opcional <parameter>flags</parameter>
-   puede ser utilizado para modificar el comportamiento de ordenación utilizando estos valores:
-  </simpara>
-  <para>
-   Tipo de banderas de ordenación:
-   <itemizedlist>
-    <listitem>
-     <simpara><constant>SORT_REGULAR</constant> - compara los elementos normalmente;
-     los detalles son descritos en la sección de los <link linkend="language.operators.comparison">operadores de comparación</link></simpara>
-    </listitem>
-    <listitem>
-     <simpara><constant>SORT_NUMERIC</constant> - compara los elementos numéricamente</simpara>
-    </listitem>
-    <listitem>
-     <simpara><constant>SORT_STRING</constant> - compara los elementos como strings</simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>SORT_LOCALE_STRING</constant> - compara los elementos como
-      strings, basado en la configuración regional actual. Esto utiliza la configuración regional,
-      que puede ser cambiada utilizando <function>setlocale</function>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>SORT_NATURAL</constant> - compara los elementos como strings
-      utilizando el "orden natural" como <function>natsort</function>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>SORT_FLAG_CASE</constant> - puede ser combinado
-      (OR a nivel de bits) con
-      <constant>SORT_STRING</constant> o
-      <constant>SORT_NATURAL</constant> para ordenar strings sin tener en cuenta la mayúscula/minúscula
-     </simpara>
-    </listitem>
-   </itemizedlist>
-  </para>
- </listitem>
-</varlistentry>
+<!ENTITY sort.flags.parameter '<varlistentry xmlns="http://docbook.org/ns/docbook">
+  <term><parameter>flags</parameter></term>
+  <listitem>
+   <simpara>
+    El segundo parámetro opcional <parameter>flags</parameter>
+    puede ser utilizado para modificar el comportamiento de ordenación utilizando estos valores:
+   </simpara>
+   <para>
+    Tipo de banderas de ordenación:
+    <itemizedlist>
+     <listitem>
+      <simpara><constant>SORT_REGULAR</constant> - compara los elementos normalmente; los
+      detalles son descritos en la sección de los <link linkend="language.operators.comparison">operadores de comparación</link></simpara>
+     </listitem>
+     <listitem>
+      <simpara><constant>SORT_NUMERIC</constant> - compara los elementos numéricamente</simpara>
+     </listitem>
+     <listitem>
+      <simpara><constant>SORT_STRING</constant> - compara los elementos como strings</simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       <constant>SORT_LOCALE_STRING</constant> - compara los elementos como
+       strings, basado en la configuración regional actual. Esto utiliza la configuración
+       regional, que puede ser cambiada utilizando <function>setlocale</function>
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       <constant>SORT_NATURAL</constant> - compara los elementos como strings
+       utilizando el "orden natural" como <function>natsort</function>
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       <constant>SORT_FLAG_CASE</constant> - puede ser combinado (OR a
+       nivel de bits) con
+       <constant>SORT_STRING</constant> o
+       <constant>SORT_NATURAL</constant> para ordenar strings sin tener en cuenta la mayúscula/minúscula
+      </simpara>
+     </listitem>
+    </itemizedlist>
+   </para>
+  </listitem>
+ </varlistentry>
 '>
 
- <!ENTITY sort.callback.description '<simpara xmlns="http://docbook.org/ns/docbook">
-&return.callbacksort;
+<!ENTITY sort.callback.description '<simpara xmlns="http://docbook.org/ns/docbook">
+ &return.callbacksort;
 </simpara>
 &callback.cmp;
 <caution xmlns="http://docbook.org/ns/docbook">
-<simpara>
-Retornar valores <emphasis>no-entero</emphasis> desde la función
-de comparación, tales como <type>float</type>, resultará en una conversión interna
-del valor de retorno del callback a <type>int</type>. Así, valores tales como
-<literal>0.99</literal> y <literal>0.1</literal> serán convertidos ambos a un
-valor entero de <literal>0</literal>, lo que comparará tales valores como iguales.
-</simpara>
+ <simpara>
+  Devolver valores <emphasis>no enteros</emphasis> (como
+  <type>float</type>) desde la función de comparación resultará en una conversión interna del valor de retorno de la retrollamada a
+  <type>int</type>. Así, valores como
+  <literal>0.99</literal> y <literal>0.1</literal> serán convertidos ambos al
+  valor entero <literal>0</literal>, por lo que se compararán como iguales.
+ </simpara>
 </caution>'>
 
- <!ENTITY sort.callback.description.presort '<caution xmlns="http://docbook.org/ns/docbook">
+<!ENTITY sort.callback.description.presort '<caution xmlns="http://docbook.org/ns/docbook">
  <para>
-  La función de callback de ordenación debe tratar cualquier valor de cualquier array en cualquier orden,
-  independientemente del orden en el que fueron proporcionados inicialmente.
+  La función de callback de ordenación debe tratar cualquier valor de cualquier array en cualquier
+  orden, independientemente del orden en el que fueron proporcionados inicialmente.
   Esto se debe a que cada array individual es ordenado primero antes de ser comparado con otros arrays.
 
   Por ejemplo:
   <programlisting role="php">
 <![CDATA[
 <?php
-$arrayA = ["cadena", 1];
+$arrayA = ["string", 1];
 $arrayB = [["value" => 1]];
-// $item1 y $item2 pueden ser cualquiera de los siguientes valores : "cadena", 1 o ["value" => 1]
-$compareFunc = static function ($item1, $item2) {
-    $value1 = is_string($item1) ? strlen($item1) : (is_array($item1) ? $item1["value"] : $item1);
-    $value2 = is_string($item2) ? strlen($item2) : (is_array($item2) ? $item2["value"] : $item2);
+// $item1 y $item2 pueden ser cualquiera de los siguientes valores : "cadena", 1 o
+["value" => 1] $compareFunc = static function ($item1,
+    $item2) { $value1 = is_string($item1) ? strlen($item1) : (is_array($item1) ? $item1["value"] :
+    $item1); $value2 = is_string($item2) ? strlen($item2) : (is_array($item2) ? $item2["value"] : $item2);
     return $value1 <=> $value2;
 };
 ?>
@@ -829,234 +802,229 @@ $compareFunc = static function ($item1, $item2) {
  </para>
 </caution>'>
 
- <!ENTITY ini.shorthandbytes '<simpara xmlns="http://docbook.org/ns/docbook">Cuando un &integer; es utilizado,
-su valor es medido en bytes. También puede utilizar la notación abreviada
-como se describe en esta
-<link linkend="faq.using.shorthandbytes">entrada de la FAQ.</link>.</simpara>'>
+<!ENTITY ini.shorthandbytes '<simpara xmlns="http://docbook.org/ns/docbook">Cuando se utiliza un <type>int</type>, el valor se
+mide en bytes. También se puede usar la notación abreviada, como se describe
+en <link linkend="faq.using.shorthandbytes">esta FAQ</link>.
+</simpara>'>
 
- <!ENTITY info.deprecated.alias 'Por razones de compatibilidad ascendente,
-el siguiente alias obsoleto puede ser utilizado: '>
+<!ENTITY info.deprecated.alias 'Por razones de compatibilidad ascendente, el
+siguiente alias obsoleto puede ser utilizado: '>
 
- <!ENTITY info.function.alias 'Esta función es un alias de: '>
+<!ENTITY info.function.alias 'Esta función es un alias de: '>
 
- <!ENTITY info.method.alias 'Este método es un alias de: '>
+<!ENTITY info.method.alias 'Este método es un alias de: '>
 
- <!ENTITY info.function.alias.deprecated '<simpara xmlns="http://docbook.org/ns/docbook">Este alias está obsoleto
-y solo existe por razones de compatibilidad. Se recomienda
-no utilizar esta función ya que puede ser eliminada en una versión futura de PHP.</simpara>'>
+<!ENTITY info.function.alias.deprecated '<simpara xmlns="http://docbook.org/ns/docbook">Este alias está obsoleto
+y solo existe por razones de compatibilidad. Se recomienda no utilizar
+esta función ya que puede ser eliminada en una versión futura de PHP.
+</simpara>'>
 
- <!ENTITY ext.windows.path.dll 'Para hacer funcionar esta extensión, algunas bibliotecas
-<acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> deben estar disponibles a través del
-<envar xmlns="http://docbook.org/ns/docbook">PATH</envar> del sistema Windows. Lea la
-<acronym xmlns="http://docbook.org/ns/docbook">F.A.Q</acronym> titulada
-"<link xmlns="http://docbook.org/ns/docbook" linkend="faq.installation.addtopath">Cómo agregar mi carpeta
-PHP a mi PATH de Windows</link>" para más información. Copiar las bibliotecas DLL desde la
-carpeta PHP a la carpeta del sistema de Windows también funciona (ya que la carpeta del sistema está por defecto en el
+<!ENTITY ext.windows.path.dll 'Para hacer funcionar esta extensión, algunas bibliotecas
+<acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> deben estar disponibles a través
+del <envar xmlns="http://docbook.org/ns/docbook">PATH</envar> del sistema Windows. Lea la
+<acronym xmlns="http://docbook.org/ns/docbook">F.A.Q</acronym> titulada "<link
+ xmlns="http://docbook.org/ns/docbook" linkend="faq.installation.addtopath">Cómo agregar mi carpeta PHP a mi PATH
+de Windows</link>" para más información. Copiar
+las bibliotecas DLL desde la carpeta PHP a la carpeta del sistema de Windows también
+funciona (ya que la carpeta del sistema está por defecto en el
 <envar xmlns="http://docbook.org/ns/docbook">PATH</envar> del sistema), pero este método no es recomendado.
-<emphasis xmlns="http://docbook.org/ns/docbook">Esta extensión requiere que los siguientes archivos estén en el
+<emphasis xmlns="http://docbook.org/ns/docbook">Esta extensión requiere que los siguientes ficheros estén en el
 <envar>PATH</envar>:</emphasis> '>
 
- <!ENTITY manual.migration.seealso 'Véase también las guías de migración entre las diferentes versiones de PHP'>
+<!ENTITY manual.migration.seealso 'Véase también las guías de migración entre las diferentes versiones de PHP'>
 
- <!ENTITY style.oop 'Estilo orientado a objetos'>
- <!ENTITY style.procedural 'Estilo procedimental'>
+<!ENTITY style.oop 'Estilo orientado a objetos'>
+<!ENTITY style.procedural 'Estilo procedimental'>
 
- <!ENTITY match '<link xmlns="http://docbook.org/ns/docbook" linkend="control-structures.match">match</link>'>
+<!ENTITY match '<link xmlns="http://docbook.org/ns/docbook" linkend="control-structures.match">match</link>'>
 
- <!ENTITY parameter.context 'Consulte la sección <link xmlns="http://docbook.org/ns/docbook" linkend="context">contexto</link>
-de este manual para una descripción de los <literal xmlns="http://docbook.org/ns/docbook">contextos</literal>.'>
+<!ENTITY parameter.context 'Consulte la sección <link xmlns="http://docbook.org/ns/docbook" linkend="context">contexto</link>
+de este manual para una descripción de los <literal xmlns="http://docbook.org/ns/docbook">contexts</literal>.'>
 
- <!ENTITY parameter.use_include_path 'Cuando está definido como &true;, el nombre del archivo también es
-buscado en <link xmlns="http://docbook.org/ns/docbook" linkend="ini.include-path">include_path</link>'>
+<!ENTITY parameter.use_include_path 'Cuando está definido como &true;, el nombre del archivo
+también es buscado en <link xmlns="http://docbook.org/ns/docbook" linkend="ini.include-path">include_path</link>'>
 
- <!-- Returns / Retornos -->
+<!-- Returns -->
 
- <!ENTITY return.type.true '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY return.type.true '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.2.0</entry>
  <entry>
   El tipo de retorno es ahora &true;, anteriormente era <type>bool</type>.
  </entry>
 </row>'>
 
- <!ENTITY return.type.true.84 '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY return.type.true.84 '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
   El tipo de retorno es ahora &true;, anteriormente era <type>bool</type>.
  </entry>
 </row>'>
 
- <!ENTITY return.type.true.85 '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY return.type.true.85 '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.5.0</entry>
  <entry>
   El tipo de retorno es ahora &true;, anteriormente era <type>bool</type>.
  </entry>
 </row>'>
 
- <!ENTITY return.falseforfailure ' o &false; si ocurre un error'>
- <!ENTITY return.falseforfailure.style.procedural '&style.procedural; retorna &false; en caso de error.'>
+<!ENTITY return.falseforfailure ' o &false; si ocurre un error'>
+<!ENTITY return.falseforfailure.style.procedural '&style.procedural; retorna &false; en caso de error.'>
 
- <!ENTITY return.success 'Esta función retorna &true; en caso de éxito&return.falseforfailure;.'>
+<!ENTITY return.success 'Esta función retorna &true; en caso de éxito&return.falseforfailure;.'>
 
- <!ENTITY return.nullorfalse 'Esta función retorna &null; en caso de éxito&return.falseforfailure;.'>
+<!ENTITY return.nullorfalse 'Esta función retorna &null; en caso de éxito&return.falseforfailure;.'>
 
- <!ENTITY return.void 'No se retorna ningún valor.'>
+<!ENTITY return.void 'No se retorna ningún valor.'>
 
- <!ENTITY return.true.always 'Retorna siempre &true;.'>
+<!ENTITY return.true.always 'Retorna siempre &true;.'>
 
- <!ENTITY return.callbacksort 'La función de comparación debe retornar un entero menor que, igual a, o mayor
-que 0 si el primer argumento es considerado, respectivamente, menor que, igual a, o mayor que el segundo.'>
+<!ENTITY return.callbacksort 'La función de comparación debe retornar un entero menor que, igual a, o mayor que 0 si el primer argumento es considerado, respectivamente, menor que, igual a, o mayor que el segundo.'>
 
- <!ENTITY return.falseproblem '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Esta función puede retornar &false;, pero también puede retornar un valor equivalente a &false;.
- Por favor, lea la sección sobre los <link linkend="language.types.boolean">booleanos</link> para más información.
- Utilice el <link linkend="language.operators.comparison">operador ===</link>
- para probar el valor de retorno exacto de esta función.
-</simpara></warning>'>
+<!ENTITY return.falseproblem '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Esta función puede
+retornar &false;, pero también puede retornar un valor equivalente a
+&false;. Por favor, lea la sección sobre los <link
+linkend="language.types.boolean">booleanos</link> para más
+información. Utilice el <link linkend="language.operators.comparison">operador
+===</link> para probar el valor de retorno exacto de esta
+función.</simpara></warning>'>
 
- <!-- Standard -->
- <!ENTITY standard.changelog.calling-on-objects '<row xmlns="http://docbook.org/ns/docbook">
+<!-- Standard -->
+<!ENTITY standard.changelog.calling-on-objects '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  O bien convertir el &object; en un &array; utilizando <function>get_mangled_object_vars</function> primero,
-  o utilizar los métodos proporcionados por una clase que implemente <interfacename>Iterator</interfacename>, tal como
-  <classname>ArrayIterator</classname>.
+  O bien convertir el
+  &object; en un &array; utilizando <function>get_mangled_object_vars</function> primero, o utilizar los métodos
+  proporcionados por una clase que implemente <interfacename>Iterator</interfacename>, tal como <classname>ArrayIterator</classname>.
  </entry>
 </row>
 <row xmlns="http://docbook.org/ns/docbook">
  <entry>7.4.0</entry>
  <entry>
-  A partir de PHP 7.4.0, las instancias de clases <link xmlns="http://docbook.org/ns/docbook" linkend="book.spl">SPL</link> son tratadas como
-  objetos vacíos sin propiedades en lugar de llamar al método <interfacename>Iterator</interfacename> con
-  el mismo nombre que esta función.
+  A partir de PHP 7.4.0, las instancias de clases <link xmlns="http://docbook.org/ns/docbook" linkend="book.spl">SPL</link> son tratadas como objetos vacíos sin propiedades en lugar de llamar al método <interfacename>Iterator</interfacename> con el mismo nombre que esta función.
  </entry>
 </row>
 '>
 
- <!ENTITY standard.changelog.binary-safe-string-comparison '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY standard.changelog.binary-safe-string-comparison '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.2.0</entry>
  <entry>
   Esta función ya no garantiza retornar
-  <code>strlen($string1) - strlen($string2)</code> cuando las longitudes
-  de las strings no son iguales, y puede retornar
-  <literal>-1</literal> o <literal>1</literal> en su lugar.
+  <code>strlen($string1) - strlen($string2)</code> cuando las longitudes de
+  las strings no son iguales, y puede retornar <literal>-1</literal> o
+  <literal>1</literal> en su lugar.
  </entry>
 </row>
 '>
 
- <!-- FileInfo -->
- <!ENTITY fileinfo.parameters.finfo '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>finfo</classname>, retornada por <function>finfo_open</function>.</simpara>'>
- <!ENTITY fileinfo.changelog.finfo-object '<row xmlns="http://docbook.org/ns/docbook">
+<!-- FileInfo -->
+<!ENTITY fileinfo.parameters.finfo '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>finfo</classname>, retornada por <function>finfo_open</function>.</simpara>'>
+<!ENTITY fileinfo.changelog.finfo-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>finfo</parameter> ahora espera una instancia de
-  <classname>finfo</classname> ; anteriormente, una &resource; era esperado.
+  El parámetro <parameter>finfo</parameter> ahora espera una instancia de <classname>finfo</classname>
+  ; anteriormente, una &resource; era esperado.
  </entry>
 </row>'>
 
- <!-- OpenSSL -->
- <!ENTITY openssl.param.x509 '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>x509</parameter></term>
-<listitem>
-    <simpara>
-        Ver los <link linkend="openssl.certparams">parámetros clave/Certificados</link>
-        para una lista de valores válidos.
-    </simpara>
-</listitem>
+<!-- OpenSSL -->
+<!ENTITY openssl.param.x509 '<varlistentry xmlns="http://docbook.org/ns/docbook">
+ <term><parameter>certificate</parameter></term>
+ <listitem>
+  <simpara>
+   Ver los <link linkend="openssl.certparams">parámetros clave/Certificados</link> para una lista de valores válidos.
+  </simpara>
+ </listitem>
 </varlistentry>'>
 
- <!ENTITY openssl.param.csr '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>csr</parameter></term>
-<listitem>
-    <simpara>
-        Ver los <link linkend="openssl.certparams">parámetros CSR</link> para obtener una lista de los valores válidos.
-    </simpara>
-</listitem>
+<!ENTITY openssl.param.csr '<varlistentry xmlns="http://docbook.org/ns/docbook">
+ <term><parameter>csr</parameter></term>
+ <listitem>
+  <simpara>
+   Ver los <link linkend="openssl.certparams">parámetros CSR</link> para obtener una lista de los valores válidos.
+  </simpara>
+ </listitem>
 </varlistentry>'>
 
- <!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>key</parameter></term>
-<listitem>
-    <simpara>
-        Ver los <link linkend="openssl.certparams">parámetros clave pública/privada</link> para obtener una lista de los valores válidos.
-    </simpara>
-</listitem>
+<!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
+ <term><parameter>key</parameter></term>
+ <listitem>
+  <simpara>
+   Ver los <link linkend="openssl.certparams">parámetros clave pública/privada</link> para obtener una lista de los valores válidos.
+  </simpara>
+ </listitem>
 </varlistentry>'>
 
- <!-- Image (GD) Notes -->
- <!ENTITY note.config.t1lib '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible
-    si PHP es compilado utilizando <option
-            role="configure">--enable-t1lib[=DIR]</option>.</simpara></note>'>
-
- <!ENTITY note.freetype '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible si
-    si PHP es compilado con soporte Freetype (<option role="configure">--with-freetype-dir=DIR</option>)
+<!-- Image (GD) Notes -->
+<!ENTITY note.config.t1lib '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible
+si PHP es compilado utilizando <option role="configure">--enable-t1lib[=DIR]</option>.
 </simpara></note>'>
 
- <!ENTITY note.gd.notrequired '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función no requiere la biblioteca GD.</simpara></note>'>
+<!ENTITY note.freetype '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible si
+si PHP es compilado con soporte Freetype (<option role="configure">--with-freetype-dir=DIR</option>)
+</simpara></note>'>
 
- <!ENTITY note.gd.interpolation '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función es afectada por
-    el método de interpolación, definido por la función <function>imagesetinterpolation</function>.</simpara></note>'>
+<!ENTITY note.gd.notrequired '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función no requiere la biblioteca GD.</simpara></note>'>
 
- <!ENTITY gd.image.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>image</parameter></term><listitem><simpara>
- Un objeto <classname>GdImage</classname>, retornado por una de las funciones de
- creación de imágenes, como <function>imagecreatetruecolor</function>.
-</simpara></listitem></varlistentry>'>
+<!ENTITY note.gd.interpolation '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función es afectada por el método de interpolación, definido por la función <function>imagesetinterpolation</function>.</simpara></note>'>
 
- <!ENTITY gd.font.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>font</parameter></term><listitem><simpara>
- Puede ser 1, 2, 3, 4, 5 para las fuentes internas de codificación Latin2
- (donde los números más grandes corresponden a fuentes anchas) o una instancia
- de <classname>GdFont</classname> retornado por <function>imageloadfont</function>.
-</simpara></listitem></varlistentry>'>
+<!ENTITY gd.image.description '<varlistentry xmlns="http://docbook.org/ns/docbook"> <term>
+<parameter>image</parameter></term><listitem><simpara> Un objeto <classname>GdImage</classname>, retornado por una de las funciones de creación de
+imágenes, como <function>imagecreatetruecolor</function>.</simpara></listitem></varlistentry>'>
 
- <!ENTITY gd.changelog.gdfont-instance '<row xmlns="http://docbook.org/ns/docbook">
- <entry>8.1.0</entry>
- <entry>
-  El parámetro <parameter>font</parameter> ahora acepta una instancia de <classname>GdFont</classname>
-  y un &integer;; anteriormente solo un  &integer; era aceptado.
- </entry>
+<!ENTITY gd.font.description '<varlistentry xmlns="http://docbook.org/ns/docbook"> <term>
+<parameter>font</parameter></term><listitem><simpara> Puede ser 1, 2, 3, 4, 5 para las fuentes internas de
+codificación Latin2 (donde los números más grandes corresponden a fuentes anchas) o una instancia de <classname>GdFont</classname> retornado
+por <function>imageloadfont</function>.</simpara></listitem></varlistentry>'>
+
+<!ENTITY gd.changelog.gdfont-instance '<row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.1.0</entry>
+  <entry>
+  El parámetro <parameter>font</parameter> ahora acepta una instancia de <classname>GdFont</classname> y
+  un &integer;; anteriormente solo un &integer; era aceptado.
+  </entry>
 </row>'>
 
- <!ENTITY gd.ttf.fontfile "
+<!ENTITY gd.ttf.fontfile "
     <varlistentry xmlns='http://docbook.org/ns/docbook'>
      <term><parameter>fontfile</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La ruta de acceso al fichero de la fuente TrueType que desea utilizar.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Dependiendo de qué versión de la biblioteca GD esté utilizando PHP, <emphasis>cuando
        <parameter>fontfile</parameter> no comienza con una barra diagonal inicial
        <literal>/</literal> entonces <literal>.ttf</literal> será añadido</emphasis>
-       al nombre del fichero y la biblioteca intentará buscar ese
-       nombre de fichero a lo largo de una ruta de acceso de fuentes definida por la biblioteca.
-      </para>
-      <para>
+       al nombre del fichero y la biblioteca intentará buscar ese nombre de fichero a lo largo de una
+       ruta de acceso de fuentes definida por la biblioteca.
+      </simpara>
+      <simpara>
        Al utilizar versiones de la biblioteca GD inferiores a 2.0.18, un carácter <literal>espacio</literal>,
-       en lugar de un punto y coma, se utilizaba como 'separador de rutas' para diferentes ficheros de fuentes.
-       El uso no intencional de esta característica resultará en el mensaje de advertencia:
+       en lugar de un punto y coma, se utilizaba como 'separador de rutas' para diferentes ficheros de
+       fuentes. El uso no intencional de esta característica resultará en el mensaje de advertencia:
        <literal>Advertencia: No se pudo encontrar/abrir la fuente</literal>. Para estas versiones afectadas, la
        única solución es mover la fuente a una ruta que no contenga espacios.
-      </para>
+      </simpara>
       <para>
        En muchos casos donde una fuente reside en el mismo directorio que el script que la utiliza,
        el siguiente truco aliviará cualquier problema de inclusión.
        <programlisting role='php'>
 <![CDATA[
 <?php
-// Establecer la variable de entorno para GD
+// Set the environment variable for GD
 putenv('GDFONTPATH=' . realpath('.'));
-// Nombre de la fuente a ser utilizada (note la falta de la extensión .ttf)
+
+// Name the font to be used (note the lack of the .ttf extension)
 $font = 'SomeFont';
 ?>
 ]]>
        </programlisting>
       </para>
       <note>
-       <para>
+       <simpara>
         Tenga en cuenta que <link linkend='ini.open-basedir'>open_basedir</link> no
         <emphasis>aplica</emphasis> a <parameter>fontfile</parameter>.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -1078,17 +1046,17 @@ $font = 'SomeFont';
 
 <!ENTITY gd.source.width 'Ancho de la fuente.'>
 
-<!ENTITY gd.image.path 'La ruta o un recurso de flujo abierto (que se cierra automáticamente después de que esta función retorne) donde guardar el archivo. Si no se define o es &null;, el flujo de imagen sin procesar se enviará directamente.'>
+<!ENTITY gd.image.path 'La ruta o un recurso de flujo abierto (que se cierra automáticamente después de que esta función retorne) donde guardar el fichero. Si no se define o es &null;, el flujo de imagen sin procesar se enviará directamente.'>
 
-<!ENTITY gd.image.new 'Crear una nueva imagen a partir de un archivo o una URL'>
+<!ENTITY gd.image.new 'Crear una nueva imagen a partir de un fichero o una URL'>
 
 <!ENTITY gd.image.source 'Recurso de imagen de origen.'>
 
 <!ENTITY gd.image.destination 'Recurso de imagen de destino.'>
 
-<!ENTITY gd.image.output 'Enviar la imagen al navegador o a un archivo'>
+<!ENTITY gd.image.output 'Enviar la imagen al navegador o a un fichero'>
 
-<!ENTITY gd.image.colors 'Si la imagen fue creada a partir de un archivo, solo se resuelven los colores utilizados en la imagen. Los colores presentes únicamente en la paleta no se resuelven.'>
+<!ENTITY gd.image.colors 'Si la imagen fue creada a partir de un fichero, solo se resuelven los colores utilizados en la imagen. Los colores presentes únicamente en la paleta no se resuelven.'>
 
 <!ENTITY gd.font.size 'El tamaño de la fuente en puntos.'>
 
@@ -1151,8 +1119,8 @@ pruebas.</simpara></warning>'>
 <!ENTITY gd.changelog.image-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>image</parameter> ahora espera una instancia de <classname>GdImage</classname>;
-  anteriormente, se esperaba un <type>resource</type> <literal>gd</literal> válido.
+  <parameter>image</parameter> ahora espera una instancia de <classname>GdImage</classname>
+  ; anteriormente, se esperaba un recurso <literal>gd</literal> de tipo <type>resource</type> válido.
  </entry>
 </row>'>
 
@@ -1160,8 +1128,8 @@ pruebas.</simpara></warning>'>
 <!ENTITY warning.csv.escape-parameter '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"><simpara>
  Cuando <parameter>escape</parameter> se define con un valor diferente a una cadena vacía
  (<literal>""</literal>), puede resultar en un CSV que no sea compatible con
- <link xlink:href="&url.rfc;4180">RFC 4180</link> o que no pueda sobrevivir a un ciclo de ida y vuelta
- a través de las funciones CSV de PHP. El valor predeterminado de <parameter>escape</parameter> es
+ <link xlink:href="&url.rfc;4180">RFC 4180</link> o que no pueda sobrevivir a un ciclo de ida
+ y vuelta a través de las funciones CSV de PHP. El valor predeterminado de <parameter>escape</parameter> es
  <literal>"\\"</literal>, por lo que se recomienda definirlo explícitamente como cadena vacía.
  El valor predeterminado cambiará en una futura versión de PHP, no antes de PHP 9.0.
 </simpara></warning>'>
@@ -1200,24 +1168,24 @@ devuelto por <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 <!ENTITY curl.changelog.handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>handle</parameter> ahora espera una instancia de <classname>CurlHandle</classname>;
-  anteriormente, se esperaba un <type>resource</type>.
+  <parameter>handle</parameter> ahora espera una instancia de <classname>CurlHandle</classname>
+  ; anteriormente, se esperaba un <type>resource</type>.
  </entry>
 </row>'>
 
 <!ENTITY curl.changelog.multi-handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>multi_handle</parameter> ahora espera una instancia de <classname>CurlMultiHandle</classname>;
-  anteriormente, se esperaba un <type>resource</type>.
+  <parameter>multi_handle</parameter> ahora espera una instancia de <classname>CurlMultiHandle</classname>
+  ; anteriormente, se esperaba un <type>resource</type>.
  </entry>
 </row>'>
 
 <!ENTITY curl.changelog.share-handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>share_handle</parameter> ahora espera una instancia de <classname>CurlShareHandle</classname>;
-  anteriormente, se esperaba un <type>resource</type>.
+  <parameter>share_handle</parameter> ahora espera una instancia de <classname>CurlShareHandle</classname>
+  ; anteriormente, se esperaba un <type>resource</type>.
  </entry>
 </row>'>
 
@@ -1226,8 +1194,8 @@ devuelto por <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 <!ENTITY dba.changelog.dba-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  El parámetro <parameter>dba</parameter> ahora espera una instancia de <classname>Dba\Connection</classname>;
-  anteriormente, se esperaba un &resource; <literal>dba</literal> válido.
+  El parámetro <parameter>dba</parameter> ahora espera una instancia de <classname>Dba\Connection</classname>
+  ; anteriormente, se esperaba un &resource; <literal>dba</literal> válido.
  </entry>
 </row>'>
 
@@ -1286,16 +1254,16 @@ devuelto por <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 <!ENTITY enchant.changelog.broker-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>broker</parameter> ahora espera una instancia de <classname>EnchantBroker</classname>;
-  anteriormente, se esperaba un &resource;.
+  <parameter>broker</parameter> ahora espera una instancia de <classname>EnchantBroker</classname>; anteriormente,
+  se esperaba un &resource;.
  </entry>
 </row>'>
 
 <!ENTITY enchant.changelog.dictionary-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
-  <parameter>dictionary</parameter> ahora espera una instancia de <classname>EnchantDictionary</classname>;
-  anteriormente, se esperaba un &resource;.
+  <parameter>dictionary</parameter> ahora espera una instancia de <classname>EnchantDictionary</classname>; anteriormente,
+  se esperaba un &resource;.
  </entry>
 </row>'>
 
@@ -1304,8 +1272,8 @@ devuelto por <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 <!ENTITY imap.changelog.imap-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>imap</parameter> ahora espera una instancia de <classname>IMAP\Connection</classname>;
-  anteriormente, se esperaba un &resource; <literal>imap</literal> válido.
+  El parámetro <parameter>imap</parameter> ahora espera una instancia de <classname>IMAP\Connection</classname>
+  ; anteriormente, se esperaba un &resource; <literal>imap</literal> válido.
  </entry>
 </row>'>
 
@@ -1317,18 +1285,18 @@ devuelto por <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 <parameter>imap</parameter></term><listitem><simpara>Un flujo IMAP devuelto por
 <function>imap_open</function>.</simpara></listitem></varlistentry>'>
 
-<!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Especifica en qué parte de la jerarquía del buzón
-comenzar la búsqueda.</simpara><simpara xmlns="http://docbook.org/ns/docbook">Hay dos caracteres especiales que se pueden
-pasar como parte del <parameter>pattern</parameter>:
+<!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Especifica en qué parte de la jerarquía del
+buzón comenzar la búsqueda.</simpara><simpara xmlns="http://docbook.org/ns/docbook">Hay dos caracteres especiales que se
+pueden pasar como parte del <parameter>pattern</parameter>:
 &apos;<literal>*</literal>&apos; y &apos;<literal>&#37;</literal>&apos;.
 &apos;<literal>*</literal>&apos; significa devolver todos los buzones. Si se pasa
-<parameter>pattern</parameter> como &apos;<literal>*</literal>&apos;, se
-obtendrá una lista de toda la jerarquía del buzón.
+<parameter>pattern</parameter> como &apos;<literal>*</literal>&apos;, se obtendrá
+una lista de toda la jerarquía del buzón.
 &apos;<literal>&#37;</literal>&apos;
 significa devolver solo el nivel actual.
 &apos;<literal>&#37;</literal>&apos; como parámetro <parameter>pattern</parameter>
-devolverá solo los buzones de nivel superior;
-&apos;<literal>~/mail/&#37;</literal>&apos; en <literal>UW_IMAPD</literal> devolverá cada buzón en el directorio <filename>~/mail</filename>, pero ninguno en las subcarpetas de ese directorio.</simpara>'>
+devolverá solo los buzones de nivel
+superior; &apos;<literal>~/mail/&#37;</literal>&apos; en <literal>UW_IMAPD</literal> devolverá cada buzón en el directorio <filename>~/mail</filename>, pero ninguno en las subcarpetas de ese directorio.</simpara>'>
 
 <!ENTITY imap.mailboxname.insecure '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
 Pasar datos no confiables a este parámetro es <emphasis>inseguro</emphasis>, a menos que
@@ -1372,9 +1340,9 @@ Pasar datos no confiables a este parámetro es <emphasis>inseguro</emphasis>, a 
 
 <!ENTITY ldap.warn.control-paged '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.4.0, y fue <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0.
-  En su lugar, se debe utilizar el parámetro <parameter>controls</parameter> de <function>ldap_search</function>.
-  Véase también <link linkend="ldap.controls">LDAP Controls</link> para más detalles.
+  Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 7.4.0, y fue <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0. En su lugar, se
+  debe utilizar el parámetro <parameter>controls</parameter> de <function>ldap_search</function>. Véase
+  también <link linkend="ldap.controls">LDAP Controls</link> para más detalles.
  </simpara>
 </warning>'>
 
@@ -1388,57 +1356,57 @@ Pasar datos no confiables a este parámetro es <emphasis>inseguro</emphasis>, a 
 <!ENTITY ldap.changelog.ldap-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>ldap</parameter> ahora espera una instancia de <classname>LDAP\Connection</classname>;
-  anteriormente, se esperaba un &resource; <literal>ldap link</literal> válido.
+  El parámetro <parameter>ldap</parameter> ahora espera una instancia de <classname>LDAP\Connection</classname>
+  ; anteriormente, se esperaba un &resource; <literal>ldap link</literal> válido.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.entry-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>entry</parameter> ahora espera una instancia de <classname>LDAP\ResultEntry</classname>;
-  anteriormente, se esperaba un &resource; <literal>ldap result entry</literal> válido.
+  El parámetro <parameter>entry</parameter> ahora espera una instancia de <classname>LDAP\ResultEntry</classname>
+  ; anteriormente, se esperaba un &resource; <literal>ldap result entry</literal> válido.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.result-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>result</parameter> ahora espera una instancia de <classname>LDAP\Result</classname>;
-  anteriormente, se esperaba un &resource; <literal>ldap result</literal> válido.
+  El parámetro <parameter>result</parameter> ahora espera una instancia de <classname>LDAP\Result</classname>
+  ; anteriormente, se esperaba un &resource; <literal>ldap result</literal> válido.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.return-result-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  Ahora devuelve una instancia de <classname>LDAP\Result</classname>;
-  anteriormente, se devolvía un &resource;.
+  Ahora devuelve una instancia de <classname>LDAP\Result</classname>; anteriormente,
+  se devolvía un &resource;.
  </entry>
 </row>'>
 
 <!ENTITY ldap.changelog.return-result-entry-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  Ahora devuelve una instancia de <classname>LDAP\ResultEntry</classname>;
-  anteriormente, se devolvía un &resource;.
+  Ahora devuelve una instancia de <classname>LDAP\ResultEntry</classname>; anteriormente,
+  se devolvía un &resource;.
  </entry>
 </row>'>
 
 <!ENTITY ldap.return-result 'Devuelve una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
 <!ENTITY ldap.return-result-array 'Devuelve una instancia de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>, un array de instancias de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
 
-<!ENTITY ldap.return-result-array-info '<simpara xmlns="http://docbook.org/ns/docbook">También es posible realizar búsquedas en paralelo. En este caso, el primer argumento debe ser un array de
-instancias de <classname>LDAP\Connection</classname>, en lugar de una sola.
-Si las búsquedas no deben utilizar todas el mismo DN base y filtro, se puede pasar un array de DN base y/o un array de filtros como argumentos.
-Estos arrays deben tener el mismo tamaño que el array de instancias de <classname>LDAP\Connection</classname>,
-ya que las primeras entradas de los arrays se utilizan para una búsqueda, las segundas entradas para otra, y así sucesivamente.
-Al realizar búsquedas en paralelo, se devuelve un array de instancias de <classname>LDAP\Result</classname>, excepto en caso de error, donde el valor de retorno será &false;.</simpara>'>
+<!ENTITY ldap.return-result-array-info '<simpara xmlns="http://docbook.org/ns/docbook">También es posible realizar búsquedas en paralelo. En este caso, el primer argumento debe ser un array de instancias de
+<classname>LDAP\Connection</classname>, en lugar de una sola.
+Si las búsquedas no deben utilizar todas el mismo DN base y filtro, se puede pasar un array de DN base y/o un array de filtros como argumentos. Estos arrays deben
+tener el mismo tamaño que el array de instancias de <classname>LDAP\Connection</classname>, ya
+que las primeras entradas de los arrays se utilizan para una búsqueda, las segundas entradas para otra, y así sucesivamente. Al realizar búsquedas en
+paralelo, se devuelve un array de instancias de <classname>LDAP\Result</classname>, excepto en caso de error, donde el valor de retorno será &false;.</simpara>'>
 
 <!-- mbstring notes -->
 
-<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><simpara>La codificación interna o la
-codificación de caracteres especificada por <function>mb_regex_encoding</function>
+<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><simpara>La codificación interna o la codificación
+de caracteres especificada por <function>mb_regex_encoding</function>
 se utilizará como codificación de caracteres para esta función.</simpara></note>'>
 
 <!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><simpara>La
@@ -1446,8 +1414,8 @@ codificación de caracteres especificada por <function>mb_regex_encoding</functi
 se utilizará como codificación de caracteres para esta función de forma predeterminada.</simpara></note>'>
 
 <!ENTITY mbstring.encoding.parameter '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>encoding</parameter>
-es la codificación de caracteres. Si se omite o es &null;, se utilizará el valor de la codificación
-de caracteres interna.</simpara>'>
+es la codificación de caracteres. Si se omite o es &null;, se utilizará el valor
+de la codificación de caracteres interna.</simpara>'>
 
 <!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Nunca utilice el modificador <literal>e</literal> con datos de entrada no confiables. No se realizará ningún escape automático (como se conoce de <function>preg_replace</function>). No tener esto en cuenta probablemente creará vulnerabilidades de ejecución remota de código en la aplicación.</simpara></warning>'>
 
@@ -1484,9 +1452,9 @@ de caracteres interna.</simpara>'>
 <!-- memcached notes -->
 
 <!ENTITY memcached.note.delete-time '<note xmlns="http://docbook.org/ns/docbook"><simpara>
-       A partir de memcached 1.3.0 (publicado en 2009) esta funcionalidad ya no está
-       soportada. Pasar un valor distinto de cero para <parameter>time</parameter> causará
-       que la eliminación falle. <methodname>Memcached::getResultCode</methodname>
+       A partir de memcached 1.3.0 (publicado en 2009) esta funcionalidad ya no está soportada. Pasar
+       un valor distinto de cero para <parameter>time</parameter> causará que
+       la eliminación falle. <methodname>Memcached::getResultCode</methodname>
        devolverá <constant>MEMCACHED_INVALID_ARGUMENTS</constant>.
       </simpara></note>
 '>
@@ -1506,73 +1474,68 @@ de caracteres interna.</simpara>'>
 
 <!ENTITY memcached.result.delete-multi '<simpara xmlns="http://docbook.org/ns/docbook">
    Devuelve un array indexado por <parameter>keys</parameter>. Cada elemento
-   es &true; si la clave correspondiente fue eliminada, o una de las
-   constantes <constant>Memcached::RES_<replaceable>*</replaceable></constant> si la eliminación correspondiente
+   es &true; si la clave correspondiente fue eliminada, o una de las constantes
+   <constant>Memcached::RES_<replaceable>*</replaceable></constant> si la eliminación correspondiente
    falló.
    </simpara>
   <simpara xmlns="http://docbook.org/ns/docbook">
-   <methodname>Memcached::getResultCode</methodname> devolverá
-   el código de resultado de la última operación de eliminación ejecutada, es decir, la operación de eliminación
-   del último elemento de <parameter>keys</parameter>.
+   <methodname>Memcached::getResultCode</methodname> devolverá el
+   código de resultado de la última operación de eliminación ejecutada, es decir, la operación
+   de eliminación del último elemento de <parameter>keys</parameter>.
   </simpara>
 '>
 
- <!-- password notes -->
+<!-- password notes -->
 
- <!ENTITY password.parameter.algo 'Una <link xmlns="http://docbook.org/ns/docbook" linkend="password.constants">constante del algoritmo
-de contraseña</link> que representa el algoritmo a utilizar durante el hasheo de la contraseña.'>
+<!ENTITY password.parameter.algo 'Una <link xmlns="http://docbook.org/ns/docbook" linkend="password.constants">constante del algoritmo de contraseña</link> que representa el algoritmo a utilizar durante el hasheo de la contraseña.'>
 
- <!ENTITY password.parameter.hash 'Un hash creado por la función <function xmlns="http://docbook.org/ns/docbook">password_hash</function>.'>
+<!ENTITY password.parameter.hash 'Un hash creado por la función <function xmlns="http://docbook.org/ns/docbook">password_hash</function>.'>
 
- <!ENTITY password.parameter.options 'Un array asociativo que contiene las opciones.
- Ver también <link xmlns="http://docbook.org/ns/docbook" linkend="password.constants">las constantes del algoritmo de contraseña</link>
- para la documentación sobre las opciones soportadas para cada algoritmo.'>
+<!ENTITY password.parameter.options 'Un array asociativo que contiene las opciones. Ver también <link xmlns="http://docbook.org/ns/docbook" linkend="password.constants">las constantes del algoritmo de contraseña</link> para la documentación sobre las opciones soportadas para cada algoritmo.'>
 
- <!ENTITY password.parameter.password 'La contraseña del usuario.'>
+<!ENTITY password.parameter.password 'La contraseña del usuario.'>
 
- <!-- pspell notes -->
+<!-- pspell notes -->
 
- <!ENTITY pspell.changelog.pspell-dictionary '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pspell.changelog.pspell-dictionary '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>dictionary</parameter> ahora espera una instancia de
-  <classname>PSpell\Dictionary</classname> ; anteriormente, se esperaba un &resource;.
+  El parámetro <parameter>dictionary</parameter> ahora espera una instancia de <classname>PSpell\Dictionary</classname>
+  ; anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
 
- <!ENTITY pspell.changelog.pspell-config '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pspell.changelog.pspell-config '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>config</parameter> ahora espera una instancia de
-  <classname>PSpell\Config</classname> ; anteriormente, se esperaba un &resource;.
+  El parámetro <parameter>config</parameter> ahora espera una instancia de <classname>PSpell\Config</classname>
+  ; anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
 
- <!ENTITY pspell.parameter.pspell-dictionary '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>PSpell\Dictionary</classname>.</simpara>'>
+<!ENTITY pspell.parameter.pspell-dictionary '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>PSpell\Dictionary</classname>.</simpara>'>
 
- <!ENTITY pspell.parameter.pspell-config '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>PSpell\Config</classname>.</simpara>'>
+<!ENTITY pspell.parameter.pspell-config '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>PSpell\Config</classname>.</simpara>'>
 
- <!-- RNP -->
+<!-- RNP -->
 
- <!ENTITY rnp.parameter.ffi-description 'El objeto FFI retornado por <function
-xmlns="http://docbook.org/ns/docbook">rnp_ffi_create</function>.'>
+<!ENTITY rnp.parameter.ffi-description 'El objeto FFI retornado por <function xmlns="http://docbook.org/ns/docbook">rnp_ffi_create</function>.'>
 
- <!ENTITY rnp.parameter.key-format 'El formato de clave para los datos (GPG, KBX, G10).'>
+<!ENTITY rnp.parameter.key-format 'El formato de clave para los datos (GPG, KBX, G10).'>
 
- <!ENTITY rnp.parameter.loadsave-flags 'Ver la descripción de los flags <constant xmlns="http://docbook.org/ns/docbook">
-RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
+<!ENTITY rnp.parameter.loadsave-flags 'Ver la descripción de los flags <constant xmlns="http://docbook.org/ns/docbook">RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
 
- <!-- socket entities -->
+<!-- socket entities -->
 
- <!ENTITY sockets.changelog.socket-param '<row xmlns="http://docbook.org/ns/docbook">
- <entry>8.0.0</entry>
- <entry>
-  <parameter>socket</parameter> ahora es una instancia de <classname>Socket</classname> ;
-  anteriormente, era un <type>resource</type>.
- </entry>
-</row>'>
+<!ENTITY sockets.changelog.socket-param '<row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.0.0</entry>
+  <entry>
+   <parameter>socket</parameter> ahora es una instancia de <classname>Socket</classname> ;
+   anteriormente, era un <type>resource</type>.
+  </entry>
+ </row>'>
 
- <!ENTITY sockets.changelog.address-param '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY sockets.changelog.address-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
   <parameter>address</parameter> ahora es una instancia de <classname>AddressInfo</classname> ;
@@ -1580,25 +1543,25 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
  </entry>
 </row>'>
 
- <!-- geaman notes -->
+<!-- geaman notes -->
 
- <!ENTITY gearman.parameter.host 'El nombre de host del servidor de trabajos.'>
+<!ENTITY gearman.parameter.host 'El nombre de host del servidor de trabajos.'>
 
- <!ENTITY gearman.parameter.port 'El puerto del servidor de trabajos.'>
+<!ENTITY gearman.parameter.port 'El puerto del servidor de trabajos.'>
 
- <!ENTITY gearman.parameter.functionname 'Una función registrada que el trabajador va a ejecutar'>
+<!ENTITY gearman.parameter.functionname 'Una función registrada que el trabajador va a ejecutar'>
 
- <!ENTITY gearman.parameter.workload 'Datos serializados a analizar'>
+<!ENTITY gearman.parameter.workload 'Datos serializados a analizar'>
 
- <!ENTITY gearman.parameter.data 'Datos adicionales necesarios para completar el trabajo'>
+<!ENTITY gearman.parameter.data 'Datos adicionales necesarios para completar el trabajo'>
 
- <!ENTITY gearman.parameter.context 'Contexto de la aplicación a asociar con una tarea'>
+<!ENTITY gearman.parameter.context 'Contexto de la aplicación a asociar con una tarea'>
 
- <!ENTITY gearman.parameter.unique 'Un identificador único utilizado para identificar una tarea particular'>
+<!ENTITY gearman.parameter.unique 'Un identificador único utilizado para identificar una tarea particular'>
 
- <!ENTITY gearman.parameter.jobhandle 'El manejador de trabajos asignado por el servidor Gearman'>
+<!ENTITY gearman.parameter.jobhandle 'El manejador de trabajos asignado por el servidor Gearman'>
 
- <!ENTITY gearman.parameter.callback '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!ENTITY gearman.parameter.callback '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>callback</parameter></term>
  <listitem>
   <simpara>
@@ -1606,7 +1569,7 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
    Debe retornar un valor válido <link linkend="gearman.constants">de retorno Gearman</link>.
   </simpara>
   <simpara>
-   Si no se proporciona una instrucción de retorno, el valor por omisión será <constant>GEARMAN_SUCCESS</constant>.
+   Si no se proporciona una instrucción de retorno, el valor predeterminado será <constant>GEARMAN_SUCCESS</constant>.
   </simpara>
   <methodsynopsis>
    <type>int</type><methodname><replaceable>callback</replaceable></methodname>
@@ -1634,166 +1597,148 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
  </listitem>
 </varlistentry>'>
 
- <!ENTITY gearman.note.callback '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY gearman.note.callback '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  El callback solo será disparado para las tareas que son añadidas (por ejemplo llamando a <methodname>GearmanClient::addTask</methodname>)
-  después de la llamada a este método.
+  El callback solo será disparado para las tareas que son añadidas (por ejemplo llamando a <methodname>GearmanClient::addTask</methodname>) después
+  de la llamada a este método.
  </simpara>
 </note>'>
 
- <!-- Date and time entities -->
- <!ENTITY date.timezone.intro.title '<title xmlns="http://docbook.org/ns/docbook">Lista de Zonas Horarias Soportadas</title>'>
+<!-- Date and time entities -->
+<!ENTITY date.timezone.intro.title '<title xmlns="http://docbook.org/ns/docbook">Lista de Zonas Horarias Soportadas</title>'>
 
- <!ENTITY date.timezone.intro "<para xmlns='http://docbook.org/ns/docbook'>Aquí, se encuentra una lista completa de las
-zonas horarias soportadas por PHP, que pueden ser utilizadas con, por ejemplo,
-<function>date_default_timezone_set</function>.
+<!ENTITY date.timezone.intro "<para xmlns='http://docbook.org/ns/docbook'>
+Aquí, se encuentra una lista completa de las zonas horarias soportadas por PHP, que
+pueden ser utilizadas con, por ejemplo, <function>date_default_timezone_set</function>.
 <caution><simpara>El comportamiento de las zonas horarias que no están listadas aquí es indefinido.</simpara></caution>
-</para><note xmlns='http://docbook.org/ns/docbook'>
-<simpara>La última versión de la base de datos de zonas horarias puede
-    ser instalada vía el comando PECL
-    <link xlink:href='&url.pecl.package.get;timezonedb' xmlns:xlink='http://www.w3.org/1999/xlink'>timezonedb</link>.
+</para><note xmlns='http://docbook.org/ns/docbook'> <simpara>La última versión de la base de datos de zonas horarias puede ser instalada
+vía el comando PECL <link xlink:href='&url.pecl.package.get;timezonedb' xmlns:xlink='http://www.w3.org/1999/xlink'>timezonedb</link>.
 </simpara></note>">
 
- <!ENTITY date.timezone.bc '<simpara xmlns="http://docbook.org/ns/docbook">
-No se utilice ninguna de las zonas horarias listadas aquí (excepto UTC), estas
-solo existen por razones de compatibilidad ascendente y su comportamiento puede provocar errores.
-Además, estas zonas horarias pueden ser eliminadas de la base de datos IANA de zonas horarias en cualquier momento.
+<!ENTITY date.timezone.bc '<simpara xmlns="http://docbook.org/ns/docbook"> No se utilice ninguna de las zonas horarias listadas
+aquí (excepto UTC), estas solo existen por razones de compatibilidad ascendente y su comportamiento puede provocar errores. Además, estas
+zonas horarias pueden ser eliminadas de la base de datos IANA de zonas horarias en cualquier momento.
 </simpara>'>
 
- <!ENTITY date.timezone.posix-signs '<simpara xmlns="http://docbook.org/ns/docbook">
-Si se ignora la advertencia anterior, tenga en cuenta que la base de datos de la IANA que proporciona el soporte de zonas
-horarias en PHP utiliza los signos POSIX lo que significa que las zonas
-<literal>Etc/GMT+n</literal> y <literal>Etc/GMT-n</literal> están invertidas
-respecto al uso común.
+<!ENTITY date.timezone.posix-signs '<simpara xmlns="http://docbook.org/ns/docbook">
+ Si se ignora la advertencia anterior, tenga en cuenta que la base de datos de la
+ IANA que proporciona el soporte de zonas horarias en PHP utiliza los signos
+ POSIX lo que significa que las zonas <literal>Etc/GMT+n</literal> y
+ <literal>Etc/GMT-n</literal> están invertidas respecto al uso común.
 </simpara>
 <simpara xmlns="http://docbook.org/ns/docbook">
-Por ejemplo, la zona horaria 8 horas después de GMT que se utiliza en China y
-en Australia Occidental es actualmente <literal>Etc/GMT-8</literal> en
-esta base de datos, y no <literal>Etc/GMT+8</literal> como se podría esperar.
+ Por ejemplo, la zona horaria 8 horas después de GMT que se utiliza en China
+ y en Australia Occidental es actualmente
+ <literal>Etc/GMT-8</literal> en esta base de datos, y no
+ <literal>Etc/GMT+8</literal> como se podría esperar.
 </simpara>
 <simpara xmlns="http://docbook.org/ns/docbook">
-Una vez más, se recomienda encarecidamente que se utilice la zona horaria correcta
-para su ubicación, como <literal>Asia/Shanghai</literal> o
-<literal>Australia/Perth</literal> para los ejemplos anteriores.
+ Una vez más, se recomienda encarecidamente que se utilice la zona horaria
+ correcta para su ubicación, como <literal>Asia/Shanghai</literal> o
+ <literal>Australia/Perth</literal> para los ejemplos anteriores.
 </simpara>'>
 
- <!ENTITY date.timezone.abbrev-volatile '<simpara xmlns="http://docbook.org/ns/docbook">
-Estas abreviaturas de zonas horarias deben ser consideradas como no permanentes, es decir
-pueden ser diferentes para cada versión de la base de datos de zonas horarias, y por lo tanto no deben ser utilizadas. Se recomienda encarecidamente evitarlas.
+<!ENTITY date.timezone.abbrev-volatile '<simpara xmlns="http://docbook.org/ns/docbook">
+Estas abreviaturas de zonas horarias deben ser consideradas como no permanentes, es decir pueden
+ser diferentes para cada versión de la base de datos de zonas horarias, y por lo
+tanto no deben ser utilizadas. Se recomienda encarecidamente evitarlas.
 </simpara>'>
 
- <!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
-Cada llamada a una función de fecha/hora generará un diagnóstico de tipo
-<constant>E_WARNING</constant> si la zona horaria no es válida.
-Ver también <function>date_default_timezone_set</function></simpara>'>
+<!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
+Cada llamada a una función de fecha/hora generará un diagnóstico de tipo <constant>E_WARNING</constant>
+si la zona horaria no es válida. Ver también <function>date_default_timezone_set</function></simpara>'>
 
- <!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
-    Emite un mensaje de tipo <constant>E_STRICT</constant> y <constant>E_NOTICE</constant>
-    durante errores de zonas horarias.</simpara></entry></row>'>
+<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
+Emite un mensaje de tipo <constant>E_STRICT</constant> y <constant>E_NOTICE</constant>
+durante errores de zonas horarias.</simpara></entry></row>'>
 
- <!ENTITY date.timestamp.description '
+<!ENTITY date.timestamp.description '
 <varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
-    El parámetro opcional <parameter>timestamp</parameter> es un timestamp
-    Unix de tipo &integer; que por omisión es la hora actual local si
-    <parameter>timestamp</parameter> es omitido o &null;. En otras
-    palabras, es por omisión el valor de la función <function>time</function>.
+El parámetro opcional <parameter>timestamp</parameter> es un
+<type>int</type> timestamp Unix que por defecto es la hora
+local actual si <parameter>timestamp</parameter> se omite o es &null;. En
+otras palabras, por defecto toma el valor de <function>time</function>.
 </simpara></listitem></varlistentry>'>
 
- <!ENTITY date.datetime.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
-<listitem><simpara>Solo en estilo procedimental: un objeto <classname>DateTime</classname>
-    retornado por <function>date_create</function></simpara></listitem></varlistentry>'>
+<!ENTITY date.datetime.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
+<listitem><simpara>Solo en estilo procedimental: un objeto <classname>DateTime</classname> retornado
+por <function>date_create</function></simpara></listitem></varlistentry>'>
 
- <!ENTITY date.datetime.description.modified '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
-<listitem><simpara>Solo en estilo procedimental: Un objeto <classname>DateTime</classname>
-    retornado por la función <function>date_create</function>.
-    Esta función modifica este objeto.</simpara></listitem></varlistentry>'>
+<!ENTITY date.datetime.description.modified '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
+<listitem><simpara>Solo en estilo procedimental: Un objeto <classname>DateTime</classname> retornado
+por la función <function>date_create</function>.
+Esta función modifica este objeto.</simpara></listitem></varlistentry>'>
 
- <!ENTITY date.datetimezone.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>object</parameter></term><listitem><simpara>
- Solo en estilo procedimental: un objeto <classname>DateTimeZone</classname>
- retornado por <function>timezone_open</function>
-</simpara></listitem></varlistentry>'>
+<!ENTITY date.datetimezone.description '<varlistentry xmlns="http://docbook.org/ns/docbook"> <term>
+<parameter>object</parameter></term><listitem><simpara> Solo en estilo procedimental: un objeto <classname>DateTimeZone</classname> retornado
+por <function>timezone_open</function> </simpara></listitem></varlistentry>'>
 
- <!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Retorna el objeto modificado <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> para encadenar métodos&return.falseforfailure;.'>
- <!ENTITY date.datetime.return.modifiedobject 'Retorna el objeto modificado <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> para encadenar métodos.'>
- <!ENTITY date.datetimeimmutable.return.modifiedobjectorfalseforfailure 'Retorna un nuevo objeto
- <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> con los datos modificados &return.falseforfailure;.'>
- <!ENTITY date.datetimeimmutable.return.modifiedobject 'Retorna un nuevo objeto
- <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> con los datos modificados.'>
+<!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Retorna el objeto modificado <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> para encadenar métodos&return.falseforfailure;.'>
+<!ENTITY date.datetime.return.modifiedobject 'Retorna el objeto modificado <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> para encadenar métodos.'>
+<!ENTITY date.datetimeimmutable.return.modifiedobjectorfalseforfailure 'Retorna un nuevo objeto <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> con los datos modificados &return.falseforfailure;.'>
+<!ENTITY date.datetimeimmutable.return.modifiedobject 'Retorna un nuevo objeto <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> con los datos modificados.'>
 
- <!ENTITY date.timezone.dbversion 'Esta lista está basada en la versión de la base de datos de zonas horarias'>
+<!ENTITY date.timezone.dbversion 'Esta lista está basada en la versión de la base de datos de zonas horarias'>
 
- <!ENTITY date.timezone.africa 'África'>
- <!ENTITY date.timezone.america 'América'>
- <!ENTITY date.timezone.antarctica 'Antártida'>
- <!ENTITY date.timezone.arctic 'Ártico'>
- <!ENTITY date.timezone.asia 'Asia'>
- <!ENTITY date.timezone.atlantic 'Atlántico'>
- <!ENTITY date.timezone.australia 'Australia'>
- <!ENTITY date.timezone.europe 'Europa'>
- <!ENTITY date.timezone.indian 'Índico'>
- <!ENTITY date.timezone.pacific 'Pacífico'>
- <!ENTITY date.timezone.others 'Otros'>
- <!ENTITY date.timezone.abbreviations 'Abreviaturas'>
+<!ENTITY date.timezone.africa 'África'>
+<!ENTITY date.timezone.america 'América'>
+<!ENTITY date.timezone.antarctica 'Antártida'>
+<!ENTITY date.timezone.arctic 'Ártico'>
+<!ENTITY date.timezone.asia 'Asia'>
+<!ENTITY date.timezone.atlantic 'Atlántico'>
+<!ENTITY date.timezone.australia 'Australia'>
+<!ENTITY date.timezone.europe 'Europa'>
+<!ENTITY date.timezone.indian 'Índico'>
+<!ENTITY date.timezone.pacific 'Pacífico'>
+<!ENTITY date.timezone.others 'Otros'>
+<!ENTITY date.timezone.abbreviations 'Abreviaturas'>
 
- <!ENTITY date.formats 'Los formatos válidos son explicados en la documentación sobre los
-<link xmlns="http://docbook.org/ns/docbook" linkend="datetime.formats">formatos de Fecha y Hora</link>.'>
- <!ENTITY date.formats.parameter 'Una cadena de fecha/hora. &date.formats;'>
+<!ENTITY date.formats 'Los formatos válidos son explicados en la documentación sobre los <link xmlns="http://docbook.org/ns/docbook" linkend="datetime.formats">formatos de Fecha y Hora</link>.'>
+<!ENTITY date.formats.parameter 'Una cadena de fecha/hora. &date.formats;'>
 
- <!-- Dom Notes -->
- <!ENTITY dom.node.inserted 'Este nodo no será mostrado en el documento,
-        a menos que sea insertado con <function xmlns="http://docbook.org/ns/docbook">DOMNode::appendChild</function>.'>
+<!-- Dom Notes -->
+<!ENTITY dom.node.inserted 'Este nodo no será mostrado en el documento, a
+menos que sea insertado con <function xmlns="http://docbook.org/ns/docbook">DOMNode::appendChild</function>.'>
 
- <!ENTITY dom.malformederror '<simpara xmlns="http://docbook.org/ns/docbook">Aunque el HTML mal-formado debería cargarse con éxito, esta función puede generar
-una advertencia de tipo <constant>E_WARNING</constant> cuando encuentre una mala etiqueta.
-<link linkend="function.libxml-use-internal-errors">Las funciones de manejo de errores libxml</link>
-pueden ser utilizadas para manejar estos errores.</simpara>'>
-
- <!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- La extensión DOM utiliza el codificado UTF-8. Utilice <function>mb_convert_encoding</function>,
- <methodname>UConverter::transcode</methodname>, o <function>iconv</function> para manipular otros codificados.
-</simpara></note>'>
-
- <!ENTITY dom.note.modern.utf8 '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.malformederror '<simpara xmlns="http://docbook.org/ns/docbook">Aunque el HTML mal-formado debería cargarse con éxito, esta función puede generar una advertencia de tipo <constant>E_WARNING</constant> cuando encuentre una mala etiqueta.<link linkend="function.libxml-use-internal-errors">Las funciones de manejo de errores libxml</link>pueden ser utilizadas para manejar estos errores.</simpara>'>
+<!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><simpara>La extensión DOM utiliza el codificado UTF-8. Utilice <function>mb_convert_encoding</function>, <methodname>UConverter::transcode</methodname>, o <function>iconv</function> para manipular otros codificados.</simpara></note>'>
+<!ENTITY dom.note.modern.utf8 '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  La extensión DOM utiliza el codificado UTF-8 al utilizar los métodos o las propiedades.
-  Los métodos del analizador detectan automáticamente el codificado o permiten al llamante especificar un codificado.
+  La extensión DOM utiliza el codificado UTF-8 al utilizar los métodos o las
+  propiedades. Los métodos del analizador detectan automáticamente el codificado o permiten al llamante especificar un codificado.
  </simpara>
 </note>'>
 
- <!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Al utilizar <function>json_encode</function> sobre un objeto
- <classname>DOMDocument</classname> el resultado será el de codificar un objeto vacío.
-</simpara></note>'>
- <!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><simpara> Al utilizar <function>json_encode</function> sobre un objeto <classname>DOMDocument</classname> el resultado será el de codificar un objeto vacío.</simpara></note>'>
+<!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  Utilice <classname>Dom\HTMLDocument</classname> para analizar y tratar el HTML moderno en lugar de <classname>DOMDocument</classname>.
+  Utilice <classname>Dom\HTMLDocument</classname> para analizar y tratar el HTML moderno en
+  lugar de <classname>DOMDocument</classname>.
  </simpara>
  <simpara>
-  Esta función analiza la entrada utilizando un analizador HTML 4. Las reglas de análisis
-  del HTML 5, que son las utilizadas por los navegadores web modernos, son diferentes.
-  Según la entrada, esto puede resultar en una estructura DOM diferente. Por lo tanto,
-  esta función no puede ser utilizada de forma segura para la sanitización del HTML.
+  Esta función analiza la entrada utilizando un analizador HTML 4. Las reglas de análisis del
+  HTML 5, que son las utilizadas por los navegadores web modernos, son diferentes. Según la entrada,
+  esto puede resultar en una estructura DOM diferente. Por lo tanto, esta función no
+  puede ser utilizada de forma segura para la sanitización del HTML.
  </simpara>
  <simpara>
   El comportamiento durante el análisis del HTML puede depender de la versión de
-  <literal>libxml</literal> que se utilice, especialmente en lo que respecta
-  a los casos límite y el manejo de errores.
-  Para un análisis conforme a la especificación HTML5,
+  <literal>libxml</literal> que se utilice, especialmente en lo que respecta a
+  los casos límite y el manejo
+  de errores. Para un análisis conforme a la especificación HTML5,
   utilice <methodname>Dom\HTMLDocument::createFromString</methodname> o
   <methodname>Dom\HTMLDocument::createFromFile</methodname>, añadidos en PHP 8.4.
  </simpara>
  <simpara>
-  Por ejemplo, algunos elementos HTML cerrarán implícitamente un elemento padre
-  cuando sean encontrados. Las reglas de cierre automático de elementos padres
-  difieren entre HTML 4 y HTML 5, y por lo tanto, la estructura DOM que
-  <classname>DOMDocument</classname> ve puede ser diferente de la que un navegador
-  web ve, lo que puede permitir potencialmente a un atacante comprometer el HTML
-  resultante.
+  Por ejemplo, algunos elementos HTML cerrarán implícitamente un elemento padre cuando sean
+  encontrados. Las reglas de cierre automático de elementos padres difieren
+  entre HTML 4 y HTML 5, y por lo tanto, la estructura DOM que
+  <classname>DOMDocument</classname> ve puede ser diferente de la que un
+  navegador web ve, lo que puede permitir potencialmente a un atacante comprometer el
+  HTML resultante.
  </simpara>
 </warning>'>
- <!ENTITY dom.tokenlist.errors '
-<itemizedlist xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.tokenlist.errors '<itemizedlist xmlns="http://docbook.org/ns/docbook">
  <listitem>
   <simpara>
    Levanta una <exceptionname>ValueError</exceptionname> si
@@ -1813,12 +1758,12 @@ pueden ser utilizadas para manejar estos errores.</simpara>'>
    espacios ASCII.
   </simpara>
  </listitem>
-</itemizedlist>
-'>
+</itemizedlist>'>
 
- <!-- Dom Examples -->
- <!ENTITY dom.book.example '<simpara xmlns="http://docbook.org/ns/docbook">El siguiente ejemplo
-utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
+
+
+<!-- Dom Examples -->
+<!ENTITY dom.book.example '<simpara xmlns="http://docbook.org/ns/docbook">El siguiente ejemplo utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
 <programlisting role="xml" xmlns="http://docbook.org/ns/docbook">
 <!-- Warning: The CDATA markup here is a little tricky. Please DO NOT BREAK it! -->
 <![CDATA[
@@ -1851,54 +1796,54 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
 </books>
 ]]></programlisting>'>
 
- <!-- Dom entities -->
- <!ENTITY dom.parameter.options '<simpara xmlns="http://docbook.org/ns/docbook">
-  <link linkend="language.operators.bitwise">Operación de &apos;OR&apos; lógica</link>
+<!-- Dom entities -->
+<!ENTITY dom.parameter.options '<simpara xmlns="http://docbook.org/ns/docbook">
+  <link linkend="language.operators.bitwise">Operación a nivel de bits <literal>OR</literal></link>
   de las <link linkend="libxml.constants">constantes de opción libxml</link>.
 </simpara>'>
 
- <!ENTITY dom.parameter.compliant.options '&dom.parameter.options;
+<!ENTITY dom.parameter.compliant.options '&dom.parameter.options;
  <simpara xmlns="http://docbook.org/ns/docbook">
   También es posible pasar <constant>Dom\HTML_NO_DEFAULT_NS</constant>
   para desactivar el uso del espacio de nombres HTML y del elemento template.
   Esto solo debería ser utilizado si las implicaciones son correctamente comprendidas.
- </simpara>'>
+</simpara>'>
 
- <!ENTITY dom.parameter.compliant.encoding '<simpara xmlns="http://docbook.org/ns/docbook">
- El codificado en el cual el documento fue creado.
- Si no se proporciona, intentará determinar el codificado más probable utilizado.
- </simpara>'>
+<!ENTITY dom.parameter.compliant.encoding '<simpara xmlns="http://docbook.org/ns/docbook">
+ El codificado en el cual el documento
+ fue creado. Si no se proporciona, intentará determinar el codificado más probable utilizado.
+</simpara>'>
 
- <!ENTITY dom.parser.compliant.note.whitespace '<refsect1 role="notes" xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.parser.compliant.note.whitespace '<refsect1 role="notes" xmlns="http://docbook.org/ns/docbook">
  &reftitle.notes;
  <note>
   <simpara>
-   Los espacios en blanco en las etiquetas <literal>html</literal> y <literal>head</literal>
-   no son considerados significativos y pueden perder su formato.
+   Los espacios en blanco en las etiquetas <literal>html</literal> y <literal>head</literal> no
+   son considerados significativos y pueden perder su formato.
   </simpara>
  </note>
 </refsect1>'>
 
- <!ENTITY dom.parameters.register_node_ns '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.parameters.register_node_ns '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>registerNodeNS</parameter></term>
  <listitem>
   <simpara>
    Indica si se deben registrar automáticamente los prefijos de espacio de nombres en vigor del nodo de contexto en el objeto <classname>DOMXPath</classname>.
-   Esto puede ser utilizado para evitar tener que llamar manualmente a <methodname>DOMXPath::registerNamespace</methodname> para cada espacio de nombres en vigor.
-   En caso de conflicto de prefijos de espacio de nombres, solo se registra el prefijo de espacio de nombres descendiente más cercano.
+   Esto puede ser utilizado para evitar tener que llamar manualmente a <methodname>DOMXPath::registerNamespace</methodname> para cada espacio de nombres en vigor. En
+   caso de conflicto de prefijos de espacio de nombres, solo se registra el prefijo de espacio de nombres descendiente más cercano.
   </simpara>
  </listitem>
 </varlistentry>'>
 
- <!ENTITY dom.parameters.serialize.options '<simpara xmlns="http://docbook.org/ns/docbook">
- Opciones adicionales.
- Las opciones <constant>LIBXML_NOEMPTYTAG</constant>
- y <constant>LIBXML_NOXMLDECL</constant> son soportadas.
- Antes de PHP 8.3.0, solo la opción <constant>LIBXML_NOEMPTYTAG</constant>
+<!ENTITY dom.parameters.serialize.options '<simpara xmlns="http://docbook.org/ns/docbook">
+ Opciones adicionales. Las
+ opciones <constant>LIBXML_NOEMPTYTAG</constant>
+ y <constant>LIBXML_NOXMLDECL</constant> son soportadas. Antes
+ de PHP 8.3.0, solo la opción <constant>LIBXML_NOEMPTYTAG</constant>
  era soportada.
 </simpara>'>
 
- <!ENTITY dom.errors.hierarchy.parent '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.errors.hierarchy.parent '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
   <listitem>
   <simpara>
@@ -1909,7 +1854,7 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
  </listitem>
 </varlistentry>'>
 
- <!ENTITY dom.errors.hierarchy.self '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.errors.hierarchy.self '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
   <listitem>
   <simpara>
@@ -1920,17 +1865,17 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
  </listitem>
 </varlistentry>'>
 
- <!ENTITY dom.errors.wrong_document '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.errors.wrong_document '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_WRONG_DOCUMENT_ERR</constant></term>
   <listitem>
   <simpara>
-    Se levanta si uno de los <parameter>nodes</parameter> transmitidos ha sido creado a partir de un documento diferente
-    del que creó este nodo.
+    Se levanta si uno de los <parameter>nodes</parameter> transmitidos ha sido creado a partir
+    de un documento diferente del que creó este nodo.
   </simpara>
  </listitem>
 </varlistentry>'>
 
- <!ENTITY dom.errors.compliant.wrong_document '<listitem xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.errors.compliant.wrong_document '<listitem xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Levanta una excepción <exceptionname>Dom\DOMException</exceptionname> con el código
   <constant>Dom\WRONG_DOCUMENT_ERR</constant> si el <parameter>node</parameter>
@@ -1938,7 +1883,7 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
  </simpara>
 </listitem>'>
 
- <!ENTITY dom.errors.compliant.common '<listitem xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.errors.compliant.common '<listitem xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Levanta una excepción <exceptionname>ValueError</exceptionname> si
   <parameter>options</parameter> contiene una opción inválida.
@@ -1951,14 +1896,14 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
  </simpara>
 </listitem>'>
 
- <!ENTITY dom.changelog.previous_hierarchy_exception 'Anteriormente, esto desencadenaba una
+<!ENTITY dom.changelog.previous_hierarchy_exception 'Anteriormente, esto desencadenaba una
  <classname xmlns="http://docbook.org/ns/docbook">DOMException</classname> con el código
  <constant xmlns="http://docbook.org/ns/docbook">DOM_HIERARCHY_REQUEST_ERR</constant>.'>
 
- <!ENTITY dom.c14n.xpath_array '<listitem xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.c14n.xpath_array '<listitem xmlns="http://docbook.org/ns/docbook">
   <para>
-   Un array de XPaths para filtrar los nodos.
-   Cada entrada en este array es un array asociativo con:
+   Un array de XPaths para filtrar los nodos. Cada
+   entrada en este array es un array asociativo con:
    <itemizedlist>
     <listitem>
      <simpara>
@@ -1974,200 +1919,196 @@ utiliza el archivo <filename>book.xml</filename>, cuyo contenido es:</simpara>
   </para>
  </listitem>'>
 
- <!-- FileSystem entities -->
- <!ENTITY fs.emits.warning.on.failure '<simpara xmlns="http://docbook.org/ns/docbook">
+<!-- FileSystem entities -->
+<!ENTITY fs.emits.warning.on.failure '<simpara xmlns="http://docbook.org/ns/docbook">
 En caso de fallo, se emitirá una advertencia de tipo <constant>E_WARNING</constant>.
 </simpara>'>
 
- <!ENTITY fs.validfp.all '<simpara xmlns="http://docbook.org/ns/docbook">El puntero de archivo debe ser válido y apuntar
-a un archivo abierto con éxito por <function>fopen</function> o
-<function>fsockopen</function> (y no cerrado aún por <function>fclose</function>).</simpara>'>
+<!ENTITY fs.validfp.all '<simpara xmlns="http://docbook.org/ns/docbook">El puntero de fichero debe ser válido y apuntar a un
+archivo abierto con éxito por <function>fopen</function> o
+<function>fsockopen</function> (y no cerrado aún por
+<function>fclose</function>).</simpara>'>
 
- <!ENTITY fs.file.pointer '<simpara xmlns="http://docbook.org/ns/docbook">Un puntero del sistema de archivos de tipo &resource;
-que es habitualmente creado utilizando la función <function>fopen</function>.</simpara>'>
+<!ENTITY fs.file.pointer '<simpara xmlns="http://docbook.org/ns/docbook">Un puntero al sistema de ficheros de tipo <type>resource</type>
+que típicamente se crea utilizando <function>fopen</function>.</simpara>'>
 
- <!ENTITY fs.file.32bit '<note xmlns="http://docbook.org/ns/docbook"><simpara>
-    Como el tipo entero de PHP es firmado y que muchas plataformas
-    utilizan enteros de 32 bits, algunas funciones relacionadas con el sistema
-    de archivos pueden retornar resultados extraños para archivos de
-    tamaño superior a 2 Go.
-</simpara></note>'>
+<!ENTITY fs.file.32bit '<note xmlns="http://docbook.org/ns/docbook"><simpara>
+    Como el tipo entero de PHP es firmado y que muchas plataformas utilizan enteros de 32 bits,
+    algunas funciones relacionadas con el sistema de archivos pueden retornar resultados extraños para ficheros
+    de tamaño superior a 2 Go.
+   </simpara></note>'>
 
- <!ENTITY ini.scanner.typed '<simpara xmlns="http://docbook.org/ns/docbook">
-A partir de PHP 5.6.1 también puede ser especificado como <constant>INI_SCANNER_TYPED</constant>.
-En este modo los booleanos, null y enteros son preservados tanto como sea posible.
-Las cadenas de caracteres <literal>"true"</literal>, <literal>"on"</literal> y <literal>"yes"</literal>
-son convertidas a &true;. <literal>"false"</literal>, <literal>"off"</literal>, <literal>"no"</literal>
-y <literal>"none"</literal> son considerados como &false;. <literal>"null"</literal> es convertido a &null; en este modo. Además todas las cadenas de caracteres numéricas son convertidas a entero si es posible.
-</simpara>'>
+<!ENTITY ini.scanner.typed '<simpara xmlns="http://docbook.org/ns/docbook">
+    A partir de PHP 5.6.1 también puede ser especificado como <constant>INI_SCANNER_TYPED</constant>.
+    En este modo los booleanos, null y enteros son preservados tanto como sea posible. Las
+    cadenas de caracteres <literal>"true"</literal>, <literal>"on"</literal> y <literal>"yes"</literal>
+    son convertidas a &true;. <literal>"false"</literal>, <literal>"off"</literal>, <literal>"no"</literal>
+    y <literal>"none"</literal> son considerados como &false;. <literal>"null"</literal> es convertido a &null;
+    en este modo. Además todas las cadenas de caracteres numéricas son convertidas a entero si es posible.
+   </simpara>'>
 
- <!-- GNUPG -->
- <!ENTITY gnupg.identifier '<simpara xmlns="http://docbook.org/ns/docbook">El identificador gnupg, generado por una llamada
-a la función <function>gnupg_init</function> o a la función
-<classname>gnupg</classname>.</simpara>'>
+<!-- GNUPG -->
+<!ENTITY gnupg.identifier '<simpara xmlns="http://docbook.org/ns/docbook">El identificador gnupg, generado por una llamada a la función
+<function>gnupg_init</function> o a la función <classname>gnupg</classname>.</simpara>'>
 
- <!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">La huella de la clave.</simpara>'>
+<!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">La huella de la clave.</simpara>'>
 
- <!-- HaruDoc -->
- <!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Emite una excepción <classname>HaruException</classname> en caso de error.</simpara>'>
+<!-- HaruDoc -->
+<!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Emite una excepción <classname>HaruException</classname> en caso de error.</simpara>'>
 
- <!-- ODBC -->
- <!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">El objeto de conexión ODBC,
-ver la documentación de la función <function>odbc_connect</function> para más
-detalles.</simpara>'><!ENTITY odbc.result.object 'El objeto de resultado ODBC'>
+<!-- ODBC -->
+<!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">El objeto de conexión ODBC, ver la documentación de
+la función <function>odbc_connect</function> para más detalles.</simpara>'><!ENTITY odbc.result.object 'El objeto de resultado ODBC'>
 
- <!ENTITY odbc.result.object-return 'Devuelve un objeto de resultado ODBC'>
+<!ENTITY odbc.result.object 'The ODBC result object'>
 
- <!ENTITY odbc.result.object-return-falseforfailure '&odbc.result.object-return;&return.falseforfailure;.'>
+<!ENTITY odbc.result.object-return 'Devuelve un objeto de resultado ODBC'>
 
- <!ENTITY odbc.parameter.catalog 'El catálogo (&apos;calificativo&apos; en el argot ODBC 2).'>
+<!ENTITY odbc.result.object-return-falseforfailure '&odbc.result.object-return;&return.falseforfailure;.'>
 
- <!ENTITY odbc.parameter.schema 'El esquema (&apos;propietario&apos; en el argot ODBC 2).'>
+<!ENTITY odbc.parameter.catalog 'El catálogo (&apos;calificativo&apos; en el argot ODBC 2).'>
 
- <!ENTITY odbc.parameter.search 'Este parámetro acepta los siguientes patrones de búsqueda:
-        <literal xmlns="http://docbook.org/ns/docbook">&#x25;</literal> para buscar cero o más caracteres, y <literal xmlns="http://docbook.org/ns/docbook">_</literal> para buscar un solo carácter.'>
+<!ENTITY odbc.parameter.schema 'El esquema (&apos;propietario&apos; en el argot ODBC 2).'>
 
- <!ENTITY odbc.result.driver-specific 'Los controladores pueden indicar columnas adicionales.'>
+<!ENTITY odbc.parameter.search 'Este parámetro acepta los siguientes patrones de búsqueda:
+<literal xmlns="http://docbook.org/ns/docbook">&#x25;</literal> para buscar cero o más caracteres,
+y <literal xmlns="http://docbook.org/ns/docbook">_</literal> para buscar un solo carácter.'>
 
- <!ENTITY odbc.changelog.connection-param '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY odbc.result.driver-specific 'Los controladores pueden indicar columnas adicionales.'>
+
+<!ENTITY odbc.changelog.connection-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  <parameter>odbc</parameter> ahora espera una instancia de
-  <classname>Odbc\Connection</classname>; anteriormente, se esperaba un <type>resource</type>.
+  <parameter>odbc</parameter> ahora espera una instancia de <classname>Odbc\Connection</classname>
+  ; anteriormente, se esperaba un <type>resource</type>.
  </entry>
 </row>'>
 
- <!ENTITY odbc.changelog.connection-return '&odbc.changelog.connection-param;
- <row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY odbc.changelog.connection-return '<row xmlns="http://docbook.org/ns/docbook">
   <entry>8.4.0</entry>
   <entry>
-  Esta función ahora devuelve una instancia de
-  <classname>Odbc\Connection</classname>; anteriormente, se devolvía un <type>resource</type>.
+   Esta función ahora devuelve una instancia de <classname>Odbc\Connection</classname>; anteriormente,
+   se devolvía un <type>resource</type>.
   </entry>
  </row>'>
 
- <!ENTITY odbc.changelog.credential-params '
-<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY odbc.changelog.credential-params '<row xmlns="http://docbook.org/ns/docbook">
   <entry>8.4.0</entry>
   <entry>
-   <parameter>user</parameter> y <parameter>password</parameter> ahora pueden ser nulos,
-   también son opcionales y valen por omisión &null;.
+   <parameter>user</parameter> y <parameter>password</parameter> ahora pueden ser
+   nulos, también son opcionales y valen por defecto &null;.
   </entry>
-</row>
-<row xmlns="http://docbook.org/ns/docbook">
+ </row>
+ <row xmlns="http://docbook.org/ns/docbook">
   <entry>8.4.0</entry>
   <entry>
-  Anteriormente, el uso de una cadena vacía para <parameter>password</parameter>
-  no incluía <literal>pwd</literal> en la cadena de conexión generada
-  para <parameter>dsn</parameter>.
-  Ahora, <literal>pwd</literal> se incluye en la cadena de conexión, con
-  un valor de cadena vacía.
-  Para restaurar el comportamiento anterior, <parameter>password</parameter> puede
-  ser definido como &null;.
+   Anteriormente, el uso de una cadena vacía para <parameter>password</parameter> no incluía
+   <literal>pwd</literal> en la cadena de conexión generada para <parameter>dsn</parameter>
+   . Ahora, <literal>pwd</literal> se incluye en la cadena de conexión, con un valor de
+   cadena vacía. Para restaurar el comportamiento anterior, <parameter>password</parameter> puede ser definido como &null;.
   </entry>
-</row>
-<row xmlns="http://docbook.org/ns/docbook">
+ </row>
+ <row xmlns="http://docbook.org/ns/docbook">
   <entry>8.4.0</entry>
   <entry>
-  Anteriormente, si <parameter>dsn</parameter> contenía <literal>uid</literal> o <literal>pwd</literal>,
-  entonces los parámetros <parameter>user</parameter> y <parameter>password</parameter> eran ignorados.
-  Ahora, <parameter>user</parameter> solo es ignorado si <parameter>dsn</parameter> contiene
-  <literal>uid</literal>, y <parameter>password</parameter> solo es ignorado si
-  <parameter>dsn</parameter> contiene <literal>pwd</literal>.
+   Anteriormente, si <parameter>dsn</parameter> contenía <literal>uid</literal> o <literal>pwd</literal>
+   , entonces los parámetros <parameter>user</parameter> y <parameter>password</parameter> eran ignorados.
+   Ahora, <parameter>user</parameter> solo es ignorado si <parameter>dsn</parameter> contiene
+   <literal>uid</literal>, y <parameter>password</parameter> solo es ignorado si
+   <parameter>dsn</parameter> contiene <literal>pwd</literal>.
   </entry>
-</row>
-'>
+ </row>'>
 
- <!ENTITY odbc.changelog.result-param '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY odbc.changelog.result-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  <parameter>statement</parameter> ahora espera una instancia de
-  <classname>Odbc\Result</classname>; anteriormente, se esperaba un <type>resource</type>.
+  <parameter>statement</parameter> ahora espera una instancia de <classname>Odbc\Result</classname>
+  ; anteriormente, se esperaba un <type>resource</type>.
  </entry>
 </row>'>
 
- <!ENTITY odbc.changelog.result-return '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY odbc.changelog.result-return '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  Esta función ahora devuelve una instancia de
-  <classname>Odbc\Result</classname>; anteriormente, se devolvía un <type>resource</type>.
+  Esta función ahora devuelve una instancia de <classname>Odbc\Result</classname>
+  ; anteriormente, se devolvía un <type>resource</type>.
  </entry>
 </row>'>
 
- <!-- OAUTH -->
- <!ENTITY oauth.callback.error 'Emite un error <constant xmlns="http://docbook.org/ns/docbook">E_ERROR</constant>
-        si la función de devolución de llamada no puede ser llamada o no ha sido especificada.'>
+<!-- OAUTH -->
+<!ENTITY oauth.callback.error 'Emite un error <constant xmlns="http://docbook.org/ns/docbook">E_ERROR</constant> si
+la función de devolución de llamada no puede ser llamada o no ha sido especificada.'>
 
- <!ENTITY oauth.changelog.error.null 'Antes de esta versión, &null; era devuelto en lugar de &false;.'>
+<!ENTITY oauth.changelog.error.null 'Antes de esta versión, &null; era devuelto en lugar de &false;.'>
 
- <!-- Oracle -->
- <!ENTITY oci.db "<simpara xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'>
-Contiene la instancia <literal>Oracle</literal> a la que debemos conectarnos.
-Esto puede ser una <link xlink:href='&url.oracle.oic.connect;'>cadena de conexión
-    rápida</link>, un nombre de conexión del archivo <filename>tnsnames.ora</filename>,
-o el nombre de una instancia local Oracle.</simpara>
-<simpara xmlns='http://docbook.org/ns/docbook'>Si no se especifica o es &null;, PHP utiliza variables de entorno como <constant>TWO_TASK</constant> (en Linux)
+<!-- Oracle -->
+<!ENTITY oci.db "<simpara xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'> Contiene la
+instancia <literal>Oracle</literal> a la que debemos conectarnos. Esto puede ser
+una <link xlink:href='&url.oracle.oic.connect;'>cadena de conexión
+rápida</link>, un nombre de conexión del
+fichero <filename>tnsnames.ora</filename>, o el nombre de una instancia
+local Oracle.
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>Si no se especifica o es &null;, PHP
+utiliza variables de entorno como <constant>TWO_TASK</constant> (en Linux)
 o <constant>LOCAL</constant> (en Windows)
 y <constant>ORACLE_SID</constant> para determinar la instancia
 <literal>Oracle</literal> a la que debemos conectarnos.
 </simpara>
 <simpara xmlns='http://docbook.org/ns/docbook'>
-Para usar el método de conexión rápida, PHP debe estar vinculado con la biblioteca
-cliente Oracle 10<emphasis>g</emphasis> o superior. La cadena de conexión rápida para Oracle
+Para usar el método de conexión rápida, PHP debe estar vinculado con la biblioteca cliente Oracle
+10<emphasis>g</emphasis> o superior. La cadena de conexión rápida para Oracle
 10<emphasis>g</emphasis> o superior es de la forma:
 <emphasis>[//]host_name[:port][/service_name]</emphasis>. Desde Oracle
 11<emphasis>g</emphasis>, la sintaxis es:
 <emphasis>[//]host_name[:port][/service_name][:server_type][/instance_name]</emphasis>.
- Opciones adicionales fueron introducidas con Oracle 19c
-Los nombres de los servicios pueden ser encontrados ejecutando la utilidad
-Oracle <literal>lsnrctl status</literal> en la máquina que ejecuta
-la base de datos.
+Opciones adicionales fueron introducidas con Oracle 19c Los
+nombres de los servicios pueden ser encontrados ejecutando la
+utilidad Oracle <literal>lsnrctl status</literal> en la máquina que ejecuta la base
+de datos.
 </simpara>
 <simpara xmlns='http://docbook.org/ns/docbook'>
-El archivo <filename>tnsnames.ora</filename> puede estar en el camino
-de búsqueda de Oracle Net, que incluye
-<filename>/your/path/to/instantclient/network/admin</filename>, <filename>$ORACLE_HOME/network/admin</filename>
-y <filename>/etc</filename>.
-Una solución alternativa sería definir <literal>TNS_ADMIN</literal>
-para que el archivo <filename>$TNS_ADMIN/tnsnames.ora</filename> sea leído.
-Asegúrese de que el demonio que ejecuta el servidor web tenga acceso de lectura a este
-archivo.
+El fichero <filename>tnsnames.ora</filename> puede estar en el camino de búsqueda de Oracle Net,
+que
+incluye <filename>/your/path/to/instantclient/network/admin</filename>, <filename>$ORACLE_HOME/network/admin</filename>
+y <filename>/etc</filename>. Una solución alternativa sería definir <literal>TNS_ADMIN</literal>
+para que el fichero <filename>$TNS_ADMIN/tnsnames.ora</filename> sea leído. Asegúrese de que el demonio que ejecuta
+el servidor web tenga acceso de lectura a este fichero.
 </simpara>">
 
- <!ENTITY oci.charset "<simpara xmlns='http://docbook.org/ns/docbook'>Determina
+<!ENTITY oci.charset "<simpara xmlns='http://docbook.org/ns/docbook'>Determina
 el juego de caracteres utilizado por la biblioteca cliente Oracle. El juego de
-caracteres no necesita ser idéntico al utilizado por la base de datos.
-Si no coincide, Oracle hará lo mejor posible para convertir los datos
-desde el juego de caracteres de la base de datos. Dependiendo de los juegos de caracteres,
-el resultado puede no ser perfecto. Además, esta conversión
-requiere un poco de tiempo del sistema.
+caracteres no necesita ser idéntico al utilizado por la base de datos. Si no coincide, Oracle
+hará lo mejor posible para convertir los datos desde el juego de caracteres de la base
+de datos. Dependiendo de los juegos de caracteres, el resultado puede no ser
+perfecto. Además, esta conversión requiere un poco de tiempo del sistema.
 </simpara>
 <simpara xmlns='http://docbook.org/ns/docbook'>Si no se especifica, la biblioteca
-cliente Oracle determinará un juego de caracteres desde la variable de entorno
-<constant>NLS_LANG</constant>.
+cliente Oracle determinará un juego de caracteres desde la variable de
+entorno <constant>NLS_LANG</constant>.
 </simpara>
 <simpara xmlns='http://docbook.org/ns/docbook'>Pasar este parámetro puede
 reducir el tiempo de conexión.
 </simpara>">
 
- <!ENTITY oci.sessionmode '<simpara xmlns="http://docbook.org/ns/docbook">Este parámetro
-está disponible a partir de PHP 5 (PECL OCI8 1.1) y acepta los siguientes valores:
-<constant>OCI_DEFAULT</constant>, <constant>OCI_SYSOPER</constant> y
-<constant>OCI_SYSDBA</constant>.
-Si bien la constante <constant>OCI_SYSOPER</constant> o la constante
+<!ENTITY oci.sessionmode '<simpara xmlns="http://docbook.org/ns/docbook">Este
+parámetro está disponible a partir de PHP 5 (PECL OCI8 1.1) y acepta los
+siguientes valores: <constant>OCI_DEFAULT</constant>,
+<constant>OCI_SYSOPER</constant> y <constant>OCI_SYSDBA</constant>. Si
+bien la constante <constant>OCI_SYSOPER</constant> o la constante
 <constant>OCI_SYSDBA</constant> es especificada, esta función intentará establecer
-una conexión privilegiada usando identidades externas. Las
-conexiones privilegiadas están desactivadas por omisión. Para activarlas, debe
+una conexión privilegiada usando identidades externas.
+Las conexiones privilegiadas están desactivadas por defecto. Para activarlas, debe
 definir la opción <link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
 a <literal>On</literal>.
 </simpara>
 <simpara xmlns="http://docbook.org/ns/docbook">
 PHP 5.3 (PECL OCI8 1.3.4) introducen el valor de modo
-<constant>OCI_CRED_EXT</constant>. Este modo solicita a Oracle usar una
-identificación externa o bien del sistema operativo, que debe ser
-configurada en la base de datos. El flag <constant>OCI_CRED_EXT</constant>
-solo puede ser usado con el nombre de usuario &quot;/&quot; asociado a una contraseña vacía.
-La opción <link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
+<constant>OCI_CRED_EXT</constant>. Este modo solicita a Oracle usar una identificación externa
+o bien del sistema operativo, que debe ser configurada en la base de
+datos. El flag <constant>OCI_CRED_EXT</constant> solo puede ser usado con el nombre
+de usuario &quot;/&quot; asociado a una contraseña vacía. La opción
+<link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
 puede ser definida a <literal>On</literal> o <literal>Off</literal>.
 </simpara>
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -2176,155 +2117,163 @@ puede ser definida a <literal>On</literal> o <literal>Off</literal>.
 <constant>OCI_SYSDBA</constant>.
 </simpara>
 <simpara xmlns="http://docbook.org/ns/docbook">
-<constant>OCI_CRED_EXT</constant> no es soportado en Windows por razones de seguridad.
+<constant>OCI_CRED_EXT</constant> no es soportado en Windows por razones
+de seguridad.
 </simpara>'>
 
- <!ENTITY oci.datatypes '<simpara xmlns="http://docbook.org/ns/docbook">Para más detalles sobre el mapeo de tipos de datos
-realizado por la extensión OCI8, lea los <link linkend="oci8.datatypes">tipos de datos
-    soportados por el driver</link>.</simpara>'>
+<!ENTITY oci.datatypes '<simpara xmlns="http://docbook.org/ns/docbook">Para más detalles sobre el mapeo de tipos de datos realizado
+por la extensión OCI8, lea los <link linkend="oci8.datatypes">tipos
+de datos soportados por el driver</link>.</simpara>'>
 
- <!ENTITY oci.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">Un identificador de conexión Oracle,
-devuelto por la función <function>oci_connect</function>, <function>oci_pconnect</function>
-o la función <function>oci_new_connect</function>.</simpara>'>
+<!ENTITY oci.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">Un identificador de conexión Oracle, devuelto
+por la función <function>oci_connect</function>, <function>oci_pconnect</function> o la
+función <function>oci_new_connect</function>.</simpara>'>
 
- <!ENTITY oci.availability.note.10g '<note xmlns="http://docbook.org/ns/docbook"><title>Requerido por la versión Oracle</title>
-<simpara>Esta función está disponible si PHP está vinculado a partir de la versión 10<emphasis>g</emphasis>
-    de la biblioteca de la base de datos Oracle.</simpara></note>'>
+<!ENTITY oci.availability.note.10g '<note xmlns="http://docbook.org/ns/docbook"><title>Requerido por la versión Oracle</title>
+<simpara>Esta función está disponible si PHP está vinculado a partir
+de la versión 10<emphasis>g</emphasis> de la biblioteca de la base de datos Oracle.</simpara></note>'>
 
- <!ENTITY oci.clientinfo.tip '<tip xmlns="http://docbook.org/ns/docbook"><title>Rendimiento</title><simpara>Con versiones antiguas de OCI8 o bases de datos Oracle antiguas, la información del cliente
-    puede ser definida usando el paquete Oracle <literal>DBMS_APPLICATION_INFO</literal>.
-    Esto es menos eficiente que usar la función
-    <function>oci_set_client_info</function>.</simpara></tip>'>
+<!ENTITY oci.clientinfo.tip '<tip xmlns="http://docbook.org/ns/docbook"><title>Rendimiento</title><simpara>Con versiones antiguas de OCI8
+o bases de datos Oracle antiguas, la información del cliente puede ser definida usando el paquete Oracle
+<literal>DBMS_APPLICATION_INFO</literal>. Esto es menos eficiente que usar la
+función <function>oci_set_client_info</function>.</simpara></tip>'>
 
- <!ENTITY oci.roundtrip.caution '<caution xmlns="http://docbook.org/ns/docbook"><title>Ida y vuelta</title>
-<simpara>Algunas funciones OCI8 requieren ida y vuelta con la base de datos.
-    Estas ida y vuelta pueden ser evitadas al usar consultas cuyo resultado es almacenado en caché.
+<!ENTITY oci.roundtrip.caution '<caution xmlns="http://docbook.org/ns/docbook"><title>Ida y vuelta</title>
+<simpara>Algunas funciones OCI8 requieren ida y vuelta con la base de datos. Estas ida
+y vuelta pueden ser evitadas al usar consultas cuyo resultado es almacenado en caché.
 </simpara></caution>'>
 
- <!ENTITY oci.use.setprefetch '<simpara xmlns="http://docbook.org/ns/docbook">Para las
-consultas que devuelven un número muy grande de líneas, el rendimiento puede
-ser muy significativamente mejorado aumentando el valor de la opción
-<link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link>
+<!ENTITY oci.use.setprefetch '<simpara xmlns="http://docbook.org/ns/docbook">Para las
+consultas que devuelven un número muy grande de líneas, el rendimiento puede ser muy significativamente mejorado
+aumentando el valor de
+la opción <link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link>
 o usando la función <function>oci_set_prefetch</function>.
 </simpara>'>
 
- <!ENTITY oci.arg.statement.id "<simpara xmlns='http://docbook.org/ns/docbook'>Un identificador de consulta OCI8
-creado por la función <function>oci_parse</function> y ejecutado por la función
-<function>oci_execute</function>, o un identificador de consulta <literal>REF
-    CURSOR</literal>.</simpara>">
 
- <!-- PCNTL Notes -->
- <!ENTITY pcntl.parameter.status '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro
-<parameter>status</parameter> es el parámetro status pasado a una llamada
-de <function>pcntl_waitpid</function> que tuvo éxito.</simpara>'>
+<!ENTITY oci.arg.statement.id
+"<simpara xmlns='http://docbook.org/ns/docbook'>Un identificador de consulta OCI8
+creado por la función <function>oci_parse</function> y ejecutado por
+la función <function>oci_execute</function>, o un identificador de consulta <literal>REF
+CURSOR</literal>.</simpara>">
 
- <!-- PS Notes -->
- <!ENTITY ps.note.visible '<simpara xmlns="http://docbook.org/ns/docbook">La nota no será visible si el documento es impreso o
-mostrado, pero será visible si el documento es convertido a PDF, ya sea por
-Acrobat Distiller™, o por Ghostview.</simpara>'>
+<!-- PCNTL Notes -->
+<!ENTITY pcntl.parameter.status '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>status</parameter>
+es el parámetro status pasado a una
+llamada de <function>pcntl_waitpid</function> que tuvo éxito.</simpara>'>
 
- <!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función es afectada por
-    la directiva de configuración <link linkend="ini.open-basedir">open_basedir</link>.</simpara></note>'>
+<!-- PS Notes -->
+<!ENTITY ps.note.visible '<simpara xmlns="http://docbook.org/ns/docbook">La nota no será visible si el documento es
+impreso o mostrado, pero será visible si el documento es convertido a PDF, ya
+sea por Acrobat Distiller™, o por Ghostview.</simpara>'>
 
- <!ENTITY note.language-construct '<note xmlns="http://docbook.org/ns/docbook"><simpara>Como esto es una estructura
-    del lenguaje, y no una función, no es posible llamarla
-    con las <link linkend="functions.variable-functions">funciones variables</link> o <link linkend="functions.named-arguments">argumentos nombrados</link>.
-</simpara></note>'>
+<!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función es afectada por la directiva de configuración <link
+linkend="ini.open-basedir">open_basedir</link>.</simpara></note>'>
 
- <!-- Common pieces in partintro-sections -->
- <!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna directiva de configuración.</simpara>'>
- <!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ningún recurso.</simpara>'>
- <!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna constante.</simpara>'>
- <!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">No se requiere ninguna biblioteca externa para compilar esta extensión.</simpara>'>
- <!ENTITY no.install '<simpara xmlns="http://docbook.org/ns/docbook">No hay instalación necesaria para
-usar estas funciones, son parte del núcleo de PHP.</simpara>'>
 
- <!-- Used in every chapter that has directive descriptions -->
- <!ENTITY ini.descriptions.title '<simpara xmlns="http://docbook.org/ns/docbook">Aquí hay una aclaración sobre
-el uso de las directivas de configuración.</simpara>'>
+<!ENTITY note.language-construct '<note xmlns="http://docbook.org/ns/docbook"><simpara>Como esto es una estructura
+del lenguaje, y no una función, no es posible llamarla con las
+<link linkend="functions.variable-functions">funciones variables</link>
+o <link linkend="functions.named-arguments">argumentos nombrados</link>.</simpara>
+</note>'>
 
- <!-- Common pieces for reference part BEGIN-->
+<!-- Common pieces in partintro-sections -->
+<!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna directiva de configuración.</simpara>'>
+<!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ningún recurso.</simpara>'>
+<!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna constante.</simpara>'>
+<!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">No se requiere ninguna biblioteca externa para compilar esta extensión.</simpara>'>
+<!ENTITY no.install '<simpara xmlns="http://docbook.org/ns/docbook">No hay instalación necesaria para usar estas
+funciones, son parte del núcleo de PHP.</simpara>'>
 
- <!-- Used in reference/$extname/ini.xml -->
- <!ENTITY extension.runtime '<simpara xmlns="http://docbook.org/ns/docbook">El comportamiento de estas funciones es
-afectado por la configuración en el archivo &php.ini;.</simpara>'>
+<!-- Used in every chapter that has directive descriptions -->
+<!ENTITY ini.descriptions.title '<simpara xmlns="http://docbook.org/ns/docbook">Aquí hay una aclaración sobre el uso de
+las directivas de configuración.</simpara>'>
 
- <!ENTITY ini.php.constants 'Para más detalles sobre los modos INI_*,
-        refiérase a <xref xmlns="http://docbook.org/ns/docbook" linkend="configuration.changes.modes"/>.'>
+<!-- Common pieces for reference part BEGIN-->
 
- <!-- Used in reference/$extname/constants.xml -->
- <!ENTITY extension.constants '<simpara xmlns="http://docbook.org/ns/docbook">Estas constantes son definidas por esta
-extensión, y solo están disponibles si esta extensión ha sido compilada con
-PHP, o bien cargada en tiempo de ejecución.</simpara>'>
+<!-- Used in reference/$extname/ini.xml -->
+<!ENTITY extension.runtime '<simpara xmlns="http://docbook.org/ns/docbook">
+El comportamiento de estas funciones es afectado por la configuración en el archivo &php.ini;.
+</simpara>'>
 
- <!-- For STANDARD Constants used in reference/$extname/constants.xml -->
- <!ENTITY extension.constants.core '<simpara xmlns="http://docbook.org/ns/docbook">Las constantes listadas aquí están
-siempre disponibles en PHP.</simpara>'>
+<!ENTITY ini.php.constants 'Para más detalles sobre los modos
+INI_*, refiérase a <xref xmlns="http://docbook.org/ns/docbook" linkend="configuration.changes.modes"/>.'>
 
- <!-- Used in reference/$extname/classes.xml -->
- <!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook">Estas clases son definidas por esta
-extensión, y solo estarán disponibles si esta extensión ha sido compilada
-con PHP, o bien cargada dinámicamente.</simpara>'>
+<!-- Used in reference/$extname/constants.xml -->
+<!ENTITY extension.constants '<simpara xmlns="http://docbook.org/ns/docbook">
+Estas constantes son definidas por esta extensión, y solo
+están disponibles si esta extensión ha sido compilada
+con PHP, o bien cargada en tiempo de ejecución.
+</simpara>'>
 
- <!-- PDO entities -->
- <!ENTITY pdo.driver-constants '<simpara xmlns="http://docbook.org/ns/docbook">Las constantes a continuación son
-definidas por este controlador y solo estarán disponibles cuando la extensión
-haya sido compilada en PHP o cargada dinámicamente del motor de ejecución.
-Además, estas constantes específicas del controlador deberían ser usadas solo
-si se usa este controlador. Usar atributos específicos de un controlador
-con otro controlador podría causar un comportamiento inesperado.
-<function>PDO::getAttribute</function> podría ser usado para obtener
-el atributo <constant>PDO::ATTR_DRIVER_NAME</constant> para verificar el
-controlador, si su código puede funcionar en múltiples controladores.</simpara>'>
+<!-- For STANDARD Constants used in reference/$extname/constants.xml -->
+<!ENTITY extension.constants.core '<simpara xmlns="http://docbook.org/ns/docbook">
+Las constantes listadas aquí están siempre disponibles en PHP.
+</simpara>'>
 
- <!ENTITY pdo.errors.exception-not-errmode '<note xmlns="http://docbook.org/ns/docbook"><simpara>
-    Una excepción será emitida incluso si el atributo <constant>PDO::ATTR_ERRMODE</constant> no vale
-    <constant>PDO::ERRMODE_EXCEPTION</constant>.</simpara></note>'>
+<!-- Used in reference/$extname/classes.xml -->
+<!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook">
+Estas clases son definidas por esta extensión, y
+solo estarán disponibles si esta extensión ha
+sido compilada con PHP, o bien cargada dinámicamente.
+</simpara>'>
 
- <!-- PDO errors -->
+<!-- PDO entities -->
+<!ENTITY pdo.driver-constants '<simpara xmlns="http://docbook.org/ns/docbook">Las constantes a continuación son definidas
+por este controlador y solo estarán disponibles cuando la extensión haya sido compilada en
+PHP o cargada dinámicamente del motor de ejecución. Además, estas constantes específicas
+del controlador deberían ser usadas solo si se usa este controlador. Usar atributos
+específicos de un controlador con otro controlador podría causar un
+comportamiento inesperado. <function>PDO::getAttribute</function> podría ser usado para obtener
+el atributo <constant>PDO::ATTR_DRIVER_NAME</constant> para verificar el controlador,
+si su código puede funcionar en múltiples controladores.</simpara>'>
 
- <!ENTITY pdo.errors '<simpara xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pdo.errors.exception-not-errmode '<note xmlns="http://docbook.org/ns/docbook"><simpara>Una excepción será emitida incluso si el atributo <constant>PDO::ATTR_ERRMODE</constant> no vale <constant>PDO::ERRMODE_EXCEPTION</constant>.</simpara></note>'>
+
+<!-- PDO errors -->
+
+<!ENTITY pdo.errors '<simpara xmlns="http://docbook.org/ns/docbook">
 Emite un error de nivel <constant>E_WARNING</constant> si el atributo <constant>PDO::ATTR_ERRMODE</constant> está definido
 a <constant>PDO::ERRMODE_WARNING</constant>.
 </simpara>
 <simpara xmlns="http://docbook.org/ns/docbook">
-Lanza una excepción <classname>PDOException</classname> si el atributo <constant>PDO::ATTR_ERRMODE</constant> está definido
-a <constant>PDO::ERRMODE_EXCEPTION</constant>.
+Lanza una excepción <classname>PDOException</classname> si el atributo <constant>PDO::ATTR_ERRMODE</constant>
+está definido a <constant>PDO::ERRMODE_EXCEPTION</constant>.
 </simpara>'>
 
- <!-- PECL entities -->
- <!ENTITY pecl.moved 'Esta extensión &link.pecl; no está integrada en PHP.'>
+<!-- PECL entities -->
+<!ENTITY pecl.moved 'Esta extensión &link.pecl; no está integrada en PHP.'>
 
- <!ENTITY pecl.bundled 'Esta extensión &link.pecl; está integrada en PHP.'>
+<!ENTITY pecl.bundled 'Esta extensión &link.pecl; está integrada en PHP.'>
 
- <!ENTITY pecl.info 'Información sobre la instalación de estas extensiones PECL
-        puede ser encontrada en el capítulo del manual titulado <link xmlns="http://docbook.org/ns/docbook" linkend="install.pecl">Instalación
-de extensiones PECL</link>. Otra información como notas sobre nuevas
-        versiones, descargas, fuentes de archivos, información sobre los mantenedores
-        así como un CHANGELOG, pueden ser encontradas aquí:'>
+<!ENTITY pecl.info 'Información sobre la instalación de estas extensiones PECL puede ser
+encontrada en el capítulo del manual titulado <link xmlns="http://docbook.org/ns/docbook" linkend="install.pecl">Instalación
+de extensiones PECL</link>. Otra información como notas sobre nuevas versiones, descargas,
+fuentes de ficheros, información sobre los mantenedores así como un CHANGELOG, pueden
+ser encontradas aquí:'>
 
- <!ENTITY pecl.info.dead 'Esta extensión es considerada no mantenida y muerta.
-        Sin embargo, el código fuente sigue disponible desde el
-<acronym xmlns="http://docbook.org/ns/docbook">SVN</acronym> de
+<!ENTITY pecl.info.dead 'Esta extensión es considerada no mantenida y muerta. Sin embargo, el
+código fuente sigue disponible desde el <acronym xmlns="http://docbook.org/ns/docbook">SVN</acronym> de
 <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> aquí: '>
 
- <!ENTITY pecl.info.dead.git 'Esta extensión es considerada muerta y no mantenida. Sin embargo, el código
-        fuente de esta extensión sigue disponible en el <acronym xmlns="http://docbook.org/ns/docbook">GIT</acronym>
-        de <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym>: '>
+<!ENTITY pecl.info.dead.git 'Esta extensión es considerada muerta y no mantenida. Sin embargo, el código fuente
+de esta extensión sigue disponible en el <acronym xmlns="http://docbook.org/ns/docbook">GIT</acronym> de
+<acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym>: '>
 
- <!ENTITY pecl.windows.download 'No hay biblioteca <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> para esta
-        extensión <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> actualmente disponible. Consulte la sección
-<link xmlns="http://docbook.org/ns/docbook" linkend="install.windows.building">Compilación en Windows</link>.'>
+<!ENTITY pecl.windows.download 'No hay biblioteca <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> para esta extensión
+<acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> actualmente disponible. Consulte la sección
+<link xmlns="http://docbook.org/ns/docbook" linkend="install.windows.building">Compilación en Windows</link>
+.'>
 
- <!ENTITY pecl.windows.download.avail 'Los binarios Windows
-        (los archivos <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym>)
-        para esta extensión <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> están disponibles en el sitio web PECL.'>
+<!ENTITY pecl.windows.download.avail 'Los binarios Windows (los ficheros <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym>)
+para esta extensión <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> están disponibles en el sitio web PECL.'>
 
- <!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
+<!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
 
- <!ENTITY pecl.moved-ver 'Esta extensión ha sido movida al módulo &link.pecl; y no será integrada en PHP a partir de PHP '>
+<!ENTITY pecl.moved-ver 'Esta extensión ha sido movida al módulo &link.pecl;
+y no será integrada en PHP a partir de PHP '>
 
- <!ENTITY pecl.moving.to.pie '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pecl.moving.to.pie '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
   El instalador de Extensiones para PHP (PHP Installer for Extensions - <acronym>PIE</acronym>) es una nueva herramienta que reemplazará PECL.
   Recomendamos usar PIE para instalar extensiones.
@@ -2332,310 +2281,298 @@ de extensiones PECL</link>. Otra información como notas sobre nuevas
  </simpara>
 </note>'>
 
- <!ENTITY warn.pecl.unmaintained '<warning xmlns="http://docbook.org/ns/docbook">
+<!ENTITY warn.pecl.unmaintained '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>Esta extensión es <emphasis>no mantenida</emphasis>.</simpara>
 </warning>'>
 
- <!-- PGSQL entities -->
+<!-- PGSQL entities -->
 
- <!ENTITY pgsql.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>PgSql\Connection</classname>.</simpara>'>
+<!ENTITY pgsql.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>PgSql\Connection</classname>.</simpara>'>
 
- <!ENTITY pgsql.parameter.connection-with-unspecified-default '<para xmlns="http://docbook.org/ns/docbook">
- Una instancia <classname>PgSql\Connection</classname>.
- Cuando <parameter>connection</parameter> no es especificado, se usa la conexión por defecto.
- La conexión por defecto es la última conexión hecha por
- <function>pg_connect</function> o <function>pg_pconnect</function>
- <warning><simpara>Desde PHP 8.1.0, usar la conexión por defecto está obsoleto.</simpara></warning>
-</para>'>
+<!ENTITY pgsql.parameter.connection-with-unspecified-default '<para xmlns="http://docbook.org/ns/docbook">Una <classname>PgSql\Connection</classname> instancia.
+Cuando <parameter>connection</parameter> no es especificado, se usa la conexión por
+defecto. La conexión predeterminada es la última conexión hecha por <function>pg_connect</function>
+o <function>pg_pconnect</function>
+<warning><simpara>Desde PHP 8.1.0, usar la conexión predeterminada está obsoleto.</simpara></warning> </para>'>
 
- <!ENTITY pgsql.parameter.connection-with-nullable-default '<para xmlns="http://docbook.org/ns/docbook">
- Una instancia <classname>PgSql\Connection</classname>.
- Cuando <parameter>connection</parameter> es &null;, se usa la conexión por defecto.
- La conexión por defecto es la última conexión hecha por
- <function>pg_connect</function> o <function>pg_pconnect</function>
- <warning><simpara>Desde PHP 8.1.0, usar la conexión por defecto está obsoleto.</simpara></warning>
- </para>'>
+<!ENTITY pgsql.parameter.connection-with-nullable-default '<para xmlns="http://docbook.org/ns/docbook"> Una instancia <classname>PgSql\Connection</classname>.
+Cuando <parameter>connection</parameter> es &null;, se usa la conexión predeterminada.
+La conexión predeterminada es la última conexión hecha por <function>pg_connect</function>
+o <function>pg_pconnect</function>
+<warning><simpara>Desde PHP 8.1.0, usar la conexión predeterminada está obsoleto.</simpara></warning> </para>'>
 
- <!ENTITY pgsql.parameter.result '<simpara xmlns="http://docbook.org/ns/docbook">
- Una instancia <classname>PgSql\Result</classname>, devuelta por <function>pg_query</function>,
- <function>pg_query_params</function>, o <function>pg_execute</function> (entre otros).
-</simpara>'>
+<!ENTITY pgsql.parameter.result '<simpara xmlns="http://docbook.org/ns/docbook"> Una instancia <classname>PgSql\Result</classname>, devuelta por <function>pg_query</function>,
+<function>pg_query_params</function>, o <function>pg_execute</function> (entre otros).</simpara>'>
 
- <!ENTITY pgsql.parameter.lob '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>PgSql\Lob</classname>, devuelta por <function>pg_lo_open</function>.</simpara>'>
+<!ENTITY pgsql.parameter.lob '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia <classname>PgSql\Lob</classname>, devuelta por <function>pg_lo_open</function>.</simpara>'>
 
- <!ENTITY pgsql.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pgsql.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">
 Un parámetro opcional que controla cómo el <type>array</type> devuelto es indexado.
 <parameter>mode</parameter> es una constante que puede tomar los siguientes valores:
 <constant>PGSQL_ASSOC</constant>, <constant>PGSQL_NUM</constant> y <constant>PGSQL_BOTH</constant>.
 Usando <constant>PGSQL_NUM</constant>, la función devolverá un array con índices numéricos,
-usando <constant>PGSQL_ASSOC</constant>, devolverá solo índices asociativos
-mientras que <constant>PGSQL_BOTH</constant> devolverá ambos índices numéricos y asociativos.</simpara>'>
+usando <constant>PGSQL_ASSOC</constant>, devolverá solo índices asociativos mientras
+que <constant>PGSQL_BOTH</constant> devolverá ambos índices numéricos y asociativos.</simpara>'>
 
- <!ENTITY pgsql.changelog.connection-object '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pgsql.changelog.connection-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>connection</parameter> ahora espera una instancia de
-  <classname>PgSql\Connection</classname> ; anteriormente, se esperaba un &resource;.
+  El parámetro <parameter>connection</parameter> ahora espera una instancia de <classname>PgSql\Connection</classname>
+  ; anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
 
- <!ENTITY pgsql.changelog.result-object '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pgsql.changelog.result-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>result</parameter> ahora espera una instancia de
-  <classname>PgSql\Result</classname> ; anteriormente, se esperaba un &resource;.
+  El parámetro <parameter>result</parameter> ahora espera una instancia de <classname>PgSql\Result</classname>
+  ; anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
 
- <!ENTITY pgsql.changelog.lob-object '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pgsql.changelog.lob-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>lob</parameter> ahora espera una instancia de
-  <classname>PgSql\Lob</classname> ; anteriormente, se esperaba un &resource;.
+  El parámetro <parameter>lob</parameter> ahora espera una instancia de <classname>PgSql\Lob</classname>
+  ; anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
 
- <!ENTITY pgsql.changelog.return-result-object '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pgsql.changelog.return-result-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  Ahora devuelve una instancia de <classname>PgSql\Result</classname> ;
-  anteriormente, se devolvía un &resource;.
+  Ahora devuelve una instancia de <classname>PgSql\Result</classname> ; anteriormente,
+  se devolvía un &resource;.
  </entry>
 </row>'>
 
- <!-- Common pieces for reference part END -->
+<!-- Common pieces for reference part END -->
 
- <!ENTITY windows.builtin '<simpara xmlns="http://docbook.org/ns/docbook">La versión Windows de PHP
-dispone del soporte automático de esta extensión. No es necesario
-añadir ninguna biblioteca adicional para disponer de estas funciones.</simpara>'>
 
- <!-- These are here as helpers for manual consistency and brievety-->
- <!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">safe mode</link>'>
+<!ENTITY windows.builtin '<simpara xmlns="http://docbook.org/ns/docbook">La versión Windows de PHP dispone
+del soporte automático de esta extensión. No es necesario añadir ninguna biblioteca
+adicional para disponer de estas funciones.</simpara>'>
 
- <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">safe mode SQL</link>'>
+<!-- These are here as helpers for manual consistency and brievety-->
+<!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">safe mode</link>'>
 
- <!-- CTYPE Notes -->
- <!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><simpara>
-    Si se proporciona un entero en el rango -128 y 255 inclusive, será interpretado como
-    el valor ASCII de un solo carácter (los valores negativos se verán añadir 256 para permitir
-    caracteres en el rango ASCII extendido). Cualquier otro entero será interpretado como
-    una cadena de caracteres que contiene los dígitos decimales del entero.</simpara></note>'>
+<!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">safe mode SQL</link>'>
 
- <!ENTITY note.ctype.parameter.non-string "<warning xmlns='http://docbook.org/ns/docbook'><simpara>
-Desde PHP 8.1.0, pasar un argumento diferente de una cadena está obsoleto.
-En el futuro, el argumento será interpretado como una cadena de caracteres en lugar de un punto de código ASCII.
-Según el comportamiento deseado, el argumento debe ser convertido a &string; o debe realizarse una llamada explícita a <function>chr</function>.</simpara></warning>">
+<!-- CTYPE Notes -->
+<!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><simpara>
+Si se proporciona un <type>int</type> entre -128 y 255 inclusive, este se interpreta como el valor
+ASCII de un solo carácter (a los valores negativos se les añade 256 para permitir
+caracteres del rango ASCII extendido). Cualquier otro entero se interpreta como un string
+que contiene los dígitos decimales del entero.</simpara></note>'>
 
- <!ENTITY ctype.result.empty-string 'Cuando se llama con una cadena vacía, el resultado será siempre &false;.'>
+<!ENTITY note.ctype.parameter.non-string '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
+A partir de PHP 8.1.0, pasar un argumento que no sea
+string está obsoleto. En el futuro, el argumento se interpretará como un string en lugar de un punto de
+código ASCII. Según el comportamiento deseado, el argumento debería convertirse a &string; o se
+debería realizar una llamada explícita a <function>chr</function>.</simpara></warning>'>
 
- <!-- FTP Notes -->
- <!ENTITY ftp.changelog.ftp-param '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY ctype.result.empty-string 'Cuando se llama con una cadena vacía, el resultado será siempre &false;.'>
+
+<!-- FTP Notes -->
+<!ENTITY ftp.changelog.ftp-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
-  El parámetro <parameter>ftp</parameter> ahora espera una instancia de
-  <classname>FTP\Connection</classname> ; anteriormente, se esperaba un &resource;.
+  El parámetro <parameter>ftp</parameter> ahora espera una instancia de <classname>FTP\Connection</classname>
+  ; anteriormente, se esperaba un &resource;.
  </entry>
 </row>'>
- <!ENTITY ftp.parameter.ftp '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>FTP\Connection</classname>.</simpara>'>
+<!ENTITY ftp.parameter.ftp '<simpara xmlns="http://docbook.org/ns/docbook">Una instancia de <classname>FTP\Connection</classname>.</simpara>'>
 
- <!-- GMP Notes -->
- <!ENTITY gmp.return 'Un objeto <classname xmlns="http://docbook.org/ns/docbook">GMP</classname>.'>
- <!ENTITY gmp.parameter '<simpara xmlns="http://docbook.org/ns/docbook">
+<!-- GMP Notes -->
+<!ENTITY gmp.return 'Un objeto <classname xmlns="http://docbook.org/ns/docbook">GMP</classname>.'>
+<!ENTITY gmp.parameter '<simpara xmlns="http://docbook.org/ns/docbook">
  Un objeto <classname>GMP</classname>, un &integer;,
  o un &string; que puede ser interpretado como un número siguiendo la misma lógica
- que si la cadena fuera usada en <function>gmp_init</function> con detección automática de la base (es decir cuando <parameter>base</parameter> es igual a 0).
+ que si la cadena fuera usada en <function>gmp_init</function> con detección automática
+ de la base (es decir cuando <parameter>base</parameter> es igual a 0).
 </simpara>'>
 
- <!-- MySQLi Notes -->
- <!ENTITY mysqli.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
+<!-- MySQLi Notes -->
+<!ENTITY mysqli.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
 <parameter>result</parameter></term><listitem><simpara>Solo estilo procedimental: Un objeto <classname>mysqli_result</classname>
 devuelto por <function>mysqli_query</function>, <function>mysqli_store_result</function>,
 <function>mysqli_use_result</function> o <function>mysqli_stmt_get_result</function>.</simpara></listitem></varlistentry>'>
- <!ENTITY mysqli.link.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>mysql</parameter></term><listitem><simpara>Solo estilo procedimental: Un objeto <classname>mysqli</classname>
-devuelto por <function>mysqli_connect</function> o <function>mysqli_init</function>
+<!ENTITY mysqli.link.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
+<parameter>mysql</parameter></term><listitem><simpara>Solo estilo procedimental: Un objeto <classname>mysqli</classname> devuelto
+por <function>mysqli_connect</function> o <function>mysqli_init</function>
 </simpara></listitem></varlistentry>'>
- <!ENTITY mysqli.stmt.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>statement</parameter></term><listitem><simpara>Solo estilo procedimental: Un objeto <classname>mysqli_stmt</classname>
-devuelto por <function>mysqli_stmt_init</function>.</simpara></listitem></varlistentry>'>
- <!ENTITY mysqli.available.mysqlnd 'Disponible solo con <link xmlns="http://docbook.org/ns/docbook"
+<!ENTITY mysqli.stmt.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
+<parameter>statement</parameter></term><listitem><simpara>Solo estilo procedimental: Un objeto <classname>mysqli_stmt</classname> devuelto
+por <function>mysqli_stmt_init</function>.</simpara></listitem></varlistentry>'>
+<!ENTITY mysqli.available.mysqlnd 'Disponible solo con <link xmlns="http://docbook.org/ns/docbook"
 linkend="book.mysqlnd">mysqlnd</link>.'>
- <!ENTITY mysqli.charset.note '<note xmlns="http://docbook.org/ns/docbook">
-<simpara>MySQLnd siempre asume el juego de caracteres predeterminado del servidor. Este juego de caracteres es enviado durante el intercambio de conexión/autenticación, el cual mysqlnd utilizará.</simpara><simpara>Libmysqlclient utiliza el juego de caracteres predeterminado establecido en el
-<filename>my.cnf</filename> o mediante una llamada explícita a <function>mysqli_options</function> antes de
-llamar a <function>mysqli_real_connect</function>, pero después de <function>mysqli_init</function>.</simpara></note>'>
- <!ENTITY mysqli.integer.overflow.as.string.note '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mysqli.charset.note '<note xmlns="http://docbook.org/ns/docbook">
+<simpara>MySQLnd siempre asume el juego de caracteres predeterminado del servidor. Este juego de caracteres es enviado durante el
+intercambio de conexión/autenticación, el cual mysqlnd utilizará.</simpara><simpara>Libmysqlclient utiliza el juego de caracteres predeterminado establecido en el
+<filename>my.cnf</filename> o mediante una llamada explícita a <function>mysqli_options</function> antes de llamar
+a <function>mysqli_real_connect</function>, pero después de <function>mysqli_init</function>.</simpara></note>'>
+<!ENTITY mysqli.integer.overflow.as.string.note '<note xmlns="http://docbook.org/ns/docbook">
 <simpara>Si el número de filas es mayor que <constant>PHP_INT_MAX</constant>,
 el número será devuelto como un &string;.</simpara></note>'>
- <!ENTITY mysqli.sqlinjection.warning '<warning xmlns="http://docbook.org/ns/docbook">
-<title>Advertencia de seguridad: Inyección SQL</title><simpara>Si la consulta contiene alguna entrada de variable,
-entonces se deben usar <link linkend="mysqli.quickstart.prepared-statements">sentencias preparadas
-parametrizadas</link> en su lugar. Alternativamente, los datos deben estar correctamente formateados y todas las cadenas deben ser escapadas usando
-la función <function>mysqli_real_escape_string</function>.</simpara></warning>'>
- <!ENTITY mysqli.conditionalexception '<simpara xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mysqli.sqlinjection.warning '<warning xmlns="http://docbook.org/ns/docbook">
+<title>Advertencia de seguridad: Inyección SQL</title><simpara>Si la consulta contiene alguna entrada de variable, entonces
+se deben usar <link linkend="mysqli.quickstart.prepared-statements">sentencias
+preparadas parametrizadas</link> en su lugar. Alternativamente, los datos
+deben estar correctamente formateados y todas las cadenas deben ser escapadas usando la
+función <function>mysqli_real_escape_string</function>
+.</simpara></warning>'>
+<!ENTITY mysqli.conditionalexception '<simpara xmlns="http://docbook.org/ns/docbook">
 Si el informe de errores de mysqli está habilitado (<constant>MYSQLI_REPORT_ERROR</constant>) y la operación solicitada falla,
-se genera una advertencia. Si, además, el modo está configurado como <constant>MYSQLI_REPORT_STRICT</constant>,
-se lanza una <classname>mysqli_sql_exception</classname> en su lugar.</simpara>'>
+se genera una advertencia. Si, además, el modo está configurado como <constant>MYSQLI_REPORT_STRICT</constant>, se
+lanza una <classname>mysqli_sql_exception</classname> en su lugar.</simpara>'>
 
- <!-- Notes for PCRE -->
- <!ENTITY pcre.pattern.warning '<simpara xmlns="http://docbook.org/ns/docbook">
+<!-- Notes for PCRE -->
+<!ENTITY pcre.pattern.warning '<simpara xmlns="http://docbook.org/ns/docbook">
 Si el patrón regex pasado no se compila a una regex válida, se emite una <constant>E_WARNING</constant>.
 </simpara>'>
 
- <!-- Notes for SAPI/Apache -->
- <!ENTITY apache.req.module '<simpara xmlns="http://docbook.org/ns/docbook">Esta función
-es soportada cuando PHP está instalado como módulo de Apache.
+<!-- Notes for SAPI/Apache -->
+<!ENTITY apache.req.module '<simpara xmlns="http://docbook.org/ns/docbook">Esta función es soportada cuando PHP
+está instalado como módulo de Apache.
 </simpara>'>
 
- <!-- Notes for SAPI/FPM -->
- <!ENTITY fpm.intro "<simpara xmlns='http://docbook.org/ns/docbook'>FPM (FastCGI Process Manager, gestor de procesos FastCGI)
-es una alternativa a la implementación PHP FastCGI con funcionalidades adicionales útiles para sitios muy altamente cargados.
-</simpara>">
+<!-- Notes for SAPI/FPM -->
+<!ENTITY fpm.intro '<simpara xmlns="http://docbook.org/ns/docbook">FPM (FastCGI Process Manager, gestor de procesos
+FastCGI) es una implementación de PHP FastCGI que contiene algunas características (principalmente) útiles para sitios con mucha carga.
+</simpara>'>
 
- <!-- SimpleXML Notes -->
- <!ENTITY simplexml.iteration '<note xmlns="http://docbook.org/ns/docbook"><simpara>SimpleXML añade propiedades
-    iterativas para casi todos sus métodos. Estas no pueden ser vistas
-    utilizando <function>var_dump</function> o cualquier otra función que examine los
-    objetos.</simpara></note>'>
+<!-- SimpleXML Notes -->
+<!ENTITY simplexml.iteration '<note xmlns="http://docbook.org/ns/docbook"><simpara>SimpleXML añade propiedades iterativas para casi
+todos sus métodos. Estas no pueden ser vistas utilizando <function>var_dump</function>
+o cualquier otra función que examine los objetos.</simpara></note>'>
 
- <!-- SQLite Notes -->
- <!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">Los nombres de columnas devueltos por
-<constant>SQLITE_ASSOC</constant> y <constant>SQLITE_BOTH</constant>
-siguen las reglas concernientes a la case definidas por la opción de configuración
-<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>.</simpara>'>
+<!-- SQLite Notes -->
+<!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">Los nombres de columnas devueltos por
+<constant>SQLITE_ASSOC</constant> y <constant>SQLITE_BOTH</constant> siguen las reglas
+concernientes a la case definidas por la opción de configuración
+<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>
+.</simpara>'>
 
- <!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">Cuando <parameter>decode_binary</parameter>
-vale &true; (por defecto), PHP va a decodificar los datos binarios, si estos han sido
-codificados con la función <function>sqlite_escape_string</function>.
-Generalmente se dejará este valor en su valor por defecto,
-a menos que se esté trabajando con bases operadas por otras
-aplicaciones.</simpara>'>
+<!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">Cuando <parameter>decode_binary</parameter>
+vale &true; (por defecto), PHP va a decodificar los datos
+binarios, si estos han sido codificados con la función
+<function>sqlite_escape_string</function>. Generalmente se dejará este valor
+en su valor predeterminado, a menos que se esté trabajando con bases
+operadas por otras aplicaciones.</simpara>'>
 
- <!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función no funcionará con
-    resultados no bufferizados.</simpara></note>'>
+<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función no funcionará con
+resultados no bufferizados.</simpara></note>'>
 
- <!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Dos sintaxis alternativas son
-    soportadas para asegurar la compatibilidad con otras bases de datos
-    (tales como MySQL): la forma recomendada es la primera, donde el parámetro
-    <parameter>dbhandle</parameter> es el primero en la función.</simpara></note>'>
+<!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Dos sintaxis alternativas son soportadas
+para asegurar la compatibilidad con otras bases de datos (tales como MySQL):
+la forma recomendada es la primera, donde el parámetro <parameter>dbhandle</parameter>
+es el primero en la función.</simpara></note>'>
 
- <!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro opcional
-<parameter>result_type</parameter> acepta una constante y determina cómo
-el array devuelto debe ser indexado. El uso de
-<constant>SQLITE_ASSOC</constant> devolverá únicamente un array asociativo
-(nombres de los campos) mientras que <constant>SQLITE_NUM</constant> devolverá un
-array indexado numéricamente (número ordinal de los campos).
-<constant>SQLITE_BOTH</constant> devolverá índices numéricos y asociativos.
-<constant>SQLITE_BOTH</constant> es el valor por defecto para esta
-función.</simpara>'>
+<!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro opcional <parameter>result_type</parameter>
+acepta una constante y determina cómo el array devuelto debe ser indexado. El
+uso de <constant>SQLITE_ASSOC</constant> devolverá únicamente un array asociativo (nombres
+de los campos) mientras que <constant>SQLITE_NUM</constant> devolverá un
+array indexado numéricamente (número ordinal de los campos). <constant>SQLITE_BOTH</constant>
+devolverá índices numéricos y asociativos.
+<constant>SQLITE_BOTH</constant> es el valor predeterminado para esta función.</simpara>'>
 
- <!-- Database Notes -->
- <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los nombres de los campos devueltos por
-    esta función son <emphasis>sensibles a la case</emphasis>.</simpara></note>'>
+<!-- Database Notes -->
+<!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los nombres de los campos devueltos por esta función
+son <emphasis>sensibles a la case</emphasis>.</simpara></note>'>
 
- <!ENTITY database.fetch-null '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función define los campos NULL al valor PHP &null;.</simpara></note>'>
+<!ENTITY database.fetch-null '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función define los campos NULL
+al valor PHP &null;.</simpara></note>'>
 
- <!-- MySQL Notes -->
- <!-- The mysql.*.description entities are used in the parameters refsect1 -->
- <!ENTITY mysql.linkid.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>link_identifier</parameter></term><listitem><simpara>
- La conexión MySQL.
- Si no se especifica, se utilizará la última conexión abierta con la función
- <function>mysql_connect</function>. Si no se encuentra una conexión de este tipo,
- la función intentará abrir una conexión, como si la función <function>mysql_connect</function> hubiera sido llamada sin argumento.
- Si no se encuentra o establece una conexión, se generará una alerta de nivel
- <constant>E_WARNING</constant>.
+<!-- MySQL Notes -->
+<!-- The mysql.*.description entities are used in the parameters refsect1 -->
+<!ENTITY mysql.linkid.description '<varlistentry xmlns="http://docbook.org/ns/docbook"> <term>
+<parameter>link_identifier</parameter></term><listitem><simpara> La conexión MySQL. Si no
+se especifica, se utilizará la última conexión abierta con la función
+<function>mysql_connect</function>. Si no se encuentra una conexión de este tipo, la
+función intentará abrir una conexión, como si la función <function>mysql_connect</function> hubiera sido llamada sin
+argumento. Si no se encuentra o establece una conexión, se generará una alerta de nivel
+<constant>E_WARNING</constant>.</simpara></listitem>
+</varlistentry>'>
+
+<!ENTITY mysql.linkid-noreopen.description '<varlistentry
+xmlns="http://docbook.org/ns/docbook"> <term>
+<parameter>link_identifier</parameter></term><listitem><simpara> La conexión MySQL. Si el identificador del
+enlace no se especifica, se utilizará la última conexión abierta con la función
+<function>mysql_connect</function>. Si no se encuentra o establece una conexión, se generará una
+alerta de nivel <constant>E_WARNING</constant>.
 </simpara></listitem></varlistentry>'>
 
- <!ENTITY mysql.linkid-noreopen.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>link_identifier</parameter></term><listitem><simpara>
- La conexión MySQL.
- Si el identificador del enlace no se especifica, se utilizará la última conexión
- abierta con la función <function>mysql_connect</function>.
- Si no se encuentra o establece una conexión, se generará una alerta de nivel
- <constant>E_WARNING</constant>.
-</simpara></listitem></varlistentry>'>
+<!ENTITY mysql.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
+<parameter>result</parameter></term><listitem><simpara>El <type>resource</type> de
+resultado que está siendo evaluado. Este resultado proviene de una llamada a
+<function>mysql_query</function>.</simpara></listitem></varlistentry>'>
 
- <!ENTITY mysql.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>result</parameter></term><listitem><simpara>
- La &resource; de resultado que acaba de ser evaluada.
- Este resultado proviene de la llamada a la función <function>mysql_query</function>.
-</simpara></listitem></varlistentry>'>
+<!ENTITY mysql.field-offset.req.description '<varlistentry xmlns="http://docbook.org/ns/docbook"> <term>
+<parameter>field_offset</parameter></term><listitem><simpara> La posición numérica del campo.
+<parameter>field_offset</parameter> comienza en <literal>0</literal>. Si
+<parameter>field_offset</parameter> no existe, se generará una alerta de nivel
+<constant>E_WARNING</constant>.</simpara></listitem></varlistentry>'>
 
- <!ENTITY mysql.field-offset.req.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>field_offset</parameter></term><listitem><simpara>
- La posición numérica del campo.
- <parameter>field_offset</parameter> comienza en <literal>0</literal>.
- Si <parameter>field_offset</parameter> no existe, se generará una alerta de nivel
- <constant>E_WARNING</constant>.
-</simpara></listitem></varlistentry>'>
+<!ENTITY mysql.alternative.note '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión estaba obsoleta en PHP 5.5.0, y fue eliminada en PHP 7.0.0. En su lugar, se puede
+utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver
+también <link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de
+la guía. Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión
-estaba obsoleta en PHP 5.5.0, y fue eliminada en PHP 7.0.0. En su lugar, se puede
-utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
-<link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también
-<link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de la guía.
-Alternativas a esta función:</simpara>'>
+<!ENTITY mysql.alternative.note.4-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta en PHP 4.3.0, y
+toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0. En
+su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión <link linkend="ref.pdo-mysql">PDO_MySQL</link>.
+Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de
+la guía. Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note.4-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
-en PHP 4.3.0, y toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0.
-En su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
-<link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir
-una API</link> de la guía. Alternativas a esta función:</simpara>'>
+<!ENTITY mysql.alternative.note.5-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta en PHP 5.3.0, y
+toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0. En
+su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión <link linkend="ref.pdo-mysql">PDO_MySQL</link>.
+Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de
+la guía. Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note.5-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
-en PHP 5.3.0, y toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0.
-En su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
-<link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir
-una API</link> de la guía.
-Alternativas a esta función:</simpara>'>
+<!ENTITY mysql.alternative.note.5-4-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta en PHP 5.4.0, y
+toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0. En
+su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión <link linkend="ref.pdo-mysql">PDO_MySQL</link>.
+Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de
+la guía. Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note.5-4-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
-en PHP 5.4.0, y toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0.
-En su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
-<link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir
-    una API</link> de la guía. Alternativas a esta función:</simpara>'>
+<!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta en PHP 5.5.0, y
+toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0. En
+su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión <link linkend="ref.pdo-mysql">PDO_MySQL</link>.
+Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de
+la guía. Alternativas a esta función:</simpara>'>
 
- <!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta
-en PHP 5.5.0, y toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0.
-En su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión
-<link linkend="ref.pdo-mysql">PDO_MySQL</link>. Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir
-    una API</link> de la guía. Alternativas a esta función:</simpara>'>
-
- <!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
-Las conexiones y los juegos de resultados abiertos de forma no persistente son automáticamente
-destruidos cuando un script PHP termina su ejecución. También, el hecho de cerrar una conexión
-y liberar los resultados siendo opcional, el hecho de hacerlo explícitamente es altamente
-recomendado. Esto devolverá los recursos inmediatamente a PHP y a MySQL, lo que mejorará las
-performance. Para más información, refiérase a la
+<!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
+Las conexiones y los juegos de resultados abiertos de forma no persistente son automáticamente destruidos
+cuando un script PHP termina su ejecución. También, el hecho de cerrar una
+conexión y liberar los resultados siendo opcional, el hecho de hacerlo explícitamente es altamente
+recomendado. Esto devolverá los recursos inmediatamente a PHP y a MySQL, lo que mejorará
+las performance. Para más información, refiérase a la
 <link linkend="language.types.resource.self-destruct">liberación de recursos</link></simpara>'>
 
- <!-- Xattr entities -->
- <!ENTITY xattr.namespace '<simpara xmlns="http://docbook.org/ns/docbook">Los atributos extendidos tienen dos espacios de nombres
-diferentes: <literal>user</literal> y <literal>root</literal>. El espacio de nombres
-<literal>user</literal> está disponible para todos los usuarios mientras que el espacio de
-nombres <literal>root</literal> solo está disponible para los usuarios con privilegios
-<literal>root</literal>. xattr opera sobre el espacio de nombres <literal>user</literal> por
-defecto, pero esto puede ser cambiado utilizando el argumento
+<!-- Xattr entities -->
+<!ENTITY xattr.namespace '<simpara xmlns="http://docbook.org/ns/docbook">Los atributos extendidos tienen dos espacios de nombres diferentes:
+user y root. El espacio de nombres user está disponible para todos los usuarios, mientras que el espacio
+de nombres root solo está disponible para usuarios con privilegios de root. xattr opera sobre el espacio
+de nombres user por defecto, pero esto se puede cambiar con el parámetro
 <parameter>flags</parameter>.</simpara>'>
 
- <!-- Notes for IPv6 -->
- <!ENTITY ipv6.brackets '<note xmlns="http://docbook.org/ns/docbook"><simpara>Al especificar direcciones
-    IPv6 en formato numérico (ej. <literal>fe80::1</literal>) se debe colocar la dirección IP
-    entre corchetes. Por ejemplo: <literal>tcp://[fe80::1]:80</literal>.
-</simpara></note>'>
+<!-- Notes for IPv6 -->
+<!ENTITY ipv6.brackets '<note xmlns="http://docbook.org/ns/docbook"><simpara>Al especificar direcciones IPv6 en formato numérico
+(ej. <literal>fe80::1</literal>) se debe colocar la dirección IP entre corchetes.
+Por ejemplo: <literal>tcp://[fe80::1]:80</literal>.</simpara></note>'>
 
- <!-- Notes for tidy -->
- <!ENTITY tidy.object 'El objeto <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>'>
+<!-- Notes for tidy -->
+<!ENTITY tidy.object 'El objeto <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>'>
 
- <!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>config</parameter> puede
-tomar la forma de un array o de una cadena de caracteres. En forma de cadena, representa el nombre del archivo de configuración y de lo contrario, es
-un array con las opciones de configuración. Lea <link xmlns:xlink="http://www.w3.org/1999/xlink"
-                                                          xlink:href="&url.tidy.conf;">&url.tidy.conf;</link> para saber más sobre cada
-opción.</simpara>
-<simpara>El parámetro <parameter>encoding</parameter> especifica el juego de caracteres
-utilizado para los documentos de entrada y salida. Los valores posibles de
-<parameter>encoding</parameter> son:
+<!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>config</parameter> puede
+tomar la forma de un array o de una cadena de caracteres. En forma de cadena,
+representa el nombre del fichero de configuración y de lo contrario, es un array
+con las opciones de configuración. Lea
+<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.tidy.conf;">&url.tidy.conf;</link>
+para saber más sobre cada opción.</simpara> <simpara>El parámetro
+<parameter>encoding</parameter> especifica el juego de caracteres utilizado para los documentos
+de entrada y salida. Los valores posibles de <parameter>encoding</parameter> son:
 <literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
 <literal>raw</literal>, <literal>utf8</literal>, <literal>iso2022</literal>,
 <literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
@@ -2643,90 +2580,84 @@ utilizado para los documentos de entrada y salida. Los valores posibles de
 <literal>utf16be</literal>, <literal>big5</literal> y
 <literal>shiftjis</literal>.</simpara>'>
 
- <!-- Snippets for the installation section -->
- <!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>No se recomienda
-    el uso de PHP en un entorno thread MPM, con Apache 2.
-    Utilice el modo prefork MPM, que es el MPM por defecto para Apache 2.0 y 2.2.
-    Para saber por qué, lea
-    la entrada de la FAQ correspondiente a la
-    <link linkend="faq.installation.apache2">utilización de Apache 2 en un entorno thread MPM</link>.</simpara></warning>'>
- <!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- Snippets for the installation section -->
+<!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>No se recomienda el uso de PHP
+en un entorno thread MPM, con Apache 2. Utilice el modo prefork MPM, que es
+el MPM predeterminado para Apache 2.0 y 2.2. Para
+saber por qué, lea la entrada de la FAQ correspondiente a la
+<link linkend="faq.installation.apache2">utilización de Apache 2 en un entorno thread MPM</link>.</simpara></warning>'>
+<!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <simpara>
- Las versiones provenientes de terceros son consideradas no oficiales y no
- son directamente soportadas por el proyecto PHP. Cualquier bug encontrado
- debe ser reportado al proveedor de estas versiones no oficiales, a menos que
- pueda ser reproducido utilizando las versiones provenientes de <link xlink:href="&url.php.downloads;">
- la zona de descargas oficial</link>.
+  Las versiones provenientes de terceros son consideradas no oficiales y
+  no son directamente soportadas por el proyecto PHP. Cualquier bug encontrado debe ser reportado al proveedor
+  de estas versiones no oficiales, a menos que pueda ser reproducido utilizando las versiones
+  provenientes de <link xlink:href="&url.php.downloads;"> la zona de descargas
+  oficial</link>.
  </simpara>
 </warning>'>
 
- <!ENTITY note.apache.slashes '<note xmlns="http://docbook.org/ns/docbook"><simpara>Recuerde que al añadir
-    valores que representan una ruta en la configuración de Apache bajo Windows,
-    todos los backslash, como <filename>c:\directorio\archivo.ext</filename>, deben ser
-    convertidos a slashes, como
-    <filename>c:/directorio/archivo.ext</filename>. Un slash final puede
-    también ser necesario para los directorios.</simpara></note>'>
+<!ENTITY note.apache.slashes '<note xmlns="http://docbook.org/ns/docbook"><simpara>Recuerde que al añadir valores
+que representan una ruta en la configuración de Apache bajo Windows, todos los
+backslash, como <filename>c:\directorio\fichero.ext</filename>, deben ser convertidos a
+slashes, como <filename>c:/directorio/fichero.ext</filename>. Un slash
+final puede también ser necesario para los directorios.</simpara></note>'>
 
- <!-- Snippets and titles for the contributors section -->
- <!ENTITY Credit.Authors.and.Contributors 'Autores y Contribuyentes'>
+<!-- Snippets and titles for the contributors section -->
+<!ENTITY Credit.Authors.and.Contributors 'Autores y Contribuyentes'>
 
- <!ENTITY Credit.Introduction '<simpara xmlns="http://docbook.org/ns/docbook">Destacamos a las personas más activas en el prólogo del manual pero hay muchos más contribuyentes
-que nos ayudan actualmente en nuestro trabajo o que han proporcionado ayuda
-preciosa al proyecto en el pasado. Hay muchos desconocidos que nos han ayudado
-mediante sus notas concernientes a las páginas del manual que son
-continuamente incluidas en el manual, trabajo del cual estamos muy agradecidos. La lista proporcionada a continuación está ordenada alfabéticamente.</simpara>'>
+<!ENTITY Credit.Introduction '<simpara xmlns="http://docbook.org/ns/docbook">Destacamos a las personas más activas en el
+prólogo del manual pero hay muchos más contribuyentes que nos ayudan actualmente en nuestro trabajo o
+que han proporcionado ayuda preciosa al proyecto en el pasado. Hay muchos desconocidos que nos han
+ayudado mediante sus notas concernientes a las páginas del manual que son
+continuamente incluidas en el manual, trabajo del cual estamos muy agradecidos. La lista proporcionada a continuación está
+ordenada alfabéticamente.
+</simpara>'>
 
- <!ENTITY Credit.Authors.and.Editors 'Autores y Editores'>
+<!ENTITY Credit.Authors.and.Editors 'Autores y Editores'>
 
- <!ENTITY Credit.Past.Authors.Text 'Los siguientes
-        contribuyentes
-        han tenido un impacto enorme al añadir contenido al manual:'>
+<!ENTITY Credit.Past.Authors.Text 'Los siguientes contribuyentes
+han tenido un impacto enorme al añadir contenido
+al manual:'>
 
- <!ENTITY Credit.Past.Editors.Text 'Los siguientes
-        contribuyentes
-        han ayudado enormemente en la edición del manual:'>
+<!ENTITY Credit.Past.Editors.Text 'Los siguientes contribuyentes han ayudado enormemente
+en la edición del manual:'>
 
- <!ENTITY Credit.Note.Editors.Title 'Mantenimiento de las notas de usuarios'>
+<!ENTITY Credit.Note.Editors.Title 'Mantenimiento de las notas de usuarios'>
 
- <!ENTITY Credit.Note.Editors.Active 'Los mantenimientos actualmente más activos son:'>
+<!ENTITY Credit.Note.Editors.Active 'Los mantenimientos actualmente más activos son:'>
 
- <!ENTITY Credit.Note.Editors.Inactive 'Estas personas también han desplegado enormes
-        esfuerzos en el mantenimiento de las notas de usuarios:'>
+<!ENTITY Credit.Note.Editors.Inactive 'Estas personas también han desplegado enormes esfuerzos en el mantenimiento
+de las notas de usuarios:'>
 
- <!ENTITY listendand ' y'>
+<!ENTITY listendand ' y'>
 
- <!-- runkit entities -->
- <!ENTITY note.runkit.selfmanipulation '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función
-    no puede ser utilizada para manipular el método en curso de utilización (o encadenado).</simpara>
+<!-- runkit entities -->
+<!ENTITY note.runkit.selfmanipulation '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función no puede
+ser utilizada para manipular el método en curso de utilización (o encadenado).</simpara>
 </note>'>
 
- <!ENTITY note.runkit.internal-override '<note xmlns="http://docbook.org/ns/docbook"><simpara>Por defecto, solo
-    las funciones definidas por el usuario pueden ser eliminadas,
-    renombradas o modificadas. Para sobreescribir funciones internas, se
-    debe activar la configuración <literal>runkit.internal_override</literal>
-    en el archivo &php.ini; del sistema entero.</simpara></note>'>
+<!ENTITY note.runkit.internal-override '<note xmlns="http://docbook.org/ns/docbook"><simpara>Por defecto, solo
+las funciones definidas por el usuario pueden ser eliminadas, renombradas o modificadas. Para
+sobrescribir funciones internas, se debe activar la configuración
+<literal>runkit.internal_override</literal> en el archivo &php.ini; del sistema entero.</simpara>
+</note>'>
 
- <!-- SSH2 Extension -->
- <!ENTITY note.ssh2.subsystem.publickey '<note xmlns="http://docbook.org/ns/docbook"><simpara>El publickey subsystem
-    es utilizado para gestionar las claves públicas en un servidor en el cual el cliente
-    ya está <emphasis>identificado</emphasis>. Para identificarse a un sistema
-    remoto utilizando la identificación por clave pública, utilice la función
-    <function>ssh2_auth_pubkey_file</function> en su lugar.</simpara></note>'>
+<!-- SSH2 Extension -->
+<!ENTITY note.ssh2.subsystem.publickey '<note xmlns="http://docbook.org/ns/docbook"><simpara>El publickey subsystem es
+utilizado para gestionar las claves públicas en un servidor en el cual el cliente ya está
+<emphasis>identificado</emphasis>. Para identificarse a un sistema remoto utilizando la
+identificación por clave pública, utilice la función
+<function>ssh2_auth_pubkey_file</function> en su lugar.</simpara></note>'>
 
- <!-- Session notes -->
- <!ENTITY returns.session.storage.retval 'El valor devuelto (habitualmente &true; en caso de éxito, &false; si ocurre un error).
-        Tenga en cuenta que este valor es devuelto internamente a PHP para análisis.'>
+<!-- Session notes -->
+<!ENTITY returns.session.storage.retval 'El valor devuelto (habitualmente &true; en caso de éxito, &false; si ocurre un error). Tenga en cuenta que este valor es devuelto internamente a PHP para análisis.'>
 
- <!-- XMLWriter Notes -->
- <!ENTITY xmlwriter.xmlwriter.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>writer</parameter></term><listitem><simpara>
- Únicamente para llamadas procedimentales.
- La instancia <classname>XMLWriter</classname> que es modificada.
- Este objeto proviene de una llamada a <function>xmlwriter_open_uri</function>
- o <function>xmlwriter_open_memory</function>.
-</simpara></listitem></varlistentry>'>
+<!-- XMLWriter Notes -->
+<!ENTITY xmlwriter.xmlwriter.description '<varlistentry xmlns="http://docbook.org/ns/docbook"> <term>
+<parameter>writer</parameter></term><listitem><simpara> Únicamente para llamadas procedimentales. La
+instancia <classname>XMLWriter</classname> que es modificada. Este objeto proviene de una llamada a <function>xmlwriter_open_uri</function> o <function>xmlwriter_open_memory</function>.</simpara></listitem></varlistentry>'>
 
- <!ENTITY xmlwriter.changelog.writer-param '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY xmlwriter.changelog.writer-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
   <parameter>writer</parameter> ahora espera una instancia de <classname>XMLWriter</classname>
@@ -2734,128 +2665,129 @@ continuamente incluidas en el manual, trabajo del cual estamos muy agradecidos. 
  </entry>
 </row>'>
 
- <!-- SOAP notes -->
- <!ENTITY soap.wsdl.mode.only "<note xmlns='http://docbook.org/ns/docbook'><simpara>Esta función solo está disponible en modo WSDL.</simpara></note>">
+<!-- SOAP notes -->
+<!ENTITY soap.wsdl.mode.only "<note xmlns='http://docbook.org/ns/docbook'><simpara>Esta función solo está disponible en modo WSDL.</simpara></note>">
 
- <!-- Stomp notes -->
- <!ENTITY stomp.param.link "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>link</parameter></term><listitem><simpara>Estilo procedimental únicamente: El identificador stomp devuelto por la función<function>stomp_connect</function>.</simpara></listitem></varlistentry>">
- <!ENTITY stomp.param.headers "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>headers</parameter></term><listitem><simpara>Array asociativo que contiene los encabezados adicionales (ejemplo: receipt).</simpara></listitem></varlistentry>">
- <!ENTITY stomp.note.transaction "<note xmlns='http://docbook.org/ns/docbook'><simpara>Un encabezado de transacción puede ser especificado, indicando que la confirmación de los mensajes debe ser parte de la transacción.</simpara></note>">
- <!ENTITY stomp.note.sync "<tip xmlns='http://docbook.org/ns/docbook'><simpara>Stomp es, por naturaleza, asíncrono. Una comunicación síncrona puede ser implementada añadiendo un encabezado <literal>receipt</literal>. Esto hará que los métodos no devuelvan nada hasta que el mensaje de confirmación no haya sido recibido o hasta que el tiempo de espera no sea alcanzado.</simpara></tip>">
+<!-- Stomp notes -->
+<!ENTITY stomp.param.link "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>link</parameter></term><listitem><simpara>Estilo procedimental únicamente: El identificador stomp devuelto por la función<function>stomp_connect</function>.</simpara></listitem></varlistentry>">
+<!ENTITY stomp.param.headers "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>headers</parameter></term><listitem><simpara>Array asociativo que contiene los encabezados adicionales (ejemplo: receipt).</simpara></listitem></varlistentry>">
+<!ENTITY stomp.note.transaction "<note xmlns='http://docbook.org/ns/docbook'><simpara>Un encabezado de transacción puede ser especificado, indicando que la confirmación de los mensajes debe ser parte de la transacción.</simpara></note>">
+<!ENTITY stomp.note.sync "<tip xmlns='http://docbook.org/ns/docbook'><simpara>Stomp es, por naturaleza, asíncrono. Una comunicación síncrona puede ser implementada añadiendo un encabezado receipt. Esto hará que los métodos no devuelvan nada hasta que el mensaje de confirmación no haya sido recibido o hasta que el tiempo de espera no sea alcanzado.</simpara></tip>">
 
- <!-- SVN notes -->
- <!ENTITY svn.relativepath "<note xmlns='http://docbook.org/ns/docbook'><simpara>Los caminos relativos pueden ser resueltos
-    si el directorio de trabajo actual es uno de los que contienen el binario PHP.
-    Para utilizar el directorio de trabajo, utilice la función <function>realpath</function>,
-    o la instrucción dirname(__FILE__).</simpara></note>">
- <!ENTITY svn.referto.status 'Refiérase a las
-<link xmlns="http://docbook.org/ns/docbook" linkend="svn.constants.status">constantes de estado</link> para los valores posibles.'>
- <!ENTITY svn.referto.type 'Refiérase a las <link xmlns="http://docbook.org/ns/docbook" linkend="svn.constants.type">constantes de tipo</link> para los valores posibles.'>
+<!-- SVN notes -->
+<!ENTITY svn.relativepath "<note xmlns='http://docbook.org/ns/docbook'><simpara>Los caminos relativos pueden ser resueltos si el directorio de trabajo actual es uno de los que contienen el binario PHP. Para utilizar el directorio de trabajo, utilice la función <function>realpath</function>, o la instrucción dirname(__FILE__).</simpara></note>">
+<!ENTITY svn.referto.status 'Refiérase a las <link xmlns="http://docbook.org/ns/docbook" linkend="svn.constants.status">constantes de estado</link> para los valores posibles.'>
+<!ENTITY svn.referto.type 'Refiérase a las <link xmlns="http://docbook.org/ns/docbook" linkend="svn.constants.type">constantes de tipo</link> para los valores posibles.'>
 
- <!-- FANN notes -->
- <!ENTITY fann.ann.description '<simpara xmlns="http://docbook.org/ns/docbook">Recurso de red neuronal.</simpara>'>
- <!ENTITY fann.train.description '<simpara xmlns="http://docbook.org/ns/docbook">Recurso de datos de entrenamiento de la red neuronal.</simpara>'>
- <!ENTITY fann.errdat.description '<simpara xmlns="http://docbook.org/ns/docbook">O bien un recurso de red neuronal, o un recurso de datos de entrenamiento de una red neuronal.</simpara>'>
- <!ENTITY fann.return.void '<simpara xmlns="http://docbook.org/ns/docbook">No devuelve ningún valor.</simpara>'>
- <!ENTITY fann.return.bool '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve &true; en caso de éxito, &false; de lo contrario.</simpara>'>
- <!ENTITY fann.return.ann '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve un recurso de red neuronal en caso de éxito, o &false; si ocurre un error.</simpara>'>
- <!ENTITY fann.return.train '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve un recurso de datos de entrenamiento en caso de éxito, o &false; si ocurre un error.</simpara>'>
- <!ENTITY fann.note.function.fann-2.2 '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ahora está disponible si la extensión fann ha sido compilada
-con libfann >= 2.2.</simpara></note>'>
+<!-- FANN notes -->
+<!ENTITY fann.ann.description '<simpara xmlns="http://docbook.org/ns/docbook">Un <type>resource</type> de red neuronal.</simpara>'>
+<!ENTITY fann.train.description '<simpara xmlns="http://docbook.org/ns/docbook">Un <type>resource</type> de datos de entrenamiento de red neuronal.</simpara>'>
+<!ENTITY fann.errdat.description '<simpara xmlns="http://docbook.org/ns/docbook">O bien un <type>resource</type> de red neuronal, o un <type>resource</type> de datos de entrenamiento de red neuronal.</simpara>'>
+<!ENTITY fann.return.void '<simpara xmlns="http://docbook.org/ns/docbook">No devuelve ningún valor.</simpara>'>
+<!ENTITY fann.return.bool '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve &true; en caso de éxito, &false; de lo contrario.</simpara>'>
+<!ENTITY fann.return.ann '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve un <type>resource</type> de red neuronal en caso de éxito, o &false; en caso de error.</simpara>'>
+<!ENTITY fann.return.train '<simpara xmlns="http://docbook.org/ns/docbook">Devuelve un <type>resource</type> de datos de entrenamiento en caso de éxito, o &false; en caso de error.</simpara>'>
+<!ENTITY fann.note.function.fann-2.2 '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ahora está disponible si la extensión fann ha sido compilada con libfann >= 2.2.</simpara></note>'>
 
- <!-- Imagick generic return types -->
- <!ENTITY imagick.return.success 'Devuelve &true; en caso de éxito.'>
- <!ENTITY imagick.imagick.throws 'Lanza una excepción <classname xmlns="http://docbook.org/ns/docbook">ImagickException</classname> si ocurre un error.'>
- <!ENTITY imagick.imagickdraw.throws 'Lanza una excepción <classname xmlns="http://docbook.org/ns/docbook">ImagickDrawException</classname> si ocurre un error.'>
- <!ENTITY imagick.imagickpixel.throws 'Lanza una excepción <classname xmlns="http://docbook.org/ns/docbook">ImagickPixelException</classname> si ocurre un error.'>
- <!ENTITY imagick.imagickpixeliterator.throws 'Lanza una excepción <classname xmlns="http://docbook.org/ns/docbook">ImagickPixelIteratorException</classname> si ocurre un error.'>
+<!-- Imagick generic return types -->
+<!ENTITY imagick.return.success 'Devuelve &true; en caso de éxito.'>
+<!ENTITY imagick.imagick.throws 'Lanza una ImagickException en caso de error.'>
+<!ENTITY imagick.imagickdraw.throws 'Lanza una ImagickDrawException en caso de error.'>
+<!ENTITY imagick.imagickpixel.throws 'Lanza una ImagickPixelException en caso de error.'>
+<!ENTITY imagick.imagickpixeliterator.throws 'Lanza una ImagickPixelIteratorException en caso de error.'>
 
- <!-- Imagick version infos -->
- <!ENTITY imagick.method.available.0x629 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.2.9 o superior.'>
- <!ENTITY imagick.method.available.0x631 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.1 o superior.'>
- <!ENTITY imagick.method.available.0x632 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.2 o superior.'>
- <!ENTITY imagick.method.available.0x636 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.6 o superior.'>
- <!ENTITY imagick.method.available.0x637 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.7 o superior.'>
- <!ENTITY imagick.method.available.0x638 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.8 o superior.'>
- <!ENTITY imagick.method.available.0x639 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.9 o superior.'>
- <!ENTITY imagick.method.available.0x640 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.0 o superior.'>
- <!ENTITY imagick.method.available.0x641 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.1 o superior.'>
- <!ENTITY imagick.method.available.0x642 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.2 o superior.'>
- <!ENTITY imagick.method.available.0x643 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.3 o superior.'>
- <!ENTITY imagick.method.available.0x644 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.4 o superior.'>
- <!ENTITY imagick.method.available.0x645 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.5 o superior.'>
- <!ENTITY imagick.method.available.0x647 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.7 o superior.'>
- <!ENTITY imagick.method.available.0x649 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.9 o superior.'>
- <!ENTITY imagick.method.available.0x653 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.5.3 o superior.'>
- <!ENTITY imagick.method.available.0x657 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.5.7 o superior.'>
+<!-- Imagick version infos -->
+<!ENTITY imagick.method.available.0x629 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.2.9 o superior.'>
+<!ENTITY imagick.method.available.0x631 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.1 o superior.'>
+<!ENTITY imagick.method.available.0x632 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.2 o superior.'>
+<!ENTITY imagick.method.available.0x636 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.6 o superior.'>
+<!ENTITY imagick.method.available.0x637 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.7 o superior.'>
+<!ENTITY imagick.method.available.0x638 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.8 o superior.'>
+<!ENTITY imagick.method.available.0x639 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.9 o superior.'>
+<!ENTITY imagick.method.available.0x640 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.0 o superior.'>
+<!ENTITY imagick.method.available.0x641 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.1 o superior.'>
+<!ENTITY imagick.method.available.0x642 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.2 o superior.'>
+<!ENTITY imagick.method.available.0x643 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.3 o superior.'>
+<!ENTITY imagick.method.available.0x644 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.4 o superior.'>
+<!ENTITY imagick.method.available.0x645 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.5 o superior.'>
+<!ENTITY imagick.method.available.0x647 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.7 o superior.'>
+<!ENTITY imagick.method.available.0x649 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.9 o superior.'>
+<!ENTITY imagick.method.available.0x653 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.5.3 o superior.'>
+<!ENTITY imagick.method.available.0x657 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.5.7 o superior.'>
 
- <!ENTITY imagick.method.not.available.0x700 'Este método no está disponible si Imagick ha sido compilado con ImageMagick versión 7.0.0 o superior.'>
+<!ENTITY imagick.method.not.available.0x700 'Este método no está disponible si Imagick ha sido compilado con ImageMagick versión 7.0.0 o superior.'>
 
- <!ENTITY imagick.constant.available 'Esta constante solo está disponible si Imagick ha sido compilado con ImageMagick versión'>
+<!ENTITY imagick.constant.available 'Esta constante solo está disponible si Imagick ha sido compilado con ImageMagick versión'>
 
- <!ENTITY imagick.deprecated.function-3-4-4 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está <emphasis>DEPRECADA</emphasis> a partir de Imagick 3.4.4. Depender de esta funcionalidad está fuertemente desaconsejado.</simpara></warning>'><!-- Imagick default channel information -->
- <!ENTITY imagick.default.channel.info 'Por omisión, vale <constant xmlns="http://docbook.org/ns/docbook">Imagick::CHANNEL_DEFAULT</constant>. Consúltese la lista de <link xmlns="http://docbook.org/ns/docbook" linkend="imagick.constants.channel">constantes de canales</link>'>
+<!ENTITY imagick.deprecated.function-3-4-4 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está <emphasis>DEPRECADA</emphasis> a partir de Imagick 3.4.4. Depender de esta funcionalidad está fuertemente desaconsejado.</simpara></warning>'><!-- Imagick default channel information -->
 
- <!-- Fuzz parameter -->
- <!ENTITY imagick.parameter.fuzz 'La cantidad de polvo de papel. Por ejemplo, definir el polvo de papel a 10 y el color rojo a una intensidad de 100 y 102 no será interpretado como el mismo color.'>
+<!-- Imagick default channel information -->
+<!ENTITY imagick.default.channel.info 'Por defecto, vale <constant xmlns="http://docbook.org/ns/docbook">Imagick::CHANNEL_DEFAULT</constant>. Consúltese la lista de <link xmlns="http://docbook.org/ns/docbook" linkend="imagick.constants.channel">constantes de canales</link>'>
 
- <!-- Channel parameter -->
- <!ENTITY imagick.parameter.channel 'Proporciona una constante de canal válida para su modo de canal. Para aplicarlo a más de un canal, combínense las <link xmlns="http://docbook.org/ns/docbook" linkend="imagick.constants.channel">constantes de canales</link> utilizando un operador a nivel de bits. &imagick.default.channel.info;'>
+<!-- Fuzz parameter -->
+<!ENTITY imagick.parameter.fuzz 'La cantidad de polvo de papel. Por ejemplo, definir el polvo de papel a 10 y el color rojo a una intensidad de 100 y 102 no será interpretado como el mismo color.'>
 
- <!-- Alpha parameter -->
- <!ENTITY imagick.parameter.alpha 'El grado de transparencia: 1.0 corresponde a totalmente opaco y 0.0 a totalmente transparente.'>
+<!-- Channel parameter -->
+<!ENTITY imagick.parameter.channel 'Proporciona una constante de canal válida para su modo de canal. Para aplicarlo a más de un canal, combínense las <link xmlns="http://docbook.org/ns/docbook" linkend="imagick.constants.channel">constantes de canales</link> utilizando un operador a nivel de bits. &imagick.default.channel.info;'>
 
- <!ENTITY imagick.imagickexception.throw 'Emite una excepción
+<!-- Alpha parameter -->
+<!ENTITY imagick.parameter.alpha 'El grado de transparencia: 1.0 corresponde a totalmente opaco y 0.0 a totalmente transparente.'>
+
+<!ENTITY imagick.imagickexception.throw 'Emite una excepción
 <classname xmlns="http://docbook.org/ns/docbook">ImagickException</classname> en caso de fallo.'>
 
- <!ENTITY imagick.bestfit.note '<note xmlns="http://docbook.org/ns/docbook">
-<simpara>
-    El comportamiento del parámetro <parameter>bestfit</parameter> cambió con Imagick 3.0.0.
-    Antes de esta versión, proporcionar las dimensiones 400x400 a una imagen de dimensiones 200x150
-    hacía que la parte izquierda permaneciera sin cambios. Con Imagick 3.0.0 y posteriores, la
-    imagen se reduce al tamaño 400x300, siendo este el mejor resultado para esas dimensiones. Si el parámetro <parameter>bestfit</parameter> es utilizado, la anchura y la altura deben ser proporcionadas.
-</simpara>
+<!ENTITY imagick.bestfit.note '<note xmlns="http://docbook.org/ns/docbook">
+ <simpara>
+  El comportamiento del parámetro <parameter>bestfit</parameter> cambió con Imagick 3.0.0.
+  Antes de esta versión, proporcionar las dimensiones 400x400 a una imagen de dimensiones 200x150 hacía
+  que la parte izquierda permaneciera sin cambios. Con Imagick 3.0.0 y posteriores, la imagen se reduce al tamaño 400x300,
+  siendo este el mejor resultado para esas dimensiones. Si el parámetro <parameter>bestfit</parameter>
+  es utilizado, la anchura y la altura deben ser proporcionadas.
+ </simpara>
 </note>'>
 
- <!ENTITY note.openssl.cnf '<note xmlns="http://docbook.org/ns/docbook">
-<simpara>
-    Debe existir un archivo <filename>openssl.cnf</filename> válido e
-    instalado para que esta función opere correctamente.
-    Ver las notas encontradas en la <link linkend="openssl.installation">sección
-    concerniente a la instalación</link> para más información.
-</simpara>
+<!ENTITY note.openssl.cnf '<note xmlns="http://docbook.org/ns/docbook">
+ <simpara>
+  Debe existir un archivo <filename>openssl.cnf</filename> válido e instalado
+  para que esta función opere correctamente. Ver
+  las notas encontradas en la <link linkend="openssl.installation">sección concerniente a
+  la instalación</link> para más información.
+ </simpara>
 </note>'>
- <!ENTITY note.openssl.param-notext '<simpara xmlns="http://docbook.org/ns/docbook">
-El parámetro opcional <parameter>notext</parameter> afecta al nivel de verbosidad del display;
-si vale &false;, se añadirán información legible por humanos en el display.
-Por omisión, el parámetro <parameter>notext</parameter> vale &true;.
+<!ENTITY note.openssl.param-notext '<simpara xmlns="http://docbook.org/ns/docbook">
+ El parámetro opcional <parameter>notext</parameter> afecta
+ al nivel de verbosidad del display; si vale &false;, se añadirán información
+ legible por humanos en el display. Por defecto, el parámetro
+ <parameter>notext</parameter> vale &true;.
 </simpara>'>
 
- <!-- COM/Dotnet -->
- <!ENTITY com.variant-arith '<note xmlns="http://docbook.org/ns/docbook">
+<!-- COM/Dotnet -->
+<!ENTITY com.variant-arith '<note xmlns="http://docbook.org/ns/docbook">
 <simpara>
-    Al igual que para todas las funciones aritméticas, los parámetros para esta función
-    pueden ser ya sea un tipo nativo de PHP (entero, string, float, bool o &null;), o una instancia de la clase COM, VARIANT o DOTNET. Los tipos nativos de PHP
-    serán convertidos a VARIANT utilizando las mismas reglas que las encontradas en el
-    constructor de la clase <xref linkend="class.variant"/>. Los objetos COM y DOTNET
-    tendrán el valor de su propiedad por defecto recuperado y utilizado como valor VARIANT.
+ Al igual que para todas las funciones aritméticas, los parámetros para esta función
+ pueden ser ya sea un tipo nativo de PHP (entero, string, float, bool o
+ &null;), o una instancia de la clase COM, VARIANT o DOTNET. Los tipos nativos de PHP
+ serán convertidos a VARIANT utilizando las mismas reglas que las encontradas en el constructor de
+ la clase <xref linkend="class.variant"/>. Los objetos COM y
+ DOTNET tendrán el valor de su propiedad predeterminada recuperado y utilizado como valor VARIANT.
 </simpara>
 <simpara>
-    Las funciones aritméticas VARIANT están interfazadas con las funciones equivalentes de la biblioteca
-    COM; para más información sobre estas funciones, consúltese la biblioteca MSDN. Las funciones PHP tienen nombres ligeramente diferentes:
-    por ejemplo, <function>variant_add</function>, en PHP, corresponde a
-    <literal>VarAdd()</literal> en la documentación MSDN.
+ Las funciones aritméticas VARIANT están interfazadas con las funciones equivalentes
+ de la biblioteca COM; para más información sobre estas funciones, consúltese
+ la biblioteca MSDN. Las funciones PHP tienen nombres ligeramente diferentes: por ejemplo,
+ <function>variant_add</function>, en PHP, corresponde a <literal>VarAdd()
+ </literal> en la documentación MSDN.
 </simpara>
 </note>
 '>
 
- <!-- phar -->
- <!ENTITY phar.write '<note xmlns="http://docbook.org/ns/docbook"><simpara>Este
-    método requiere que la variable de configuración INI <literal>phar.readonly</literal>
-    esté definida a <literal>0</literal> para funcionar con los objetos <classname>Phar</classname>.
-    De lo contrario, se lanzará una excepción <classname>PharException</classname>.</simpara></note>'>
+<!-- phar -->
+<!ENTITY phar.write '<note xmlns="http://docbook.org/ns/docbook"><simpara>Este método
+requiere que la variable de configuración INI <literal>phar.readonly</literal> esté definida
+a <literal>0</literal> para funcionar con los objetos <classname>Phar</classname>
+. De lo contrario, se lanzará una excepción <classname>PharException</classname>.</simpara></note>'>
 
- <!ENTITY phar.note.performance '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY phar.note.performance '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
   <function>Phar::addFile</function>, <function>Phar::addFromString</function> y <function>Phar::offsetSet</function>
   registran un nuevo archivo phar cada vez que son llamadas. Si las prestaciones son una preocupación,
@@ -2864,7 +2796,7 @@ Por omisión, el parámetro <parameter>notext</parameter> vale &true;.
  </simpara>
 </note>'>
 
- <!ENTITY phardata.note.performance '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY phardata.note.performance '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
   <function>PharData::addFile</function>, <function>PharData::addFromString</function> y <function>PharData::offsetSet</function>
   registran un nuevo archivo phar cada vez que son llamadas. Si las prestaciones son una preocupación,
@@ -2873,72 +2805,71 @@ Por omisión, el parámetro <parameter>notext</parameter> vale &true;.
  </simpara>
 </note>'>
 
- <!-- XML -->
- <!ENTITY libxml.required '<simpara xmlns="http://docbook.org/ns/docbook">
- Esta extensión requiere la extensión PHP <link linkend="book.libxml">libxml</link>.
- Esto significa pasar la opción de configuración
- <option role="configure">--with-libxml</option>, o anterior a PHP 7.4
- la opción de configuración <option role="configure">--enable-libxml</option>,
- aunque esto se realiza implícitamente ya que libxml está activado por omisión.
+<!-- XML -->
+<!ENTITY libxml.required '<simpara xmlns="http://docbook.org/ns/docbook">
+ Esta extensión requiere la extensión PHP <link linkend="book.libxml">libxml</link>. Esto significa
+ pasar la opción de configuración <option role="configure">--with-libxml</option>,
+ o anterior a PHP 7.4 la opción de configuración <option role="configure">--enable-libxml</option>,
+ aunque esto se realiza implícitamente ya que libxml
+ está activado por defecto.
 </simpara>'>
 
- <!-- XMLReader -->
- <!ENTITY xmlreader.libxml20620.note '<caution xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible
-    si PHP es compilado utilizando la biblioteca libxml 20620 o posterior.</simpara></caution>'>
+<!-- XMLReader -->
+<!ENTITY xmlreader.libxml20620.note '<caution xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible si PHP es compilado utilizando la biblioteca libxml 20620 o posterior.</simpara></caution>'>
 
- <!-- inotify -->
- <!ENTITY inotify.instance.description 'Recurso retornado por
+<!-- inotify -->
+<!ENTITY inotify.instance.description 'Recurso retornado por
 <function xmlns="http://docbook.org/ns/docbook">inotify_init</function>'>
 
- <!-- User streams -->
- <!ENTITY userstream.not.implemented.warning '<simpara xmlns="http://docbook.org/ns/docbook">Emite una advertencia
+<!-- User streams -->
+<!ENTITY userstream.not.implemented.warning '<simpara xmlns="http://docbook.org/ns/docbook">Emite una advertencia
 <constant>E_WARNING</constant> si la llamada a este método falla
 (i.e. no implementado).</simpara>'>
+<!ENTITY userstream.updates.context '<note xmlns="http://docbook.org/ns/docbook"><simpara>La propiedad
+<varname linkend="streamwrapper.props.context">streamWrapper::$context</varname>
+es actualizada si un contexto válido es pasado a la función.</simpara></note>'>
 
- <!ENTITY userstream.updates.context '<note xmlns="http://docbook.org/ns/docbook"><simpara>La propiedad
-    <varname linkend="streamwrapper.props.context">streamWrapper::$context</varname>
-    es actualizada si un contexto válido es pasado a la función.</simpara></note>'>
+<!ENTITY stream.bucket.param '<parameter>bucket</parameter> ahora espera una instancia de <classname>StreamBucket</classname>; anteriormente, se esperaba una <classname>stdClass</classname>.'>
+<!ENTITY stream.bucket.return 'Esta función ahora retorna una instancia de <classname>StreamBucket</classname>; anteriormente, se retornaba una <classname>stdClass</classname>.'>
 
- <!ENTITY stream.bucket.param '<parameter>bucket</parameter> ahora espera una instancia de <classname>StreamBucket</classname>; anteriormente, se esperaba una <classname>stdClass</classname>.'>
- <!ENTITY stream.bucket.return 'Esta función ahora retorna una instancia de <classname>StreamBucket</classname>; anteriormente, se retornaba una <classname>stdClass</classname>.'>
-
- <!-- Gmagick -->
- <!ENTITY gmagick.return.success 'Retorna &true; en caso de éxito.'>
- <!ENTITY gmagick.gmagickexception.throw 'Emite una excepción
+<!-- Gmagick -->
+<!ENTITY gmagick.return.success 'Retorna &true; en caso de éxito.'>
+<!ENTITY gmagick.gmagickexception.throw 'Emite una excepción
 <classname xmlns="http://docbook.org/ns/docbook">GmagickException</classname> en caso de error.'>
 
- <!-- Reflection -->
- <!ENTITY reflection.export.return 'Si el parámetro <parameter xmlns="http://docbook.org/ns/docbook">return</parameter>
-        está definido a &true;, la exportación será retornada en forma de &string;,
-        de lo contrario, &null; será retornado.'>
+<!-- Reflection -->
+<!ENTITY reflection.export.return 'Si el parámetro <parameter xmlns="http://docbook.org/ns/docbook">return</parameter> se
+establece a &true;, entonces la exportación se devuelve como un <type xmlns="http://docbook.org/ns/docbook">string</type>,
+de lo contrario se devuelve &null;.'>
 
- <!ENTITY reflection.export.param.return 'Definirlo a &true; retornará
-        la exportación en lugar de emitirla. Definirlo a &false; (por omisión) hará lo contrario.'>
+<!ENTITY reflection.export.param.return 'Definirlo a &true; retornará la exportación
+en lugar de emitirla. Definirlo a &false; (por defecto) hará lo contrario.'>
 
- <!ENTITY reflection.invoke.reference 'Si la función tiene argumentos que necesitan ser
-        referencias, entonces deben ser pasados por referencia en la lista de argumentos.'>
+<!ENTITY reflection.invoke.reference 'Si la función tiene argumentos que necesitan
+ser referencias, entonces deben ser pasados por referencia en la lista de argumentos.'>
 
- <!ENTITY reflection.export.param.name 'La reflexión a exportar.'>
+<!ENTITY reflection.export.param.name 'La reflexión a exportar.'>
 
- <!ENTITY reflection.getattributes.param.name '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!ENTITY reflection.getattributes.param.name '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>name</parameter></term>
 <listitem>
  <simpara>
-  Filtrar los resultados para incluir únicamente las instancias
-  de <classname>ReflectionAttribute</classname> para los atributos correspondientes a este nombre de clase.
+  Filtrar los resultados para incluir únicamente las instancias de <classname>ReflectionAttribute</classname>
+  para los atributos correspondientes a este nombre de clase.
  </simpara>
 </listitem>
 </varlistentry>'>
 
- <!ENTITY reflection.getattributes.param.flags '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!ENTITY reflection.getattributes.param.flags '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>flags</parameter></term>
 <listitem>
  <simpara>
-  Flags para determinar cómo filtrar los resultados, si <parameter>name</parameter> es proporcionado.
+  Flags para determinar cómo filtrar los resultados, si <parameter>name</parameter>
+  es proporcionado.
  </simpara>
  <simpara>
-  El valor por omisión es <literal>0</literal> que solo retornará los resultados
-  para los atributos que son de la clase <parameter>name</parameter>.
+  El valor predeterminado es <literal>0</literal> que solo retornará los resultados para los atributos que
+  son de la clase <parameter>name</parameter>.
  </simpara>
  <simpara>
   La única otra opción disponible es utilizar <constant>ReflectionAttribute::IS_INSTANCEOF</constant>,
@@ -2947,313 +2878,294 @@ Por omisión, el parámetro <parameter>notext</parameter> vale &true;.
 </listitem>
 </varlistentry>'>
 
- <!-- ZIP -->
- <!ENTITY zip.filename.separator '<note xmlns="http://docbook.org/ns/docbook"><simpara>Para una portabilidad máxima, se recomienda siempre utilizar barras oblicuas (<literal>/</literal>) como separador de directorio en los nombres de archivos zip.</simpara></note>'>
+<!-- ZIP -->
+<!ENTITY zip.filename.separator '<note xmlns="http://docbook.org/ns/docbook"><simpara>Para una portabilidad máxima, se recomienda siempre utilizar barras oblicuas (<literal>/</literal>) como separador de directorio en los nombres de archivos zip.</simpara></note>'>
 
- <!-- Win32Service -->
- <!ENTITY win32service.false.error ', &false; si hay un problema con los parámetros o un <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">Código de Error Win32</link> en caso de fallo.'>
- <!ENTITY win32service.success.false.error 'Retorna &true; en caso de éxito&win32service.false.error;'>
- <!ENTITY win32service.noerror.false.error 'retornaba <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> en caso de éxito&win32service.false.error;'>
+<!-- Win32Service -->
+<!ENTITY win32service.false.error ', &false; si hay un problema con los parámetros o un <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">Código de Error Win32</link> en caso de fallo.'>
+<!ENTITY win32service.success.false.error 'Retorna &true; en caso de éxito&win32service.false.error;'>
+<!ENTITY win32service.noerror.false.error 'retornaba <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> en caso de éxito&win32service.false.error;'>
 
- <!-- SNMP -->
- <!ENTITY snmp.set.type.values '<simpara xmlns="http://docbook.org/ns/docbook">
-El <acronym>MIB</acronym> define el tipo de cada identificador de objeto. Debe
-ser especificado como un carácter simple de la lista siguiente.
+<!-- SNMP -->
+<!ENTITY snmp.set.type.values '<simpara xmlns="http://docbook.org/ns/docbook">
+ El <acronym>MIB</acronym> define el tipo de cada identificador de objeto. Debe ser especificado como un carácter simple de la lista siguiente.
 </simpara>
 <table xmlns="http://docbook.org/ns/docbook">
-<title>tipos</title>
-<tgroup cols="2">
-    <tbody>
-        <row><entry>=</entry><entry>El tipo es recuperado desde el MIB</entry></row>
-        <row><entry>i</entry><entry>INTEGER</entry> </row>
-        <row><entry>u</entry><entry>INTEGER</entry></row>
-        <row><entry>s</entry><entry>STRING</entry></row>
-        <row><entry>x</entry><entry>HEX STRING</entry></row>
-        <row><entry>d</entry><entry>DECIMAL STRING</entry></row>
-        <row><entry>n</entry><entry>NULLOBJ</entry></row>
-        <row><entry>o</entry><entry>OBJID</entry></row>
-        <row><entry>t</entry><entry>TIMETICKS</entry></row>
-        <row><entry>a</entry><entry>IPADDRESS</entry></row>
-        <row><entry>b</entry><entry>BITS</entry></row>
-    </tbody>
-</tgroup>
+ <title>tipos</title>
+ <tgroup cols="2">
+  <tbody>
+   <row><entry>=</entry><entry>El tipo es recuperado desde el MIB</entry></row>
+   <row><entry>i</entry><entry>INTEGER</entry> </row>
+   <row><entry>u</entry><entry>INTEGER</entry></row>
+   <row><entry>s</entry><entry>STRING</entry></row>
+   <row><entry>x</entry><entry>HEX STRING</entry></row>
+   <row><entry>d</entry><entry>DECIMAL STRING</entry></row>
+   <row><entry>n</entry><entry>NULLOBJ</entry></row>
+   <row><entry>o</entry><entry>OBJID</entry></row>
+   <row><entry>t</entry><entry>TIMETICKS</entry></row>
+   <row><entry>a</entry><entry>IPADDRESS</entry></row>
+   <row><entry>b</entry><entry>BITS</entry></row>
+  </tbody>
+ </tgroup>
 </table>
 <simpara xmlns="http://docbook.org/ns/docbook">
-Si la constante <constant>OPAQUE_SPECIAL_TYPES</constant> ha sido definida durante
-la compilación de la biblioteca <acronym>SNMP</acronym>, los caracteres siguientes
-también estarán disponibles:
+ Si la constante <constant>OPAQUE_SPECIAL_TYPES</constant> ha sido definida durante la compilación de la biblioteca <acronym>SNMP</acronym>, los caracteres siguientes también estarán disponibles:
 </simpara>
 <table xmlns="http://docbook.org/ns/docbook">
-<title>tipos</title>
-<tgroup cols="2">
-    <tbody>
-        <row><entry>U</entry><entry>int64 sin signo</entry></row>
-        <row><entry>I</entry><entry>int64 con signo</entry></row>
-        <row><entry>F</entry><entry>float</entry></row>
-        <row><entry>D</entry><entry>double</entry></row>
-    </tbody>
-</tgroup>
+ <title>tipos</title>
+ <tgroup cols="2">
+  <tbody>
+   <row><entry>U</entry><entry>int64 sin signo</entry></row>
+   <row><entry>I</entry><entry>int64 con signo</entry></row>
+   <row><entry>F</entry><entry>float</entry></row>
+   <row><entry>D</entry><entry>double</entry></row>
+  </tbody>
+ </tgroup>
 </table>
 '>
- <!ENTITY snmp.set.type.values.asn.mapping '<simpara xmlns="http://docbook.org/ns/docbook">
-La mayoría de estos valores utilizan el tipo ASN.1 correspondiente. &apos;s&apos;, &apos;x&apos;, &apos;d&apos; y &apos;b&apos;
-son todas formas diferentes de especificar el valor OCTET STRING y el tipo sin signo
-&apos;u&apos; también es utilizado para manejar los valores Gauge32.
+<!ENTITY snmp.set.type.values.asn.mapping '<simpara xmlns="http://docbook.org/ns/docbook">
+ La mayoría de estos valores utilizan el tipo ASN.1 correspondiente. &apos;s&apos;, &apos;x&apos;, &apos;d&apos; y &apos;b&apos; son todas formas diferentes de especificar el valor OCTET STRING y el
+ tipo sin signo &apos;u&apos; también es utilizado para manejar los valores Gauge32.
 </simpara>
 '>
- <!ENTITY snmp.set.type.values.equal.note '<simpara xmlns="http://docbook.org/ns/docbook">
-Si los archivos MIB son cargados en el árbol MIB con "snmp_read_mib" o especificándolos
-en la configuración de libsnmp, &apos;=&apos; podrá ser utilizado como parámetro
-de tipo para todos los identificadores de objetos, ya que el tipo puede ser leído automáticamente desde el MIB.
+<!ENTITY snmp.set.type.values.equal.note '<simpara xmlns="http://docbook.org/ns/docbook">
+ Si los ficheros MIB se cargan en el árbol MIB con "snmp_read_mib" o especificándolos en la configuración de libsnmp, se puede usar &apos;=&apos; como el
+ parámetro <parameter>type</parameter> para todos los identificadores de objeto, ya que entonces el tipo se puede leer automáticamente desde el MIB.
 </simpara>
 '>
- <!ENTITY snmp.set.type.values.bitset.note '<simpara xmlns="http://docbook.org/ns/docbook">
-Nota que hay 2 formas de definir una variable de tipo BITS como i.e.
-"SYNTAX    BITS {telnet(0), ftp(1), http(2), icmp(3), snmp(4), ssh(5), https(6)}":
+<!ENTITY snmp.set.type.values.bitset.note '<simpara xmlns="http://docbook.org/ns/docbook">
+ Nota que hay 2 formas de definir una variable de tipo BITS como i.e. "SYNTAX
+ BITS {telnet(0), ftp(1), http(2), icmp(3), snmp(4), ssh(5), https(6)}":
 </simpara>
 <itemizedlist xmlns="http://docbook.org/ns/docbook">
-<listitem>
-    <simpara>
-        Utilizando el tipo "b" y una lista de octetos. Este método no es
-        recomendado ya que la petición GET para un mismo OID retornará i.e. 0xF8.
-    </simpara>
-</listitem>
-<listitem>
-    <simpara>
-        Utilizando el tipo "x" y un número hexadecimal pero sin(!) el prefijo usual
-        "0x".
-    </simpara>
-</listitem>
+ <listitem>
+  <simpara>
+   Utilizando el tipo "b" y una lista de octetos. Este método no es recomendado ya que la petición GET para un mismo OID retornará i.e. 0xF8.
+  </simpara>
+ </listitem>
+ <listitem>
+  <simpara>
+   Utilizando el tipo "x" y un número hexadecimal pero sin(!) el prefijo usual "0x".
+  </simpara>
+ </listitem>
 </itemizedlist>
 <simpara xmlns="http://docbook.org/ns/docbook">
-Consúltese la sección sobre ejemplos para más detalles.
+ Consúltese la sección sobre ejemplos para más detalles.
 </simpara>
 '>
- <!ENTITY snmp.methods.exceptions_enable.refsect '<refsect1 role="errors" xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.methods.exceptions_enable.refsect '<refsect1 role="errors" xmlns="http://docbook.org/ns/docbook">
 &reftitle.errors;
 <simpara>
-    Este método no lanza excepciones por omisión.
-    Para activar el lanzamiento de excepciones SNMPException cuando
-    ocurren errores de la biblioteca,
-    el parámetro de la clase SNMP <parameter>exceptions_enabled</parameter>
-    debe ser definido al valor correspondiente. Ver las <link linkend="snmp.props.exceptions-enabled">
-    explicaciones sobre <parameter>SNMP::$exceptions_enabled</parameter></link>
-    para más detalles.
+ Este método no lanza excepciones por defecto. Para activar
+ el lanzamiento de excepciones SNMPException cuando ocurren errores de la biblioteca, el parámetro
+ de la clase SNMP <parameter>exceptions_enabled</parameter>
+ ebe ser definido al valor correspondiente. Ver las <link linkend="snmp.props.exceptions-enabled"> explicaciones
+ sobre <parameter>SNMP::$exceptions_enabled</parameter></link> para más detalles.
 </simpara>
 </refsect1>
 '>
 
- <!-- Eio -->
- <!ENTITY eio.callback.proto '<para xmlns="http://docbook.org/ns/docbook">
-La función de retrollamada <parameter xmlns="http://docbook.org/ns/docbook">callback</parameter>
-es llamada cuando la petición está terminada.
+<!-- Eio -->
+<!ENTITY eio.callback.proto '<para xmlns="http://docbook.org/ns/docbook"> La función
+de retrollamada <parameter xmlns="http://docbook.org/ns/docbook">callback</parameter> es llamada cuando la petición está terminada.
 Debe corresponder al siguiente prototipo: <programlisting role="php"><![CDATA[
 void callback(mixed $data, int $result[, resource $req]);
 ]]></programlisting>
 <variablelist xmlns="http://docbook.org/ns/docbook">
-    <varlistentry xmlns="http://docbook.org/ns/docbook">
-        <term><parameter>data</parameter></term>
-        <listitem><simpara>representa los datos personalizados pasados a la petición.</simpara></listitem>
-    </varlistentry>
-    <varlistentry xmlns="http://docbook.org/ns/docbook">
-        <term><parameter>result</parameter></term>
-        <listitem><simpara>representa el valor resultante específico de la petición; básicamente,
-            el valor retornado por la llamada al sistema correspondiente.</simpara></listitem>
-    </varlistentry>
-    <varlistentry xmlns="http://docbook.org/ns/docbook">
-        <term><parameter>req</parameter></term>
-        <listitem><simpara>es el recurso opcional de la petición que puede ser
-            utilizado con funciones como <function>eio_get_last_error</function>.</simpara></listitem>
-    </varlistentry>
+<varlistentry xmlns="http://docbook.org/ns/docbook">
+<term><parameter>data</parameter></term>
+<listitem><simpara>representa los datos personalizados pasados a la petición.</simpara></listitem>
+</varlistentry>
+<varlistentry xmlns="http://docbook.org/ns/docbook">
+<term><parameter>result</parameter></term>
+<listitem><simpara>representa el valor resultante específico de la petición; básicamente, el valor retornado por la llamada
+al sistema correspondiente.</simpara></listitem>
+</varlistentry>
+<varlistentry xmlns="http://docbook.org/ns/docbook">
+<term><parameter>req</parameter></term>
+<listitem><simpara>es el recurso opcional de la petición que puede ser utilizado con funciones como <function>eio_get_last_error</function>.</simpara></listitem>
+</varlistentry>
 </variablelist>
 </para>
 '>
 
- <!ENTITY eio.request.pri.values '<simpara
+<!ENTITY eio.request.pri.values '<simpara
 xmlns="http://docbook.org/ns/docbook">La prioridad de la petición: <constant
-        xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>, <constant
-        xmlns="http://docbook.org/ns/docbook">EIO_PRI_MIN</constant>, <constant
-        xmlns="http://docbook.org/ns/docbook">EIO_PRI_MAX</constant>, o &null;.
-Si &null; es pasado, el parámetro <parameter
-        xmlns="http://docbook.org/ns/docbook">pri</parameter>, internamente, es definido a
+xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>, <constant
+xmlns="http://docbook.org/ns/docbook">EIO_PRI_MIN</constant>, <constant
+xmlns="http://docbook.org/ns/docbook">EIO_PRI_MAX</constant>, o &null;. Si
+&null; es pasado, el parámetro <parameter
+xmlns="http://docbook.org/ns/docbook">pri</parameter>, internamente, es definido a
 <constant xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>.
 </simpara>
 '>
 
- <!ENTITY eio.warn.relpath '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docbook">Evitar los
-    caminos relativos.</simpara></warning>
+<!ENTITY eio.warn.relpath '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docbook">Evite las rutas
+relativas.</simpara></warning>
 '>
 
- <!ENTITY trader.arg.array.of.real 'Array de valores reales.'>
- <!ENTITY trader.arg.array.of.real.high 'Precio alto, array de valores reales.'>
- <!ENTITY trader.arg.array.of.real.low 'Precio bajo, array de valores reales.'>
- <!ENTITY trader.arg.array.of.real.close 'Precio cerrado, array de valores reales.'>
- <!ENTITY trader.arg.array.of.real.open 'Precio abierto, array de valores reales.'>
- <!ENTITY trader.arg.array.of.real.volume 'Volumen intercambiado, array de valores reales.'>
- <!ENTITY trader.arg.array.of.real.periods 'Array de valores reales.'>
- <!ENTITY trader.arg.penetration 'Porcentaje de penetración de una vela en otra vela.'>
- <!ENTITY trader.arg.vfactor 'Factor de volumen. Intervalo válido: 1 a 0.'>
- <!ENTITY trader.arg.time.period 'Número de período. Intervalo válido: 2 a 100000.'>
- <!ENTITY trader.arg.fast.period 'Número de período para el MA rápido. Intervalo válido: 2 a 100000.'>
- <!ENTITY trader.arg.slow.period 'Número de período para el MA. Intervalo válido: 2 a 100000.'>
- <!ENTITY trader.arg.signal.period 'Suavizado de la línea de señal (número de período). Intervalo válido: 1 a 100000.'>
- <!ENTITY trader.arg.fastk.period 'Período de tiempo para construir la línea Fast-K. Intervalo válido: 1 a 100000.'>
- <!ENTITY trader.arg.fastd.period 'Suavizado para realizar la línea Fast-D. Intervalo válido: 1 a 100000, habitualmente definido a 3.'>
- <!ENTITY trader.arg.slowk.period 'Suavizado para realizar la línea Slow-K. Intervalo válido: 1 a 100000, habitualmente definido a 3.'>
- <!ENTITY trader.arg.slowd.period 'Suavizado para realizar la línea Slow-D. Intervalo válido: 1 a 100000.'>
- <!ENTITY trader.arg.min.period 'Un valor inferior al mínimo será modificado a la período mínimo. Intervalo válido: 2 a 100000'>
- <!ENTITY trader.arg.max.period 'Un valor superior al mínimo será modificado a la período máximo. Intervalo válido: 2 a 100000'>
- <!ENTITY trader.arg.ma.type 'Tipo de media móvil. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
- <!ENTITY trader.arg.fast.ma.type 'Tipo de media móvil para MA rápido. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
- <!ENTITY trader.arg.slow.ma.type 'Tipo de media móvil para MA lento. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
- <!ENTITY trader.arg.fastd.ma.type 'Tipo de media móvil para Fast-D. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
- <!ENTITY trader.arg.fastk.ma.type 'Tipo de media móvil para Fast-K. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
- <!ENTITY trader.arg.slowd.ma.type 'Tipo de media móvil para Slow-D. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
- <!ENTITY trader.arg.slowk.ma.type 'Tipo de media móvil para Slow-K. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
- <!ENTITY trader.arg.signal.ma.type 'Tipo de media móvil para la línea de señal. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.array.of.real 'Array de valores reales.'>
+<!ENTITY trader.arg.array.of.real.high 'Precio alto, array de valores reales.'>
+<!ENTITY trader.arg.array.of.real.low 'Precio bajo, array de valores reales.'>
+<!ENTITY trader.arg.array.of.real.close 'Precio cerrado, array de valores reales.'>
+<!ENTITY trader.arg.array.of.real.open 'Precio abierto, array de valores reales.'>
+<!ENTITY trader.arg.array.of.real.volume 'Volumen intercambiado, array de valores reales.'>
+<!ENTITY trader.arg.array.of.real.periods 'Array de valores reales.'>
+<!ENTITY trader.arg.penetration 'Porcentaje de penetración de una vela en otra vela.'>
+<!ENTITY trader.arg.vfactor 'Factor de volumen. Intervalo válido: 1 a 0.'>
+<!ENTITY trader.arg.time.period 'Número de período. Intervalo válido: 2 a 100000.'>
+<!ENTITY trader.arg.fast.period 'Número de período para el MA rápido. Intervalo válido: 2 a 100000.'>
+<!ENTITY trader.arg.slow.period 'Número de período para el MA. Intervalo válido: 2 a 100000.'>
+<!ENTITY trader.arg.signal.period 'Suavizado de la línea de señal (número de período). Intervalo válido: 1 a 100000.'>
+<!ENTITY trader.arg.fastk.period 'Período de tiempo para construir la línea Fast-K. Intervalo válido: 1 a 100000.'>
+<!ENTITY trader.arg.fastd.period 'Suavizado para realizar la línea Fast-D. Intervalo válido: 1 a 100000, habitualmente definido a 3.'>
+<!ENTITY trader.arg.slowk.period 'Suavizado para realizar la línea Slow-K. Intervalo válido: 1 a 100000, habitualmente definido a 3.'>
+<!ENTITY trader.arg.slowd.period 'Suavizado para realizar la línea Slow-D. Intervalo válido: 1 a 100000.'>
+<!ENTITY trader.arg.min.period 'Un valor inferior al mínimo será modificado a la período mínimo. Intervalo válido: 2 a 100000'>
+<!ENTITY trader.arg.max.period 'Un valor superior al mínimo será modificado a la período máximo. Intervalo válido: 2 a 100000'>
+<!ENTITY trader.arg.ma.type 'Tipo de media móvil. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.fast.ma.type 'Tipo de media móvil para MA rápido. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.slow.ma.type 'Tipo de media móvil para MA lento. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.fastd.ma.type 'Tipo de media móvil para Fast-D. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.fastk.ma.type 'Tipo de media móvil para Fast-K. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.slowd.ma.type 'Tipo de media móvil para Slow-D. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.slowk.ma.type 'Tipo de media móvil para Slow-K. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.signal.ma.type 'Tipo de media móvil para la línea de señal. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
+<!ENTITY trader.arg.nbdevup 'Multiplicador de desviación para la banda superior. Intervalo válido: <link xmlns="http://docbook.org/ns/docbook" linkend="constant.trader-real-min">TRADER_REAL_MIN</link> a <link xmlns="http://docbook.org/ns/docbook" linkend="constant.trader-real-max">TRADER_REAL_MAX</link>.'>
+<!ENTITY trader.arg.nbdevdn 'Multiplicador de desviación para la banda inferior. Intervalo válido: <link xmlns="http://docbook.org/ns/docbook" linkend="constant.trader-real-min">TRADER_REAL_MIN</link> a <link xmlns="http://docbook.org/ns/docbook" linkend="constant.trader-real-max">TRADER_REAL_MAX</link>.'>
+<!ENTITY trader.arg.fast.limit 'Límite superior del algoritmo adaptativo. Intervalo válido: 0.01 a 0.99.'>
+<!ENTITY trader.arg.slow.limit 'Límite inferior del algoritmo adaptativo. Intervalo válido: 0.01 a 0.99.'>
 
- <!ENTITY trader.arg.nbdevup 'Multiplicador de desviación para la banda superior. Intervalo válido: <link xmlns="http://docbook.org/ns/docbook" linkend="constant.trader-real-min">TRADER_REAL_MIN</link> a <link xmlns="http://docbook.org/ns/docbook" linkend="constant.trader-real-max">TRADER_REAL_MAX</link>.'>
- <!ENTITY trader.arg.nbdevdn 'Multiplicador de desviación para la banda inferior. Intervalo válido: <link xmlns="http://docbook.org/ns/docbook" linkend="constant.trader-real-min">TRADER_REAL_MIN</link> a <link xmlns="http://docbook.org/ns/docbook" linkend="constant.trader-real-max">TRADER_REAL_MAX</link>.'>
- <!ENTITY trader.arg.fast.limit 'Límite superior del algoritmo adaptativo. Intervalo válido: 0.01 a 0.99.'>
- <!ENTITY trader.arg.slow.limit 'Límite inferior del algoritmo adaptativo. Intervalo válido: 0.01 a 0.99.'>
-
- <!-- mongodb -->
- <!ENTITY mongodb.changelog.class-removed '
-    <row xmlns="http://docbook.org/ns/docbook">
+<!-- mongodb -->
+<!ENTITY mongodb.changelog.class-removed '
+       <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            Esta clase ha sido eliminada.
+         Esta clase ha sido eliminada.
         </entry>
-    </row>
+       </row>
 '>
 
- <!ENTITY mongodb.changelog.function-removed '
-    <row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mongodb.changelog.function-removed '
+       <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            Esta función ha sido eliminada.
+         Esta función ha sido eliminada.
         </entry>
-    </row>
+       </row>
 '>
 
- <!ENTITY mongodb.changelog.method-removed '
-    <row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mongodb.changelog.method-removed '
+       <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            Este método ha sido eliminado.
+         Este método ha sido eliminado.
         </entry>
-    </row>
+       </row>
 '>
 
- <!ENTITY mongodb.changelog.serializable-interface-removed '
-    <row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mongodb.changelog.serializable-interface-removed '
+       <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            <simpara>
-                Esta clase ya no implementa la interfaz
-                <interfacename>Serializable</interfacename>.
-            </simpara>
+         <simpara>
+          Esta clase ya no implementa la interfaz
+          <interfacename>Serializable</interfacename>.
+         </simpara>
         </entry>
-    </row>
+       </row>
 '>
 
- <!ENTITY mongodb.changelog.tentative-return-types '
-<row xmlns="http://docbook.org/ns/docbook">
-  <entry>PECL mongodb 1.15.0</entry>
-  <entry>
-    Los tipos de retorno de los métodos son declarados como provisionales en PHP 8.0 y posteriores,
-    lo que desencadena avisos de depreciación en el código que implementa esta interfaz sin declarar
-    los tipos de retorno apropiados.
-    El atributo <code>#[ReturnTypeWillChange]</code> puede ser añadido
-    para ignorar la notificación de depreciación.
-  </entry>
-</row>
+<!ENTITY mongodb.changelog.tentative-return-types '
+       <row xmlns="http://docbook.org/ns/docbook">
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Los tipos de retorno de los métodos son declarados como provisionales en PHP 8.0 y posteriores, lo
+         que desencadena avisos de depreciación en el código que implementa esta interfaz
+         sin declarar los tipos de retorno apropiados. El atributo <code>#[ReturnTypeWillChange]</code>
+         puede ser añadido para ignorar la notificación de depreciación.
+        </entry>
+       </row>
 '>
 
- <!ENTITY mongodb.changelog.tentative-return-types-enforced '
-    <row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mongodb.changelog.tentative-return-types-enforced '
+       <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            Los tipos de retorno previamente declarados como provisionales ahora son aplicados.
+         Los tipos de retorno previamente declarados como provisionales ahora son aplicados.
         </entry>
-    </row>
+       </row>
 '>
 
- <!ENTITY mongodb.changelog.throw-unacknowledged-write '
-    <row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mongodb.changelog.throw-unacknowledged-write '
+       <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            <simpara>
-                Este método ahora lanza una excepción cuando es llamado
-                para una escritura no reconocida, en lugar de retornar &null;.
-            </simpara>
+         <simpara>
+          Este método ahora lanza una excepción cuando es llamado para una escritura no reconocida, en lugar de retornar &null;.
+         </simpara>
         </entry>
-    </row>
+       </row>
 '>
 
- <!ENTITY mongodb.option.collation '
-<row xmlns="http://docbook.org/ns/docbook">
-<entry>collation</entry>
-<entry><type class="union"><type>array</type><type>object</type></type></entry>
-<entry>
-    <simpara>
-        <link xlink:href="&url.mongodb.docs.collation;" xmlns:xlink="http://www.w3.org/1999/xlink">Collation</link> permite a los usuarios especificar reglas específicas del lenguaje para la comparación de cadenas, por ejemplo, reglas para mayúsculas o acentos. Al especificar una collation, el campo <literal>"locale"</literal> es obligatorio; todos los demás campos de la collation son opcionales. Para la descripción de estos campos, consúltese el <link xlink:href="&url.mongodb.docs.collation;#collation-document" xmlns:xlink="http://www.w3.org/1999/xlink">documento Collation</link>.
-    </simpara>
-    <simpara>
-        Si la collation no es especificada pero la colección tiene una collation por omisión, la operación utilizará la collation especificada para la colección. Si ninguna collation es especificada para la colección o para la operación, MongoDB utilizará el binario simple de comparación utilizado en versiones anteriores para las comparaciones de cadenas.
-    </simpara>
-    <simpara>
-        Esta opción está disponible en MongoDB 3.4+ y una excepción será emitida en tiempo de ejecución si es especificada en una versión anterior.
-    </simpara>
-</entry>
-</row>
+<!ENTITY mongodb.option.collation '
+         <row xmlns="http://docbook.org/ns/docbook">
+          <entry>collation</entry>
+          <entry><type class="union"><type>array</type><type>object</type></type></entry>
+          <entry>
+           <simpara>
+            <link xlink:href="&url.mongodb.docs.collation;" xmlns:xlink="http://www.w3.org/1999/xlink">Collation</link> permite a los usuarios especificar reglas específicas del lenguaje para la comparación de cadenas, por ejemplo, reglas para mayúsculas o acentos. Al especificar una collation, el campo <literal>"locale"</literal> es obligatorio; todos los demás campos de la collation son opcionales. Para la descripción de estos campos, consúltese el <link xlink:href="&url.mongodb.docs.collation;#collation-document" xmlns:xlink="http://www.w3.org/1999/xlink">documento Collation</link>.
+           </simpara>
+           <simpara>
+            Si la collation no es especificada pero la colección tiene una collation predeterminada, la operación utilizará la collation especificada para la colección. Si ninguna collation es especificada para la colección o para la operación, MongoDB utilizará el binario simple de comparación utilizado en versiones anteriores para las comparaciones de cadenas.
+           </simpara>
+           <simpara>
+            Esta opción está disponible en MongoDB 3.4+ y una excepción será emitida en tiempo de ejecución si es especificada en una versión anterior.
+           </simpara>
+          </entry>
+         </row>
 '>
-
- <!ENTITY mongodb.option.let '
- <row xmlns="http://docbook.org/ns/docbook">
-  <entry>let</entry>
-  <entry><type class="union"><type>array</type><type>object</type></type></entry>
-  <entry>
-   <simpara>
-    Diccionario de nombres y valores de parámetros. Los valores deben ser constantes o expresiones cerradas que no hagan referencia a campos del documento. Los parámetros pueden ser accedidos luego como variables en un contexto de expresión agregada (por ejemplo <literal>$$var</literal>).
-   </simpara>
-   <simpara>
-    Esta opción está disponible en MongoDB 5.0+ y resultará en una excepción en tiempo de ejecución si es especificada para una versión anterior del servidor.
-   </simpara>
-  </entry>
- </row>
+<!ENTITY mongodb.option.let '
+         <row xmlns="http://docbook.org/ns/docbook">
+          <entry>let</entry>
+          <entry><type class="union"><type>array</type><type>object</type></type></entry>
+          <entry>
+           <simpara>
+            Diccionario de nombres y valores de parámetros. Los valores deben ser constantes o expresiones cerradas que no hagan referencia a campos del documento. Los parámetros pueden ser accedidos luego como variables en un contexto de expresión agregada (por ejemplo <literal>$$var</literal>).
+           </simpara>
+           <simpara>
+            Esta opción está disponible en MongoDB 5.0+ y resultará en una excepción en tiempo de ejecución si es especificada para una versión anterior del servidor.
+           </simpara>
+          </entry>
+         </row>
 '>
-
- <!ENTITY mongodb.option.encryption.keyVaultClient '
+<!ENTITY mongodb.option.encryption.keyVaultClient '
          <row xmlns="http://docbook.org/ns/docbook">
           <entry>keyVaultClient</entry>
           <entry><classname>MongoDB\Driver\Manager</classname></entry>
-          <entry>El Manager utilizado para enrutar las peticiones de claves de datos a un cluster MongoDB diferente. Por omisión, el Manager y cluster actual es utilizado.</entry>
+          <entry>El Manager utilizado para enrutar las peticiones de claves de datos a un cluster MongoDB diferente. Por defecto, el Manager y cluster actual es utilizado.</entry>
          </row>
 '>
- <!ENTITY mongodb.option.encryption.keyVaultNamespace '
+<!ENTITY mongodb.option.encryption.keyVaultNamespace '
          <row xmlns="http://docbook.org/ns/docbook">
           <entry>keyVaultNamespace</entry>
-          <entry>&string;</entry>
+          <entry><type>string</type></entry>
           <entry>Un nombre de espacio completamente calificado (por ejemplo <literal>"databaseName.collectionName"</literal>) denotando la colección que contiene todas las claves de datos utilizadas para el cifrado y descifrado. Esta opción es requerida.</entry>
-</row>
-'><!ENTITY mongodb.option.encryption.kmsProviders '
+         </row>
+'>
+<!ENTITY mongodb.option.encryption.kmsProviders '
          <row xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
           <entry>kmsProviders</entry>
-          <entry>&array;</entry>
+          <entry><type>array</type></entry>
           <entry>
            <simpara>
-            Un documento que contiene la configuración de uno o varios
-            proveedores KMS, que se utilizan para cifrar las claves de datos.
-            Los proveedores soportados son <literal>"aws"</literal>,
-            <literal>"azure"</literal>, <literal>"gcp"</literal> y
-            <literal>"local"</literal>, y al menos uno debe ser especificado.
+            Un documento que contiene la configuración de uno o más proveedores KMS, que se utilizan para cifrar claves de datos. Los proveedores admitidos incluyen <literal>"aws"</literal>, <literal>"azure"</literal>, <literal>"gcp"</literal>, <literal>"kmip"</literal> y <literal>"local"</literal>, y se debe especificar al menos uno.
            </simpara>
            <simpara>
             Si se especifica un documento vacío para <literal>"aws"</literal>,
-            <literal>"azure"</literal>, o <literal>"gcp"</literal>, el controlador
-            intentará configurar el proveedor utilizando
+            <literal>"azure"</literal> o <literal>"gcp"</literal>, el
+            controlador intentará configurar el proveedor utilizando
             <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Automatic Credentials</link>.
            </simpara>
            <simpara>
@@ -3278,7 +3190,6 @@ azure: {
     clientId: <string>,
     clientSecret: <string>,
     identityPlatformEndpoint: <optional string> // Defaults to "login.microsoftonline.com"
-
 }
 ]]>
            </programlisting>
@@ -3291,7 +3202,6 @@ gcp: {
     email: <string>,
     privateKey: <base64 string>|<MongoDB\BSON\Binary>,
     endpoint: <optional string> // Defaults to "oauth2.googleapis.com"
-
 }
 ]]>
            </programlisting>
@@ -3319,8 +3229,7 @@ local: {
           </entry>
          </row>
 '>
-
- <!ENTITY mongodb.option.encryption.masterKey-options-by-provider '
+<!ENTITY mongodb.option.encryption.masterKey-options-by-provider '
   <para xmlns="http://docbook.org/ns/docbook">
    <table>
     <title>Opciones del proveedor <literal>"aws"</literal></title>
@@ -3377,7 +3286,7 @@ local: {
       <row>
        <entry>keyVersion</entry>
        <entry>string</entry>
-       <entry>Opcional. Una versión específica de la clave nombrada. Por omisión, se utiliza la versión primaria de la clave.</entry>
+       <entry>Opcional. Una versión específica de la clave nombrada. De forma predeterminada, se utiliza la versión primaria de la clave.</entry>
       </row>
      </tbody>
     </tgroup>
@@ -3418,12 +3327,12 @@ local: {
       <row>
        <entry>keyVersion</entry>
        <entry>string</entry>
-       <entry>Opcional. Una versión específica de la clave nombrada. Por omisión, se utiliza la versión primaria de la clave.</entry>
+       <entry>Opcional. Una versión específica de la clave nombrada. De forma predeterminada, se utiliza la versión primaria de la clave.</entry>
       </row>
       <row>
        <entry>endpoint</entry>
        <entry>string</entry>
-       <entry>Opcional. Host con puerto opcional. El valor por omisión es "cloudkms.googleapis.com".</entry>
+       <entry>Opcional. Host con puerto opcional. El valor predeterminado es "cloudkms.googleapis.com".</entry>
       </row>
      </tbody>
     </tgroup>
@@ -3454,28 +3363,22 @@ local: {
       <row>
        <entry>delegated</entry>
        <entry>bool</entry>
-       <entry>Opcional. Si es verdadero, esta clave debe ser descifrada por el servidor KMIP.</entry>
+       <entry>Opcional. Si es true, esta clave debe ser descifrada por el servidor KMIP.</entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
 '>
-
- <!ENTITY mongodb.option.encryption.tlsOptions '
- <row xmlns="http://docbook.org/ns/docbook">
-  <entry>tlsOptions</entry>
-  <entry><type>array</type></entry>
-  <entry>
-   <simpara>
-    Un documento que contiene la configuración TLS de uno o varios
-    proveedores KMS.
-    Los proveedores soportados son <literal>"aws"</literal>,
-    <literal>"azure"</literal>, <literal>"gcp"</literal> y
-    <literal>"kmip"</literal>.
-    Todos los proveedores soportan las siguientes opciones:
-   </simpara>
-   <programlisting role="javascript">
+<!ENTITY mongodb.option.encryption.tlsOptions '
+         <row xmlns="http://docbook.org/ns/docbook">
+          <entry>tlsOptions</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <simpara>
+            Un documento que contiene la configuración TLS de uno o varios proveedores KMS. Los proveedores soportados son <literal>"aws"</literal>, <literal>"azure"</literal>, <literal>"gcp"</literal> y <literal>"kmip"</literal>. Todos los proveedores soportan las siguientes opciones:
+           </simpara>
+           <programlisting role="javascript">
 <![CDATA[
 <provider>: {
     tlsCaFile: <optional string>,
@@ -3484,120 +3387,119 @@ local: {
     tlsDisableOCSPEndpointCheck: <optional bool>
 }
 ]]>
-   </programlisting>
-  </entry>
- </row>
+           </programlisting>
+          </entry>
+         </row>
 '>
-
- <!ENTITY mongodb.option.maxCommitTimeMS '
-<row xmlns="http://docbook.org/ns/docbook">
- <entry>maxCommitTimeMS</entry>
- <entry>integer</entry>
- <entry>
-  <simpara>
-   El tiempo máximo en milisegundos para permitir que una sola
-   comando <literal>commitTransaction</literal> se ejecute.
-  </simpara>
-  <simpara>
-   Si se especifica, <literal>maxCommitTimeMS</literal> debe ser un entero
-   32 bits con signo superior o igual a cero.
-  </simpara>
- </entry>
-</row>
+<!ENTITY mongodb.option.maxCommitTimeMS '
+         <row xmlns="http://docbook.org/ns/docbook">
+          <entry>maxCommitTimeMS</entry>
+          <entry>integer</entry>
+          <entry>
+           <simpara>
+            El tiempo máximo en milisegundos para permitir que una sola comando
+            <literal>commitTransaction</literal> se ejecute.
+           </simpara>
+           <simpara>
+            Si se especifica, <literal>maxCommitTimeMS</literal> debe ser un entero
+            32 bits con signo superior o igual a cero.
+           </simpara>
+          </entry>
+         </row>
 '>
- <!ENTITY mongodb.option.readConcern '
-<row xmlns="http://docbook.org/ns/docbook">
-<entry>readConcern</entry>
-<entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
-<entry>
-    <simpara>
-        Una preocupación de lectura a aplicar a la operación.
-    </simpara>
-    <simpara>
-        Esta opción está disponible en MongoDB 3.2+ y se traducirá en
-        una excepción en el momento de la ejecución si se especifica para
-        una versión más antigua del servidor.
-    </simpara>
-</entry>
-</row>
+<!ENTITY mongodb.option.readConcern '
+         <row xmlns="http://docbook.org/ns/docbook">
+          <entry>readConcern</entry>
+          <entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
+          <entry>
+           <simpara>
+            Una preocupación de lectura a aplicar a la operación.
+           </simpara>
+           <simpara>
+            Esta opción está disponible en MongoDB 3.2+ y se traducirá en una excepción en el
+            momento de la ejecución si se especifica para una versión más antigua del
+            servidor.
+           </simpara>
+          </entry>
+         </row>
 '>
- <!ENTITY mongodb.option.readPreference '
-<row xmlns="http://docbook.org/ns/docbook">
-<entry>readPreference</entry>
-<entry><classname>MongoDB\Driver\ReadPreference</classname></entry>
-<entry>
-    <simpara>
-        Una preferencia de lectura a utilizar para seleccionar un servidor
-        para la operación.
-    </simpara>
-</entry>
-</row>
+<!ENTITY mongodb.option.readPreference '
+         <row xmlns="http://docbook.org/ns/docbook">
+          <entry>readPreference</entry>
+          <entry><classname>MongoDB\Driver\ReadPreference</classname></entry>
+          <entry>
+           <simpara>
+            Una preferencia de lectura a utilizar para seleccionar un servidor para la operación.
+           </simpara>
+          </entry>
+         </row>
 '>
- <!ENTITY mongodb.option.session '
-<row xmlns="http://docbook.org/ns/docbook">
-<entry>session</entry>
-<entry><classname>MongoDB\Driver\Session</classname></entry>
-<entry>
-    <simpara>
-        Una sesión a asociar a la operación.
-    </simpara>
-</entry>
-</row>
+<!ENTITY mongodb.option.session '
+         <row xmlns="http://docbook.org/ns/docbook">
+          <entry>session</entry>
+          <entry><classname>MongoDB\Driver\Session</classname></entry>
+          <entry>
+           <simpara>
+            Una sesión a asociar a la operación.
+           </simpara>
+          </entry>
+         </row>
 '>
- <!ENTITY mongodb.option.transactionReadWriteConcern '
-<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>
-    Si se utiliza una <literal>"session"</literal> que tiene una transacción
-    en curso, no se puede especificar la opción <literal>"readConcern"</literal>
-    o <literal>"writeConcern"</literal>. Intentar hacer esto lanzará una excepción
-    <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>.
-    En su lugar, debe definir estas opciones cuando se crea la transacción con
-    <methodname>MongoDB\Driver\Session::startTransaction</methodname>.
-</simpara>
-</warning>
+<!ENTITY mongodb.option.transactionReadWriteConcern '
+     <warning xmlns="http://docbook.org/ns/docbook">
+      <simpara>
+       Si se utiliza una <literal>"session"</literal> que tiene una transacción en
+       curso, no se puede especificar la opción <literal>"readConcern"</literal> o
+       <literal>"writeConcern"</literal>. Intentar hacer esto lanzará una excepción
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       . En su lugar, debe definir estas opciones cuando se crea
+       la transacción con
+       <methodname>MongoDB\Driver\Session::startTransaction</methodname>.
+      </simpara>
+     </warning>
 '>
- <!ENTITY mongodb.option.writeConcern '
-<row xmlns="http://docbook.org/ns/docbook">
-<entry>writeConcern</entry>
-<entry><classname>MongoDB\Driver\WriteConcern</classname></entry>
-<entry>
-    <simpara>
-        Una preocupación de escritura a aplicar a la operación.
-    </simpara>
-</entry>
-</row>
+<!ENTITY mongodb.option.writeConcern '
+         <row xmlns="http://docbook.org/ns/docbook">
+          <entry>writeConcern</entry>
+          <entry><classname>MongoDB\Driver\WriteConcern</classname></entry>
+          <entry>
+           <simpara>
+            Una preocupación de escritura a aplicar a la operación.
+           </simpara>
+          </entry>
+         </row>
 '>
- <!ENTITY mongodb.parameter.namespace '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>namespace</parameter> (<type>string</type>)</term>
-<listitem>
-    <simpara>
-        Un espacio de nombres completamente calificado (ej. <literal>"databaseName.collectionName"</literal>)
-    </simpara>
-</listitem>
-</varlistentry>
+<!ENTITY mongodb.parameter.namespace '
+   <varlistentry xmlns="http://docbook.org/ns/docbook">
+    <term><parameter>namespace</parameter> (<type>string</type>)</term>
+    <listitem>
+     <simpara>
+      Un espacio de nombres completamente calificado (ej. <literal>"databaseName.collectionName"</literal>)
+     </simpara>
+    </listitem>
+   </varlistentry>
 '>
- <!ENTITY mongodb.parameter.db '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>db</parameter> (<type>string</type>)</term>
-<listitem>
-    <simpara>
-        El nombre de la base de datos sobre la cual se ejecutará el comando.
-    </simpara>
-</listitem>
-</varlistentry>
+<!ENTITY mongodb.parameter.db '
+   <varlistentry xmlns="http://docbook.org/ns/docbook">
+    <term><parameter>db</parameter> (<type>string</type>)</term>
+    <listitem>
+     <simpara>
+      El nombre de la base de datos sobre la cual se ejecutará el comando.
+     </simpara>
+    </listitem>
+   </varlistentry>
 '>
- <!ENTITY mongodb.parameter.bulkwrite '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWrite</classname>)</term>
-<listitem>
-    <simpara>
-        Escritura(s) a ejecutar.
-    </simpara>
-</listitem>
-</varlistentry>
+<!ENTITY mongodb.parameter.bulkwrite '
+   <varlistentry xmlns="http://docbook.org/ns/docbook">
+    <term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWrite</classname>)</term>
+    <listitem>
+     <simpara>
+      Escritura(s) a ejecutar.
+     </simpara>
+    </listitem>
+   </varlistentry>
 '>
- <!ENTITY mongodb.parameter.bulkwritecommand '
+<!ENTITY mongodb.parameter.bulkwritecommand '
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWriteCommand</classname>)</term>
     <listitem>
@@ -3607,344 +3509,314 @@ local: {
     </listitem>
    </varlistentry>
 '>
- <!ENTITY mongodb.parameter.command '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>command</parameter> (<classname>MongoDB\Driver\Command</classname>)</term>
-<listitem>
-    <simpara>
-        El comando a ejecutar.
-    </simpara>
-</listitem>
-</varlistentry>
+<!ENTITY mongodb.parameter.command '
+   <varlistentry xmlns="http://docbook.org/ns/docbook">
+    <term><parameter>command</parameter> (<classname>MongoDB\Driver\Command</classname>)</term>
+    <listitem>
+     <simpara>
+      El comando a ejecutar.
+     </simpara>
+    </listitem>
+   </varlistentry>
 '>
- <!ENTITY mongodb.parameter.encryptOpts '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-  <term>
-    <parameter>options</parameter>
-  </term>
-  <listitem>
-    <para>
+<!ENTITY mongodb.parameter.encryptOpts '
+   <varlistentry xmlns="http://docbook.org/ns/docbook">
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
       <table>
-        <title>Opciones de cifrado</title>
-        <tgroup cols="3">
-          <thead>
-            <row>
-              <entry>Opción</entry>
-              <entry>Tipo</entry>
-              <entry>Descripción</entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry>algorithm</entry>
-              <entry>
-                <type>string</type>
-              </entry>
-              <entry>
-                <simpara>
-                  El algoritmo de cifrado a utilizar. Esta opción es requerida. Especifique una de las siguientes constantes de
-                  <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption</link>:
-                </simpara>
-                <simplelist>
-                  <member>
-                    <constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC</constant>
-                  </member>
-                  <member>
-                    <constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_RANDOM</constant>
-                  </member>
-                  <member>
-                    <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>
-                  </member>
-                  <member>
-                    <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_UNINDEXED</constant>
-                  </member>
-                  <member>
-                    <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>
-                  </member>
-                </simplelist>
-              </entry>
-            </row>
-            <row>
-              <entry>contentionFactor</entry>
-              <entry>
-                <type>int</type>
-              </entry>
-              <entry>
-                <simpara>
-                  El factor de contención para evaluar las consultas con cargas útiles cifradas indexadas.
-                </simpara>
-                <simpara>
-                  Esta opción se aplica únicamente y solo puede ser especificada cuando
-                  <literal>algorithm</literal> es
-                  <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant> o
-                  <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-                </simpara>
-              </entry>
-            </row>
-            <row>
-              <entry>keyAltName</entry>
-              <entry>
-                <type>string</type>
-              </entry>
-              <entry>
-                <simpara>
-                  Identifica un documento de colección de cofre de claves por <literal>keyAltName</literal>. Esta opción es mutuamente exclusiva
-                  con <literal>keyId</literal> y una de las dos es requerida.
-                </simpara>
-              </entry>
-            </row>
-            <row>
-              <entry>keyId</entry>
-              <entry>
-                <classname>MongoDB\BSON\Binary</classname>
-              </entry>
-              <entry>
-                <simpara>
-                  Identifica una clave de datos por <literal>_id</literal>. El valor es un UUID (subtipo binario 4). Esta opción es mutuamente
-                  exclusiva con <literal>keyAltName</literal> y una de las dos es requerida.
-                </simpara>
-              </entry>
-            </row>
-            <row>
-              <entry>queryType</entry>
-              <entry>
-                <type>string</type>
-              </entry>
-              <entry>
-                <simpara>
-                  El tipo de consulta para evaluar las consultas con cargas útiles cifradas indexadas. Especifique una de las siguientes constantes de
-                  <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption</link>:
-                </simpara>
-                <simplelist>
-                  <member>
-                    <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant>
-                  </member>
-                  <member>
-                    <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant>
-                  </member>
-                </simplelist>
-                <simpara>
-                  Esta opción se aplica únicamente y solo puede ser especificada cuando
-                  <literal>algorithm</literal> es
-                  <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant> o
-                  <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-                </simpara>
-              </entry>
-            </row>
-            <row>
-              <entry>rangeOpts</entry>
-              <entry>
-                <type>array</type>
-              </entry>
-              <entry>
-                <simpara>
-                  Opciones de índice para un campo de cifrado interrogeable que soporta consultas "range". Las opciones a continuación deben coincidir
-                  con los valores definidos en <literal>encryptedFields</literal> de la colección objetivo. Para los tipos de campo BSON double y decimal128,
-                  <literal>min</literal>, <literal>max</literal> y <literal>precision</literal> deben ser todos definidos o todos no definidos.
-                </simpara>
-                <para>
-                  <table>
-                    <title>Opciones de índice de rango</title>
-                    <tgroup cols="3">
-                      <thead>
-                        <row>
-                          <entry>Opción</entry>
-                          <entry>Tipo</entry>
-                          <entry>Descripción</entry>
-                        </row>
-                      </thead>
-                      <tbody>
-                        <row>
-                          <entry>min</entry>
-                          <entry>
-                            <type>mixed</type>
-                          </entry>
-                          <entry>Requisito si <literal>precision</literal> está definido. El valor BSON mínimo del rango.</entry>
-                        </row>
-                        <row>
-                          <entry>max</entry>
-                          <entry>
-                            <type>mixed</type>
-                          </entry>
-                          <entry>Requisito si <literal>precision</literal> está definido. El valor BSON máximo del rango.</entry>
-                        </row>
-                        <row>
-                          <entry>sparsity</entry>
-                          <entry>
-                            <type>int</type>
-                          </entry>
-                          <entry>Opcional. Entero positivo de 64 bits.</entry>
-                        </row>
-                        <row>
-                          <entry>precision</entry>
-                          <entry>
-                            <type>int</type>
-                          </entry>
-                          <entry>
-                           Opcional. Entero positivo de 32 bits que especifica la precisión a utilizar
-                           para el cifrado explícito. Solo puede ser definido para los tipos
-                           de campo BSON double o decimal128.
-                          </entry>
-                       </row>
-                       <row>
-                        <entry>trimFactor</entry>
-                        <entry><type>int</type></entry>
-                        <entry>Opcional. Entero positivo de 32 bits.</entry>
-                       </row>
-                      </tbody>
-                    </tgroup>
-                  </table>
-                </para>
-              </entry>
-            </row>
-          </tbody>
-        </tgroup>
+       <title>Opciones de cifrado</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Opción</entry>
+          <entry>Tipo</entry>
+          <entry>Descripción</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>algorithm</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <simpara>
+            El algoritmo de cifrado a utilizar. Esta opción es requerida. Especifique
+            una de las siguientes constantes de
+            <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption</link>:
+           </simpara>
+           <simplelist>
+            <member><constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC</constant></member>
+            <member><constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_RANDOM</constant></member>
+            <member><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant></member>
+            <member><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_UNINDEXED</constant></member>
+            <member><constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant></member>
+           </simplelist>
+          </entry>
+         </row>
+         <row>
+          <entry>contentionFactor</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <simpara>
+            El factor de contención para evaluar las consultas con cargas útiles cifradas
+            indexadas.
+           </simpara>
+           <simpara>
+            Esta opción se aplica únicamente y solo puede ser especificada cuando
+            <literal>algorithm</literal> es
+            <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>
+            o
+            <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
+           </simpara>
+          </entry>
+         </row>
+         <row>
+          <entry>keyAltName</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <simpara>
+            Identifica un documento de colección de cofre de claves por
+            <literal>keyAltName</literal>. Esta opción es mutuamente exclusiva
+            con <literal>keyId</literal> y una de las dos es requerida.
+           </simpara>
+          </entry>
+         </row>
+         <row>
+          <entry>keyId</entry>
+          <entry><classname>MongoDB\BSON\Binary</classname></entry>
+          <entry>
+           <simpara>
+            Identifica una clave de datos por <literal>_id</literal>. El valor es un UUID
+            (subtipo binario 4). Esta opción es mutuamente exclusiva con
+            <literal>keyAltName</literal> y una de las dos es requerida.
+           </simpara>
+          </entry>
+         </row>
+         <row>
+          <entry>queryType</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <simpara>
+            El tipo de consulta para evaluar las consultas con cargas útiles cifradas
+            indexadas. Especifique una de las siguientes constantes de
+            <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption</link>:
+           </simpara>
+           <simplelist>
+            <member><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant></member>
+            <member><constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant></member>
+           </simplelist>
+           <simpara>
+            Esta opción se aplica únicamente y solo puede ser especificada cuando
+            <literal>algorithm</literal> es
+            <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>
+            o <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
+           </simpara>
+          </entry>
+         </row>
+         <row>
+          <entry>rangeOpts</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <simpara>
+            Opciones de índice para un campo de cifrado interrogeable que soporta
+            consultas "range". Las opciones a continuación deben coincidir con los valores definidos en
+            <literal>encryptedFields</literal> de la colección objetivo. Para los
+            tipos de campo BSON double y decimal128, <literal>min</literal>,
+            <literal>max</literal> y <literal>precision</literal> deben ser todos
+            definidos o todos no definidos.
+           </simpara>
+           <para>
+            <table>
+             <title>Opciones de índice de rango</title>
+             <tgroup cols="3">
+              <thead>
+               <row>
+                <entry>Opción</entry>
+                <entry>Tipo</entry>
+                <entry>Descripción</entry>
+               </row>
+              </thead>
+              <tbody>
+               <row>
+                <entry>min</entry>
+                <entry><type>mixed</type></entry>
+                <entry>
+                 Requisito si <literal>precision</literal> está definido. El valor
+                 BSON mínimo del rango.
+                </entry>
+               </row>
+               <row>
+                <entry>max</entry>
+                <entry><type>mixed</type></entry>
+                <entry>
+                 Requisito si <literal>precision</literal> está definido. El valor
+                 BSON máximo del rango.
+                </entry>
+               </row>
+               <row>
+                <entry>sparsity</entry>
+                <entry><type>int</type></entry>
+                <entry>Opcional. Entero positivo de 64 bits.</entry>
+               </row>
+               <row>
+                <entry>precision</entry>
+                <entry><type>int</type></entry>
+                <entry>
+                 Opcional. Entero positivo de 32 bits que especifica la precisión a
+                 utilizar para el cifrado explícito. Solo puede ser definido para los tipos de
+                 campo BSON double o decimal128.
+                </entry>
+               </row>
+               <row>
+                <entry>trimFactor</entry>
+                <entry><type>int</type></entry>
+                <entry>Opcional. Entero positivo de 32 bits.</entry>
+               </row>
+              </tbody>
+             </tgroup>
+            </table>
+           </para>
+          </entry>
+         </row>
+        </tbody>
+       </tgroup>
       </table>
-    </para>
-  </listitem>
-</varlistentry>
+     </para>
+    </listitem>
+   </varlistentry>
 '>
- <!ENTITY mongodb.parameter.query '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>query</parameter> (<classname>MongoDB\Driver\Query</classname>)</term>
-<listitem>
-    <simpara>
-        La consulta a ejecutar.
-    </simpara>
-</listitem>
-</varlistentry>
+<!ENTITY mongodb.parameter.query '
+   <varlistentry xmlns="http://docbook.org/ns/docbook">
+    <term><parameter>query</parameter> (<classname>MongoDB\Driver\Query</classname>)</term>
+    <listitem>
+     <simpara>
+      La consulta a ejecutar.
+     </simpara>
+    </listitem>
+   </varlistentry>
 '>
- <!ENTITY mongodb.parameter.typeMap '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>typeMap</parameter> (<type>array</type>)</term>
-<listitem>
-    <simpara>
-        <link linkend="mongodb.persistence.typemaps">Configuración del mapa de tipos</link>.
-    </simpara>
-</listitem>
-</varlistentry>
+<!ENTITY mongodb.parameter.typeMap '
+   <varlistentry xmlns="http://docbook.org/ns/docbook">
+    <term><parameter>typeMap</parameter> (<type>array</type>)</term>
+    <listitem>
+     <simpara>
+      <link linkend="mongodb.persistence.typemaps">Configuración del mapa de tipos</link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
 '>
- <!ENTITY mongodb.parameter.filter '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>filter</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
-<listitem>
-    <simpara>
-        El <link xlink:href="&url.mongodb.docs;tutorial/query-documents/" xmlns:xlink="http://www.w3.org/1999/xlink">atributo de la consulta</link>.
-        Un atributo vacío hará coincidir todos los documentos de la colección.
-    </simpara>
-    <note>
-        <simpara>
-            Al evaluar los criterios de consulta, MongoDB compara los tipos y los valores según sus propias <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">reglas de comparación para los tipos BSON</link>, que difieren de las reglas de <link linkend="types.comparisons">comparación</link> y de <link linkend="language.types.type-juggling">manipulación de tipos</link> de PHP. Al hacer coincidir un tipo BSON especial, los criterios de consulta deben utilizar la <link linkend="mongodb.bson">clase BSON</link> (ej.: utilizar <classname>MongoDB\BSON\ObjectId</classname> para hacer coincidir un <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
-        </simpara>
-    </note>
-</listitem>
-</varlistentry>
+<!ENTITY mongodb.parameter.filter '
+   <varlistentry xmlns="http://docbook.org/ns/docbook">
+    <term><parameter>filter</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
+    <listitem>
+     <simpara>
+      El <link xlink:href="&url.mongodb.docs;tutorial/query-documents/" xmlns:xlink="http://www.w3.org/1999/xlink">atributo de la consulta</link>.
+      Un atributo vacío hará coincidir todos los documentos de la colección.
+     </simpara>
+     <note>
+      <simpara>
+       Al evaluar los criterios de consulta, MongoDB compara los tipos y los valores según sus propias <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">reglas de comparación para los tipos BSON</link>, que difieren de las reglas de <link linkend="types.comparisons">comparación</link> y de <link linkend="language.types.type-juggling">manipulación de tipos</link> de PHP. Al hacer coincidir un tipo BSON especial, los criterios de consulta deben utilizar la <link linkend="mongodb.bson">clase BSON</link> (ej.: utilizar <classname>MongoDB\BSON\ObjectId</classname> para hacer coincidir un <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
 '>
- <!ENTITY mongodb.returns.cursor '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\Cursor</classname> en caso de éxito.</simpara>'>
- <!ENTITY mongodb.returns.writeresult '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\WriteResult</classname> en caso de éxito.</simpara>'>
- <!ENTITY mongodb.returns.bulkwritecommandresult '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\BulkWriteCommandResult</classname> en caso de éxito.</simpara>'>
- <!ENTITY mongodb.throws.std '&mongodb.throws.argumentparsing;&mongodb.throws.connection;&mongodb.throws.authentication;'>
- <!ENTITY mongodb.throws.session-readwriteconcern '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si la opción <literal>"session"</literal> se utiliza con una transacción asociada en combinación con una opción <literal>"readConcern"</literal> o <literal>"writeConcern"</literal>.</member>'>
- <!ENTITY mongodb.throws.session-unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si la opción <literal>"session"</literal> se utiliza junto con una preocupación de escritura no reconocida.</member>'>
- <!ENTITY mongodb.throws.bulkwritecommandexception '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\BulkWriteCommandException</classname> en caso de error de escritura (por ejemplo, fallo de comando, error de escritura o preocupación de escritura)</member>'>
- <!ENTITY mongodb.throws.bulkwriteexception '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\BulkWriteException</classname> en caso de error de una operación de escritura (un error WriteError y WriteConcern)</member>'>
- <!ENTITY mongodb.throws.argumentparsing '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\InvalidArgumentException</classname> en caso de error durante el análisis de un argumento.</member>'>
- <!ENTITY mongodb.throws.authentication '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\AuthenticationException</classname> si se requiere una identificación pero falla</member>'>
- <!ENTITY mongodb.throws.connection '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\ConnectionException</classname> si la conexión al servidor falla por una razón distinta a un problema de identificación</member>'>
- <!ENTITY mongodb.throws.bson.unexpected '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> si la entrada no contiene exactamente un documento BSON. Las razones posibles incluyen, pero no se limitan a, BSON inválido, datos adicionales (después de leer un documento BSON), o un error inesperado de <link xlink:href="&url.mongodb.libbson;" xmlns:xlink="http://www.w3.org/1999/xlink">libbson</link>.</member>'>
- <!ENTITY mongodb.throws.unacknowledged '
-    <member xmlns="http://docbook.org/ns/docbook">
-        Levanta una excepción <classname>MongoDB\Driver\Exception\LogicException</classname>
-        si la escritura no ha sido reconocida.
-    </member>
-'>
+<!ENTITY mongodb.returns.cursor '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\Cursor</classname> en caso de éxito.</simpara>'>
+<!ENTITY mongodb.returns.writeresult '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\WriteResult</classname> en caso de éxito.</simpara>'>
+<!ENTITY mongodb.returns.bulkwritecommandresult '<simpara xmlns="http://docbook.org/ns/docbook">Retorna un <classname>MongoDB\Driver\BulkWriteCommandResult</classname> en caso de éxito.</simpara>'>
+<!ENTITY mongodb.throws.std '&mongodb.throws.argumentparsing;&mongodb.throws.connection;&mongodb.throws.authentication;'>
+<!ENTITY mongodb.throws.session-readwriteconcern '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si la opción <literal>"session"</literal> se utiliza con una transacción asociada en combinación con una opción <literal>"readConcern"</literal> o <literal>"writeConcern"</literal>.</member>'>
+<!ENTITY mongodb.throws.session-unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si la opción <literal>"session"</literal> se utiliza junto con una preocupación de escritura no reconocida.</member>'>
+<!ENTITY mongodb.throws.bulkwritecommandexception '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\BulkWriteCommandException</classname> en caso de error de escritura (por ejemplo, fallo de comando, error de escritura o preocupación de escritura)</member>'>
+<!ENTITY mongodb.throws.bulkwriteexception '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\BulkWriteException</classname> en caso de error de una operación de escritura (un error WriteError y WriteConcern)</member>'>
+<!ENTITY mongodb.throws.argumentparsing '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> en caso de error durante el análisis de un argumento.</member>'>
+<!ENTITY mongodb.throws.authentication '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\AuthenticationException</classname> si se requiere una identificación pero falla</member>'>
+<!ENTITY mongodb.throws.connection '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\ConnectionException</classname> si la conexión al servidor falla por una razón distinta a un problema de identificación</member>'>
+<!ENTITY mongodb.throws.bson.unexpected '<member xmlns="http://docbook.org/ns/docbook">Lanza una excepción <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> si la entrada no contiene exactamente un documento BSON. Las razones posibles incluyen, pero no se limitan a, BSON inválido, datos adicionales (después de leer un documento BSON), o un error inesperado de <link xlink:href="&url.mongodb.libbson;" xmlns:xlink="http://www.w3.org/1999/xlink">libbson</link>.</member>'>
+<!ENTITY mongodb.throws.unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Levanta una excepción <classname>MongoDB\Driver\Exception\LogicException</classname>si la escritura no ha sido reconocida.</member>'>
 
 <!-- Not used in EN anymore -->
 <!ENTITY mongodb.note.queryable-encryption-preview ''>
 
- <!ENTITY mongodb.note.decimal128 '
-<note xmlns="http://docbook.org/ns/docbook">
-<simpara>
-    <classname>MongoDB\BSON\Decimal128</classname> solo es compatible con
-    MongoDB 3.4+. Si se intenta utilizar el tipo BSON con una versión antigua
-    de MongoDB, se emitirá un error.
-</simpara>
-</note>
+<!ENTITY mongodb.note.decimal128 '
+   <note xmlns="http://docbook.org/ns/docbook">
+    <simpara>
+     <classname>MongoDB\BSON\Decimal128</classname> solo es compatible con
+     MongoDB 3.4+. Si se intenta utilizar el tipo BSON con una versión antigua
+     de MongoDB, se emitirá un error.
+    </simpara>
+   </note>
 '>
-
 <!ENTITY mongodb.note.extended-json '
   <note xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <simpara>
- La salida es coherente con la función <function>MongoDB\BSON\toJSON</function>,
- que utiliza el formato JSON extendido específico del controlador. Esto no corresponde
- necesariamente a las representaciones JSON extendidas
- <link xlink:href="&url.mongodb.specs.extendedjson;#relaxed-extended-json-example">relajadas</link>
- o <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">canónicas</link>
- utilizadas por <function>MongoDB\BSON\toRelaxedExtendedJSON</function> y
- <function>MongoDB\BSON\toCanonicalExtendedJSON</function>, respectivamente.
- </simpara>
- </note>
- '>
+   <simpara>
+    La salida es coherente con la función <function>MongoDB\BSON\toJSON</function>
+    , que utiliza el formato JSON extendido específico del controlador. Esto no corresponde
+    necesariamente a las representaciones JSON extendidas
+    <link xlink:href="&url.mongodb.specs.extendedjson;#relaxed-extended-json-example">relajadas</link>
+    o <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">canónicas</link>
+    utilizadas por
+    <function>MongoDB\BSON\toRelaxedExtendedJSON</function> y
+    <function>MongoDB\BSON\toCanonicalExtendedJSON</function>, respectivamente.
+   </simpara>
+  </note>
+'>
 <!ENTITY mongodb.note.forking '
- <note xmlns="http://docbook.org/ns/docbook">
- <simpara>
- En las plataformas Unix, la extensión MongoDB es sensible a los scripts que utilizan
- la llamada al sistema fork() sin llamar a exec(). No se deben reutilizar
- instancias <classname>MongoDB\Driver\Manager</classname> en un proceso
- hijo derivado de un fork.
- </simpara>
- </note>
- '>
+   <note xmlns="http://docbook.org/ns/docbook">
+    <simpara>
+     En las plataformas Unix, la extensión MongoDB es sensible a los scripts que
+     utilizan la llamada al sistema fork() sin llamar a exec(). No se deben reutilizar
+     instancias <classname>MongoDB\Driver\Manager</classname> en un proceso hijo derivado
+     de un fork.
+    </simpara>
+   </note>
+'>
 
 <!ENTITY mongodb.note.uint32 '
- <note xmlns="http://docbook.org/ns/docbook">
- <simpara>
- Dado que el tipo entero de PHP es firmado, algunos valores
- devueltos por este método pueden aparecer como enteros negativos
- en las plataformas de 32 bits. El formateador "&#37;u" de
- <function>sprintf</function> puede ser utilizado para obtener una
- representación en forma de string del valor decimal no firmado.
- </simpara>
- </note>'>
+  <note xmlns="http://docbook.org/ns/docbook">
+   <simpara>
+    Dado que el tipo integer de PHP es con signo, algunos de los valores devueltos por
+    este método pueden aparecer como enteros negativos en plataformas de 32 bits. El formateador
+    <literal>"&#37;u"</literal> de <function>sprintf</function> se puede
+    utilizar para obtener una representación en forma de string del valor decimal sin signo.
+   </simpara>
+  </note>
+'>
 
 <!ENTITY mongodb.note.server.readpreference '
- <note xmlns="http://docbook.org/ns/docbook">
- <simpara>
- La opción <literal>readPreference</literal> no controla el servidor hacia
- el cual el controlador emite la operación; siempre se ejecutará en este objeto
- servidor. En su lugar, puede ser utilizado al emitir
- la operación a un secundario (desde una conexión de conjunto de réplicas,
- no autónoma) o el nodo Mongos para asegurarse de que el controlador defina el
- protocolo de fila en consecuencia o añada la preferencia de lectura a
- la operación, respectivamente.
- </simpara>
- </note>
- '>
+  <note xmlns="http://docbook.org/ns/docbook">
+   <simpara>
+    La opción <literal>"readPreference"</literal> no controla el servidor hacia el
+    cual el controlador emite la operación; siempre se ejecutará en este objeto servidor. En su
+    lugar, puede ser utilizado al emitir la operación a un secundario (desde una conexión de
+    conjunto de réplicas, no autónoma) o el nodo Mongos para asegurarse de que
+    el controlador defina el protocolo de fila en consecuencia o añada la preferencia de
+    lectura a la operación, respectivamente.
+   </simpara>
+  </note>
+'>
 
 <!ENTITY mongodb.note.server.write '
- <note xmlns="http://docbook.org/ns/docbook">
- <simpara>
- Es responsabilidad del llamante asegurarse de que el
- servidor sea capaz de ejecutar la operación de escritura. Por
- ejemplo, la ejecución de una operación de escritura en un
- secundario (excluyendo su base de datos "local") fallará.
- </simpara>
- </note>
- '>
+  <note xmlns="http://docbook.org/ns/docbook">
+   <simpara>
+    Es responsabilidad del llamante asegurarse de que el servidor sea capaz de ejecutar la
+    operación de escritura. Por ejemplo, la ejecución de una operación de escritura
+    en un secundario (excluyendo su base de datos "local") fallará.
+   </simpara>
+  </note>
+'>
 
 <!ENTITY mongodb.warning.duplicate-keys '
- <warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
- Los documentos BSON pueden contener técnicamente claves duplicadas ya que
- los documentos se almacenan como una lista de pares clave-valor;
- sin embargo, las aplicaciones deben abstenerse de generar
- documentos con claves duplicadas ya que el comportamiento del servidor y del
- controlador puede ser indefinido. Dado que los objetos y arrays de PHP no pueden
- tener claves duplicadas, los datos también podrían perderse al decodificar
- un documento BSON con claves duplicadas.
- </simpara>
- </warning>
- '>
+   <warning xmlns="http://docbook.org/ns/docbook">
+    <simpara>
+     Los documentos BSON pueden contener técnicamente claves duplicadas ya que los documentos
+     se almacenan como una lista de pares clave-valor; sin embargo, las aplicaciones deben abstenerse
+     de generar documentos con claves duplicadas ya que el comportamiento del servidor y
+     del controlador puede ser indefinido. Dado que los objetos y arrays de PHP no pueden
+     tener claves duplicadas, los datos también podrían perderse al decodificar un documento BSON con claves duplicadas.
+    </simpara>
+   </warning>
+'>
 
 <!-- Radius -->
 <!ENTITY radius.request.required '<note xmlns="http://docbook.org/ns/docbook"><simpara>Una petición debe ser creada mediante la función <function>radius_create_request</function> antes de que esta función pueda ser llamada.</simpara></note>'>
@@ -3958,590 +3830,585 @@ local: {
 <!ENTITY posix.parameter.fd '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>file_descriptor</parameter></term>
  <listitem>
- <simpara>
- El descriptor de archivo, que debe ser ya sea una recurso
- de archivo, o un entero. Un entero se asume como un descriptor
- de archivo que puede ser pasado directamente a la llamada al sistema
- subyacente.
- </simpara>
+  <simpara>
+   El descriptor de fichero, el cual se espera que sea un
+   <type>resource</type> de fichero o un <type>int</type>. Se asumirá que un <type>int</type>
+   es un descriptor de fichero que puede ser pasado directamente a la
+   llamada al sistema subyacente.
+  </simpara>
  </listitem>
- </varlistentry>'>
+</varlistentry>'>
 
 <!ENTITY posix.rlimits '
- <simpara xmlns="http://docbook.org/ns/docbook">
- Cada recurso tiene un límite soft y hard asociados. El límite
- soft corresponde al valor que el núcleo fuerza para el recurso
- correspondiente. El límite hard actúa como un techo del límite soft.
- Un proceso no privilegiado solo puede definir su límite soft en un
- valor comprendido entre 0 y el límite hard, lo que solo hará bajar
- su límite hard.
- </simpara>
- '>
+<simpara xmlns="http://docbook.org/ns/docbook">
+  Cada recurso tiene un límite soft y hard asociados. El límite soft
+  corresponde al valor que el núcleo fuerza para el recurso correspondiente.
+  El límite hard actúa como un techo del límite soft. Un proceso no
+  privilegiado solo puede definir su límite soft en un valor comprendido entre
+  0 y el límite hard, lo que solo hará bajar su límite hard.
+</simpara>
+'>
 
 <!-- strings snippets -->
 <!ENTITY strings.stripped.characters '
  <itemizedlist xmlns="http://docbook.org/ns/docbook">
- <listitem>
- <simpara>
- <literal>" "</literal>: carácter <acronym>SP</acronym> en <acronym>ASCII</acronym>
- <literal>0x20</literal>, un espacio ordinario.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\t"</literal>: carácter <acronym>HT</acronym> en <acronym>ASCII</acronym>
- <literal>0x09</literal>, una tabulación.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\n"</literal>: carácter <acronym>LF</acronym> en <acronym>ASCII</acronym>
- <literal>0x0A</literal>, un salto de línea (line feed).
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\r"</literal>: carácter <acronym>CR</acronym> en <acronym>ASCII</acronym>
- <literal>0x0D</literal>, un retorno de carro.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\0"</literal>: carácter <acronym>NUL</acronym> en <acronym>ASCII</acronym>
- <literal>0x00</literal>, el octeto NUL.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\v"</literal>: carácter <acronym>VT</acronym> en <acronym>ASCII</acronym>
- <literal>0x0B</literal>, una tabulación vertical.
- </simpara>
- </listitem>
- </itemizedlist>
- '>
+    <listitem>
+     <simpara>
+      <literal>" "</literal>: carácter <acronym>SP</acronym> en <acronym>ASCII</acronym>
+      <literal>0x20</literal>, un espacio ordinario.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\t"</literal>: carácter <acronym>HT</acronym> en <acronym>ASCII</acronym>
+      <literal>0x09</literal>, una tabulación.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\n"</literal>: carácter <acronym>LF</acronym> en <acronym>ASCII</acronym>
+      <literal>0x0A</literal>, un salto de línea (line feed).
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\r"</literal>: carácter <acronym>CR</acronym> en <acronym>ASCII</acronym>
+      <literal>0x0D</literal>, un retorno de carro.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\0"</literal>: carácter <acronym>NUL</acronym> en <acronym>ASCII</acronym>
+      <literal>0x00</literal>, el octeto NUL.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\v"</literal>: carácter <acronym>VT</acronym> en <acronym>ASCII</acronym>
+      <literal>0x0B</literal>, una tabulación vertical.
+     </simpara>
+    </listitem>
+   </itemizedlist>
+'>
 
 <!ENTITY strings.stripped.unicode '
  <itemizedlist xmlns="http://docbook.org/ns/docbook">
- <listitem>
- <simpara>
- <literal>" "</literal> (<acronym>Unicode</acronym> U+0020), un espacio ordinario.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\t"</literal> (<acronym>Unicode</acronym> U+0009), una tabulación.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\n"</literal> (<acronym>Unicode</acronym> U+000A), un salto de línea.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\r"</literal> (<acronym>Unicode</acronym> U+000D), un retorno de carro.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\0"</literal> (<acronym>Unicode</acronym> U+0000), el octeto NUL.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\v"</literal> (<acronym>Unicode</acronym> U+000B), una tabulación vertical.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\f"</literal> (<acronym>Unicode</acronym> U+000C), un avance de página.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u00A0"</literal> (<acronym>Unicode</acronym> U+00A0), un ESPACIO INSÉCABLE.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u1680"</literal> (<acronym>Unicode</acronym> U+1680), una MARCA DE ESPACIO OGHAM.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2000"</literal> (<acronym>Unicode</acronym> U+2000), un CUADRADO MEDIO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2001"</literal> (<acronym>Unicode</acronym> U+2001), un CUADRADO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2002"</literal> (<acronym>Unicode</acronym> U+2002), un ESPACIO MEDIO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2003"</literal> (<acronym>Unicode</acronym> U+2003), un ESPACIO CUADRADO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2004"</literal> (<acronym>Unicode</acronym> U+2004), un ESPACIO DE UN-TERCIO-DE-CUADRADO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2005"</literal> (<acronym>Unicode</acronym> U+2005), un ESPACIO DE UN-CUARTO-DE-CUADRADO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2006"</literal> (<acronym>Unicode</acronym> U+2006), un ESPACIO DE UN-SEXTO-DE-CUADRADO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2007"</literal> (<acronym>Unicode</acronym> U+2007), un ESPACIO PARA DÍGITOS.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2008"</literal> (<acronym>Unicode</acronym> U+2008), un ESPACIO DE PUNTUACIÓN.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2009"</literal> (<acronym>Unicode</acronym> U+2009), un ESPACIO FINO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u200A"</literal> (<acronym>Unicode</acronym> U+200A), un ESPACIO PELUDO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2028"</literal> (<acronym>Unicode</acronym> U+2028), un SEPARADOR DE LÍNEA.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u2029"</literal> (<acronym>Unicode</acronym> U+2029), un SEPARADOR DE PÁRRAFO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u202F"</literal> (<acronym>Unicode</acronym> U+202F), un ESPACIO INSÉCABLE ESTRECHO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u205F"</literal> (<acronym>Unicode</acronym> U+205F), un ESPACIO MATEMÁTICO MEDIO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u3000"</literal> (<acronym>Unicode</acronym> U+3000), un ESPACIO IDEOGRÁFICO.
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u0085"</literal> (<acronym>Unicode</acronym> U+0085), una LÍNEA SIGUIENTE (NEL).
- </simpara>
- </listitem>
- <listitem>
- <simpara>
- <literal>"\u180E"</literal> (<acronym>Unicode</acronym> U+180E), un SEPARADOR DE VOCALES MONGOL.
- </simpara>
- </listitem>
- </itemizedlist>
- '>
+    <listitem>
+     <simpara>
+      <literal>" "</literal> (<acronym>Unicode</acronym> U+0020), un espacio ordinario.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\t"</literal> (<acronym>Unicode</acronym> U+0009), una tabulación.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\n"</literal> (<acronym>Unicode</acronym> U+000A), un salto de línea.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\r"</literal> (<acronym>Unicode</acronym> U+000D), un retorno de carro.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\0"</literal> (<acronym>Unicode</acronym> U+0000), el octeto NUL.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\v"</literal> (<acronym>Unicode</acronym> U+000B), una tabulación vertical.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\f"</literal> (<acronym>Unicode</acronym> U+000C), un avance de página.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u00A0"</literal> (<acronym>Unicode</acronym> U+00A0), un ESPACIO INSÉCABLE.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u1680"</literal> (<acronym>Unicode</acronym> U+1680), una MARCA DE ESPACIO OGHAM.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u2000"</literal> (<acronym>Unicode</acronym> U+2000), un CUADRADO MEDIO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u2001"</literal> (<acronym>Unicode</acronym> U+2001), un CUADRADO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u2002"</literal> (<acronym>Unicode</acronym> U+2002), un ESPACIO MEDIO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u2003"</literal> (<acronym>Unicode</acronym> U+2003), un ESPACIO CUADRADO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u2004"</literal> (<acronym>Unicode</acronym> U+2004), un ESPACIO DE UN-TERCIO-DE-CUADRADO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u2005"</literal> (<acronym>Unicode</acronym> U+2005), un ESPACIO DE UN-CUARTO-DE-CUADRADO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\u2006"</literal> (<acronym>Unicode</acronym> U+2006), un ESPACIO DE UN-SEXTO-DE-CUADRADO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u2007"</literal> (<acronym>Unicode</acronym> U+2007), un ESPACIO PARA DÍGITOS.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u2008"</literal> (<acronym>Unicode</acronym> U+2008), un ESPACIO DE PUNTUACIÓN.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u2009"</literal> (<acronym>Unicode</acronym> U+2009), un ESPACIO FINO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u200A"</literal> (<acronym>Unicode</acronym> U+200A), un ESPACIO PELUDO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u2028"</literal> (<acronym>Unicode</acronym> U+2028), un SEPARADOR DE LÍNEA.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u2029"</literal> (<acronym>Unicode</acronym> U+2029), un SEPARADOR DE PÁRRAFO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u202F"</literal> (<acronym>Unicode</acronym> U+202F), un ESPACIO INSÉCABLE ESTRECHO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u205F"</literal> (<acronym>Unicode</acronym> U+205F), un ESPACIO MATEMÁTICO MEDIO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u3000"</literal> (<acronym>Unicode</acronym> U+3000), un ESPACIO IDEOGRÁFICO.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u0085"</literal> (<acronym>Unicode</acronym> U+0085), una LÍNEA SIGUIENTE (NEL).
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+     <literal>"\u180E"</literal> (<acronym>Unicode</acronym> U+180E), un SEPARADOR DE VOCALES MONGOL.
+     </simpara>
+    </listitem>
+   </itemizedlist>
+'>
 
 <!ENTITY strings.parameter.characters.optional '
  <simpara xmlns="http://docbook.org/ns/docbook">
- Opcionalmente, los caracteres a eliminar también pueden ser especificados utilizando
- el parámetro <parameter>characters</parameter>.
- Basta con listar todos los caracteres que deben ser eliminados.
- Con <literal>..</literal>, es posible especificar un rango creciente de caracteres.
+  Opcionalmente, los caracteres a eliminar también pueden ser especificados utilizando el
+  parámetro <parameter>characters</parameter>.
+  Basta con listar todos los caracteres que deben ser eliminados.
+  Con <literal>..</literal>, es posible especificar un rango creciente de caracteres.
  </simpara>
- '>
+'>
 
 <!ENTITY strings.parameter.unicode.optional '
  <simpara xmlns="http://docbook.org/ns/docbook">
- Opcionalmente, los caracteres a eliminar también pueden ser especificados utilizando
- el parámetro <parameter>characters</parameter>.
- Basta con listar todos los caracteres a eliminar.
+  Opcionalmente, los caracteres a eliminar también pueden ser especificados utilizando el
+  parámetro <parameter>characters</parameter>.
+  Basta con listar todos los caracteres a eliminar.
  </simpara>
- '>
+'>
 
 <!ENTITY strings.parameter.encoding '
  <simpara xmlns="http://docbook.org/ns/docbook">
- Un argumento opcional que define el codificado utilizado durante
- la conversión de caracteres.
+  Un argumento opcional que define el codificado utilizado durante la conversión de caracteres.
  </simpara>
 
  <simpara xmlns="http://docbook.org/ns/docbook">
- Si se omite, el valor por omisión del parámetro <parameter>encoding</parameter>
- es el valor de la opción de configuración
- <link linkend="ini.default-charset">default_charset</link>.
+  Si se omite, el valor predeterminado del parámetro <parameter>encoding</parameter> es el valor de la opción de configuración
+  <link linkend="ini.default-charset">default_charset</link>
+  .
  </simpara>
 
  <simpara xmlns="http://docbook.org/ns/docbook">
- Aunque este argumento es técnicamente opcional, se recomienda encarecidamente
- especificar el valor correcto para su código si la opción de configuración
- <link linkend="ini.default-charset">default_charset</link>
- ha sido definida incorrectamente para la entrada proporcionada.
+  Aunque este argumento es técnicamente opcional, se recomienda encarecidamente especificar el valor
+  correcto para su código si la opción
+  de configuración <link linkend="ini.default-charset">default_charset</link>
+  ha sido definida incorrectamente para la entrada proporcionada.
  </simpara>
- '>
+'>
 
 <!ENTITY strings.parameter.format '
- <varlistentry xmlns="http://docbook.org/ns/docbook">
+<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>format</parameter></term>
  <listitem>
- <simpara>
- La cadena de formato está compuesta por cero o más directivas:
- caracteres ordinarios (excepto <literal>&#37;</literal>)
- que se copian directamente al resultado y
- <emphasis>especificaciones de conversión</emphasis>,
- cada una con su propio parámetro.
- </simpara>
+  <simpara>
+   La cadena de formato está compuesta por cero o más directivas:
+   caracteres ordinarios (excepto <literal>&#37;</literal>) que se
+   copian directamente al resultado y <emphasis>especificaciones de
+   conversión</emphasis>, cada una con su propio
+   parámetro.
+  </simpara>
 
- <simpara>
- Una especificación de conversión que sigue este prototipo:
- <literal>&#37;[argnum$][flags][width][.precision]specifier</literal>.
- </simpara>
+  <simpara>
+   Una especificación de conversión que sigue este prototipo:
+   <literal>&#37;[argnum$][flags][width][.precision]specifier</literal>.
+  </simpara>
 
-<formalpara>
- <title>Argnum</title>
- <para>
-  Un &integer; seguido de un signo dólar <literal>$</literal>,
-  para especificar qué número de argumento tratar en la conversión.
- </para>
-</formalpara>
+  <formalpara>
+   <title>Argnum</title>
+   <para>
+    Un &integer; seguido de un signo dólar <literal>$</literal>,
+    para especificar qué número de argumento tratar en la conversión.
+   </para>
+  </formalpara>
 
-<formalpara>
- <title>Banderas</title>
- <para>
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>Bandera</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry><literal>-</literal></entry>
-      <entry>
-       Justifica el texto a la izquierda dado el ancho del campo;
-       la justificación a la derecha es el comportamiento por omisión.
-      </entry>
-     </row>
-     <row>
-      <entry><literal>+</literal></entry>
-      <entry>
-       Prefija los números positivos con un signo más
-       <literal>+</literal>; por omisión solo los números
-       negativos son prefijados con un signo negativo.
-      </entry>
-     </row>
-     <row>
-      <entry><literal> </literal>(espacio)</entry>
-      <entry>
-       Rellena el resultado con espacios.
-       Esto es por omisión.
-      </entry>
-     </row>
-     <row>
-      <entry><literal>0</literal></entry>
-      <entry>
-       Rellena solo los números a la izquierda con ceros.
-       Con el especificador <literal>s</literal> esto también puede
-       rellenar a la derecha con ceros.
-      </entry>
-     </row>
-     <row>
-      <entry><literal>&apos;</literal>(char)</entry>
-      <entry>
-       Rellena el resultado con el carácter (char).
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
- </para>
-</formalpara>
+  <formalpara>
+   <title>Banderas</title>
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>Bandera</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry><literal>-</literal></entry>
+        <entry>
+         Justifica el texto a la izquierda dado el ancho del campo;
+         la justificación a la derecha es el comportamiento predeterminado.
+        </entry>
+       </row>
+       <row>
+        <entry><literal>+</literal></entry>
+        <entry>
+         Prefija los números positivos con un signo más
+         <literal>+</literal>; por defecto solo los
+         números negativos son prefijados con un signo negativo.
+        </entry>
+       </row>
+       <row>
+        <entry><literal> </literal>(espacio)</entry>
+        <entry>
+         Rellena el resultado con espacios.
+         Esto es por defecto.
+        </entry>
+       </row>
+       <row>
+        <entry><literal>0</literal></entry>
+        <entry>
+         Rellena solo los números a la izquierda con ceros. Con
+         el especificador <literal>s</literal> esto también puede rellenar
+         a la derecha con ceros.
+        </entry>
+       </row>
+       <row>
+        <entry><literal>&apos;</literal>(char)</entry>
+        <entry>
+         Rellena el resultado con el carácter (char).
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </formalpara>
 
-<formalpara>
- <title>Ancho</title>
- <para>
-  Sea un entero indicando el número de caracteres (mínimo)
-  que esta conversión debe producir, o <literal>*</literal>.
-  Si <literal>*</literal> es utilizado, entonces el ancho es proporcionado
-  como un valor entero adicional precediendo al que se formatea
-  por el especificador.
- </para>
-</formalpara>
-
-<formalpara>
- <title>Precisión</title>
- <para>
-  Un punto <literal>.</literal> seguido opcionalmente
-  sea de un entero, o de <literal>*</literal>,
-  cuya significación depende del especificador:
-  <itemizedlist>
-   <listitem>
-    <simpara>
-     Para los especificadores <literal>e</literal>, <literal>E</literal>,
-     <literal>f</literal> y <literal>F</literal>:
-     esto es el número de dígitos a mostrar después
-     de la coma (por omisión, esto es 6).
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     Para los especificadores <literal>g</literal>, <literal>G</literal>,
-     <literal>h</literal> y <literal>H</literal>:
-     esto es el número máximo de dígitos significativos a mostrar.
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     Para el especificador <literal>s</literal>: actúa como un punto de corte,
-     definiendo un límite máximo de caracteres de la cadena.
-    </simpara>
-   </listitem>
-  </itemizedlist>
-  <note>
-   <simpara>
-    Si el punto es especificado sin un valor explícito para la precisión,
-    0 es asumido. Si <literal>*</literal> es utilizado, la precisión es
-    proporcionada como un valor entero adicional precediendo al que se formatea
+  <formalpara>
+   <title>Ancho</title>
+   <para>
+    Sea un entero indicando el número de caracteres (mínimo)
+    que esta conversión debe producir, o <literal>*</literal>.
+    Si <literal>*</literal> es utilizado, entonces el ancho es proporcionado
+    como un valor entero adicional precediendo al que se formatea
     por el especificador.
+   </para>
+  </formalpara>
+
+  <formalpara>
+   <title>Precisión</title>
+   <para>
+    Un punto <literal>.</literal> seguido opcionalmente sea
+    de un entero, o de <literal>*</literal>,
+    cuya significación depende del especificador:
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       Para los especificadores <literal>e</literal>, <literal>E</literal>,
+       <literal>f</literal> y <literal>F</literal>
+       : esto es el número de dígitos a mostrar
+       después de la coma (por defecto, esto es 6).
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Para los especificadores <literal>g</literal>, <literal>G</literal>,
+       <literal>h</literal> y <literal>H</literal>
+       : esto es el número máximo de
+       dígitos significativos a mostrar.
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Para el especificador <literal>s</literal>: actúa como un punto de corte,
+       definiendo un límite máximo de caracteres de la cadena.
+      </simpara>
+     </listitem>
+    </itemizedlist>
+    <note>
+     <simpara>
+      Si el punto es especificado sin un valor explícito para la precisión,
+      0 es asumido. Si <literal>*</literal> es utilizado, la precisión es
+      proporcionada como un valor entero adicional precediendo al que se formatea
+      por el especificador.
+     </simpara>
+    </note>
+   </para>
+  </formalpara>
+
+  <para>
+   <table>
+    <title>Especificadores</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Especificador</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><literal>&#37;</literal></entry>
+       <entry>
+        Un carácter de porcentaje literal. No se necesita ningún argumento.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>b</literal></entry>
+       <entry>
+        El argumento es tratado como un entero y presentado
+        como un número binario.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>c</literal></entry>
+       <entry>
+        El argumento es tratado como un entero y presentado como
+        el carácter de código ASCII correspondiente.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>d</literal></entry>
+       <entry>
+        El argumento es tratado como un entero y presentado como
+        un número entero decimal (firmado).
+       </entry>
+      </row>
+      <row>
+       <entry><literal>e</literal></entry>
+       <entry>
+        El argumento es tratado como una notación científica (ej. 1.2e+2).
+       </entry>
+      </row>
+      <row>
+       <entry><literal>E</literal></entry>
+       <entry>
+        Como el especificador <literal>e</literal> pero utiliza una
+        letra mayúscula (por ejemplo 1.2E+2).
+       </entry>
+      </row>
+      <row>
+       <entry><literal>f</literal></entry>
+       <entry>
+        El argumento es tratado como un número de coma flotante (tipo &float;) y presentado como un
+        número de coma flotante (teniendo en cuenta la configuración local).
+       </entry>
+      </row>
+      <row>
+       <entry><literal>F</literal></entry>
+       <entry>
+        El argumento es tratado como un número de coma flotante (tipo &float;) y presentado como un
+        número de coma flotante (sin tener en cuenta la configuración local).
+       </entry>
+      </row>
+      <row>
+       <entry><literal>g</literal></entry>
+       <entry>
+        <simpara>
+         Formato general.
+        </simpara>
+        <simpara>
+         Sea P igual a la precisión si diferente de 0, 6 si la precisión
+         es omitida o 1 si la precisión
+         es cero. Entonces, si la conversión con el estilo E tuviera como exponente X:
+        </simpara>
+        <simpara>
+         Si P > X ≥ −4, la conversión es con estilo f y precisión P − (X + 1). De lo
+         contrario, la conversión es con el estilo e y precisión P - 1.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry><literal>G</literal></entry>
+       <entry>
+        Como el especificador <literal>g</literal> pero utiliza
+        <literal>E</literal> y <literal>f</literal>.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>h</literal></entry>
+       <entry>
+        Como el especificador <literal>g</literal> pero utiliza <literal>F</literal>.
+        Disponible a partir de PHP 8.0.0.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>H</literal></entry>
+       <entry>
+        Como el especificador <literal>g</literal> pero utiliza
+        <literal>E</literal> y <literal>F</literal>. Disponible a partir de PHP 8.0.0.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>o</literal></entry>
+       <entry>
+        El argumento es tratado como un entero y presentado
+        como un número octal.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>s</literal></entry>
+       <entry>
+        El argumento es tratado y presentado como una cadena de caracteres.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>u</literal></entry>
+       <entry>
+        El argumento es tratado como un entero y presentado como
+        un número decimal no firmado.
+       </entry>
+      </row>
+      <row>
+       <entry><literal>x</literal></entry>
+       <entry>
+        El argumento es tratado como un entero y presentado como
+        un número hexadecimal (las letras en minúsculas).
+       </entry>
+      </row>
+      <row>
+       <entry><literal>X</literal></entry>
+       <entry>
+        El argumento es tratado como un entero y presentado como
+        un número hexadecimal (las letras en mayúsculas).
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <warning>
+   <simpara>
+    El especificador de tipo <literal>c</literal> ignora el alineamiento y el tamaño.
    </simpara>
-  </note>
- </para>
-</formalpara>
+  </warning>
 
-<para>
- <table>
-  <title>Especificadores</title>
-  <tgroup cols="2">
-   <thead>
-    <row>
-     <entry>Especificador</entry>
-     <entry>&Description;</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry><literal>&#37;</literal></entry>
-     <entry>
-      Un carácter de porcentaje literal. No se necesita ningún argumento.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>b</literal></entry>
-     <entry>
-      El argumento es tratado como un entero y presentado
-      como un número binario.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>c</literal></entry>
-     <entry>
-      El argumento es tratado como un entero y presentado
-      como el carácter de código ASCII correspondiente.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>d</literal></entry>
-     <entry>
-      El argumento es tratado como un entero y presentado
-      como un número entero decimal (firmado).
-     </entry>
-    </row>
-    <row>
-     <entry><literal>e</literal></entry>
-     <entry>
-      El argumento es tratado como una notación científica
-      (ej. <literal>1.2e+2</literal>).
-     </entry>
-    </row>
-    <row>
-     <entry><literal>E</literal></entry>
-     <entry>
-      Como el especificador <literal>e</literal> pero utiliza
-      una letra mayúscula (por ejemplo 1.2E+2).
-     </entry>
-    </row>
-    <row>
-     <entry><literal>f</literal></entry>
-     <entry>
-      El argumento es tratado como un número de coma flotante
-      (tipo &float;) y presentado como un número de coma
-      flotante (teniendo en cuenta la configuración local).
-     </entry>
-    </row>
-    <row>
-     <entry><literal>F</literal></entry>
-     <entry>
-      El argumento es tratado como un número de coma flotante
-      (tipo &float;) y presentado como un número de coma
-      flotante (sin tener en cuenta la configuración local).
-     </entry>
-    </row>
-    <row>
-     <entry><literal>g</literal></entry>
-     <entry>
-      <simpara>
-       Formato general.
-      </simpara>
-      <simpara>
-       Sea P igual a la precisión si diferente de 0, 6 si la precisión
-       es omitida o 1 si la precisión es cero.
-       Entonces, si la conversión con el estilo E tuviera como exponente X:
-      </simpara>
-      <simpara>
-       Si P > X ≥ −4, la conversión es con estilo f y precisión P − (X + 1).
-       De lo contrario, la conversión es con el estilo e y precisión P - 1.
-      </simpara>
-     </entry>
-    </row>
-    <row>
-     <entry><literal>G</literal></entry>
-     <entry>
-      Como el especificador <literal>g</literal> pero utiliza
-      <literal>E</literal> y <literal>f</literal>.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>h</literal></entry>
-     <entry>
-      Como el especificador <literal>g</literal> pero utiliza <literal>F</literal>.
-      Disponible a partir de PHP 8.0.0.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>H</literal></entry>
-     <entry>
-      Como el especificador <literal>g</literal> pero utiliza
-      <literal>E</literal> y <literal>F</literal>. Disponible a partir de PHP 8.0.0.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>o</literal></entry>
-     <entry>
-      El argumento es tratado como un entero y presentado
-      como un número octal.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>s</literal></entry>
-     <entry>
-      El argumento es tratado y presentado como una cadena de caracteres.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>u</literal></entry>
-     <entry>
-      El argumento es tratado como un entero y presentado
-      como un número decimal no firmado.
-     </entry>
-    </row>
-    <row>
-     <entry><literal>x</literal></entry>
-     <entry>
-      El argumento es tratado como un entero y presentado
-      como un número hexadecimal (las letras en minúsculas).
-     </entry>
-    </row>
-    <row>
-     <entry><literal>X</literal></entry>
-     <entry>
-      El argumento es tratado como un entero y presentado
-      como un número hexadecimal (las letras en mayúsculas).
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
-</para>
+  <warning>
+   <simpara>
+    Intentar utilizar una combinación de una cadena y especificadores con juegos de caracteres que necesitan más de un octeto por carácter dará un resultado inesperado.
+   </simpara>
+  </warning>
 
-<warning>
- <simpara>
-  El especificador de tipo <literal>c</literal> ignora el alineamiento y el tamaño.
- </simpara>
-</warning>
-
-<warning>
- <simpara>
-  Intentar utilizar una combinación de una cadena
-  y especificadores con juegos de caracteres que necesitan
-  más de un octeto por carácter dará un resultado inesperado.
- </simpara>
-</warning>
-
-<para>
- Las variables serán forzadas a un tipo apropiado para el especificador:
- <table>
-  <title>Manejo de tipos</title>
-  <tgroup cols="2">
-   <thead>
-    <row>
-     <entry>Tipo</entry>
-     <entry>Especificadores</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry><type>string</type></entry>
-     <entry><literal>s</literal></entry>
-    </row>
-    <row>
-     <entry><type>int</type></entry>
-     <entry>
-      <literal>d</literal>,
-      <literal>u</literal>,
-      <literal>c</literal>,
-      <literal>o</literal>,
-      <literal>x</literal>,
-      <literal>X</literal>,
-      <literal>b</literal>
-     </entry>
-    </row>
-    <row>
-     <entry><type>float</type></entry>
-     <entry>
-      <literal>e</literal>,
-      <literal>E</literal>,
-      <literal>f</literal>,
-      <literal>F</literal>,
-      <literal>g</literal>,
-      <literal>G</literal>,
-      <literal>h</literal>,
-      <literal>H</literal>
-     </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
-</para>
+  <para>
+   Las variables serán forzadas a un tipo apropiado para el especificador:
+   <table>
+    <title>Manejo de tipos</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Tipo</entry>
+       <entry>Especificadores</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><type>string</type></entry>
+       <entry><literal>s</literal></entry>
+      </row>
+      <row>
+       <entry><type>int</type></entry>
+       <entry>
+        <literal>d</literal>,
+        <literal>u</literal>,
+        <literal>c</literal>,
+        <literal>o</literal>,
+        <literal>x</literal>,
+        <literal>X</literal>,
+        <literal>b</literal>
+       </entry>
+      </row>
+      <row>
+       <entry><type>float</type></entry>
+       <entry>
+        <literal>e</literal>,
+        <literal>E</literal>,
+        <literal>f</literal>,
+        <literal>F</literal>,
+        <literal>g</literal>,
+        <literal>G</literal>,
+        <literal>h</literal>,
+        <literal>H</literal>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
  </listitem>
- </varlistentry>
- '>
+</varlistentry>
+'>
 
- <!ENTITY strings.scanf.parameter.format '
+<!ENTITY strings.scanf.parameter.format '
 <varlistentry xmlns="http://docbook.org/ns/docbook">
      <term><parameter>format</parameter></term>
      <listitem>
       <para>
-       El formato interpretado para <parameter>string</parameter> se describe
-       en la documentación de la <function>sprintf</function> con las siguientes diferencias:
+       El formato interpretado para <parameter>string</parameter> se describe en
+       la documentación de la <function>sprintf</function> con
+       las siguientes diferencias:
        <simplelist>
         <member>
          La función no tiene en cuenta el contexto local.
@@ -4572,34 +4439,37 @@ local: {
     </varlistentry>
 '>
 
- <!ENTITY strings.parameter.needle.non-string '
+<!ENTITY strings.parameter.needle.non-string '
  <simpara xmlns="http://docbook.org/ns/docbook">
-  Anterior a PHP 8.0.0, si <parameter>needle</parameter> no es una cadena de caracteres,
-  se convierte en un entero y se aplica como valor ordinal de un carácter.
-  Este comportamiento está obsoleto a partir de PHP 7.3.0, y confiar en él
+  Anterior a PHP 8.0.0, si <parameter>needle</parameter> no es una cadena de caracteres, se
+  convierte en un entero y se aplica como valor ordinal de un
+  carácter. Este comportamiento está obsoleto a partir de PHP 7.3.0, y confiar en él
   está fuertemente desaconsejado. Dependiendo del comportamiento esperado,
   <parameter>needle</parameter> debe ser explícitamente convertido a una cadena de caracteres,
   o debe realizarse una llamada explícita a <function>chr</function>.
  </simpara>
-'><!ENTITY strings.changelog.needle-empty '<row xmlns="http://docbook.org/ns/docbook">
+'>
+
+<!ENTITY strings.changelog.needle-empty '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
   <parameter>needle</parameter> acepta ahora una cadena vacía.
  </entry>
 </row>'>
 
- <!ENTITY strings.changelog.encoding '
-<row xmlns="http://docbook.org/ns/docbook">
-<entry>5.6.0</entry>
-<entry>
-    El valor por omisión para el parámetro <parameter>encoding</parameter>
-    ha sido modificado para ser el valor de la opción de configuración
-    <link linkend="ini.default-charset">default_charset</link>.
-</entry>
-</row>
+<!ENTITY strings.changelog.encoding '
+ <row xmlns="http://docbook.org/ns/docbook">
+  <entry>5.6.0</entry>
+  <entry>
+   El valor predeterminado para el parámetro <parameter>encoding</parameter> ha sido modificado
+   para ser el valor de la opción de configuración
+   <link linkend="ini.default-charset">default_charset</link>
+   .
+  </entry>
+ </row>
 '>
 
- <!ENTITY strings.changelog.ascii-case-conversion '
+<!ENTITY strings.changelog.ascii-case-conversion '
  <row xmlns="http://docbook.org/ns/docbook">
   <entry>8.2.0</entry>
   <entry>
@@ -4609,7 +4479,7 @@ local: {
  </row>
 '>
 
- <!ENTITY strings.changelog.ascii-case-folding '
+<!ENTITY strings.changelog.ascii-case-folding '
  <row xmlns="http://docbook.org/ns/docbook">
   <entry>8.2.0</entry>
   <entry>
@@ -4620,7 +4490,7 @@ local: {
  </row>
 '>
 
- <!ENTITY strings.changelog.sprintf '
+<!ENTITY strings.changelog.sprintf '
   <informaltable xmlns="http://docbook.org/ns/docbook">
    <tgroup cols="2">
     <thead>
@@ -4668,7 +4538,8 @@ local: {
    </tgroup>
   </informaltable>
 '>
- <!ENTITY strings.changelog.vsprintf '
+
+<!ENTITY strings.changelog.vsprintf '
   <informaltable xmlns="http://docbook.org/ns/docbook">
    <tgroup cols="2">
     <thead>
@@ -4708,7 +4579,7 @@ local: {
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Lanza una <classname>ArgumentCountError</classname> cuando se proporcionan menos argumentos de los requeridos;
+       Lanza una <classname>ValueError</classname> cuando se proporcionan menos argumentos de los requeridos;
        anteriormente, esta función emitía un <constant>E_WARNING</constant>.
       </entry>
      </row>
@@ -4716,29 +4587,30 @@ local: {
    </tgroup>
   </informaltable>
 '>
- <!ENTITY strings.errors.sprintf '
+
+<!ENTITY strings.errors.sprintf '
   <simpara xmlns="http://docbook.org/ns/docbook">
-A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si el número de argumentos es nulo.
-Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
-A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si <literal>[width]</literal> es inferior a cero o superior a <constant>PHP_INT_MAX</constant>.
-Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
-A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si <literal>[precision]</literal> es inferior a cero o superior a <constant>PHP_INT_MAX</constant>.
-Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
-A partir de PHP 8.0.0, se lanza una <classname>ArgumentCountError</classname> cuando se proporcionan menos argumentos de los requeridos.
-Anterior a PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</constant> en su lugar.
-</simpara>
+   A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si el número de argumentos es nulo. Anterior a
+   PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
+   A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si <literal>[width]</literal> es inferior a cero o superior a <constant>PHP_INT_MAX</constant>.
+   Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
+   A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si <literal>[precision]</literal> es inferior a cero o superior a <constant>PHP_INT_MAX</constant>.
+   Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
+  </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
+   A partir de PHP 8.0.0, se lanza una <classname>ArgumentCountError</classname> cuando se proporcionan menos argumentos de los requeridos. Anterior a
+   PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</constant> en su lugar.
+  </simpara>
 '>
 
 <!ENTITY strings.errors.vsprintf '
   <simpara xmlns="http://docbook.org/ns/docbook">
-   A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si el número de argumentos es cero.
-   Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
+   A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si el número de argumentos es cero. Anterior a
+   PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
   </simpara>
   <simpara xmlns="http://docbook.org/ns/docbook">
    A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> si <literal>[width]</literal> es menor que cero o mayor que <constant>PHP_INT_MAX</constant>.
@@ -4749,58 +4621,60 @@ Anterior a PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</
    Anterior a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
   </simpara>
   <simpara xmlns="http://docbook.org/ns/docbook">
-   A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> cuando se proporcionan menos argumentos de los requeridos.
-   Anterior a PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</constant> en su lugar.
+   A partir de PHP 8.0.0, se lanza un <classname>ValueError</classname> cuando se proporcionan menos argumentos de los requeridos. Anterior a
+   PHP 8.0.0, se devolvía &false; y se emitía un <constant>E_WARNING</constant> en su lugar.
   </simpara>
 '>
 
- <!ENTITY strings.comparison.return '
+<!ENTITY strings.comparison.return '
   <simpara xmlns="http://docbook.org/ns/docbook">
    Devuelve un valor inferior a 0 si <parameter>string1</parameter>
    es inferior a <parameter>string2</parameter>; un valor superior
    a 0 si <parameter>string1</parameter> es superior a
    <parameter>string2</parameter>, y <literal>0</literal> si son
-   iguales.
-   No se puede deducir ningún significado particular de este valor,
+   iguales. No
+   se puede deducir ningún significado particular de este valor,
    excepto su signo.
   </simpara>
 '>
 
- <!-- filter snippets -->
- <!-- TODO: Remove -->
- <!ENTITY filter.param.filter '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>filter</parameter></term>
-<listitem>
-    <simpara>
-     El filtro a aplicar.
-     Puede ser un filtro de validación utilizando una de las constantes
-     <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>, un filtro de
-     limpieza utilizando una de las constantes
-     <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant> o <constant>FILTER_UNSAFE_RAW</constant>,
-     o un filtro personalizado utilizando <constant>FILTER_CALLBACK</constant>.
-    </simpara>
-    <simpara>
-     El valor por omisión es <constant>FILTER_DEFAULT</constant>,
-     que es un alias de <constant>FILTER_UNSAFE_RAW</constant>.
-    </simpara>
-</listitem>
-</varlistentry>
+<!-- filter snippets -->
+<!-- TODO: Remove -->
+<!ENTITY filter.param.filter '
+ <varlistentry xmlns="http://docbook.org/ns/docbook">
+  <term><parameter>filter</parameter></term>
+  <listitem>
+   <simpara>
+    El filtro a aplicar.
+    Puede ser un filtro de validación utilizando una de las constantes
+    <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>
+    , un filtro de limpieza utilizando una de las constantes
+    <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant>
+    o <constant>FILTER_UNSAFE_RAW</constant>, o un filtro personalizado utilizando
+    <constant>FILTER_CALLBACK</constant>.
+   </simpara>
+   <simpara>
+    El valor predeterminado es <constant>FILTER_DEFAULT</constant>,
+    que es un alias de <constant>FILTER_UNSAFE_RAW</constant>
+    .
+   </simpara>
+  </listitem>
+ </varlistentry>
 '>
 
- <!-- csprng snippets -->
- <!ENTITY csprng.sources '
+<!-- csprng snippets -->
+<!ENTITY csprng.sources '
 <simpara xmlns="http://docbook.org/ns/docbook">
-Las fuentes de aleatoriedad por orden de prioridad son las siguientes:
+ Las fuentes de aleatoriedad por orden de prioridad son las siguientes:
 </simpara>
 <itemizedlist xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-<listitem>
+ <listitem>
   <simpara>
    Linux: <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
   </simpara>
-</listitem>
-<listitem>
-   <simpara>
+ </listitem>
+ <listitem>
+  <simpara>
    FreeBSD >= 12 (PHP >= 7.3): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
   </simpara>
  </listitem>
@@ -4839,41 +4713,41 @@ Las fuentes de aleatoriedad por orden de prioridad son las siguientes:
   <simpara>
    Solaris (PHP >= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
   </simpara>
-</listitem>
-<listitem>
-    <simpara>
-      Cualquier combinación de un sistema operativo y una versión de PHP no mencionada anteriormente:
-      <filename>/dev/urandom</filename>.
-    </simpara>
-</listitem>
-<listitem>
-    <simpara>
-      Si ninguna de las fuentes de aleatoriedad está disponible o todas fallan al generar
-      aleatoriedad, se lanzará una excepción de tipo <classname>Random\RandomException</classname>.
-    </simpara>
-</listitem>
+ </listitem>
+ <listitem>
+  <simpara>
+   Cualquier combinación de un sistema operativo y una versión de PHP no mencionada anteriormente: <filename>/dev/urandom</filename>.
+  </simpara>
+ </listitem>
+ <listitem>
+  <simpara>
+   Si ninguna de las fuentes de aleatoriedad está disponible o todas fallan al generar aleatoriedad, se lanzará
+   una excepción de tipo <classname>Random\RandomException</classname>
+   .
+  </simpara>
+ </listitem>
 </itemizedlist>
 '>
- <!ENTITY csprng.errors '
-<listitem xmlns="http://docbook.org/ns/docbook">
-<simpara>
-    Si no se encuentra ninguna fuente de datos aleatorios, se lanzará una
-    <classname>Random\RandomException</classname>.
-</simpara>
-</listitem>
+<!ENTITY csprng.errors '
+ <listitem xmlns="http://docbook.org/ns/docbook">
+  <simpara>
+   Si no se encuentra ninguna fuente de datos aleatorios, se lanzará
+   una <classname>Random\RandomException</classname>.
+  </simpara>
+ </listitem>
 '>
- <!ENTITY csprng.function.backport '
-<note xmlns="http://docbook.org/ns/docbook">
-<simpara>
-    Aunque esta función fue añadida en PHP 7.0, una
-    <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.csprng.compat;">implementación en espacio de usuario</link>
-    está disponible para PHP 5.2 hasta 5.6, inclusive.
-</simpara>
-</note>
+<!ENTITY csprng.function.backport '
+ <note xmlns="http://docbook.org/ns/docbook">
+  <simpara>
+   Aunque esta función fue añadida en PHP 7.0, una
+   <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.csprng.compat;">implementación en espacio de usuario</link>
+   está disponible para PHP 5.2 hasta 5.6, inclusive.
+  </simpara>
+ </note>
 '>
 
- <!-- Random snippets -->
- <!ENTITY random.engineErrors '
+<!-- Random snippets -->
+<!ENTITY random.engineErrors '
  <listitem xmlns="http://docbook.org/ns/docbook">
   <simpara>
    Cualquier <classname>Throwable</classname> lanzado por el método <methodname>Random\Engine::generate</methodname>
@@ -4882,27 +4756,27 @@ Las fuentes de aleatoriedad por orden de prioridad son las siguientes:
  </listitem>
 '>
 
- <!-- URI snippets -->
- <!ENTITY uri.errors.invalidUriException '
+<!-- URI snippets -->
+<!ENTITY uri.errors.invalidUriException '
   <simpara>
    Si la URI resultante es inválida, se lanza una excepción <exceptionname>Uri\InvalidUriException</exceptionname>.
   </simpara>
- '>
+'>
 
- <!ENTITY uri.errors.invalidUrlException '
+<!ENTITY uri.errors.invalidUrlException '
   <simpara>
    Si la URL resultante es inválida, se lanza una excepción <exceptionname>Uri\WhatWg\InvalidUrlException</exceptionname>.
   </simpara>
- '>
+'>
 
- <!-- UOPZ snippets -->
+<!-- UOPZ snippets -->
 
- <!ENTITY uopz.warn.removed.function-5-0-0 '<warning
+<!ENTITY uopz.warn.removed.function-5-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
-    <emphasis>ELIMINADA</emphasis> en PECL uopz 5.0.0.</simpara></warning>'>
+<emphasis>ELIMINADA</emphasis> en PECL uopz 5.0.0.</simpara></warning>'>
 
- <!-- XML snippets -->
- <!ENTITY xml.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!-- XML snippets -->
+<!ENTITY xml.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>parser</parameter></term>
  <listitem>
   <simpara>
@@ -4911,12 +4785,12 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
  </listitem>
 </varlistentry>'>
 
- <!ENTITY xml.handler.description '<para xmlns="http://docbook.org/ns/docbook">
- Si &null; se pasa, el controlador se reinicia a su estado por omisión.
+<!ENTITY xml.handler.description '<para xmlns="http://docbook.org/ns/docbook">
+ Si &null; se pasa, el controlador se reinicia a su estado predeterminado.
  <warning>
   <simpara>
-    Una cadena vacía también reiniciará el controlador,
-    sin embargo esta funcionalidad está deprecada a partir de PHP 8.4.0.
+    Una cadena vacía también reiniciará el controlador, sin embargo
+    esta funcionalidad está deprecada a partir de PHP 8.4.0.
   </simpara>
  </warning>
 </para>
@@ -4932,21 +4806,21 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
   <simpara>
    Esta funcionalidad está deprecada a partir de PHP 8.4.0.
   </simpara>
-</warning>
+ </warning>
 </para>
 <warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  A partir de PHP 8.4.0, se verifica la validez del callable durante la configuración del controlador,
-  y no en el momento de su llamada.
-  Esto significa que <function>xml_set_object</function> debe ser llamado antes
-  de definir un método como cadena como devolución de llamada.
+  A partir de PHP 8.4.0, se verifica la validez del callable durante la configuración del controlador, y no
+  en el momento de su
+  llamada. Esto significa que <function>xml_set_object</function> debe ser llamado antes de definir
+  un método como cadena como devolución de llamada.
   Sin embargo, como este comportamiento también está deprecado a partir de PHP 8.4.0,
   se recomienda utilizar un <type>callable</type> adecuado para el método.
  </simpara>
 </warning>
 '>
 
- <!ENTITY xml.handler.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
+<!ENTITY xml.handler.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>parser</parameter></term>
  <listitem>
   <simpara>
@@ -4958,7 +4832,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
 <!ENTITY xml.changelog.handler-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  Pasar un <type>string</type> no <type>callable</type> a
+  Pasar un valor no <type>callable</type> de tipo <type>string</type> a
   <parameter>handler</parameter> ahora está obsoleto;
   utilice un callable apropiado para los métodos, o &null; para reinicializar el gestor.
  </entry>
@@ -4971,41 +4845,41 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
  </entry>
 </row>'>
 
- <!ENTITY xml.changelog.parser-param '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY xml.changelog.parser-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
  <entry>
   <parameter>parser</parameter> ahora espera una instancia de <classname>XMLParser</classname>
-  en lugar de un <type>resource</type> <literal>xml</literal>.
+  ; anteriormente, se esperaba un recurso <literal>xml</literal> de tipo <type>resource</type> válido.
  </entry>
 </row>'>
 
- <!-- Migration Guide snippets -->
- <!ENTITY migration56.openssl.peer-verification '
-<simpara xmlns="http://docbook.org/ns/docbook">
-    Todos los flujos clientes cifrados activan ahora la verificación por pares por omisión.
-    Por omisión, esto utilizará el CA OpenSSL por omisión para verificar el par
-    de certificados. En la mayoría de los casos, no se necesita realizar ninguna modificación
-    para comunicarse con servidores y certificados SSL válidos, sabiendo que los distribuidores
-    configuran generalmente OpenSSL para utilizar los CA conocidos.
-</simpara>
+<!-- Migration Guide snippets -->
+<!ENTITY migration56.openssl.peer-verification '
+   <simpara xmlns="http://docbook.org/ns/docbook">
+    Todos los flujos clientes cifrados activan ahora la verificación por pares por defecto.
+    Por defecto, esto utilizará el paquete de CA predeterminado de OpenSSL para verificar el
+    par de certificados. En la mayoría de los casos, no se necesita realizar ninguna modificación
+    para comunicarse con servidores y certificados SSL válidos, sabiendo que los
+    distribuidores configuran generalmente OpenSSL para utilizar los CA conocidos.
+   </simpara>
 
-<simpara xmlns="http://docbook.org/ns/docbook">
-    El CA por omisión puede ser sobrescrito a nivel global utilizando las
+   <simpara xmlns="http://docbook.org/ns/docbook">
+    El paquete de CA predeterminado puede ser sobrescrito a nivel global utilizando las
     opciones de configuración openssl.cafile o openssl.capath, o mediante una solicitud
     básica utilizando las opciones de contexto
     <link linkend="context.ssl.cafile"><parameter>cafile</parameter></link> o
-    <link linkend="context.ssl.capath"><parameter>capath</parameter></link>.
-</simpara>
+    <link linkend="context.ssl.capath"><parameter>capath</parameter></link>
+    .
+   </simpara>
 
-<simpara xmlns="http://docbook.org/ns/docbook">
-    Aunque no se recomienda en general, es posible desactivar la
-    verificación de certificados por pares para una solicitud definiendo la
-    opción de contexto <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>
-    a &false;, y para desactivar la validación del nombre de los pares, configurando
-    la opción de contexto
-    <link linkend="context.ssl.verify-peer-name"><parameter>verify_peer_name</parameter></link>
+   <simpara xmlns="http://docbook.org/ns/docbook">
+    Aunque no se recomienda en general, es posible desactivar la verificación de certificados
+    por pares para una solicitud definiendo la opción de contexto
+    <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>
+    a &false;, y para desactivar la validación del nombre de los pares, configurando la opción de
+    contexto <link linkend="context.ssl.verify-peer-name"><parameter>verify_peer_name</parameter></link>
     a &false;.
-</simpara>
+   </simpara>
 '>
 
 <!-- Keep this comment at the end of the file

--- a/preface.xml
+++ b/preface.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: dee52c067be3be96a735f0c33cbcf0009a996b2e Maintainer: yago Status: ready -->
-<!-- Reviewed: yes Maintainer: seros -->
+<!-- EN-Revision: dee52c067be3be96a735f0c33cbcf0009a996b2e Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
 
 <preface xml:id="preface" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook">
  <info>
@@ -11,37 +10,37 @@
    <simpara>
     <acronym>PHP</acronym>, que significa <emphasis>PHP: Preprocesador de
     Hipertexto</emphasis>, es un lenguaje de programación de propósito general,
-    de código abierto y ampliamente utilizado, especialmente adecuado para el desarrollo web y
-    que se puede incrustar en HTML. Su sintaxis se basa en C, Java y Perl, y es fácil de aprender.
-    El objetivo principal del lenguaje es permitir a los desarrolladores web escribir páginas web
-    dinámicas rápidamente, pero se puede hacer mucho más con PHP.
+    de código abierto y ampliamente utilizado, especialmente adecuado para el
+    desarrollo web y que se puede incrustar en HTML. Su sintaxis se basa en C,
+    Java y Perl, y es fácil de aprender. El objetivo principal del lenguaje es
+    permitir a los desarrolladores web escribir páginas web dinámicas
+    rápidamente, pero se puede hacer mucho más con PHP.
    </simpara>
   </abstract>
  </info>
-
  <para>
-  Este manual consiste principalmente en una <link linkend="funcref">
+  Este manual consta principalmente de una <link linkend="funcref">
   referencia de funciones</link>, aunque también contiene una
   <link linkend="langref">referencia del lenguaje</link>, explicaciones
-  de algunas de las <link linkend="features">características</link>
-  importantes de PHP, y otra información
-  <link linkend="appendices">suplementaria</link>.
+  de algunas de las principales <link linkend="features">características</link>
+  de PHP, y otra información <link linkend="appendices">suplementaria</link>.
  </para>
-
  <simpara>
-  Este manual incluye información sobre las dos versiones principales más recientes de PHP (versiones 7 y 8).
-  No se incluye información sobre extensiones que ya no forman parte de estas versiones de PHP ni sobre cambios
-  en funciones de versiones anteriores. Los archivos de versiones antiguas del manual, que documentan lanzamientos
+  Este manual incluye información que cubre las dos versiones principales más
+  recientes de PHP (versiones 7 y 8). No se incluye información sobre
+  extensiones que ya no están incluidas en esas versiones de PHP ni sobre
+  cambios en funciones de versiones anteriores del manual. Los archivos
+  históricos de versiones anteriores del manual, que documentan lanzamientos
   previos de PHP, están disponibles en la sección "Más documentación" en la
-  <link xlink:href="&url.php.docs;">página de "Documentación" del sitio web de PHP</link>.
+  <link xlink:href="&url.php.docs;">página de "Documentación" del sitio web
+  de PHP</link>.
  </simpara>
-
  <para>
-  Este manual se puede descargar en diferentes formatos en <link
+  Este manual se puede descargar en varios formatos en <link
   xlink:href="&url.php.doc.downloads;">&url.php.doc.downloads;</link>.
   Puede encontrarse más información sobre cómo se desarrolla este manual en el
-  apéndice <link linkend="about">"Acerca de este manual"</link>. Si está
-  interesado en la <link linkend="history">Historia de PHP</link>,
+  apéndice <link linkend="about">'Acerca del manual'</link>. Si está
+  interesado en la <link linkend="history">historia de PHP</link>,
   visite el apéndice correspondiente.
  </para>
 


### PR DESCRIPTION
### General Description
This Pull Request performs a comprehensive review, formatting update, and structural synchronization of the root translation and configuration files for the PHP Spanish manual (`doc-es`), aligned with the original English repository (`doc-en`).

---

### Modified Files & Key Changes

* **`preface.xml`**
  - **Maintenance & Quality:** Marked the file as `Reviewed: yes`.
  - **Translation Refinements:** Improved sentence structure and syntax (e.g., using *"Este manual consta principalmente de..."* instead of the literal *"Este manual consiste principalmente en..."*).
  - **Formatting Alignment:** Standardized line wrapping and indentation to mirror the structure of the English original, and removed trailing whitespaces.

* **`extensions.ent`**
  - **Maintenance:** Marked status as `Reviewed: yes`.
  - **Linter Fixes:** Removed an extra newline character at the end of the file (`new blank line at EOF`).

* **`language-defs.ent`**
  - **Maintenance:** Marked status as `Reviewed: yes`.
  - **Glosary Consistency:** Standardized titles and entity definitions to follow project rules:
    - Lowercased descriptions like *"Sinopsis de la clase / interfaz / enum"*.
    - Replaced the discouraged term *"Requerimientos"* with *"Requisitos"* (Requirements).
    - Replaced *"Ver también"* with *"Véase también"* (See also).

* **`bookinfo.xml`**
  - **Maintenance:** Marked status as `Reviewed: yes`.
  - Sychronized line breaks and formatting for one-to-one mapping with `doc-en`.

* **`language-snippets.ent`**
  - **Maintenance:** Marked status as `Reviewed: yes`.
  - **Glossary Corrections:** Updated *"por omisión"* to the recommended translation *"por defecto"* (by default).
  - **Technical Terminology:** Adjusted randomness warnings (e.g., changed *"sembrando mt_srand"* to *"inicializando mt_srand"* for seeding, and corrected phrasing to *"Prefiera utilizar..."*).
  - **XML Indentation:** Unified indent layouts of `<caution>` elements to maintain layout parity with `doc-en`.

---

### Local Verification & Quality
- All modified files in this commit have been validated locally.