### PR TITLE
[Review] Review and refine appendices/configure translation files

### DIFF
--- a/appendices/configure/index.xml
+++ b/appendices/configure/index.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 2bb07c8c43f028c665a33bfc08a22639e9e35dc6 Maintainer: yago Status: ready -->
-<!-- Reviewed: no Maintainer: seros -->
+<!-- EN-Revision: 2bb07c8c43f028c665a33bfc08a22639e9e35dc6 Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
 <appendix xml:id="configure" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Opciones de configuración</title>
 
  <sect1 xml:id="configure.about">
   <title>Listado de opciones de configuración del núcleo</title>
   <para>
-   A continuación se muestra una lista de parte de las opciones de configuración usadas
-   por el script <filename>configure</filename> de PHP cuando se compila en entornos
-   como UNIX. La mayoría de las opciones de configuración se enumeran en su ubicación
-   correspondiente de las páginas de referencia de cada extensión, no aquí. Para una lista
-   actualizada y completa de las opciones de configuración, ejecute <command>./configure --help</command>
-   en el directorio origen de PHP después de ejecutar <command>autoconf</command>
+   A continuación se muestra una lista parcial de las opciones de configuración utilizadas
+   por el script <filename>configure</filename> de PHP al compilar en entornos de
+   tipo Unix. La mayoría de las opciones de configuración se enumeran en su ubicación
+   correspondiente de las páginas de referencia de cada extensión, no aquí. Para obtener una lista
+   completa y actualizada de las opciones de configuración, se debe ejecutar <command>./configure --help</command>
+   en el directorio de código fuente de PHP después de haber ejecutado <command>autoconf</command>
    (véase también el capítulo de <link linkend="install">Instalación</link>).
-   Podría ser interesante también consultar la documentación de
-   <link xlink:href="&url.gnu.configure;">GNU configure</link> para mayor
-   información en otras opciones de <command>configure</command>
-   como <literal>--prefix=PREFIJO</literal>.
+   También puede ser de interés consultar la documentación de
+   <link xlink:href="&url.gnu.configure;">GNU configure</link> para obtener
+   información sobre otras opciones de <command>configure</command>
+   como <literal>--prefix=PREFIX</literal>.
   </para>
 
   <note>
    <para>
-    Estas opciones se utilizan únicamente durante la compilación. Si desea alterar la
-    configuración en tiempo de ejecución de PHP, por favor vea el capítulo sobre <link
+    Estas opciones se utilizan únicamente durante la compilación. Si se desea modificar la
+    configuración en tiempo de ejecución de PHP, consúltese el capítulo sobre <link
     linkend="configuration">Configuración en tiempo de ejecución</link>.
    </para>
   </note>
@@ -32,7 +31,7 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     <link linkend="configure.options.misc">Misceláneo</link>
+     <link linkend="configure.options.misc">Otras opciones</link>
     </simpara>
    </listitem>
    <listitem>

--- a/appendices/configure/misc.xml
+++ b/appendices/configure/misc.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4c676dacf58ff5d779eed96739ab4660204cbe7f Maintainer: yago Status: ready -->
-<!-- Reviewed: no Maintainer: seros -->
+<!-- EN-Revision: 4c676dacf58ff5d779eed96739ab4660204cbe7f Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
  <sect3 xml:id="configure.options.misc" xmlns="http://docbook.org/ns/docbook">
   <title>Otras opciones</title>
   <variablelist>
@@ -21,8 +20,8 @@
     </term>
     <listitem>
      <para>
-      Establece la forma de presentar los ficheros instalados. El tipo es PHP (predeterminado)
-      o GNU. Ten en cuenta que si estás instalando las páginas del manual bajo PREFIX (por defecto), elige el
+      Establecer la forma de presentar los ficheros instalados. El tipo es PHP (predeterminado)
+      o GNU. Se debe tener en cuenta que si se instalan las páginas de manual bajo PREFIX (predeterminado), se debe elegir el
       estilo GNU para que puedan ser encontradas en la ruta de búsqueda de la utilidad <filename>manpath</filename>.
      </para>
     </listitem>
@@ -33,7 +32,7 @@
     </term>
     <listitem>
      <para>
-      Instalar PEAR en DIR (valor predeterminado PREFIJO/lib/php).
+      Instalar PEAR en DIR (valor predeterminado PREFIX/lib/php).
      </para>
     </listitem>
    </varlistentry>
@@ -84,8 +83,8 @@
     </term>
     <listitem>
      <para>
-      Incluir flujos de PHP experimentales. ¡No se use a menos que este
-      probando el código!.
+      Incluir flujos de PHP experimentales. No usar a menos que se esté
+      probando el código.
      </para>
     </listitem>
    </varlistentry>

--- a/appendices/configure/php.xml
+++ b/appendices/configure/php.xml
@@ -1,68 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 91da56315cff97da3020dd2934040e5035a6d1c6 Maintainer: aeoris Status: ready -->
-<!-- Reviewed: yes -->
-<sect3 xml:id="configure.options.php" xmlns="http://docbook.org/ns/docbook">
- <title>Opciones de PHP</title>
- <variablelist>
-  <varlistentry xml:id="configure.enable-maintainer-mode">
-   <term>
-    <option role="configure">--enable-maintainer-mode</option>
-   </term>
-   <listitem>
-    <para>
-     Habilita las reglas y dependencias de Make, que no son útiles (y en ocasiones son confusas)
-     para el usuario habitual.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="configure.with-config-file-path">
-   <term>
-    <option role="configure">--with-config-file-path=PATH</option>
-   </term>
-   <listitem>
-    <para>
-     Establece la ruta a seguir para &php.ini;, el valor por defecto es <literal>/PREFIX/lib</literal>.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="configure.disable-short-tags">
-   <term>
-    <option role="configure">--disable-short-tags</option>
-   </term>
-   <listitem>
-    <para>
-     Deshabilita la forma corta de la etiqueta de inicio php &lt;? por defecto.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="configure.with-libdir">
-   <term>
-    <option role="configure">--with-libdir</option>
-   </term>
-   <listitem>
-    <para>
-     Especifica el directorio donde existen las bibliotecas para construir PHP en un
-     sistema Unix. Para sistemas de 64 bits, es necesario especificar este argumento
-     al directorio <literal>lib64</literal>, como por ejemplo:
-     <literal>--with-libdir=lib64</literal>.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="configure.enable-zts">
-   <term>
-    <option role="configure">--enable-zts</option>
-   </term>
-   <listitem>
-    <para>
-     Habilita la seguridad de hilos.
-     Antes de PHP 8.0.0 en sistemas no Windows, la opción se llamaba
-     <option role="configure">--enable-maintainer-zts</option>.
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
-</sect3>
+<!-- EN-Revision: 91da56315cff97da3020dd2934040e5035a6d1c6 Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
+ <sect3 xml:id="configure.options.php" xmlns="http://docbook.org/ns/docbook">
+  <title>Opciones de PHP</title>
+  <variablelist>
+   <varlistentry xml:id="configure.enable-maintainer-mode">
+    <term>
+     <option role="configure">--enable-maintainer-mode</option>
+    </term>
+    <listitem>
+     <para>
+      Habilita las reglas y dependencias de make que no son útiles (y en ocasiones confusas)
+      para el instalador ocasional.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="configure.with-config-file-path">
+    <term>
+     <option role="configure">--with-config-file-path=PATH</option>
+    </term>
+    <listitem>
+     <para>
+      Establece la ruta en la que se buscará &php.ini;, el valor predeterminado es <literal>PREFIX/lib</literal>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="configure.disable-short-tags">
+    <term>
+     <option role="configure">--disable-short-tags</option>
+    </term>
+    <listitem>
+     <para>
+      Deshabilita por defecto el formato corto de la etiqueta de inicio &lt;?.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="configure.with-libdir">
+    <term>
+     <option role="configure">--with-libdir</option>
+    </term>
+    <listitem>
+     <para>
+      Especifica el directorio donde se encuentran las bibliotecas para compilar PHP en un
+      sistema Unix. Para sistemas de 64 bits, se requiere especificar este argumento
+      con el directorio <literal>lib64</literal>, como por ejemplo:
+      <literal>--with-libdir=lib64</literal>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="configure.enable-zts">
+    <term>
+     <option role="configure">--enable-zts</option>
+    </term>
+    <listitem>
+     <para>
+      Habilita la seguridad de hilos.
+      Antes de PHP 8.0.0 en sistemas no Windows, la opción se llamaba
+      <option role="configure">--enable-maintainer-zts</option>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect3>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/appendices/configure/servers.xml
+++ b/appendices/configure/servers.xml
@@ -1,125 +1,125 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6a5b42e0d34c76890fd96be2b0b57516363b4c8a Maintainer: aeoris Status: ready -->
-<!-- Reviewed: yes -->
-<sect3 xml:id="configure.options.servers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Opciones SAPI</title>
- <para>
-  La siguiente lista contiene los SAPI&amp;s disponibles (<literal>
+<!-- EN-Revision: 6a5b42e0d34c76890fd96be2b0b57516363b4c8a Maintainer: argosback Status: ready -->
+<!-- Reviewed: yes Maintainer: argosback -->
+ <sect3 xml:id="configure.options.servers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Opciones SAPI</title>
+  <para>
+  La siguiente lista contiene las SAPI disponibles (<literal>
   Server Application Programming Interface</literal>) para PHP.
- </para>
- <variablelist>
-  <varlistentry xml:id="configure.with-apxs">
-   <term>
-    <option role="configure">--with-apxs[=FILE]</option>
-   </term>
-   <listitem>
-    <para>
-     Crea un módulo compartido de Apache. FILE es la ruta opcional de la
-     herramienta Apache apxs, por defecto a apxs. Asegúrese de especificar
-     la versión de apxs que está instalada en su sistema y NO la que está
-     en los fuentes de Apache.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="configure.with-apache">
-   <term>
-    <option role="configure">--with-apache[=DIR]</option>
-   </term>
-   <listitem>
-    <para>
-     Crea un módulo estático de Apache. DIR es el directorio de Apache,
-     por defecto es <filename>/usr/local/apache</filename>.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="configure.with-mod-charset">
-   <term>
-    <option role="configure">--with-mod_charset</option>
-   </term>
-   <listitem>
-    <para>
-     Habilita la tranferencia de tablas para mod_charset (Apache en Ruso).
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="configure.with-apxs2">
-   <term>
-    <option role="configure">--with-apxs2[=FILE]</option>
-   </term>
-   <listitem>
-    <para>
-     Crea un módulo compartido de Apache 2.0. FILE es la ruta opcional a la
-     herramienta apxs, por defecto a apxs.
-    </para>
-   </listitem>
-  </varlistentry>
+  </para>
+  <variablelist>
+   <varlistentry xml:id="configure.with-apxs">
+    <term>
+     <option role="configure">--with-apxs[=FILE]</option>
+    </term>
+    <listitem>
+     <para>
+      Compila un módulo compartido de Apache. FILE es la ruta de acceso opcional a la
+      herramienta apxs de Apache; el valor predeterminado es apxs. Se debe asegurar de especificar
+      la versión de apxs instalada en el sistema y no la que se encuentra
+      en el archivo comprimido del código fuente de Apache.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="configure.with-apache">
+    <term>
+     <option role="configure">--with-apache[=DIR]</option>
+    </term>
+    <listitem>
+     <para>
+      Compila un módulo estático de Apache. DIR es el directorio de compilación de nivel superior de Apache;
+      el valor predeterminado es <filename>/usr/local/apache</filename>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="configure.with-mod-charset">
+    <term>
+     <option role="configure">--with-mod_charset</option>
+    </term>
+    <listitem>
+     <para>
+      Habilita la transferencia de tablas para mod_charset (Apache en ruso).
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="configure.with-apxs2">
+    <term>
+     <option role="configure">--with-apxs2[=FILE]</option>
+    </term>
+    <listitem>
+     <para>
+      Compila un módulo compartido de Apache 2.0. FILE es la ruta de acceso opcional a la
+      herramienta apxs; el valor predeterminado es apxs.
+     </para>
+    </listitem>
+   </varlistentry>
 
-  <varlistentry xml:id="configure.disable-cli">
-   <term>
-    <option role="configure">--disable-cli</option>
-   </term>
-   <listitem>
-    <para>
-     Deshabilita la versión CLI de PHP (esto
-     fuerza<link linkend="configure.without-pear">--without-pear</link>).
-     Para mayor información, vea la sección acerca de
-     <link linkend="features.commandline">Usando PHP desde la línea de comando</link>.
-    </para>
-   </listitem>
-  </varlistentry>
+   <varlistentry xml:id="configure.disable-cli">
+    <term>
+     <option role="configure">--disable-cli</option>
+    </term>
+    <listitem>
+     <para>
+      Deshabilita la versión CLI de PHP (esto
+      fuerza <link linkend="configure.without-pear">--without-pear</link>).
+      Para obtener más información, véase la sección sobre
+      <link linkend="features.commandline">Uso de PHP desde la línea de comandos</link>.
+     </para>
+    </listitem>
+   </varlistentry>
 
-  <varlistentry xml:id="configure.enable-phpdbg">
-   <term>
-    <option role="configure">--enable-phpdbg</option>
-   </term>
-   <listitem>
-    <para>
-     Habilitar el soporte para el módulo SAPI de depuración interactiva phpdbg.
-    </para>
-   </listitem>
-  </varlistentry>
+   <varlistentry xml:id="configure.enable-phpdbg">
+    <term>
+     <option role="configure">--enable-phpdbg</option>
+    </term>
+    <listitem>
+     <para>
+      Habilita el soporte para el módulo SAPI de depuración interactiva phpdbg.
+     </para>
+    </listitem>
+   </varlistentry>
 
-  <varlistentry xml:id="configure.enable-embed">
-   <term>
-    <option role="configure">--enable-embed[=TYPE]</option>
-   </term>
-   <listitem>
-    <para>
-     Habilita la creación de la librería SAPI. TYPE es
-     <literal>shared</literal> o <literal>static</literal>,
-     el valor por defecto es <literal>shared</literal>.
-    </para>
-   </listitem>
-  </varlistentry>
+   <varlistentry xml:id="configure.enable-embed">
+    <term>
+     <option role="configure">--enable-embed[=TYPE]</option>
+    </term>
+    <listitem>
+     <para>
+      Habilita la creación de la biblioteca SAPI. TYPE es
+      <literal>shared</literal> o <literal>static</literal>,
+      el valor por defecto es <literal>shared</literal>.
+     </para>
+    </listitem>
+   </varlistentry>
 
-  <varlistentry xml:id="configure.with-servlet">
-   <term>
-    <option role="configure">--with-servlet[=DIR]</option>
-   </term>
-   <listitem>
-    <para>
-     Incluye soporte para servlet. DIR es el directorio base de instalación de JSDK.
-     Este SAPI requiere que la extensión de java sea creada como un dl compartido.
-    </para>
-   </listitem>
-  </varlistentry>
+   <varlistentry xml:id="configure.with-servlet">
+    <term>
+     <option role="configure">--with-servlet[=DIR]</option>
+    </term>
+    <listitem>
+     <para>
+      Incluye soporte para servlet. DIR es el directorio base de instalación del JSDK.
+      Esta SAPI requiere que la extensión Java se compile como una biblioteca dinámica compartida (dl).
+     </para>
+    </listitem>
+   </varlistentry>
 
-  <varlistentry xml:id="configure.disable-cgi">
-   <term>
-    <option role="configure">--disable-cgi</option>
-   </term>
-   <listitem>
-    <para>
-     Desabilita la versión CGI de la construcción de PHP.
-    </para>
-    <para>
-     Este argumento también habilita FastCGI.
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
-</sect3>
+   <varlistentry xml:id="configure.disable-cgi">
+    <term>
+     <option role="configure">--disable-cgi</option>
+    </term>
+    <listitem>
+     <para>
+      Deshabilita la compilación de la versión CGI de PHP.
+     </para>
+     <para>
+      Este argumento también habilita FastCGI.
+     </para>
+    </listitem>
+   </varlistentry>
+
+  </variablelist>
+ </sect3>
 
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
This PR performs a thorough quality review and structural synchronization of the `appendices/configure` translation files. 

The review focuses on three main pillars: technical accuracy, compliance with the Spanish style guidelines, and consistency in cross-references.

### Key Refinements

* **Technical Term & Literal Fixes**:
  - Restored configuration parameters that had translated placeholders (e.g., `--prefix=PREFIJO` was reverted to `--prefix=PREFIX` and `PREFIJO/lib/php` was reverted to `PREFIX/lib/php`). Using translated placeholders in code-like parameters can lead to confusion as they represent literal parameter syntaxes.
  - Corrected a leading slash mismatch in the default configuration path (`/PREFIX/lib` -> `PREFIX/lib`).

* **Style & Tone Compliance (Impersonalization)**:
  - Several descriptions used informal direct address ("tú" style, e.g., *"Ten en cuenta"*, *"si estás instalando"*, *"elige"*). These have been rewritten using the standard impersonal passive form (*"Se debe tener en cuenta"*, *"se debe elegir"*) to comply with the project guidelines.
  - Standardized the verb forms used across options. For example, in `misc.xml`, options consistently use the infinitive (e.g. *"Establecer"* instead of *"Establece"*), while `servers.xml` options consistently use the third-person singular (e.g. *"Habilita"* instead of *"Habilitar"*).

* **Coherence & Glossary Corrections**:
  - Fixed SAPI plural and gender agreement according to RAE rules (acronyms do not pluralize with a lowercase 's' in Spanish and SAPI is feminine: *"las SAPI disponibles"* instead of *"los SAPI&amp;s disponibles"*).
  - Replaced the prohibited term *"librería"* with *"biblioteca"* (library).
  - Synchronized the link text in `index.xml` for the miscellaneous options from *"Misceláneo"* to *"Otras opciones"* to match the actual title of the target section in `misc.xml`.
  - Corrected minor typos (*"tranferencia"* -> *"transferencia"*, *"Desabilita"* -> *"Deshabilita"*) and capitalized language descriptors (*"Apache en Ruso"* -> *"Apache en ruso"*).

### Verification
All modifications have been validated against the English source and are in perfect synchrony.