### PR TITLE
[Sync EN] fix return-value prose for 4 encrypt/stream functions (#853)

### DIFF
--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cc7976fa40eef4c07fc1e90813146be1503fb464 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-chacha20poly1305-encrypt">
  <refnamediv>
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve la clave de cifrado y la etiqueta en caso de éxito, &return.falseforfailure;.
+   Devuelve el texto cifrado y la etiqueta de autenticación como una cadena de bytes binarios sin procesar.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cc7976fa40eef4c07fc1e90813146be1503fb464 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-chacha20poly1305-ietf-encrypt">
  <refnamediv>
@@ -67,7 +67,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve la clave de cifrado y la etiqueta en caso de éxito, &return.falseforfailure;.
+   Devuelve el texto cifrado y la etiqueta de autenticación como una cadena de bytes binarios sin procesar.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cc7976fa40eef4c07fc1e90813146be1503fb464 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-xchacha20poly1305-ietf-encrypt">
  <refnamediv>
@@ -68,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve la clave de cifrado y la etiqueta en caso de éxito, &return.falseforfailure;.
+   Devuelve el texto cifrado y la etiqueta de autenticación como una cadena de bytes binarios sin procesar.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cc7976fa40eef4c07fc1e90813146be1503fb464 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-stream-xchacha20-xor-ic">
  <refnamediv>
@@ -73,7 +73,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   El texto cifrado, o &return.falseforfailure;.
+   El texto cifrado.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Ces fonctions lèvent `SodiumException` au lieu de retourner `false` ; suppression de `&return.falseforfailure;` et clarification du type retourné.

Closes #853