### PR TITLE
[Sync EN] remove return.falseproblem banner from pcntl_setcpuaffinity (#855)

### DIFF
--- a/reference/pcntl/functions/pcntl-setcpuaffinity.xml
+++ b/reference/pcntl/functions/pcntl-setcpuaffinity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aa120f36c5762e99f9ee121d8caf910e0a67121e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 74b6239160f459a2b089263d31cb84a47117b4a6 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.pcntl-setcpuaffinity" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -47,7 +47,6 @@
   <simpara>
    &return.success;
   </simpara>
-  &return.falseproblem;
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
La fonction ne peut retourner qu'un booléen (`true`/`false`), la bannière `&return.falseproblem;` ne s'applique pas.

Closes #855