### PR TITLE
[Sync EN] remove duplicate Opcache section from other-changes.xml (#856)

### DIFF
--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 750153283926d760d97dfe59a19d7c13c602625a Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.other-changes">
  <title>Otros cambios</title>
@@ -338,19 +338,6 @@
     que se separó de <link linkend="book.dom">ext/dom</link>
     para su reutilización en otras extensiones.
     La nueva extensión no está expuesta directamente al espacio de usuario.
-   </simpara>
-
-  </sect3>
-
-  <sect3 xml:id="migration85.other-changes.extensions.opcache">
-   <title>Opcache</title>
-
-   <simpara>
-    La <link linkend="book.opcache">extensión Opcache</link> ahora viene siempre
-    integrada en el binario de PHP y siempre se carga.
-    Las directivas INI <link linkend="ini.opcache.enable">opcache.enable</link>
-    y <link linkend="ini.opcache.enable-cli">opcache.enable_cli</link> siguen
-    siendo válidas.
    </simpara>
 
   </sect3>


### PR DESCRIPTION
La section Opcache était dupliquée (elle se trouve aussi dans `incompatible.xml`).

Closes #856