### PR TITLE
[Sync EN] move setlocale block to Standard section (#858)

### DIFF
--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 570cdc0ceb6db0452b080c97bb5990b2a11dfbc3 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Cambios incompatibles con versiones anteriores</title>
@@ -444,12 +444,6 @@
    si el valor de read_and_close no es de un tipo válido compatible con int.
   </simpara>
 
-  <simpara>
-   Pasar un entero <literal>0</literal> como argumento <parameter>locales</parameter>
-   a <function>setlocale</function> ya no es compatible y ahora lanza
-   un <exceptionname>TypeError</exceptionname>.
-  </simpara>
-
  </sect2>
 
  <sect2 xml:id="migration85.incompatible.simplexml">
@@ -552,6 +546,12 @@
    El uso de una función de la familia printf con un formateador que no especificó
    previamente la precisión incorrectamente restablece la precisión en lugar de tratarla
    como una precisión de 0.
+  </simpara>
+
+  <simpara>
+   Pasar un entero <literal>0</literal> como argumento <parameter>locales</parameter>
+   a <function>setlocale</function> ya no es compatible y ahora lanza
+   un <exceptionname>TypeError</exceptionname>.
   </simpara>
 
  </sect2>


### PR DESCRIPTION
Closes #858