### PR TITLE
fix(sync-en): synchronise Dom\ParentNode children property (#869)

### DIFF
--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.dom-document" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Dom\Document</title>
@@ -107,6 +107,12 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-document.props.children">children</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type class="union"><type>Dom\HTMLElement</type><type>null</type></type>
      <varname linkend="dom-document.props.body">body</varname>
     </fieldsynopsis>
@@ -208,6 +214,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-document.props.childelementcount">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.dom-documentfragment" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Dom\DocumentFragment</title>
@@ -61,6 +61,12 @@
      <type>int</type>
      <varname linkend="dom-documentfragment.props.childelementcount">childElementCount</varname>
     </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-documentfragment.props.children">children</varname>
+    </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
@@ -96,6 +102,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.childelementcount">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documentfragment.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.dom-element" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Dom\Element</title>
@@ -124,8 +124,19 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-element.props.children">children</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type>string</type>
      <varname linkend="dom-element.props.innerhtml">innerHTML</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.outerhtml">outerHTML</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -232,10 +243,24 @@
       <xi:fallback/>
      </xi:include>
     </varlistentry>
+    <varlistentry xml:id="dom-element.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
     <varlistentry xml:id="dom-element.props.innerhtml">
      <term><varname>innerHTML</varname></term>
      <listitem>
       <simpara>El HTML interno (o XML para documentos XML) del elemento.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.outerhtml">
+     <term><varname>outerHTML</varname></term>
+     <listitem>
+      <simpara>
+       El HTML externo (o XML para documentos XML) del elemento, incluyendo
+       el propio elemento. Disponible a partir de PHP 8.5.0.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.substitutednodevalue">

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.dom-parentnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La interfaz Dom\ParentNode</title>
@@ -23,12 +23,35 @@
      <interfacename>Dom\ParentNode</interfacename>
     </oointerface>
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-parentnode.props.children">children</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])">
      <xi:fallback/>
     </xi:include>
    </classsynopsis>
 
+  </section>
+
+  <section xml:id="dom-parentnode.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-parentnode.props.children">
+     <term><varname>children</varname></term>
+     <listitem>
+      <simpara>
+       Una <classname>Dom\HTMLCollection</classname> que contiene todos los elementos
+       hijo de este nodo. Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </section>
 
  </partintro>


### PR DESCRIPTION
Closes #869

Sync with EN commit `34314b7c6eab4d9b7efabd42154b38fcc5db1fef`.

- `dom-document.xml`: ajout de la propriété `children`
- `dom-documentfragment.xml`: ajout de la propriété `children`
- `dom-element.xml`: ajout des propriétés `children` et `outerHTML`
- `dom-parentnode.xml`: ajout de la propriété `children` (fieldsynopsis + section props)