### PR TITLE
[Sync EN] drop obsolete WDDX and Java integration claims from intro (#870)

### DIFF
--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 77f5f3b3a8bbe1ad7727201c7603d1419dd7840f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 0bae88c19601e7f67ae6a22a8f9aa44cb9342cc1 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="introduction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -153,16 +153,12 @@ echo "Hola, soy un script PHP!";
    <link linkend="book.curl">cURL</link> o <link linkend="book.sockets">sockets</link>
    como CouchDB.
   </para>
-  <para>
+  <simpara>
    PHP soporta numerosos protocolos como
    LDAP, IMAP, SNMP, NNTP, POP3, HTTP, COM (en Windows) y
-   muchos otros. También puede abrir sockets de red,
-   e interactuar con cualquier otro protocolo. PHP soporta
-   el formato complejo WDDX, que permite la comunicación entre todos
-   los lenguajes web. En términos de interconexión, PHP también soporta
-   los objetos Java, y los utiliza de manera transparente
-   como objetos integrados.
-  </para>
+   muchos otros. También puede abrir sockets de red
+   e interactuar con cualquier otro protocolo.
+  </simpara>
   <para>
    PHP posee funcionalidades útiles en el
    <link linkend="refs.basic.text">tratamiento de texto</link>,


### PR DESCRIPTION
Closes #870

Sync avec le commit EN `0bae88c19601e7f67ae6a22a8f9aa44cb9342cc1`.

- `chapters/intro.xml`: suppression des mentions WDDX et Java obsolètes, `<para>` → `<simpara>`