### PR TITLE
[Sync EN] rename CURL_TCP_KEEPCNT to CURLOPT_TCP_KEEPCNT (#871)

### DIFF
--- a/appendices/migration84/constants.xml
+++ b/appendices/migration84/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8a6397d39aefd23c61d64aa4e9af919772541e2a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d0ac0a55fc0606f0c0c2f0b277d7d38699cc025a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.constants">
  <title>Nuevas constantes globales</title>
@@ -28,7 +28,7 @@
     <constant>CURL_HTTP_VERSION_3ONLY</constant>
    </member>
    <member>
-    <constant>CURL_TCP_KEEPCNT</constant>
+    <constant>CURLOPT_TCP_KEEPCNT</constant>
    </member>
    <member>
     <constant>CURLOPT_PREREQFUNCTION</constant>


### PR DESCRIPTION
Closes #871

Sync avec le commit EN `d0ac0a55fc0606f0c0c2f0b277d7d38699cc025a`.

- `appendices/migration84/constants.xml`: `CURL_TCP_KEEPCNT` → `CURLOPT_TCP_KEEPCNT`