### PR TITLE
fix(sync-en): fix dead external links in the manual (#874)

### DIFF
--- a/install/windows/commandline.xml
+++ b/install/windows/commandline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2dbf3d9064d4cb07f0a2f7d06641c877a2e5ed24 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="install.windows.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Ejecución de PHP en línea de comandos en sistemas Windows</title>
@@ -178,12 +178,10 @@ Windows Registry Editor Version 5.00
 "InheritConsoleHandles"=dword:00000001
 ]]>
    </screen>
-   Más información sobre este problema puede encontrarse en este <link
-   xlink:href="http://support.microsoft.com/default.aspx?scid=kb;en-us;321788">artículo de la base de conocimientos de Microsoft: 321788</link>.
+   Más información sobre este problema puede encontrarse en el artículo
+   de la base de conocimientos de Microsoft: 321788.
    A partir de Windows 10, este ajuste parece estar invertido, haciendo que la instalación por defecto de
-   Windows 10 soporte automáticamente los manejadores de consola heredados. Este <link
-   xlink:href="https://social.msdn.microsoft.com/Forums/en-US/f19d740d-21c8-4dc2-a9ab-d5c0527e932b/nasty-file-association-regression-bug-in-windows-10-console?forum=windowssdk">
-   post del foro de Microsoft</link> proporciona la explicación.
+   Windows 10 soporte automáticamente los manejadores de consola heredados.
   </para>
  </note>
 </sect1>

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -565,7 +565,7 @@
    </term>
    <listitem>
     <simpara>
-     Constante de control - Afirmación (<link xlink:href="&url.rfc;45282">RFC 4528</link>).
+     Constante de control - Afirmación (<link xlink:href="&url.rfc;4528">RFC 4528</link>).
      Disponible a partir de PHP 7.3.0.
     </simpara>
    </listitem>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Arquitectura y funcionalidades especiales</titleabbrev>
@@ -28,7 +28,7 @@
    En la parte superior de esta pila se encuentra una
    <link xlink:href="&url.mongodb.library;">biblioteca PHP</link>,
    que distribuye un
-   <link xlink:href="&url.packagist.package;/mongodb/mongodb">paquete Composer</link>.
+   <link xlink:href="&url.packagist.package;mongodb/mongodb">paquete Composer</link>.
    Esta biblioteca proporciona una API coherente con otros
    <link xlink:href="&url.mongodb.drivers;">controladores</link>
    MongoDB e implementa diversas


### PR DESCRIPTION
Closes #874

Sync avec le commit EN `10e6a2b042104bd7481b6c21ddbfda594683e3c4`.

- `install/windows/commandline.xml`: suppression des deux liens Microsoft morts (KB321788 et forum MSDN), conservation du texte
- `reference/ldap/constants.xml`: correction `&url.rfc;45282` → `&url.rfc;4528`
- `reference/mongodb/architecture.xml`: correction du lien Composer (`/mongodb/mongodb` → `mongodb/mongodb`)