### PR TITLE
ci: track XInclude href and xpointer in the structure check

### DIFF
--- a/.github/scripts/check-structure.php
+++ b/.github/scripts/check-structure.php
@@ -27,7 +27,9 @@
 
 // Attributes that are part of the "structure": they are included in an
 // element's signature (a role= or an xml:id that changes = drift).
-const STRUCTURAL_ATTRIBUTES = ['role', 'choice', 'class', 'xml:id', 'rep'];
+// href and xpointer come from XInclude: a translated target silently selects
+// nothing and breaks the build, so they must mirror doc-en exactly.
+const STRUCTURAL_ATTRIBUTES = ['role', 'choice', 'class', 'xml:id', 'rep', 'href', 'xpointer'];
 
 // Elements whose content is text (inline). We record the element itself but do
 // NOT descend into it: its prose is the translator's business.


### PR DESCRIPTION
Follow-up to a review remark on php/doc-pt_br#787: XInclude `xpointer` (and `href`) are structural, so they belong in the element signature. A translated target selects nothing and breaks the build.

Checked over every file using XInclude in this repo: no new false positive. The same run on doc-es surfaced a real one (`@role='procedimental'` inside an xpointer predicate), which is exactly the class of bug this is meant to catch.