### PR TITLE
[Sync EN] ext/dom: drop empty xi:fallback elements in Dom\Element

### DIFF
--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.dom-element" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Dom\Element</title>
@@ -41,9 +41,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -145,21 +143,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Aún no documentado</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Aún no documentado</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -191,9 +183,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.classname">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.classname')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.classname')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.classlist">
      <term><varname>classList</varname></term>
@@ -214,39 +204,25 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.id">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.id')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.id')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.firstelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.firstelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.firstelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.lastelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.lastelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.lastelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.childelementcount">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.childelementcount')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.childelementcount')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.previouselementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.previouselementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.previouselementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.nextelementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.children">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.innerhtml">
      <term><varname>innerHTML</varname></term>


### PR DESCRIPTION
The outerHTML property from php/doc-en 9a5e44a0ca is already translated here; what was still missing on this file is 603435cd84, which removes the empty xi:fallback elements that hide failed XIncludes.

Fixes: #861