### PR TITLE
[Sync EN] language/control-structures: runnable (WASM) examples

### DIFF
--- a/language/control-structures.xml
+++ b/language/control-structures.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ede9d209f64d4cd71bf22fcfaed14c6fc269523c Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no Maintainer: julionc -->
-<chapter xml:id="language.control-structures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="language.control-structures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <title>Estructuras de Control</title>
 
  <sect1 xml:id="control-structures.intro">

--- a/language/control-structures/alternative-syntax.xml
+++ b/language/control-structures/alternative-syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.alternative-syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,11 +14,19 @@
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php if ($a == 5): ?>
+<?php
+$a = 5;
+if ($a == 5): ?>
 A igual 5
 <?php endif; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+A igual 5
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -30,6 +38,7 @@ A igual 5
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 5;
 if ($a == 5):
     echo "a igual 5";
     echo "...";
@@ -39,9 +48,14 @@ elseif ($a == 6):
 else:
     echo "a no vale ni 5 ni 6";
 endif;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a igual 5...
+]]>
+   </screen>
   </informalexample>
  </para>
  <note>
@@ -56,12 +70,20 @@ endif;
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php switch ($foo): ?>
+<?php
+$foo = 1;
+switch ($foo): ?>
     <?php case 1: ?>
-    // ...
+    Foo vale 1
 <?php endswitch; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Parse error: syntax error, unexpected T_INLINE_HTML "    ", expecting "endswitch" or "case" or "default" in script on line 4
+]]>
+   </screen>
   </informalexample>
   <para>
    Mientras que esto es válido, ya que la última nueva línea después de la estructura <literal>switch</literal> se considera parte de la etiqueta de cierre <literal>?&gt;</literal> y, por lo tanto, no se muestra nada entre <literal>switch</literal> y <literal>case</literal>:
@@ -69,12 +91,20 @@ endif;
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php switch ($foo): ?>
+<?php
+$foo = 1;
+switch ($foo): ?>
 <?php case 1: ?>
-    ...
+    Foo vale 1
 <?php endswitch; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+    Foo vale 1
+]]>
+   </screen>
   </informalexample>
  </warning>
  <para>

--- a/language/control-structures/break.xml
+++ b/language/control-structures/break.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.break" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -28,27 +28,61 @@ foreach ($arr as $val) {
     if ($val == 'stop') {
         break;    /* También podría utilizarse 'break 1;' aquí. */
     }
-    echo "$val<br />\n";
+    echo "$val\n";
 }
-
-/* Uso del argumento opcional. */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+un
+dos
+tres
+cuatro
+]]>
+   </screen>
+  </informalexample>
+ </para>
+ <simpara>
+  Uso del argumento opcional:
+ </simpara>
+ <para>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 $i = 0;
 while (++$i) {
     switch ($i) {
         case 5:
-            echo "At 5<br />\n";
+            echo "At 5\n";
             break 1;  /* Termina únicamente el switch. */
         case 10:
-            echo "At 10; quitting<br />\n";
+            echo "At 10; quitting\n";
             break 2;  /* Termina el switch y el ciclo while. */
         default:
             break;
     }
+    echo "$i\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+At 5
+5
+6
+7
+8
+9
+At 10; quitting
+]]>
+   </screen>
   </informalexample>
  </para>
 

--- a/language/control-structures/continue.xml
+++ b/language/control-structures/continue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16389a7b31069481d6c8c0705172bee5ef1ddf5f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="control-structures.continue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -39,7 +39,6 @@ foreach ($arr as $key => $value) {
     }
     echo $value . "\n";
 }
-?>
 ]]>
    </programlisting>
    &examples.outputs;
@@ -66,7 +65,6 @@ while ($i++ < 5) {
     }
     echo "Neither does this.\n";
 }
-?>
 ]]>
    </programlisting>
    &examples.outputs;
@@ -87,35 +85,6 @@ Inner
 Outer
 Middle
 Inner
-]]>
-   </screen>
-  </informalexample>
- </para>
- <para>
-  Olvidar el punto y coma después de <literal>continue</literal> puede llevar a confusión. Aquí hay un ejemplo de lo que no se debe hacer:
- </para>
- <para>
-  <informalexample>
-   <programlisting role="php">
-<![CDATA[
-<?php
-for ($i = 0; $i < 5; ++$i) {
-    if ($i == 2)
-        continue
-    print "$i\n";
-}
-?>
-]]>
-   </programlisting>
-   <para>
-    Se puede esperar que el resultado sea:
-   </para>
-   <screen>
-<![CDATA[
-0
-1
-3
-4
 ]]>
    </screen>
   </informalexample>

--- a/language/control-structures/declare.xml
+++ b/language/control-structures/declare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5499acf9df7e1338d540bde207acc859792cd139 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="control-structures.declare" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -33,7 +33,7 @@ declare (directive)
   los literales pueden ser utilizados como valor de estas directivas. Las variables
   y constantes no pueden ser utilizadas. Para ilustrar:
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Esto es correcto:
@@ -42,7 +42,6 @@ declare(ticks=1);
 // Esto es incorrecto:
 const TICK_VALUE = 1;
 declare(ticks=TICK_VALUE);
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -59,7 +58,7 @@ declare(ticks=TICK_VALUE);
   sigue (incluso si el fichero con <literal>declare</literal> ha sido
   incluido después, no afecta al fichero padre).
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Estas declaraciones son idénticas.
@@ -72,7 +71,6 @@ declare(ticks=1) {
 // o esto
 declare(ticks=1);
 // script entero aquí
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -119,12 +117,20 @@ $a = 1; // causa un evento tick
 
 if ($a > 0) {
     $a += 2; // causa un evento tick
-    print $a; // causa un evento tick
+    print $a . "\n"; // causa un evento tick
 }
-
-?>
 ]]>
    </programlisting>
+  &example.outputs;
+   <screen>
+<![CDATA[
+tick_handler() llamado
+tick_handler() llamado
+tick_handler() llamado
+3
+tick_handler() llamado
+]]>
+   </screen>
   </example>
  </para>
  <simpara>
@@ -139,12 +145,11 @@ if ($a > 0) {
    directiva <literal>encoding</literal>.
   <example>
    <title>Declaración de una codificación para un script</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 declare(encoding='ISO-8859-1');
 // el código
-?>
 ]]>
     </programlisting>
    </example>

--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 53fb200fed6d316b0616a915eb87a40de1d80f51 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -29,9 +29,14 @@ $i = 0;
 do {
     echo $i;
 } while ($i > 0);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+0
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -52,23 +57,32 @@ do {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 50;
+$factor = 0.5;
+$minimum_limit = 20;
 do {
     if ($i < 5) {
-        echo "i no es suficientemente grande";
+        echo "i no es suficientemente grande\n";
         break;
     }
     $i *= $factor;
     if ($i < $minimum_limit) {
+        echo "i es menor que el límite mínimo después del factor\n";
         break;
     }
-    echo "i es bueno";
+    echo $i ." es bueno\n";
 
     /* ...procesamiento de i... */
 
 } while (0);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+25 es bueno
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>

--- a/language/control-structures/else.xml
+++ b/language/control-structures/else.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 690c3ea7c7d416c55e2c54d90bfd1f7f4d489288 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="control-structures.else" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -21,14 +21,21 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 5;
 if ($a > $b) {
-  echo "a es más grande que b";
+  echo "a es más grande que b\n";
 } else {
-  echo "a es más pequeño que b";
+  echo "a NO es más grande que b\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a NO es más grande que b
+]]>
+   </screen>
   </informalexample>
   Las sentencias después del <literal>else</literal> solo se
   ejecutan si la expresión del <literal>if</literal>
@@ -53,9 +60,14 @@ if ($a)
         echo "b";
 else
     echo "c";
-?>
 ]]>
     </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+
+]]>
+   </screen>
    </informalexample>
    A pesar de la indentación (que no tiene importancia en PHP), el
    <literal>else</literal> se asocia con el <literal>if ($b)</literal>,

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.elseif" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -22,6 +22,8 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 1;
+$b = 1;
 if ($a > $b) {
     echo "a es más grande que b";
 } elseif ($a == $b) {
@@ -29,9 +31,14 @@ if ($a > $b) {
 } else {
     echo "a es más pequeño que b";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a es igual a b
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -67,6 +74,8 @@ if ($a > $b) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 
 /* Mala práctica: */
 if ($a > $b):
@@ -76,12 +85,20 @@ else if ($a == $b): // no compilará
 endif;
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Parse error: syntax error, unexpected token "if", expecting ":" in script on line 8
+]]>
+   </screen>
   </informalexample>
 
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 
 /* Buena práctica: */
 if ($a > $b):
@@ -91,10 +108,14 @@ elseif ($a == $b): // Las dos palabras están unidas
 else:
     echo $a." es más grande o igual a ".$b;
 endif;
-
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+3 es más grande que 1
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -57,38 +57,71 @@ for (expr1; expr2; expr3)
    <programlisting role="php">
 <![CDATA[
 <?php
-/* ejemplo 1 */
-
 for ($i = 1; $i <= 10; $i++) {
-    echo $i;
+    echo $i . " ";
 }
-
-/* ejemplo 2 */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 for ($i = 1; ; $i++) {
     if ($i > 10) {
         break;
     }
-    echo $i;
+    echo $i . " ";
 }
-
-/* ejemplo 3 */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 $i = 1;
 for (; ; ) {
     if ($i > 10) {
         break;
     }
-    echo $i;
+    echo $i . " ";
     $i++;
 }
-
-/* ejemplo 4 */
-
-for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i . " ", $i++);
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -129,11 +162,32 @@ $people = array(
 );
 
 for($i = 0; $i < count($people); ++$i) {
-    $people[$i]['salt'] = mt_rand(000000, 999999);
+    $people[$i]['salt'] = random_int(100000, 999999);
 }
-?>
+var_dump($people);
 ]]>
    </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(2) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(5) "Kalle"
+    ["salt"]=>
+    int(454478)
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(6) "Pierre"
+    ["salt"]=>
+    int(776978)
+  }
+}
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -153,11 +207,32 @@ $people = array(
 );
 
 for($i = 0, $size = count($people); $i < $size; ++$i) {
-    $people[$i]['salt'] = mt_rand(000000, 999999);
+    $people[$i]['salt'] = random_int(100000, 999999);
 }
-?>
+var_dump($people);
 ]]>
    </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(2) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(5) "Kalle"
+    ["salt"]=>
+    int(454478)
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(6) "Pierre"
+    ["salt"]=>
+    int(776978)
+  }
+}
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ba7093cf7f30dbcd301c62536ac7ef8664d891f4 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
@@ -51,14 +51,14 @@ foreach (iterable_expression as $key => $value) {
 <![CDATA[
 <?php
 
-/* Ejemplo: solo valor */
+echo "Solo valor\n";
 $array = [1, 2, 3, 17];
 
 foreach ($array as $value) {
     echo "Elemento actual de \$array: $value.\n";
 }
 
-/* Ejemplo: clave y valor */
+echo "\n\nClave y valor:\n";
 $array = [
     "one" => 1,
     "two" => 2,
@@ -70,7 +70,7 @@ foreach ($array as $key => $value) {
     echo "Clave: $key => Valor: $value\n";
 }
 
-/* Ejemplo: arrays multidimensionales clave-valor */
+echo "\n\nArrays multidimensionales clave-valor:\n";
 $grid = [];
 $grid[0][0] = "a";
 $grid[0][1] = "b";
@@ -83,13 +83,44 @@ foreach ($grid as $y => $row) {
     }
 }
 
-/* Ejemplo: arrays dinámicos */
+echo "\n\nArrays dinámicos:\n";
 foreach (range(1, 5) as $value) {
     echo "$value\n";
 }
-?>
 ]]>
   </programlisting>
+  &example.outputs;
+  <screen>
+<![CDATA[
+Solo valor
+Elemento actual de $array: 1.
+Elemento actual de $array: 2.
+Elemento actual de $array: 3.
+Elemento actual de $array: 17.
+
+
+Clave y valor:
+Clave: one => Valor: 1
+Clave: two => Valor: 2
+Clave: three => Valor: 3
+Clave: seventeen => Valor: 17
+
+
+Arrays multidimensionales clave-valor:
+Valor en posición x=0 y y=0: a
+Valor en posición x=1 y y=0: b
+Valor en posición x=0 y y=1: y
+Valor en posición x=1 y y=1: z
+
+
+Arrays dinámicos:
+1
+2
+3
+4
+5
+]]>
+  </screen>
  </example>
  <note>
   <para>
@@ -140,12 +171,13 @@ foreach ($array as [$a, $b]) {
 foreach ($array as list($a, $b)) {
     echo "A: $a; B: $b\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
+A: 1; B: 2
+A: 3; B: 4
 A: 1; B: 2
 A: 3; B: 4
 ]]>
@@ -175,7 +207,6 @@ foreach ($array as [, , $c]) {
     // Omitiendo $a y $b
     echo "$c\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -206,7 +237,6 @@ $array = [
 foreach ($array as [$a, $b, $c]) {
     echo "A: $a; B: $b; C: $c\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -239,10 +269,25 @@ foreach ($arr as &$value) {
     $value = $value * 2;
 }
 // $arr es ahora [2, 4, 6, 8]
+var_dump($arr);
 unset($value); // romper la referencia con el último elemento
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(8)
+}
+]]>
+    </screen>
    </informalexample>
   </para>
   <warning>
@@ -261,25 +306,48 @@ foreach ($arr as &$value) {
     $value = $value * 2;
 }
 // $arr es ahora [2, 4, 6, 8]
+var_dump($arr);
 
 // sin un unset($value), $value sigue siendo una referencia al último elemento: $arr[3]
 
+echo "\nOtro bucle:\n";
 foreach ($arr as $key => $value) {
     // $arr[3] se actualizará con cada valor de $arr...
-    echo "{$key} => {$value} ";
-    print_r($arr);
+    echo "{$key} => {$value}\n";
 }
 // ...hasta que finalmente el penúltimo valor se copie sobre el último valor
-?>
+var_dump($arr);
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-0 => 2 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 2 )
-1 => 4 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 4 )
-2 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
-3 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(8)
+}
+
+Otro bucle:
+0 => 2
+1 => 4
+2 => 6
+3 => 6
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(6)
+}
 ]]>
     </screen>
    </informalexample>
@@ -291,10 +359,19 @@ foreach ($arr as $key => $value) {
 <?php
 foreach ([1, 2, 3, 4] as &$value) {
     $value = $value * 2;
+    echo $value . "\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2
+4
+6
+8
+]]>
+   </screen>
   </example>
  </sect2>
 

--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7204e2dbb9b484c8b67bb5ad4a93fa1369c5b317 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.goto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -38,14 +38,11 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-
 goto a;
 echo 'Foo';
 
 a:
 echo 'Bar';
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -72,8 +69,6 @@ for ($i = 0, $j = 50; $i < 100; $i++) {
 echo "i = $i";
 end:
 echo 'j hit 17';
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -97,15 +92,12 @@ for ($i = 0, $j = 50; $i < 100; $i++) {
     }
 }
 echo "$i = $i";
-
-?>
 ]]>
    </programlisting>
-   &example.outputs;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
-Fatal error: 'goto' into loop or switch statement is disallowed in
-script on line 2
+Fatal error: 'goto' into loop or switch statement is disallowed in script on line 2
 ]]>
    </screen>
   </example>

--- a/language/control-structures/if.xml
+++ b/language/control-structures/if.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.if" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -39,11 +39,18 @@ if (expression)
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 if ($a > $b)
-  echo "a es más grande que b";
-?>
+  echo "a es más grande que b\n";
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a es más grande que b
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -59,13 +66,22 @@ if ($a > $b)
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 if ($a > $b) {
-  echo "a es más grande que b";
+  echo "a es más grande que b\n";
   $b = $a;
 }
-?>
+var_dump($b);
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a es más grande que b
+int(3)
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -51,7 +51,7 @@
  <para>
   <example>
    <title>Ejemplo con <literal>include</literal></title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 vars.php
 <?php
@@ -86,7 +86,7 @@ echo "Una $fruit $color"; // Una manzana verde
  <para>
   <example>
    <title>Inclusión de ficheros dentro de una función</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -106,8 +106,6 @@ function foo()
 
 foo();                      // Una pomme verte
 echo "Una $fruit $couleur"; // Una  verte
-
-?>
 ]]>
    </programlisting>
   </example>
@@ -137,7 +135,7 @@ echo "Una $fruit $couleur"; // Una  verte
  <para>
   <example>
    <title>Utilizar la instrucción <literal>include</literal> vía HTTP</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -156,7 +154,6 @@ include 'file.php?foo=1&bar=2';
 
 // Funciona
 include 'http://www.example.com/file.php?foo=1&bar=2';
-?>
 ]]>
    </programlisting>
   </example>
@@ -201,7 +198,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
   al comparar el valor devuelto.
   <example>
    <title>Comparación del valor devuelto de una inclusión</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // No funciona, evaluado como include(('vars.php') == TRUE), es decir include('1')
@@ -213,7 +210,6 @@ if (include('vars.php') == TRUE) {
 if ((include 'vars.php') == TRUE) {
     echo 'OK';
 }
-?>
 ]]>
    </programlisting>
   </example>
@@ -221,7 +217,7 @@ if ((include 'vars.php') == TRUE) {
  <para>
   <example>
    <title><literal>include</literal> y <function>return</function></title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 return.php
 <?php
@@ -284,7 +280,7 @@ echo $bar; // muestra 1
   <example>
    <title>Uso del buffer de salida para incluir un fichero PHP en
    una cadena</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $string = get_include_contents('somefile.php');
@@ -297,8 +293,6 @@ function get_include_contents($filename) {
     }
     return false;
 }
-
-?>
 ]]>
    </programlisting>
   </example>

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 840bdb9be79855ee4b2cc66c22cf3e88b781398a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -19,14 +19,13 @@
 
  <example>
   <title>Estructura de una expresión <literal>match</literal></title>
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $return_value = match (subject_expression) {
     single_conditional_expression => return_expression,
     conditional_expression1, conditional_expression2 => return_expression,
 };
-?>
 ]]>
   </programlisting>
 
@@ -44,7 +43,6 @@ $return_value = match ($food) {
 };
 
 var_dump($return_value);
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -71,7 +69,6 @@ $output = match (true) {
 };
 
 var_dump($output);
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -134,7 +131,7 @@ string(12) "Adolescente"
   Solo la expresión de retorno correspondiente a la expresión condicional correspondiente será evaluada.
   Por ejemplo:
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $result = match ($x) {
@@ -143,7 +140,6 @@ $result = match ($x) {
     $this->baz => beep(), // beep() no es llamado a menos que $x === $this->baz
     // etc.
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -156,7 +152,7 @@ $result = match ($x) {
  </para>
  <para>
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $result = match ($x) {
@@ -167,7 +163,6 @@ $result = match ($x) {
     $b => 5,
     $c => 5,
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -177,7 +172,7 @@ $result = match ($x) {
   Este patrón coincide con todo lo que no ha sido buscado previamente.
   Por ejemplo:
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $expressionResult = match ($condition) {
@@ -185,7 +180,6 @@ $expressionResult = match ($condition) {
     3, 4 => bar(),
     default => baz(),
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -218,7 +212,6 @@ try {
 } catch (\UnhandledMatchError $e) {
     var_dump($e);
 }
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -226,15 +219,15 @@ try {
 <![CDATA[
 object(UnhandledMatchError)#1 (7) {
   ["message":protected]=>
-  string(33) "Unhandled match value of type int"
+  string(22) "Unhandled match case 5"
   ["string":"Error":private]=>
   string(0) ""
   ["code":protected]=>
   int(0)
   ["file":protected]=>
-  string(9) "/in/ICgGK"
+  string(6) "script"
   ["line":protected]=>
-  int(6)
+  int(5)
   ["trace":"Error":private]=>
   array(0) {
   }
@@ -257,7 +250,6 @@ object(UnhandledMatchError)#1 (7) {
    <programlisting role="php">
 <![CDATA[
 <?php
-
 $age = 23;
 
 $result = match (true) {
@@ -268,7 +260,6 @@ $result = match (true) {
 };
 
 var_dump($result);
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -294,7 +285,6 @@ $result = match (true) {
 };
 
 var_dump($result);
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d149b6ddca64beb9de38cbd4bfd8d19d3bd0b60e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>switch</title>
@@ -39,32 +39,39 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 // Este switch:
 
 switch ($i) {
     case 0:
-        echo "i igual 0";
+        echo "i igual 0\n";
         break;
     case 1:
-        echo "i igual 1";
+        echo "i igual 1\n";
         break;
     case 2:
-        echo "i igual 2";
+        echo "i igual 2\n";
         break;
 }
 
 // Equivale a:
-
 if ($i == 0) {
-    echo "i igual 0";
+    echo "i igual 0\n";
 } elseif ($i == 1) {
-    echo "i igual 1";
+    echo "i igual 1\n";
 } elseif ($i == 2) {
-    echo "i igual 2";
+    echo "i igual 2\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i igual 1
+i igual 1
+]]>
+   </screen>
   </example>
  </para>
  <para>
@@ -87,17 +94,25 @@ if ($i == 0) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i) {
     case 0:
-        echo "i igual 0";
+        echo "i igual 0\n";
     case 1:
-        echo "i igual 1";
+        echo "i igual 1\n";
     case 2:
-        echo "i igual 2";
+        echo "i igual 2\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i igual 1
+i igual 2
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -126,6 +141,8 @@ switch ($i) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i) {
     case 0:
     case 1:
@@ -135,9 +152,14 @@ switch ($i) {
     case 3:
         echo "i igual 3";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i es menor que 3 pero no es negativo
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -147,6 +169,8 @@ switch ($i) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 4;
+
 switch ($i) {
     case 0:
         echo "i igual 0";
@@ -160,9 +184,14 @@ switch ($i) {
     default:
        echo "i no es igual a 2, ni a 1, ni a 0.";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i no es igual a 2, ni a 1, ni a 0.
+]]>
+   </screen>
   </informalexample>
   <note>
    <simpara>
@@ -206,11 +235,14 @@ switch ($target) {
         print "D";
         break;
 }
-
-// Muestra "B"
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+B
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -237,11 +269,14 @@ switch (true) {
         print "D";
         break;
 }
-
-// Muestra "B"
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+B
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -253,6 +288,8 @@ switch (true) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i):
     case 0:
         echo "i igual 0";
@@ -266,18 +303,25 @@ switch ($i):
     default:
         echo "i no es igual a 2, ni a 1, ni a 0";
 endswitch;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i igual 1
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
-  Es posible utilizar un punto y coma en lugar de dos puntos después
-  de un case, como sigue :
+  Es posible utilizar un punto y coma en lugar de dos puntos después de un case.
+    A partir de PHP 8.5.0, esta sintaxis está obsoleta.
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
+$beer = 'cola';
+
 switch($beer)
 {
     case 'leffe';
@@ -289,9 +333,21 @@ switch($beer)
         echo 'Por favor, haga una elección...';
         break;
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 6
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 7
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 8
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 11
+Por favor, haga una elección...
+]]>
+   </screen>
   </informalexample>
   &warn.deprecated.feature-8-5-0;
  </para>

--- a/language/control-structures/while.xml
+++ b/language/control-structures/while.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -59,24 +59,55 @@ endwhile;
    <programlisting role="php">
 <![CDATA[
 <?php
-/* ejemplo 1 */
-
 $i = 1;
 while ($i <= 10) {
-    echo $i++;  /* El valor mostrado es $i antes del incremento
-                   (post-incremento)  */
+    echo $i++ . "\n";  /* El valor mostrado es $i antes del incremento
+                          (post-incremento)  */
 }
-
-/* ejemplo 2 */
-
-$i = 1;
-while ($i <= 10):
-    echo $i;
-    $i++;
-endwhile;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$i = 1;
+while ($i <= 10):
+    echo $i . "\n";
+    $i++;
+endwhile;
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>


### PR DESCRIPTION
Port of php/doc-en b8147b7f03506e41f01631c32a907b955593525a. foreach.xml, goto.xml, match.xml and switch.xml also carry 17c238517825dfb7ec3edfef5972acd944ffbc1e, the next commit on those files.

The deprecation notices in the switch semicolon example were checked against php:8.5-rc-cli: the Spanish example has three cases, so it emits four notices (lines 6, 7, 8 and 11), not the five of the English page.

Fixes: #889