### PR TITLE
[Sync EN] ext/curl: document more curl deprecations

### DIFF
--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5cdc4c99779c1bd1b770b15a5fc6438b39223c28 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <variablelist xml:id="constant.curl-getinfo.constants" role="constant_list">
  <title><function>curl_getinfo</function></title>
@@ -114,7 +114,7 @@
   </term>
   <listitem>
    <simpara>
-    La longitud del contenido descargado, leída desde el campo Content-Length:
+    La longitud del contenido descargado, leída desde el campo Content-Length:. Obsoleto desde cURL 7.55.0. Utilícese <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> en su lugar.
    </simpara>
   </listitem>
  </varlistentry>
@@ -137,7 +137,7 @@
   </term>
   <listitem>
    <simpara>
-    El tamaño especificado del envío.
+    El tamaño especificado del envío. Obsoleto desde cURL 7.55.0. Utilícese <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> en su lugar.
    </simpara>
   </listitem>
  </varlistentry>
@@ -454,7 +454,7 @@
   <listitem>
    <simpara>
     El protocolo utilizado en la última conexión HTTP. El valor de retorno será exactamente uno de los valores <constant>CURLPROTO_<replaceable>*</replaceable></constant>.
-    Disponible a partir de PHP 7.3.0 y cURL 7.52.0
+    Disponible a partir de PHP 7.3.0 y cURL 7.52.0. Obsoleto desde cURL 7.85.0. Utilícese <constant>CURLINFO_SCHEME</constant> en su lugar.
    </simpara>
   </listitem>
  </varlistentry>
@@ -672,7 +672,7 @@
   </term>
   <listitem>
    <simpara>
-    El número total de octetos descargados.
+    El número total de octetos descargados. Obsoleto desde cURL 7.55.0. Utilícese <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> en su lugar.
    </simpara>
   </listitem>
  </varlistentry>
@@ -695,7 +695,7 @@
   </term>
   <listitem>
    <simpara>
-    El número total de octetos subidos.
+    El número total de octetos subidos. Obsoleto desde cURL 7.55.0. Utilícese <constant>CURLINFO_SIZE_UPLOAD_T</constant> en su lugar.
    </simpara>
   </listitem>
  </varlistentry>
@@ -718,7 +718,7 @@
   </term>
   <listitem>
    <simpara>
-    La velocidad media de descarga.
+    La velocidad media de descarga. Obsoleto desde cURL 7.55.0. Utilícese <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> en su lugar.
    </simpara>
   </listitem>
  </varlistentry>
@@ -741,7 +741,7 @@
   </term>
   <listitem>
    <simpara>
-    La velocidad media de subida.
+    La velocidad media de subida. Obsoleto desde cURL 7.55.0. Utilícese <constant>CURLINFO_SPEED_UPLOAD_T</constant> en su lugar.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e7e81a179eabc75e1b37947c7696afd557cef656 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5cdc4c99779c1bd1b770b15a5fc6438b39223c28 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <variablelist role="constant_list">
  <title><function>curl_setopt</function></title>
@@ -1635,7 +1635,7 @@
     es usado.
     Definir esta opción en &null; desactivará el soporte de Kerberos para FTP.
     Por omisión en &null;.
-    Disponible a partir de cURL 7.16.4.
+    Disponible a partir de cURL 7.16.4 y obsoleto a partir de cURL 8.17.0.
    </para>
   </listitem>
  </varlistentry>
@@ -2453,14 +2453,14 @@
    (<type>int</type>)
   </term>
   <listitem>
-   <para>
+   <simpara>
     Un bitmask de valores
     <constant>CURLPROTO_<replaceable>*</replaceable></constant>.
     Si se usa, este bitmask limita los protocolos que cURL puede usar en la transferencia.
     Por omisión, esto vale <constant>CURLPROTO_ALL</constant>, es decir, cURL aceptará todos los protocolos que soporta.
-    Ver <constant>CURLOPT_REDIR_PROTOCOLS</constant>.
+    Ver <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant>.
     Disponible a partir de cURL 7.19.4 y depreciado a partir de cURL 7.85.0.
-   </para>
+   </simpara>
   </listitem>
  </varlistentry>
  <varlistentry xml:id="constant.curlopt-protocols-str">
@@ -3763,8 +3763,6 @@
       <parameter>keyLength</parameter>
      </methodparam>
     </methodsynopsis>
-   </para>
-   <para>
     <variablelist role="function_parameters">
      <varlistentry>
       <term>
@@ -4137,12 +4135,12 @@
    (<type>int</type>)
   </term>
   <listitem>
-   <para>
+   <simpara>
     &true; para habilitar y &false; para deshabilitar el inicio anticipado de TLS,
     que es un modo donde un cliente TLS comienza a enviar datos de aplicación
     antes de verificar el mensaje <literal>Finished</literal> del servidor.
-    Disponible a partir de PHP 7.0.7 y cURL 7.42.0.
-   </para>
+    Disponible a partir de PHP 7.0.7 y cURL 7.42.0. Obsoleto desde cURL 8.15.0.
+   </simpara>
   </listitem>
  </varlistentry>
  <varlistentry xml:id="constant.curlopt-ssl-options">


### PR DESCRIPTION
Port of php/doc-en 5cdc4c99779c1bd1b770b15a5fc6438b39223c28.

Fixes: #891