### PR TITLE
[Sync EN] ext/intl: document the IntlListFormatter class (PHP 8.5)

### DIFF
--- a/appendices/migration85/new-classes.xml
+++ b/appendices/migration85/new-classes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration85.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nuevas clases e interfaces</title>
@@ -29,6 +29,13 @@
    <member><classname>Filter\FilterFailedException</classname></member>
   </simplelist>
   <!-- RFC: https://wiki.php.net/rfc/filter_throw_on_failure -->
+ </sect2>
+
+ <sect2 xml:id="migration85.new-classes.intl">
+  <title>Intl</title>
+  <simplelist>
+   <member><classname>IntlListFormatter</classname></member>
+  </simplelist>
  </sect2>
 
  <sect2 xml:id="migration85.new-classes.uri">

--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 91791cdde04dd89898656fbec1aa8e7e0bf0460d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
@@ -12,7 +12,7 @@
  <!-- {{{ Prefacio -->
  <preface xml:id="intro.intl">
   &reftitle.intro;
-  <para>
+  <simpara>
    La extensión de Internationalization (también llamada Intl) es una
    interfaz para la biblioteca <link xlink:href="&url.icu.home;">ICU</link>,
    que permite a los desarrolladores PHP realizar operaciones
@@ -22,18 +22,18 @@
    <link xlink:href="&url.icu.uca;">UCA</link>-conforme, la
    localización de límites de texto y el uso de identificadores
    de configuración regional, zonas horarias y glifos.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Esta extensión tiende a seguir de cerca la API ICU, lo que hace que quienes
    tengan experiencia con esta biblioteca en C, C++ o Java puedan
    encontrar fácilmente su camino en la API PHP. Además, la documentación ICU
    puede ser muy útil para comprender las funciones ICU.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Intl está constituido por varios módulos, cada uno exponiendo APIs de ICU:
-  </para>
+  </simpara>
 
   <itemizedlist>
    <listitem>
@@ -105,13 +105,13 @@
    <title>Enlaces</title>
    <itemizedlist>
     <listitem>
-     <para><link xlink:href="&url.icu.docs;">Varias docs ICU</link></para>
+     <simpara><link xlink:href="&url.icu.docs;">Varias docs ICU</link></simpara>
     </listitem>
     <listitem>
-     <para><link xlink:href="&url.icu.userguide;">Guía de usuario ICU</link></para>
+     <simpara><link xlink:href="&url.icu.userguide;">Guía de usuario ICU</link></simpara>
     </listitem>
     <listitem>
-     <para><link xlink:href="&url.icu.uca;">Algoritmo de collation Unicode</link></para>
+     <simpara><link xlink:href="&url.icu.uca;">Algoritmo de collation Unicode</link></simpara>
     </listitem>
    </itemizedlist>
   </section>
@@ -140,6 +140,7 @@
  &reference.intl.intlrulebasedbreakiterator;
  &reference.intl.intlcodepointbreakiterator;
  &reference.intl.intldatepatterngenerator;
+ &reference.intl.intllistformatter;
  &reference.intl.intlpartsiterator;
  &reference.intl.uconverter;
 

--- a/reference/intl/intllistformatter.xml
+++ b/reference/intl/intllistformatter.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.intllistformatter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La clase IntlListFormatter</title>
+ <titleabbrev>IntlListFormatter</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ IntlListFormatter intro -->
+  <section xml:id="intllistformatter.intro">
+   &reftitle.intro;
+   <simpara>
+    Formatea, ordena y puntúa una lista de elementos según las reglas
+    específicas de la configuración regional. Requiere ICU 67 o posterior.
+   </simpara>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="intllistformatter.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>IntlListFormatter</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-and">IntlListFormatter::TYPE_AND</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-or">IntlListFormatter::TYPE_OR</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-units">IntlListFormatter::TYPE_UNITS</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-wide">IntlListFormatter::WIDTH_WIDE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-short">IntlListFormatter::WIDTH_SHORT</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-narrow">IntlListFormatter::WIDTH_NARROW</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlListFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlListFormatter'])"/>
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+  <section xml:id="intllistformatter.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="intllistformatter.constants.type-and">
+     <term><constant>IntlListFormatter::TYPE_AND</constant></term>
+     <listitem>
+      <simpara>
+       Formatea una lista utilizando una conjunción (por ejemplo, "A, B y C").
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.type-or">
+     <term><constant>IntlListFormatter::TYPE_OR</constant></term>
+     <listitem>
+      <simpara>
+       Formatea una lista utilizando una disyunción (por ejemplo, "A, B o C").
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.type-units">
+     <term><constant>IntlListFormatter::TYPE_UNITS</constant></term>
+     <listitem>
+      <simpara>
+       Formatea una lista de unidades (por ejemplo, "3 ft, 7 in").
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-wide">
+     <term><constant>IntlListFormatter::WIDTH_WIDE</constant></term>
+     <listitem>
+      <simpara>
+       Utiliza el formato de lista más amplio (el más explícito), normalmente
+       con las conjunciones escritas por completo.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-short">
+     <term><constant>IntlListFormatter::WIDTH_SHORT</constant></term>
+     <listitem>
+      <simpara>
+       Utiliza un formato de lista corto, normalmente con abreviaturas.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-narrow">
+     <term><constant>IntlListFormatter::WIDTH_NARROW</constant></term>
+     <listitem>
+      <simpara>
+       Utiliza el formato de lista más estrecho, con una puntuación mínima.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="changelog" xml:id="intllistformatter.changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        La clase fue añadida.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
+ </partintro>
+
+ &reference.intl.entities.intllistformatter;
+
+</reference>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+-->

--- a/reference/intl/intllistformatter/construct.xml
+++ b/reference/intl/intllistformatter/construct.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="intllistformatter.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlListFormatter::__construct</refname>
+  <refpurpose>Crea una nueva instancia de IntlListFormatter</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="IntlListFormatter">
+   <modifier>public</modifier> <methodname>IntlListFormatter::__construct</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlListFormatter::TYPE_AND</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>width</parameter><initializer><constant>IntlListFormatter::WIDTH_WIDE</constant></initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Crea una nueva instancia de <classname>IntlListFormatter</classname> para la
+   configuración regional indicada.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      La configuración regional a utilizar para el formateo.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <simpara>
+      El tipo de lista. Una de las constantes <constant>IntlListFormatter::TYPE_<replaceable>*</replaceable></constant>:
+      <constant>IntlListFormatter::TYPE_AND</constant>,
+      <constant>IntlListFormatter::TYPE_OR</constant> o
+      <constant>IntlListFormatter::TYPE_UNITS</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width</parameter></term>
+    <listitem>
+     <simpara>
+      La anchura de la lista. Una de las constantes <constant>IntlListFormatter::WIDTH_<replaceable>*</replaceable></constant>:
+      <constant>IntlListFormatter::WIDTH_WIDE</constant>,
+      <constant>IntlListFormatter::WIDTH_SHORT</constant> o
+      <constant>IntlListFormatter::WIDTH_NARROW</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lanza una <exceptionname>IntlException</exceptionname> si el formateador no
+   puede ser creado (por ejemplo, una configuración regional inválida o una
+   versión de ICU inferior a 67).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       La clase fue añadida.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlListFormatter::format</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intllistformatter/format.xml
+++ b/reference/intl/intllistformatter/format.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="intllistformatter.format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlListFormatter::format</refname>
+  <refpurpose>Formatea una lista de elementos</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlListFormatter">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlListFormatter::format</methodname>
+   <methodparam><type>array</type><parameter>list</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Formatea una lista de elementos como una cadena adaptada a la configuración
+   regional.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>list</parameter></term>
+    <listitem>
+     <simpara>
+      Un array de cadenas a formatear como lista.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La lista formateada como cadena, o &false; en caso de error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo con <methodname>IntlListFormatter::format</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlListFormatter('es_ES', IntlListFormatter::TYPE_AND, IntlListFormatter::WIDTH_WIDE);
+echo $fmt->format(['uno', 'dos', 'tres']);
+// uno, dos y tres
+
+$fmt = new IntlListFormatter('es_ES', IntlListFormatter::TYPE_OR, IntlListFormatter::WIDTH_WIDE);
+echo $fmt->format(['uno', 'dos', 'tres']);
+// uno, dos o tres
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlListFormatter::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Port of php/doc-en e1b9f588815a51682acf68f9b8929f49ad612488.

The example output was checked against php:8.5-rc-cli with ext/intl built in: 'uno, dos y tres' and 'uno, dos o tres' for es_ES.

Fixes: #893