### PR TITLE
[Sync EN] features/commandline: clarify the Windows note for multiple workers

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 07b2f1dcff1d8beb846f5671e5f4bf2ab8d33ebf Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Utilización de la línea de comandos</title>
  <titleabbrev>Utilización de líneas de comando</titleabbrev>
 
- <!--Introduction: {{{-->
  <section xml:id="features.commandline.introduction" annotations="chunk:false">
   <title>Introducción</title>
 
@@ -44,9 +43,7 @@
    </para>
   </note>
  </section>
- <!--}}}-->
 
- <!--Differences: {{{-->
  <section xml:id="features.commandline.differences">
   <title>Diferencia con otros <acronym>SAPI</acronym>s</title>
 
@@ -232,9 +229,7 @@ $ php -f otro_directorio/test.php
    </itemizedlist>
   </para>
  </section>
- <!--}}}-->
 
- <!--Options: {{{-->
  <section xml:id="features.commandline.options">
   <title>Opciones de línea de comandos</title>
   <titleabbrev>Opciones</titleabbrev>
@@ -872,9 +867,7 @@ date.sunrise_zenith => 90.583333 => 90.583333
    </para>
   </note>
  </section>
- <!--}}}-->
 
- <!--Usage: {{{-->
  <section xml:id="features.commandline.usage">
   <title>Ejecución de archivos PHP</title>
   <titleabbrev>Utilización</titleabbrev>
@@ -1082,9 +1075,7 @@ Esto es una línea de comando a una opción.
   </note>
 
  </section>
- <!--}}}-->
 
- <!--I/O Streams: {{{-->
  <section xml:id="features.commandline.io-streams">
   <title>Flujos de entrada/salida</title>
   <titleabbrev>Flujos I/O</titleabbrev>
@@ -1179,9 +1170,7 @@ php -r 'fwrite(STDERR, "stderr\n");'
    </para>
   </note>
  </section>
- <!--}}}-->
 
- <!--Interactive shell: {{{-->
  <section xml:id="features.commandline.interactive">
   <title>Shell Interactivo</title>
 
@@ -1213,9 +1202,9 @@ php >
    </programlisting>
   </example>
 
-  <simpara>
-   El shell interactivo también proporciona autocompletado de funciones, constantes, nombres de clases, variables, llamadas a métodos estáticos y constantes de clases utilizando la tecla de tabulación. Desde PHP 8.4.0, la ruta hacia el archivo de historial puede establecerse utilizando la variable de entorno <envar>PHP_HISTFILE</envar>.
-  </simpara>
+  <para>
+   El shell interactivo también proporciona autocompletado de funciones, constantes, nombres de clases, variables, llamadas a métodos estáticos y constantes de clases utilizando la tecla de tabulación.
+  </para>
 
   <example>
    <title>Autocompletado usando la tecla de tabulación</title>
@@ -1248,9 +1237,10 @@ php > $foo[TAB]ThisIsAReallyLongVariableName
    </programlisting>
   </example>
 
-  <para>
+  <simpara>
    El shell interactivo almacena su historial y puede acceder a él utilizando las teclas arriba y abajo. El historial se guarda en el archivo <filename>~/.php_history</filename>.
-  </para>
+   Desde PHP 8.4.0, la ruta hacia el archivo de historial puede establecerse utilizando la variable de entorno <envar>PHP_HISTFILE</envar>.
+  </simpara>
 
   <para>
    El &cli.sapi; proporciona 2 directivas del &php.ini;: <parameter>cli.pager</parameter> y <parameter>cli.prompt</parameter>. La directiva <parameter>cli.pager</parameter> permite la definición de un programa externo (como <filename>less</filename>) a utilizar como pager para la salida en lugar de mostrarla directamente en la pantalla. La directiva <parameter>cli.prompt</parameter> permite la modificación del prompt <literal>php &gt;</literal>.
@@ -1363,9 +1353,7 @@ php >
    </para>
   </section>
  </section>
- <!--}}}-->
 
- <!--Built-in CLI Web Server: {{{-->
  <section xml:id="features.commandline.webserver">
   <title>Servidor web interno</title>
 
@@ -1456,7 +1444,7 @@ php >
   </simpara>
   <note>
    <simpara>
-    Esta funcionalidad no está soportada en Windows.
+    Los procesos de trabajo múltiples no están soportados en Windows.
    </simpara>
   </note>
   <note>
@@ -1622,7 +1610,6 @@ $ php -S 0.0.0.0:8000
   </example>
 
  </section>
- <!--}}}-->
 
  <section xml:id="features.commandline.ini">
   <title>Configuraciones INI</title>


### PR DESCRIPTION
Port of php/doc-en 07b2f1dcff1d8beb846f5671e5f4bf2ab8d33ebf, plus the skeleton comments cleanup from c62ef37e0d.

Two structural drifts on this file are also fixed so the structure check passes: the PHP_HISTFILE sentence sat in the tab completion paragraph instead of the history one, and the surrounding blocks did not match doc-en.

Fixes: #896