### PR TITLE
[Sync EN] exec: remove dead code in the example

### DIFF
--- a/reference/exec/functions/exec.xml
+++ b/reference/exec/functions/exec.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b412bbd26214f7281ac7dd858710e09952a275f2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 462dddda87baa86fd760dcb1e3a0d2096e00a59b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -126,10 +126,8 @@
 <?php
 // Muestra el nombre de usuario que ejecuta el proceso php/http
 // (en un sistema que tenga "whoami" en el camino de ejecutables)
-$output=null;
-$retval=null;
-exec('whoami', $output, $retval);
-echo "Devuelto con estado $retval y salida:\n";
+exec('whoami', $output, $result_code);
+echo "Devuelto con estado $result_code y salida:\n";
 print_r($output);
 ?>
 ]]>


### PR DESCRIPTION
Port of php/doc-en 462dddda87baa86fd760dcb1e3a0d2096e00a59b.

Fixes: #900