### PR TITLE
[Sync EN] bookinfo: drop the removed frontpage entities

### DIFF
--- a/bookinfo.xml
+++ b/bookinfo.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d2dd02b7bdd1f1c3becbe06444c354f5e6f0e34 Maintainer: argosback Status: ready -->
+<!-- EN-Revision: 75772fd985edd7dc6f94b067bd2ef3ab59511cb5 Maintainer: argosback Status: ready -->
 <!-- Reviewed: yes Maintainer: argosback -->
 
  <info xmlns="http://docbook.org/ns/docbook" xml:id="bookinfo">
-  &frontpage.authors;
   <pubdate><?dbtimestamp format="Y-m-d"?></pubdate>
-  &frontpage.editors;
 
   <authorgroup xml:id="translators">
   <othercredit class="translator">


### PR DESCRIPTION
Port of php/doc-en 75772fd985edd7dc6f94b067bd2ef3ab59511cb5: the frontpage.authors and frontpage.editors entities were emptied upstream and moved to entities.remove.ent, so referencing them here no longer makes sense. The Spanish translator credits are kept.

Fixes: #901