### PR TITLE
[Sync EN] Remove 72 unused entities from language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: argosback Status: ready -->
+<!-- EN-Revision: 9eb61e3573bc9af825caa0aba34932850aa1b666 Maintainer: argosback Status: ready -->
 <!-- Reviewed: yes Maintainer: argosback -->
 
 <!ENTITY installation.enabled.disable 'Esta extensión está activada por defecto. Puede ser desactivada utilizando la opción de configuración: '>
@@ -7,16 +7,6 @@
 <!-- Not used in EN anymore -->
 <!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>El generador
 de números aleatorios se inicializa automáticamente.</entry></row>'>
-
-<!ENTITY warn.deprecated.feature-5-3-0.removed-6-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>Esta característica está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0. Depender de esta característica está
-altamente desaconsejado.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-6-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0. Depender de esta función está
-altamente desaconsejado.</simpara></warning>'>
 
 <!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
@@ -104,11 +94,6 @@ una excepción no es interceptada cuando ha sido lanzada en una función de devo
 <!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>Si los argumentos son pasados por referencia,
 todas sus modificaciones serán reflejadas en los valores devueltos por esta función. A partir de PHP 7, los
 valores actuales también serán devueltos si los argumentos son pasados por su valor.</simpara></note>'>
-
-<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>Dado que esta función depende del ámbito
-actual para determinar los detalles de los argumentos, estos no pueden ser utilizados como
-argumento de una función en versiones de PHP anteriores a 5.3.0. Si este valor debe ser pasado, el resultado debe ser
-asignado a una variable y esta variable debe ser pasada.</simpara></note>'>
 
 <!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara> A partir de PHP 8.0.0, la familia de funciones
 func_*() está diseñada para ser esencialmente transparente con respecto a los argumentos nombrados,
@@ -250,43 +235,19 @@ Esta extensión debe ser utilizada bajo su propio riesgo.</simpara></warning>'>
 <!ENTITY deprecated.function 'Esta función está obsoleta.'>
 <!ENTITY removed.function 'Esta función ha sido eliminada.'>
 
-<!ENTITY warn.deprecated.feature-5-3-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0. Depender de esta funcionalidad
-está altamente desaconsejado.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido <emphasis>ELIMINADA</emphasis>
 a partir de PHP 5.4.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-5-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 5.4.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0. Depender de esta funcionalidad
-está altamente desaconsejado.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.feature-5-6-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 5.6.0. Depender de esta funcionalidad
 está altamente desaconsejado.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 7.0.0. Depender de esta funcionalidad
-está altamente desaconsejado.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-7-1-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0. Depender de esta funcionalidad
-está altamente desaconsejado.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-7-1-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0. Depender de esta función
 está altamente desaconsejado.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-0-0.removed-8-0-0 '<warning
@@ -311,11 +272,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0, y <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0. Depender de esta funcionalidad
 está altamente desaconsejado.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.function-7-2-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0. Depender de esta función
-está altamente desaconsejado.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-7-2-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP
@@ -326,19 +282,9 @@ xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0. Depender de esta funcionalidad
 está altamente desaconsejado.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.function-7-3-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0. Depender de esta función
-está altamente desaconsejado.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-7-3-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 7.3.0, y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 8.0.0. Depender de esta función
-está altamente desaconsejado.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-7-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 7.4.0. Depender de esta funcionalidad
 está altamente desaconsejado.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-4-0 '<warning
@@ -385,11 +331,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 8.3.0. Depender de esta función
 está altamente desaconsejado.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-8-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>Esta característica está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 8.4.0. Depender de esta característica
-está altamente desaconsejado.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-8-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>Esta función está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 8.4.0. Depender de esta función
@@ -408,53 +349,12 @@ está altamente desaconsejado.</simpara></warning>'>
 <!ENTITY removed.php.future 'Esta funcionalidad obsoleta <emphasis xmlns="http://docbook.org/ns/docbook">será</emphasis>
 ciertamente <emphasis xmlns="http://docbook.org/ns/docbook">eliminada</emphasis> en el futuro.'>
 
-<!ENTITY warn.deprecated.function.removed-5-3-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis> y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 5.3.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function.removed-5-5-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis>, y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 5.5.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>Este alias está <emphasis>OBSOLETO</emphasis> a partir de PHP 5.3.0.
-Depender de este alias está fuertemente desaconsejado.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.func-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.4.0.
-Depender de esta función está fuertemente desaconsejado.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
 <simpara>Este alias está <emphasis>OBSOLETO</emphasis> a partir de PHP 5.4.0.
 Depender de este alias está fuertemente desaconsejado.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.func-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0.
-Depender de esta función está fuertemente desaconsejado.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-5-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-4-1-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 4.1.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Este alias está
 <emphasis>OBSOLETO</emphasis> a partir de PHP 5.4.0. y ha sido <emphasis>ELIMINADO</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-6-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.6.0 y ha sido
-<emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
 <!ENTITY warn.removed.function-7-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta función ha sido
@@ -520,15 +420,6 @@ Al utilizar <function>fsockopen</function> para crear un socket
 <literal>ssl://</literal>, es responsabilidad del desarrollador detectar
 y suprimir el aviso.</simpara></warning>'>
 
-<!ENTITY warn.undocumented.class '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Esta clase está actualmente no documentada; solo la lista de sus propiedades y
-  métodos está disponible.
- </simpara>
-</warning>
-'>
-
 <!ENTITY warn.undocumented.func '<warning xmlns="http://docbook.org/ns/docbook"> <simpara>Esta función está actualmente
 no documentada; solo la lista de sus argumentos está disponible.
 </simpara></warning>'>
@@ -537,64 +428,6 @@ no documentada; solo la lista de sus argumentos está disponible.
 <!-- Deprecation and removal warnings designed for use with a list of
      alternatives. See en/reference/regex/functions/ereg.xml and
      en/reference/regex/reference.xml for examples of these in action. -->
-
-<!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 4.1.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Las alternativas a esta función incluyen:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Esta funcionalidad está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Las alternativas a esta funcionalidad incluyen:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Las alternativas a esta función incluyen:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Esta función está <emphasis>OBSOLETA</emphasis> a partir de PHP 5.5.0 y ha sido
- <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Las alternativas a esta función incluyen:
-</simpara>
-'>
-
-<!ENTITY warn.removed.feature.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Esta funcionalidad ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Las alternativas a esta funcionalidad incluyen:
-</simpara>
-'>
-
-<!ENTITY warn.removed.function.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Esta función ha sido <emphasis>ELIMINADA</emphasis> a partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Las alternativas a esta función incluyen:
-</simpara>
-'>
 
 <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -629,8 +462,6 @@ evitar su uso.</simpara></warning>
 
 <!ENTITY version.exists.asof 'Existe a partir de PHP '>
 
-<!ENTITY version.trunk.changelog 'Futuro'>
-
 <!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">Esta función no contiene ningún parámetro.</simpara>'>
 
 <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">El ejemplo anterior mostrará:</simpara>'>
@@ -650,8 +481,6 @@ evitar su uso.</simpara></warning>
 <!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.0:</simpara>'>
 
 <!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.1:</simpara>'>
-
-<!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.2:</simpara>'>
 
 <!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 7.3:</simpara>'>
 
@@ -675,8 +504,6 @@ evitar su uso.</simpara></warning>
 
 <!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.4 es similar a:</simpara>'>
 
-<!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Salida del ejemplo anterior en PHP 8.5:</simpara>'>
-
 <!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">La salida del ejemplo anterior en PHP 8.5 es similar a:</simpara>'>
 
 <!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en una máquina de 32 bits:</simpara>'>
@@ -687,10 +514,6 @@ evitar su uso.</simpara></warning>
 es similar a:</simpara>'>
 
 <!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán:</simpara>'>
-
-<!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 32 bits:</simpara>'>
-
-<!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Resultado de los ejemplos anteriores en una máquina de 64 bits:</simpara>'>
 
 <!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Los ejemplos anteriores mostrarán
 algo similar a:</simpara>'>
@@ -813,11 +636,6 @@ siguiente alias obsoleto puede ser utilizado: '>
 <!ENTITY info.function.alias 'Esta función es un alias de: '>
 
 <!ENTITY info.method.alias 'Este método es un alias de: '>
-
-<!ENTITY info.function.alias.deprecated '<simpara xmlns="http://docbook.org/ns/docbook">Este alias está obsoleto
-y solo existe por razones de compatibilidad. Se recomienda no utilizar
-esta función ya que puede ser eliminada en una versión futura de PHP.
-</simpara>'>
 
 <!ENTITY ext.windows.path.dll 'Para hacer funcionar esta extensión, algunas bibliotecas
 <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> deben estar disponibles a través
@@ -945,20 +763,7 @@ función.</simpara></warning>'>
  </listitem>
 </varlistentry>'>
 
-<!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
- <term><parameter>key</parameter></term>
- <listitem>
-  <simpara>
-   Ver los <link linkend="openssl.certparams">parámetros clave pública/privada</link> para obtener una lista de los valores válidos.
-  </simpara>
- </listitem>
-</varlistentry>'>
-
 <!-- Image (GD) Notes -->
-<!ENTITY note.config.t1lib '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible
-si PHP es compilado utilizando <option role="configure">--enable-t1lib[=DIR]</option>.
-</simpara></note>'>
-
 <!ENTITY note.freetype '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función solo está disponible si
 si PHP es compilado con soporte Freetype (<option role="configure">--with-freetype-dir=DIR</option>)
 </simpara></note>'>
@@ -1107,10 +912,6 @@ $font = 'SomeFont';
     Utilizado junto con <function>imagesetinterpolation</function>, disponible a partir de PHP 5.5.0.
 </simpara>'>
 
-<!ENTITY gd.changlog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
-    <entry>7.0.0</entry><entry>El soporte de T1Lib fue eliminado de PHP, por lo tanto esta función fue eliminada.</entry>
-</row>'>
-
 <!ENTITY gd.deprecated.gd-formats '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Los formatos
 de imagen GD y GD2 son formatos propietarios de libgd. Deben considerarse
 <emphasis>obsoletos</emphasis>, y solo deben utilizarse con fines de desarrollo y
@@ -1135,10 +936,6 @@ pruebas.</simpara></warning>'>
 </simpara></warning>'>
 
 <!-- DBM notes -->
-
-<!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>dbm_identifier</parameter></term><listitem><simpara>El identificador de enlace DBM,
-devuelto por <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
@@ -1281,10 +1078,6 @@ devuelto por <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 <parameter>imap</parameter></term><listitem><simpara>Una instancia de <classname>IMAP\Connection</classname>.</simpara></listitem></varlistentry>'>
 
 <!-- Deprecated -->
-<!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><simpara>Un flujo IMAP devuelto por
-<function>imap_open</function>.</simpara></listitem></varlistentry>'>
-
 <!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Especifica en qué parte de la jerarquía del
 buzón comenzar la búsqueda.</simpara><simpara xmlns="http://docbook.org/ns/docbook">Hay dos caracteres especiales que se
 pueden pasar como parte del <parameter>pattern</parameter>:
@@ -1437,17 +1230,11 @@ de la codificación de caracteres interna.</simpara>'>
 
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_ciphername</constant>, o el nombre del algoritmo como cadena.</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv '<simpara xmlns="http://docbook.org/ns/docbook">Utilizado para la inicialización en los modos CBC, CFB, OFB, y en algunos algoritmos en modo STREAM. Si no se proporciona un IV, siendo necesario para un algoritmo, la función emite una advertencia y utiliza un IV con todos sus bytes establecidos a "<literal>\0</literal>".</simpara>'>
-
 <!ENTITY mcrypt.parameter.iv.strict '<simpara xmlns="http://docbook.org/ns/docbook">Utilizado para la inicialización en los modos CBC, CFB, OFB, y en algunos algoritmos en modo STREAM. Si el tamaño del IV proporcionado no es soportado por el modo de encadenamiento o no se proporcionó un IV, pero el modo de encadenamiento requiere uno, la función emitirá una advertencia y devolverá &false;.</simpara>'>
 
 <!ENTITY mcrypt.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_MODE_modename</constant>, o una de las siguientes cadenas: "ecb", "cbc", "cfb", "ofb", "nofb" o "stream".</simpara>'>
 
  <!-- MCVE notes -->
-
-<!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>conn</parameter></term><listitem><simpara>Un recurso MCVE_CONN devuelto por
-<function>m_initengine</function>.</simpara></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
@@ -1553,8 +1340,6 @@ de la codificación de caracteres interna.</simpara>'>
 
 <!ENTITY gearman.parameter.workload 'Datos serializados a analizar'>
 
-<!ENTITY gearman.parameter.data 'Datos adicionales necesarios para completar el trabajo'>
-
 <!ENTITY gearman.parameter.context 'Contexto de la aplicación a asociar con una tarea'>
 
 <!ENTITY gearman.parameter.unique 'Un identificador único utilizado para identificar una tarea particular'>
@@ -1638,12 +1423,6 @@ zonas horarias pueden ser eliminadas de la base de datos IANA de zonas horarias 
  <literal>Australia/Perth</literal> para los ejemplos anteriores.
 </simpara>'>
 
-<!ENTITY date.timezone.abbrev-volatile '<simpara xmlns="http://docbook.org/ns/docbook">
-Estas abreviaturas de zonas horarias deben ser consideradas como no permanentes, es decir pueden
-ser diferentes para cada versión de la base de datos de zonas horarias, y por lo
-tanto no deben ser utilizadas. Se recomienda encarecidamente evitarlas.
-</simpara>'>
-
 <!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
 Cada llamada a una función de fecha/hora generará un diagnóstico de tipo <constant>E_WARNING</constant>
 si la zona horaria no es válida. Ver también <function>date_default_timezone_set</function></simpara>'>
@@ -1673,9 +1452,7 @@ Esta función modifica este objeto.</simpara></listitem></varlistentry>'>
 <parameter>object</parameter></term><listitem><simpara> Solo en estilo procedimental: un objeto <classname>DateTimeZone</classname> retornado
 por <function>timezone_open</function> </simpara></listitem></varlistentry>'>
 
-<!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Retorna el objeto modificado <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> para encadenar métodos&return.falseforfailure;.'>
 <!ENTITY date.datetime.return.modifiedobject 'Retorna el objeto modificado <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> para encadenar métodos.'>
-<!ENTITY date.datetimeimmutable.return.modifiedobjectorfalseforfailure 'Retorna un nuevo objeto <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> con los datos modificados &return.falseforfailure;.'>
 <!ENTITY date.datetimeimmutable.return.modifiedobject 'Retorna un nuevo objeto <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> con los datos modificados.'>
 
 <!ENTITY date.timezone.dbversion 'Esta lista está basada en la versión de la base de datos de zonas horarias'>
@@ -1691,8 +1468,6 @@ por <function>timezone_open</function> </simpara></listitem></varlistentry>'>
 <!ENTITY date.timezone.indian 'Índico'>
 <!ENTITY date.timezone.pacific 'Pacífico'>
 <!ENTITY date.timezone.others 'Otros'>
-<!ENTITY date.timezone.abbreviations 'Abreviaturas'>
-
 <!ENTITY date.formats 'Los formatos válidos son explicados en la documentación sobre los <link xmlns="http://docbook.org/ns/docbook" linkend="datetime.formats">formatos de Fecha y Hora</link>.'>
 <!ENTITY date.formats.parameter 'Una cadena de fecha/hora. &date.formats;'>
 
@@ -1954,8 +1729,6 @@ que típicamente se crea utilizando <function>fopen</function>.</simpara>'>
 <!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">La huella de la clave.</simpara>'>
 
 <!-- HaruDoc -->
-<!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Emite una excepción <classname>HaruException</classname> en caso de error.</simpara>'>
-
 <!-- ODBC -->
 <!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">El objeto de conexión ODBC, ver la documentación de
 la función <function>odbc_connect</function> para más detalles.</simpara>'><!ENTITY odbc.result.object 'El objeto de resultado ODBC'>
@@ -2212,12 +1985,6 @@ Las constantes listadas aquí están siempre disponibles en PHP.
 </simpara>'>
 
 <!-- Used in reference/$extname/classes.xml -->
-<!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook">
-Estas clases son definidas por esta extensión, y
-solo estarán disponibles si esta extensión ha
-sido compilada con PHP, o bien cargada dinámicamente.
-</simpara>'>
-
 <!-- PDO entities -->
 <!ENTITY pdo.driver-constants '<simpara xmlns="http://docbook.org/ns/docbook">Las constantes a continuación son definidas
 por este controlador y solo estarán disponibles cuando la extensión haya sido compilada en
@@ -2244,8 +2011,6 @@ está definido a <constant>PDO::ERRMODE_EXCEPTION</constant>.
 <!-- PECL entities -->
 <!ENTITY pecl.moved 'Esta extensión &link.pecl; no está integrada en PHP.'>
 
-<!ENTITY pecl.bundled 'Esta extensión &link.pecl; está integrada en PHP.'>
-
 <!ENTITY pecl.info 'Información sobre la instalación de estas extensiones PECL puede ser
 encontrada en el capítulo del manual titulado <link xmlns="http://docbook.org/ns/docbook" linkend="install.pecl">Instalación
 de extensiones PECL</link>. Otra información como notas sobre nuevas versiones, descargas,
@@ -2267,8 +2032,6 @@ de esta extensión sigue disponible en el <acronym xmlns="http://docbook.org/ns/
 
 <!ENTITY pecl.windows.download.avail 'Los binarios Windows (los ficheros <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym>)
 para esta extensión <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> están disponibles en el sitio web PECL.'>
-
-<!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
 
 <!ENTITY pecl.moved-ver 'Esta extensión ha sido movida al módulo &link.pecl;
 y no será integrada en PHP a partir de PHP '>
@@ -2354,8 +2117,6 @@ del soporte automático de esta extensión. No es necesario añadir ninguna bibl
 adicional para disponer de estas funciones.</simpara>'>
 
 <!-- These are here as helpers for manual consistency and brievety-->
-<!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">safe mode</link>'>
-
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">safe mode SQL</link>'>
 
 <!-- CTYPE Notes -->
@@ -2447,35 +2208,6 @@ todos sus métodos. Estas no pueden ser vistas utilizando <function>var_dump</fu
 o cualquier otra función que examine los objetos.</simpara></note>'>
 
 <!-- SQLite Notes -->
-<!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">Los nombres de columnas devueltos por
-<constant>SQLITE_ASSOC</constant> y <constant>SQLITE_BOTH</constant> siguen las reglas
-concernientes a la case definidas por la opción de configuración
-<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>
-.</simpara>'>
-
-<!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">Cuando <parameter>decode_binary</parameter>
-vale &true; (por defecto), PHP va a decodificar los datos
-binarios, si estos han sido codificados con la función
-<function>sqlite_escape_string</function>. Generalmente se dejará este valor
-en su valor predeterminado, a menos que se esté trabajando con bases
-operadas por otras aplicaciones.</simpara>'>
-
-<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>Esta función no funcionará con
-resultados no bufferizados.</simpara></note>'>
-
-<!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Dos sintaxis alternativas son soportadas
-para asegurar la compatibilidad con otras bases de datos (tales como MySQL):
-la forma recomendada es la primera, donde el parámetro <parameter>dbhandle</parameter>
-es el primero en la función.</simpara></note>'>
-
-<!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro opcional <parameter>result_type</parameter>
-acepta una constante y determina cómo el array devuelto debe ser indexado. El
-uso de <constant>SQLITE_ASSOC</constant> devolverá únicamente un array asociativo (nombres
-de los campos) mientras que <constant>SQLITE_NUM</constant> devolverá un
-array indexado numéricamente (número ordinal de los campos). <constant>SQLITE_BOTH</constant>
-devolverá índices numéricos y asociativos.
-<constant>SQLITE_BOTH</constant> es el valor predeterminado para esta función.</simpara>'>
-
 <!-- Database Notes -->
 <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Los nombres de los campos devueltos por esta función
 son <emphasis>sensibles a la case</emphasis>.</simpara></note>'>
@@ -2536,12 +2268,6 @@ su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</li
 Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de
 la guía. Alternativas a esta función:</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">Esta función estaba obsoleta en PHP 5.5.0, y
-toda la <link linkend="book.mysql">extensión original MySQL</link> fue eliminada en PHP 7.0.0. En
-su lugar, se puede utilizar la extensión <link linkend="book.mysqli">MySQLi</link> o la extensión <link linkend="ref.pdo-mysql">PDO_MySQL</link>.
-Ver también <link linkend="mysqlinfo.api.choosing">MySQL: elegir una API</link> de
-la guía. Alternativas a esta función:</simpara>'>
-
 <!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
 Las conexiones y los juegos de resultados abiertos de forma no persistente son automáticamente destruidos
 cuando un script PHP termina su ejecución. También, el hecho de cerrar una
@@ -2564,21 +2290,6 @@ Por ejemplo: <literal>tcp://[fe80::1]:80</literal>.</simpara></note>'>
 
 <!-- Notes for tidy -->
 <!ENTITY tidy.object 'El objeto <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>'>
-
-<!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">El parámetro <parameter>config</parameter> puede
-tomar la forma de un array o de una cadena de caracteres. En forma de cadena,
-representa el nombre del fichero de configuración y de lo contrario, es un array
-con las opciones de configuración. Lea
-<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.tidy.conf;">&url.tidy.conf;</link>
-para saber más sobre cada opción.</simpara> <simpara>El parámetro
-<parameter>encoding</parameter> especifica el juego de caracteres utilizado para los documentos
-de entrada y salida. Los valores posibles de <parameter>encoding</parameter> son:
-<literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
-<literal>raw</literal>, <literal>utf8</literal>, <literal>iso2022</literal>,
-<literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
-<literal>utf16</literal>, <literal>utf16le</literal>,
-<literal>utf16be</literal>, <literal>big5</literal> y
-<literal>shiftjis</literal>.</simpara>'>
 
 <!-- Snippets for the installation section -->
 <!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>No se recomienda el uso de PHP
@@ -2692,10 +2403,6 @@ instancia <classname>XMLWriter</classname> que es modificada. Este objeto provie
 <!-- Imagick generic return types -->
 <!ENTITY imagick.return.success 'Devuelve &true; en caso de éxito.'>
 <!ENTITY imagick.imagick.throws 'Lanza una ImagickException en caso de error.'>
-<!ENTITY imagick.imagickdraw.throws 'Lanza una ImagickDrawException en caso de error.'>
-<!ENTITY imagick.imagickpixel.throws 'Lanza una ImagickPixelException en caso de error.'>
-<!ENTITY imagick.imagickpixeliterator.throws 'Lanza una ImagickPixelIteratorException en caso de error.'>
-
 <!-- Imagick version infos -->
 <!ENTITY imagick.method.available.0x629 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.2.9 o superior.'>
 <!ENTITY imagick.method.available.0x631 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.1 o superior.'>
@@ -2705,14 +2412,10 @@ instancia <classname>XMLWriter</classname> que es modificada. Este objeto provie
 <!ENTITY imagick.method.available.0x638 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.8 o superior.'>
 <!ENTITY imagick.method.available.0x639 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.3.9 o superior.'>
 <!ENTITY imagick.method.available.0x640 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.0 o superior.'>
-<!ENTITY imagick.method.available.0x641 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.1 o superior.'>
-<!ENTITY imagick.method.available.0x642 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.2 o superior.'>
-<!ENTITY imagick.method.available.0x643 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.3 o superior.'>
 <!ENTITY imagick.method.available.0x644 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.4 o superior.'>
 <!ENTITY imagick.method.available.0x645 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.5 o superior.'>
 <!ENTITY imagick.method.available.0x647 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.7 o superior.'>
 <!ENTITY imagick.method.available.0x649 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.4.9 o superior.'>
-<!ENTITY imagick.method.available.0x653 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.5.3 o superior.'>
 <!ENTITY imagick.method.available.0x657 'Este método solo está disponible si Imagick ha sido compilado con ImageMagick versión 6.5.7 o superior.'>
 
 <!ENTITY imagick.method.not.available.0x700 'Este método no está disponible si Imagick ha sido compilado con ImageMagick versión 7.0.0 o superior.'>
@@ -2833,7 +2536,6 @@ es actualizada si un contexto válido es pasado a la función.</simpara></note>'
 <!ENTITY stream.bucket.return 'Esta función ahora retorna una instancia de <classname>StreamBucket</classname>; anteriormente, se retornaba una <classname>stdClass</classname>.'>
 
 <!-- Gmagick -->
-<!ENTITY gmagick.return.success 'Retorna &true; en caso de éxito.'>
 <!ENTITY gmagick.gmagickexception.throw 'Emite una excepción
 <classname xmlns="http://docbook.org/ns/docbook">GmagickException</classname> en caso de error.'>
 
@@ -2883,7 +2585,6 @@ ser referencias, entonces deben ser pasados por referencia en la lista de argume
 
 <!-- Win32Service -->
 <!ENTITY win32service.false.error ', &false; si hay un problema con los parámetros o un <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">Código de Error Win32</link> en caso de fallo.'>
-<!ENTITY win32service.success.false.error 'Retorna &true; en caso de éxito&win32service.false.error;'>
 <!ENTITY win32service.noerror.false.error 'retornaba <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> en caso de éxito&win32service.false.error;'>
 
 <!-- SNMP -->
@@ -3028,7 +2729,6 @@ relativas.</simpara></warning>
 <!ENTITY trader.arg.fast.ma.type 'Tipo de media móvil para MA rápido. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
 <!ENTITY trader.arg.slow.ma.type 'Tipo de media móvil para MA lento. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
 <!ENTITY trader.arg.fastd.ma.type 'Tipo de media móvil para Fast-D. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
-<!ENTITY trader.arg.fastk.ma.type 'Tipo de media móvil para Fast-K. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
 <!ENTITY trader.arg.slowd.ma.type 'Tipo de media móvil para Slow-D. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
 <!ENTITY trader.arg.slowk.ma.type 'Tipo de media móvil para Slow-K. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
 <!ENTITY trader.arg.signal.ma.type 'Tipo de media móvil para la línea de señal. Una constante de la serie <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> debe ser utilizada.'>
@@ -3736,8 +3436,6 @@ local: {
 <!ENTITY mongodb.throws.unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Levanta una excepción <classname>MongoDB\Driver\Exception\LogicException</classname>si la escritura no ha sido reconocida.</member>'>
 
 <!-- Not used in EN anymore -->
-<!ENTITY mongodb.note.queryable-encryption-preview ''>
-
 <!ENTITY mongodb.note.decimal128 '
    <note xmlns="http://docbook.org/ns/docbook">
     <simpara>
@@ -4457,18 +4155,6 @@ local: {
  </entry>
 </row>'>
 
-<!ENTITY strings.changelog.encoding '
- <row xmlns="http://docbook.org/ns/docbook">
-  <entry>5.6.0</entry>
-  <entry>
-   El valor predeterminado para el parámetro <parameter>encoding</parameter> ha sido modificado
-   para ser el valor de la opción de configuración
-   <link linkend="ini.default-charset">default_charset</link>
-   .
-  </entry>
- </row>
-'>
-
 <!ENTITY strings.changelog.ascii-case-conversion '
  <row xmlns="http://docbook.org/ns/docbook">
   <entry>8.2.0</entry>
@@ -4640,28 +4326,6 @@ local: {
 
 <!-- filter snippets -->
 <!-- TODO: Remove -->
-<!ENTITY filter.param.filter '
- <varlistentry xmlns="http://docbook.org/ns/docbook">
-  <term><parameter>filter</parameter></term>
-  <listitem>
-   <simpara>
-    El filtro a aplicar.
-    Puede ser un filtro de validación utilizando una de las constantes
-    <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>
-    , un filtro de limpieza utilizando una de las constantes
-    <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant>
-    o <constant>FILTER_UNSAFE_RAW</constant>, o un filtro personalizado utilizando
-    <constant>FILTER_CALLBACK</constant>.
-   </simpara>
-   <simpara>
-    El valor predeterminado es <constant>FILTER_DEFAULT</constant>,
-    que es un alias de <constant>FILTER_UNSAFE_RAW</constant>
-    .
-   </simpara>
-  </listitem>
- </varlistentry>
-'>
-
 <!-- csprng snippets -->
 <!ENTITY csprng.sources '
 <simpara xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
Port of php/doc-en 9eb61e3573bc9af825caa0aba34932850aa1b666. None of the removed entities is referenced anywhere in doc-es.

Fixes: #902