### PR TITLE
[Sync EN] Fix broken examples in snmp2_getnext and SOAP pages

### DIFF
--- a/reference/snmp/functions/snmp2-getnext.xml
+++ b/reference/snmp/functions/snmp2-getnext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-getnext">
  <refnamediv>
@@ -19,7 +19,7 @@
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   La función <function>snmp2_get_next</function> se utiliza para leer
+   La función <function>snmp2_getnext</function> se utiliza para leer
    el valor del objeto <acronym>SNMP</acronym> que sigue inmediatamente
    al objeto <parameter>object_id</parameter> especificado.
   </simpara>
@@ -85,11 +85,11 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo con <function>snmp2_get_next</function></title>
+   <title>Ejemplo con <function>snmp2_getnext</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$nameOfSecondInterface = snmp2_get_next('localhost', 'public', 'IF-MIB::ifName.1');
+$nameOfSecondInterface = snmp2_getnext('localhost', 'public', 'IF-MIB::ifName.1');
 ?>
 ]]>
    </programlisting>

--- a/reference/soap/soapclient/getlastrequestheaders.xml
+++ b/reference/soap/soapclient/getlastrequestheaders.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapclient.getlastrequestheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/soap/soapclient/getlastresponse.xml
+++ b/reference/soap/soapclient/getlastresponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="soapclient.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -45,7 +45,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "Response:\n" . $client->__getLastResponse() . "\n";
 ?>

--- a/reference/soap/soapclient/getlastresponseheaders.xml
+++ b/reference/soap/soapclient/getlastresponseheaders.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapclient.getlastresponseheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/soap/soapserver/getlastresponse.xml
+++ b/reference/soap/soapserver/getlastresponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7e1f81cbbe7613ce7bbe65cc93c45fae38e0942b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="soapserver.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Port of php/doc-en 84534c795fc64cc1866ae267fec3574249ec5f74. Three of the five SOAP examples already had the missing new, so only the revisions move there.

Fixes: #903