### PR TITLE
[Sync EN] shell_exec: note that the backtick operator is deprecated

### DIFF
--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7973fd533364af4dd6282ca9e7bee2dffec39b1c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 81593f08db3320d5366bf925c8561f097a9d69ad Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.shell-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,10 +16,10 @@
    <type class="union"><type>string</type><type>false</type><type>null</type></type><methodname>shell_exec</methodname>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   <function>shell_exec</function> es idéntico a los
-   <link linkend="language.operators.execution">comillas invertidas</link>.
-  </para>
+  <simpara>
+   <function>shell_exec</function> es idéntico a las
+   <link linkend="language.operators.execution">comillas invertidas</link>, ahora obsoletas.
+  </simpara>
   <note>
    <para>
     En Windows, el tubo subyacente se abre en modo texto lo que puede causar que


### PR DESCRIPTION
Port of php/doc-en 81593f08db3320d5366bf925c8561f097a9d69ad.

Fixes: #910