### PR TITLE
[Sync EN] ext/session: add PHP 8.4 deprecation notices for session directives

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7f1b75ed358430c1db0e37c832d2926735d5f5c2 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7fabff299de8a894888e8064797ed3278f50b356 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 
 <section xml:id="session.configuration" xmlns="http://docbook.org/ns/docbook">
@@ -118,13 +118,13 @@
       <entry><link linkend="ini.session.use-only-cookies">session.use_only_cookies</link></entry>
       <entry>"1"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry></entry>
+      <entry>Desactivar este ajuste está obsoleto a partir de PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.referer-check">session.referer_check</link></entry>
       <entry>""</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry></entry>
+      <entry>Definir un valor no vacío está obsoleto a partir de PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.cache-limiter">session.cache_limiter</link></entry>
@@ -142,20 +142,25 @@
       <entry><link linkend="ini.session.use-trans-sid">session.use_trans_sid</link></entry>
       <entry>"0"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>
-      </entry>
+      <entry>Activar este ajuste está obsoleto a partir de PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link></entry>
       <entry>"a=href,area=href,frame=src,form="</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Disponible a partir de PHP 7.1.0.</entry>
+      <entry>
+       Disponible a partir de PHP 7.1.0.
+       Modificar este ajuste está obsoleto a partir de PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link></entry>
       <entry><literal>$_SERVER['HTTP_HOST']</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Disponible a partir de PHP 7.1.0.</entry>
+      <entry>
+       Disponible a partir de PHP 7.1.0.
+       Definir un valor no vacío está obsoleto a partir de PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
@@ -460,6 +465,12 @@
       sido encontrada, el identificador de sesión será considerado inválido.
       Por omisión, esta opción es una cadena vacía.
      </simpara>
+     <warning>
+      <simpara>
+       Definir <literal>session.referer_check</literal> con un valor no vacío
+       está obsoleto a partir de PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 
@@ -577,6 +588,12 @@
       identificadores de sesiones en las URL.
       Por omisión, vale <literal>1</literal> (activado).
      </simpara>
+     <warning>
+      <simpara>
+       Desactivar <literal>session.use_only_cookies</literal> está obsoleto
+       a partir de PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 
@@ -734,6 +751,12 @@
       Especifica si el soporte del SID es transparente o no. Por omisión vale <literal>0</literal>
       (desactivado).
      </simpara>
+     <warning>
+      <simpara>
+       Activar <literal>session.use_trans_sid</literal> está obsoleto
+       a partir de PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        El sistema de gestión de sesiones por URL representa un riesgo
@@ -762,13 +785,19 @@
       <literal>session.trans_sid_tags</literal> especifica las etiquetas HTML que
       son reescritas para incluir el ID de sesión cuando el soporte del SID
       transparente está activado. Por omisión
-      <literal>a=href,area=href,frame=src,input=src,form=</literal>
+      <literal>a=href,area=href,frame=src,form=</literal>
      </simpara>
      <simpara>
       <literal>form</literal> es una etiqueta especial. La variable de formulario
       <literal>&lt;input hidden="session_id" name="session_name"&gt;</literal>
       es añadida.
      </simpara>
+     <warning>
+      <simpara>
+       Modificar <literal>session.trans_sid_tags</literal> respecto a su valor
+       por omisión está obsoleto a partir de PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        Antes de PHP 7.1.0, <link linkend="ini.url-rewriter.tags">url_rewriter.tags</link>
@@ -794,6 +823,12 @@
       entre los hosts. Por ejemplo:
       <literal>php.net,wiki.php.net,bugs.php.net</literal>
      </simpara>
+     <warning>
+      <simpara>
+       Definir <literal>session.trans_sid_hosts</literal> con un valor no
+       vacío está obsoleto a partir de PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 


### PR DESCRIPTION
Port of php/doc-en 7fabff299de8a894888e8064797ed3278f50b356.

Fixes: #911