### PR TITLE
[Sync EN] gitignore the build temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 entities.*.xml
 output
 .docker/built
+temp/


### PR DESCRIPTION
Port of the .gitignore part of php/doc-en 32184e34712aa9a56e21f0eab6b2f414757accc8. The manual.xml added there carries a do-not-translate marker, so it is not mirrored here.

Fixes: #912