### PR TITLE
[Sync EN] Add note that the mssql_query() example uses a removed extension

### DIFF
--- a/security/database.xml
+++ b/security/database.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7204e2dbb9b484c8b67bb5ad4a93fa1369c5b317 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 0009ebd09f938e8f066779bb9bb774baed10bd8a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <chapter xml:id="security.database" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Seguridad en bases de datos</title>
@@ -312,6 +312,17 @@ $result = mssql_query($query);
    ejecutando con los privilegios suficientes, el atacante ahora podría tener una cuenta
    con la cual acceder a esta máquina.
   </para>
+  <note>
+   <simpara>
+    La función <function>mssql_query</function> pertenecía a la extensión
+    <literal>mssql</literal>, que fue
+    <link linkend="migration70.removed-exts-sapis">eliminada en PHP 7.0.0</link>.
+    Aquí se utiliza únicamente para ilustrar el ataque; el código actual que se
+    conecta a MSSQL Server debería utilizar en su lugar las extensiones
+    <link linkend="book.sqlsrv">sqlsrv</link> o
+    <link linkend="ref.pdo-sqlsrv">pdo_sqlsrv</link>.
+   </simpara>
+  </note>
   <note>
    <para>
     Algunos ejemplos anteriores están vinculados a un servidor de bases de datos específico, pero esto no significa que un ataque similar sea imposible contra otros productos. Tu servidor de bases de datos puede ser igualmente vulnerable de otra manera.


### PR DESCRIPTION
Port of php/doc-en 0009ebd09f938e8f066779bb9bb774baed10bd8a.

Fixes: #914