### PR TITLE
[Sync EN] Fix reference to non-existent "example three"

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fa67e21421448a20fe701a20897c30f93072e64b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -41,13 +41,13 @@
     </programlisting>
    </example>
   </para>
-  <para>
-   Las etiquetas cortas (tercer ejemplo) están disponibles por omisión,
-   pero pueden ser desactivadas a través de la opción
+  <simpara>
+   Las etiquetas cortas (la tercera línea del ejemplo anterior) están disponibles
+   por omisión, pero pueden ser desactivadas a través de la opción
    <link linkend="ini.short-open-tag">short_open_tag</link>
    del fichero de configuración &php.ini;, o están desactivadas por omisión si PHP
    es compilado con la opción <option>--disable-short-tags</option>.
-  </para>
+  </simpara>
   <para>
    <note>
     <para>


### PR DESCRIPTION
Port of php/doc-en fa67e21421448a20fe701a20897c30f93072e64b.

Fixes: #916