### PR TITLE
[Sync EN] Fix incorrect claim that opcache_invalidate() skips the file cache

### DIFF
--- a/reference/opcache/functions/opcache-invalidate.xml
+++ b/reference/opcache/functions/opcache-invalidate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 87d6bb1bbd5f118f5b0cf0160438f06c0f91ea45 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 82cdc19b6292e0f840e6b22ca430105d9f0aa89e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.opcache-invalidate">
  <refnamediv>
@@ -20,7 +20,9 @@
    Si el argumento <parameter>force</parameter> no está definido o vale &false;,
    el script solo se invalidará si la fecha/hora de modificación del script
    es más reciente que el opcode en caché.
-   Esta función solo invalida el caché en memoria y no el caché de ficheros.
+   Si la directiva <link linkend="ini.opcache.file-cache">opcache.file_cache</link>
+   está activada, esta función también invalida la entrada correspondiente
+   del caché de ficheros.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Port of php/doc-en 82cdc19b6292e0f840e6b22ca430105d9f0aa89e.

Fixes: #919