### PR TITLE
[Sync EN] Fix grammar in strings functions

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.crypt">
  <refnamediv>
@@ -28,9 +28,9 @@
   <para>
    <function>password_hash</function> utiliza un hash fuerte, genera un salt fuerte, y aplica todo automáticamente. <function>password_hash</function> es solo un gestor de <function>crypt</function> y es compatible con contraseñas con hash existentes. Se recomienda encarecidamente el uso de la función <function>password_hash</function>.
   </para>
-  <para>
-   El tipo de hash es activado por el argumento <parameter>salt</parameter>. Si no se proporciona ningún <parameter>salt</parameter>, PHP generará dos caracteres (DES), a menos que el sistema predeterminado sea MD5, en cuyo caso se generará un <parameter>salt</parameter> compatible con MD5. PHP define una constante llamada <constant>CRYPT_SALT_LENGTH</constant> que permite conocer la longitud del <parameter>salt</parameter> disponible para el sistema de hash utilizado.
-  </para>
+  <simpara>
+   El tipo de hash es activado por el argumento <parameter>salt</parameter>. Si no se proporciona ningún <parameter>salt</parameter>, PHP generará automáticamente un <parameter>salt</parameter> estándar de dos caracteres (DES) o de doce caracteres (MD5), según la disponibilidad de crypt() MD5. PHP define una constante llamada <constant>CRYPT_SALT_LENGTH</constant> que permite conocer la longitud del <parameter>salt</parameter> disponible para el sistema de hash utilizado.
+  </simpara>
   <para>
    <function>crypt</function>, cuando se utiliza con el cifrado estándar DES, devuelve el <parameter>salt</parameter> en los dos primeros caracteres de la cadena devuelta. Solo utiliza los primeros 8 caracteres de <parameter>string</parameter>, lo que hace que todas las cadenas más largas, que tienen los mismos primeros 8 octetos, devuelvan el mismo resultado (siempre que el <parameter>salt</parameter> sea siempre el mismo).
   </para>

--- a/reference/strings/functions/get-html-translation-table.xml
+++ b/reference/strings/functions/get-html-translation-table.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eabde0419cf90f596f60db00e31fcb6ebe41ac55 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.get-html-translation-table" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -22,14 +22,14 @@
    <function>htmlentities</function>.
   </para>
   <note>
-   <para>
+   <simpara>
     Los caracteres especiales pueden ser codificados de diferentes maneras. Por ejemplo,
     <literal>"</literal> puede ser codificado como <literal>&amp;quot;</literal>,
-    <literal>&amp;#34;</literal> o <literal>&amp;#x22</literal>.
+    <literal>&amp;#34;</literal> o <literal>&amp;#x22;</literal>.
     <function>get_html_translation_table</function> devuelve
     únicamente la forma utilizada por <function>htmlspecialchars</function> y
     <function>htmlentities</function>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/strings/functions/ltrim.xml
+++ b/reference/strings/functions/ltrim.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27ae0a4a16cdfc868a884c0f0dad7023b5f2709c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.ltrim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,14 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>characters</parameter><initializer>" \n\r\t\v\x00"</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Elimina los espacios (u otros caracteres) del inicio de un string.
-  </para>
+  </simpara>
+  <simpara>
+   Sin el segundo parámetro,
+   <function>ltrim</function> eliminará estos caracteres:
+  </simpara>
+  &strings.stripped.characters;
  </refsect1>
 
  <refsect1 role="parameters">
@@ -82,8 +87,8 @@ var_dump($clean);
     &example.outputs;
     <screen>
 <![CDATA[
-string(32) "        These are a few words :) ...  "
-string(16) "    Example string
+string(32) "		These are a few words :) ...  "
+string(16) "	Example string
 "
 string(11) "Hello World"
 

--- a/reference/strings/functions/quoted-printable-decode.xml
+++ b/reference/strings/functions/quoted-printable-decode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6330e4d73192c49a6867c6bbc3cbf09d63a1e36a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.quoted-printable-decode">
  <refnamediv>
@@ -14,14 +14,14 @@
    <type>string</type><methodname>quoted_printable_decode</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>quoted_printable_decode</function> devuelve la string
    <parameter>str</parameter>, después de convertirla del formato
    <literal>quoted printable</literal> binario de 8 bits (de acuerdo con la
    <link xlink:href="&url.rfc;2045">RFC2045</link>, sección 6.7, y no la
    <link xlink:href="&url.rfc;2821">RFC2821</link>, sección 4.5.2, para que las
-   comas adicionales no sean eliminadas del inicio de la línea).
-  </para>
+   comas adicionales no sean eliminadas del inicio de una línea).
+  </simpara>
   <para>
    Esta función es similar a <function>imap_qprint</function>, excepto que
    no requiere el módulo IMAP para funcionar.

--- a/reference/strings/functions/setlocale.xml
+++ b/reference/strings/functions/setlocale.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec01a42be50e84f192c0b19fc6e9cf40a0f7ac31 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.setlocale">
  <refnamediv>
@@ -25,13 +25,13 @@
    Establece la información de configuración local.
   </para>
   <warning>
-   <para>
+   <simpara>
     La información de configuración local se mantiene por proceso, no por hilo. Si está ejecutando PHP en una API de servidor multihilo,
     puede experimentar cambios repentinos en la configuración local mientras se ejecuta un script, aunque el script nunca haya llamado a
     <function>setlocale</function>. Esto ocurre debido a otros scripts que se ejecutan en diferentes hilos del mismo proceso al mismo tiempo,
     cambiando la configuración local del proceso usando <function>setlocale</function>.
     En Windows, la información de configuración local se mantiene por hilo a partir de PHP 7.0.5.
-   </para>
+   </simpara>
   </warning>
  </refsect1>
 

--- a/reference/strings/functions/str-repeat.xml
+++ b/reference/strings/functions/str-repeat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.str-repeat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -36,10 +36,10 @@
     <varlistentry>
      <term><parameter>times</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Número de veces que el string <parameter>string</parameter>
        debe ser multiplicado.
-      </para>
+      </simpara>
       <para>
        <parameter>times</parameter> debe ser positivo o nulo.
        Si <parameter>times</parameter> es 0, la función retorna

--- a/reference/strings/functions/stripos.xml
+++ b/reference/strings/functions/stripos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.stripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    Busca la posición numérica de la primera ocurrencia de
    <parameter>needle</parameter> en el string <parameter>haystack</parameter>.
   </para>
-  <para>
-   A diferencia de la función <function>strpos</function>,
+  <simpara>
+   A diferencia de <function>strpos</function>,
    <function>stripos</function> no distingue entre mayúsculas y minúsculas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/strings/functions/strncasecmp.xml
+++ b/reference/strings/functions/strncasecmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b68bf2b63200534e022bc65e800cae6c75abf26 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.strncasecmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/strings/functions/strpbrk.xml
+++ b/reference/strings/functions/strpbrk.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.strpbrk" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,10 +14,10 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam><type>string</type><parameter>characters</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   <function>strpbrk</function> busca el conjunto de caracteres
-   <parameter>characters</parameter> en el string <parameter>string</parameter>.
-  </para>
+  <simpara>
+   <function>strpbrk</function> busca en el string <parameter>string</parameter>
+   cualquiera de los caracteres de <parameter>characters</parameter>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/strings/functions/strripos.xml
+++ b/reference/strings/functions/strripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.strripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,10 +21,10 @@
    <parameter>needle</parameter> en el string
    <parameter>haystack</parameter>.
   </para>
-  <para>
-   A diferencia de la función <function>strrpos</function>,
+  <simpara>
+   A diferencia de <function>strrpos</function>,
    <function>strripos</function> es insensible a mayúsculas y minúsculas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Port of php/doc-en 46efd980535e8de6f6639a0015d2ad1e4bfe9d00. ltrim.xml also carries 17c238517825dfb7ec3edfef5972acd944ffbc1e, the next commit on that file, and gains the second paragraph doc-en has had for a while. localeconv.xml is handled in its own branch, where the same two commits apply.

Fixes: #921