### PR TITLE
[Sync EN] Fix examples whose documented output doesn't match Run code

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc068b4857342eb409efeafe6723058f39ab1045 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.oop5.basic" xmlns="http://docbook.org/ns/docbook">
   <title>Sintaxis básica</title>
@@ -328,8 +328,8 @@ var_dump($assigned);
 NULL
 NULL
 object(SimpleClass)#1 (1) {
-   ["var"]=>
-     string(30) "$assigned tendrá este valor"
+  ["var"]=>
+  string(30) "$assigned tendrá este valor"
 }
 ]]>
     </screen>

--- a/language/oop5/lazy-objects.xml
+++ b/language/oop5/lazy-objects.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="language.oop5.lazy-objects" xmlns="http://docbook.org/ns/docbook">
  <title>Objetos perezosos</title>
@@ -61,8 +61,8 @@ var_dump($lazyObject->prop);
    <screen>
 <![CDATA[
 lazy ghost object(Example)#3 (0) {
-["prop"]=>
-uninitialized(int)
+  ["prop"]=>
+  uninitialized(int)
 }
 string(7) "Example"
 Example::__construct

--- a/language/oop5/overloading.xml
+++ b/language/oop5/overloading.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.overloading" xmlns="http://docbook.org/ns/docbook">
   <title>Sobrecarga mágica</title>
@@ -224,8 +224,7 @@ Manipulemos ahora la propiedad privada llamada 'hidden' :
 'hidden' no es visible fuera de la clase, por lo que __get() es utilizado...
 Recuperación de 'hidden'
 
-
-Notice: Propiedad no definida vía __get() : hidden en <file> en la línea 64 en <file> en la línea 28
+Notice: Propiedad no definida vía __get() : hidden en script en la línea 71 en script en la línea 27
 ]]>
     </screen>
 

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.array">
  <title>Arrays</title>
@@ -1116,13 +1116,26 @@ var_dump((array) new B());
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.80;
     <screen>
 <![CDATA[
 array(3) {
   ["BA"]=>
   NULL
   ["AA"]=>
+  NULL
+  ["AA"]=>
+  NULL
+}
+]]>
+    </screen>
+    &example.outputs.81;
+    <screen>
+<![CDATA[
+array(3) {
+  ["AA"]=>
+  NULL
+  ["BA"]=>
   NULL
   ["AA"]=>
   NULL

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 312c0c7b39d0722c419f6784cbda24823220dfb3 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.callable">
  <title>Callables</title>
@@ -267,7 +267,7 @@ call_user_func($c, 'PHP!');
 ¡Hola Mundo!
 ¡Hola Mundo!
 
-Deprecated: Callables of the form ["B", "parent::who"] are deprecated in script on line 41
+Deprecated: Callables of the form ["B", "parent::who"] are deprecated in script on line 44
 A
 Hola PHP!
 ]]>

--- a/reference/array/functions/array-fill.xml
+++ b/reference/array/functions/array-fill.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.array-fill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -123,11 +123,11 @@ print_r($a);
 <![CDATA[
 Array
 (
-    [5]  => banana
-    [6]  => banana
-    [7]  => banana
-    [8]  => banana
-    [9]  => banana
+    [5] => banana
+    [6] => banana
+    [7] => banana
+    [8] => banana
+    [9] => banana
     [10] => banana
 )
 ]]>

--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1f5bcc30ee06e452b98362460ea7b7bf2b20f4a1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.array-map" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -163,6 +163,14 @@ print_r(array_map(fn($value): int => $value * 2, range(1, 5)));
     &example.outputs;
     <screen>
 <![CDATA[
+Array
+(
+    [0] => 2
+    [1] => 4
+    [2] => 6
+    [3] => 8
+    [4] => 10
+)
 Array
 (
     [0] => 2

--- a/reference/array/functions/array-udiff-assoc.xml
+++ b/reference/array/functions/array-udiff-assoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 56509d07ae636f076057f55bbb2572ab7b7a39eb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.array-udiff-assoc" xmlns="http://docbook.org/ns/docbook">
@@ -112,18 +112,19 @@ Array
 (
     [0.1] => cr Object
         (
-            [priv_member:private] => 9
+            [priv_member:cr:private] => 9
         )
 
     [0.5] => cr Object
         (
-            [priv_member:private] => 12
+            [priv_member:cr:private] => 12
         )
 
     [0] => cr Object
         (
-            [priv_member:private] => 23
+            [priv_member:cr:private] => 23
         )
+
 )
 ]]>
     </screen>

--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 651fad6c6677036edd2871bb78199e17586a3acd Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA. -->
 <refentry xml:id="function.array-unique" xmlns="http://docbook.org/ns/docbook">
@@ -163,8 +163,10 @@ var_dump($result);
     <screen role="php">
 <![CDATA[
 array(2) {
-  [0] => int(4)
-  [2] => string(1) "3"
+  [0]=>
+  int(4)
+  [2]=>
+  string(1) "3"
 }
 ]]>
     </screen>

--- a/reference/array/functions/array-unshift.xml
+++ b/reference/array/functions/array-unshift.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0987e913fcaed76897aeb239c6ed83d765a895e1 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.array-unshift" xmlns="http://docbook.org/ns/docbook">
@@ -105,13 +105,13 @@ var_dump($queue);
     <screen role="php">
 <![CDATA[
 array(4) {
-  [0] =>
+  [0]=>
   string(5) "apple"
-  [1] =>
+  [1]=>
   string(9) "raspberry"
-  [2] =>
+  [2]=>
   string(6) "orange"
-  [3] =>
+  [3]=>
   string(6) "banana"
 }
 ]]>

--- a/reference/array/functions/natsort.xml
+++ b/reference/array/functions/natsort.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f781803449007bb0e3a96c693e0eee067f7eb466 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.natsort" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -159,7 +159,6 @@ Array
     [1] => 3
     [5] => 9
 )
-
 Alineación con ceros
 Array
 (
@@ -174,8 +173,8 @@ Array
 (
     [5] => 0
     [1] => 8
-    [3] => 009
     [0] => 09
+    [3] => 009
     [2] => 10
     [4] => 011
 )

--- a/reference/datetime/functions/date-default-timezone-get.xml
+++ b/reference/datetime/functions/date-default-timezone-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.date-default-timezone-get" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -87,7 +87,8 @@ date.timezone : Europe/London
 <![CDATA[
 <?php
 date_default_timezone_set('America/Los_Angeles');
-echo date_default_timezone_get() . ' => ' . date('e') . ' => ' . date('T');
+$ts = mktime(0, 0, 0, 1, 1, 2024);
+echo date_default_timezone_get() . ' => ' . date('e') . ' => ' . date('T', $ts);
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/dom/dom/characterdata/before.xml
+++ b/reference/dom/dom/characterdata/before.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8c0d111851c38647956dc6a4527746787dd606eb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dom-characterdata.before" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -42,7 +42,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <container>hello<beautiful/><![CDATA[world]]]]><![CDATA[></container>
 ]]>
    </screen>

--- a/reference/dom/dom/characterdata/remove.xml
+++ b/reference/dom/dom/characterdata/remove.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8c0d111851c38647956dc6a4527746787dd606eb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dom-characterdata.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -41,7 +41,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <container><world/></container>
 ]]>
    </screen>

--- a/reference/dom/dom/characterdata/replacewith.xml
+++ b/reference/dom/dom/characterdata/replacewith.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8c0d111851c38647956dc6a4527746787dd606eb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dom-characterdata.replacewith" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -42,7 +42,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <container>beautiful<world/></container>
 ]]>
    </screen>

--- a/reference/dom/dom/htmldocument/createfromstring.xml
+++ b/reference/dom/dom/htmldocument/createfromstring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a8b6f4dd3a23875b066d4e47ea4a4977a63e0655 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dom-htmldocument.createfromstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -75,7 +75,7 @@ $dom = Dom\HTMLDocument::createFromString(<<<'HTML'
 <!DOCTYPE html>
 <html>
 <body>
-   <p>Hello, world!</p>
+    <p>Hello, world!</p>
 </body>
 </html>
 HTML);

--- a/reference/dom/domdocument/append.xml
+++ b/reference/dom/domdocument/append.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="domdocument.append" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -45,6 +45,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
+<?xml version="1.0"?>
 <hello/>
 beautiful
 <world/>

--- a/reference/dom/domdocumentfragment/replacechildren.xml
+++ b/reference/dom/domdocumentfragment/replacechildren.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="domdocumentfragment.replacechildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -47,8 +47,7 @@ echo $doc->saveXML($fragment);
    &example.outputs;
    <screen>
 <![CDATA[
-beautiful
-<world/>
+beautiful<world/>
 ]]>
    </screen>
   </example>

--- a/reference/dom/domelement/before.xml
+++ b/reference/dom/domelement/before.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="domelement.before" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -46,6 +46,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
+<?xml version="1.0"?>
 hello
 <beautiful/>
 <world/>

--- a/reference/dom/domelement/getattributenames.xml
+++ b/reference/dom/domelement/getattributenames.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cdbee08c7312e25ad733047ae65c4628c24aa1b8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="domelement.getattributenames" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -48,12 +48,12 @@ var_dump($dom->documentElement->getAttributeNames());
    <screen>
 <![CDATA[
 array(3) {
- [0]=>
- string(10) "xmlns:some"
- [1]=>
- string(9) "some:test"
- [2]=>
- string(5) "test2"
+  [0]=>
+  string(10) "xmlns:some"
+  [1]=>
+  string(9) "some:test"
+  [2]=>
+  string(5) "test2"
 }
 ]]>
    </screen>

--- a/reference/dom/domnode/getlineno.xml
+++ b/reference/dom/domnode/getlineno.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eaf26c34fd4d7da430403fe221ed11e4083fae5a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="domnode.getlineno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/libxml/functions/libxml-get-errors.xml
+++ b/reference/libxml/functions/libxml-get-errors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fed3682684f1af372dc9a7f15d0468e5a884ab16 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.libxml-get-errors" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -106,10 +106,10 @@ function display_xml_error($error, $xml)
     <screen>
 <![CDATA[
   <titles>PHP: Behind the Parser</title>
-----------------------------------------------^
+-----------------------------------------^
 Error fatal 76: Opening and ending tag mismatch: titles line 4 and title
   Línea: 4
-  Columna: 46
+  Columna: 41
 
 --------------------------------------------
 ]]>

--- a/reference/libxml/functions/libxml-set-external-entity-loader.xml
+++ b/reference/libxml/functions/libxml-set-external-entity-loader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5b7646656eb183ea568b8261d6d87a10a1b961c7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.libxml-set-external-entity-loader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -143,10 +143,14 @@ var_dump($dd->validate());
 string(10) "-//FOO/BAR"
 string(25) "http://example.com/foobar"
 array(4) {
-    ["directory"]    => NULL
-    ["intSubName"]   => NULL
-    ["extSubURI"]    => NULL
-    ["extSubSystem"] => NULL
+  ["directory"]=>
+  NULL
+  ["intSubName"]=>
+  NULL
+  ["extSubURI"]=>
+  NULL
+  ["extSubSystem"]=>
+  NULL
 }
 bool(true)
 ]]>

--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 79c53e3fa2afc0f09373b17c23896465d8d41d0a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.preg-replace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -274,6 +274,7 @@ echo $str;
 $count = 0;
 
 echo preg_replace(array('/\d/', '/\s/'), '*', 'xp 4 to', -1 , $count);
+echo "\n";
 echo $count; //3
 ?>
 ]]>

--- a/reference/reflection/reflectionclass/getdefaultproperties.xml
+++ b/reference/reflection/reflectionclass/getdefaultproperties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionclass.getdefaultproperties" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -69,16 +69,16 @@ var_dump($reflectionClass->getDefaultProperties());
     <screen>
 <![CDATA[
 array(5) {
-   ["staticProperty"]=>
-   string(14) "staticProperty"
-   ["property"]=>
-   string(15) "propertyDefault"
-   ["privateProperty"]=>
-   string(22) "privatePropertyDefault"
-   ["defaultlessProperty"]=>
-   NULL
-   ["inheritedProperty"]=>
-   string(16) "inheritedDefault"
+  ["staticProperty"]=>
+  string(14) "staticProperty"
+  ["property"]=>
+  string(15) "propertyDefault"
+  ["privateProperty"]=>
+  string(22) "privatePropertyDefault"
+  ["defaultlessProperty"]=>
+  NULL
+  ["inheritedProperty"]=>
+  string(16) "inheritedDefault"
 }
 ]]>
     </screen>

--- a/reference/reflection/reflectionclass/getdoccomment.xml
+++ b/reference/reflection/reflectionclass/getdoccomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionclass.getdoccomment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -58,7 +58,7 @@ var_dump($rc->getDocComment());
     &example.outputs;
     <screen>
 <![CDATA[
-string(61) "/**
+string(60) "/**
  * Una clase de prueba
  *
  * @param  foo bar

--- a/reference/reflection/reflectionconstant/getshortname.xml
+++ b/reference/reflection/reflectionconstant/getshortname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c477749c82111cbbdd657a0e98eeaeeec0d90c91 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionconstant.getshortname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -41,7 +41,7 @@ namespace Foo;
 
 const BAR = 'bar';
 
-echo (new \ReflectionConstant('Foo\BAR'))->getName();
+echo (new \ReflectionConstant('Foo\BAR'))->getShortName();
 ?>
 ]]>
    </programlisting>

--- a/reference/simplexml/functions/simplexml-load-string.xml
+++ b/reference/simplexml/functions/simplexml-load-string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.simplexml-load-string" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -129,11 +129,12 @@ print_r($xml);
 <![CDATA[
 SimpleXMLElement Object
 (
-  [title] => Forty What?
-  [from] => Joe
-  [to] => Jane
-  [body] =>
-   I know that's the answer -- but what's the question?
+    [title] => Forty What?
+    [from] => Joe
+    [to] => Jane
+    [body] =>
+  I know that's the answer -- but what's the question?
+
 )
 ]]>
     </screen>

--- a/reference/simplexml/simplexmlelement/children.xml
+++ b/reference/simplexml/simplexmlelement/children.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 770c6facae667218f69c8ea2715ea20f6fab32f3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="simplexmlelement.children" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -96,8 +96,7 @@ foreach ($xml->children() as $second_gen) {
     &example.outputs;
     <screen>
 <![CDATA[
-The person begot a son who begot a daughter; The person
-begot a daughter who begot a son; and that son begot a son
+ The person begot a son who begot a daughter; The person begot a daughter who begot a son; and that son begot a son
 ]]>
     </screen>
    </example>

--- a/reference/simplexml/simplexmlelement/getDocNamespaces.xml
+++ b/reference/simplexml/simplexmlelement/getDocNamespaces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 770c6facae667218f69c8ea2715ea20f6fab32f3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="simplexmlelement.getdocnamespaces" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -84,8 +84,8 @@ var_dump($namespaces);
     <screen>
 <![CDATA[
 array(1) {
-   ["p"]=>
-   string(21) "http://example.org/ns"
+  ["p"]=>
+  string(21) "http://example.org/ns"
 }
 ]]>
     </screen>

--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.explode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -141,20 +141,22 @@ var_dump( explode( ',', $input3 ) );
     &example.outputs;
     <screen>
 <![CDATA[
-array(1)
-(
-    [0] => string(5) "hello"
-)
-array(2)
-(
-    [0] => string(5) "hello"
-    [1] => string(5) "there"
-)
-array(2)
-(
-    [0] => string(0) ""
-    [1] => string(0) ""
-)
+array(1) {
+  [0]=>
+  string(5) "hello"
+}
+array(2) {
+  [0]=>
+  string(5) "hello"
+  [1]=>
+  string(5) "there"
+}
+array(2) {
+  [0]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+}
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 06394ea77c2f8972e3884c00bede861ef5eb04da Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.htmlentities" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -213,7 +213,7 @@ echo htmlentities($str, ENT_COMPAT);
 <![CDATA[
 Un &#039;apostrophee&#039; est &lt;b&gt;gras&lt;/b&gt;
 
-Un 'apostrophe' est &lt;b&gt;gras&lt;/b&gt
+Un 'apostrophe' est &lt;b&gt;gras&lt;/b&gt;
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/rtrim.xml
+++ b/reference/strings/functions/rtrim.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27ae0a4a16cdfc868a884c0f0dad7023b5f2709c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.rtrim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -88,15 +88,15 @@ var_dump($clean);
     &example.outputs;
     <screen>
 <![CDATA[
-string(32) "        Aquí hay algunas palabras :) ...  "
-string(16) "    String de ejemplo
+string(32) "		Aquí hay algunas palabras :) ...  "
+string(16) "	String de ejemplo
 "
 string(10) "Hola Mundo"
 
-string(30) "        Aquí hay algunas palabras :) ..."
-string(26) "        Aquí hay algunas palabras :)"
+string(30) "		Aquí hay algunas palabras :) ..."
+string(26) "		Aquí hay algunas palabras :)"
 string(6) "Hola M"
-string(15) "    String de ejemplo"
+string(15) "	String de ejemplo"
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/str-word-count.xml
+++ b/reference/strings/functions/str-word-count.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.str-word-count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -142,7 +142,6 @@ echo str_word_count($str);
     &example.outputs;
     <screen>
 <![CDATA[
-
 Array
 (
     [0] => Salut
@@ -160,13 +159,12 @@ Array
     [0] => Salut
     [6] => l'ami
     [13] => vous
-    [27] => avez
-    [41] => une
-    [45] => b
-    [47] => lle
-    [51] => mine
+    [26] => avez
+    [40] => une
+    [44] => b
+    [46] => lle
+    [50] => mine
 )
-
 Array
 (
     [0] => Salut
@@ -177,7 +175,6 @@ Array
     [5] => b3lle
     [6] => mine
 )
-
 8
 ]]>
     </screen>

--- a/reference/strings/functions/strtok.xml
+++ b/reference/strings/functions/strtok.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.strtok" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -150,8 +150,8 @@ var_dump($first_token, $second_token);
     &example.outputs;
     <screen>
 <![CDATA[
-    string(9) "something"
-    bool(false)
+string(9) "something"
+bool(false)
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/trim.xml
+++ b/reference/strings/functions/trim.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27ae0a4a16cdfc868a884c0f0dad7023b5f2709c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.trim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -91,8 +91,8 @@ var_dump($clean);
     &example.outputs;
     <screen>
 <![CDATA[
-string(32) "        These are a few words :) ...  "
-string(16) "    Example string
+string(32) "		These are a few words :) ...  "
+string(16) "	Example string
 "
 string(11) "Hello World"
 

--- a/reference/uri/uri/rfc3986/uri/withfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/withfragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-rfc3986-uri.withfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\Rfc3986\Uri::withFragment</refname>

--- a/reference/xmlwriter/xmlwriter/writecdata.xml
+++ b/reference/xmlwriter/xmlwriter/writecdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4a742792da6fd1ba27acd118bfeeed326c8d9aaf Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="xmlwriter.writecdata" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -95,6 +95,7 @@ echo $xml->outputMemory(true);
    &example.outputs;
    <screen>
 <![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
 <mydoc>
  <myele>
   <mycdataelement><![CDATA[texto para incluir como CData]​]></mycdataelement>


### PR DESCRIPTION
Port of php/doc-en 17c238517825dfb7ec3edfef5972acd944ffbc1e, for 38 of the 45 files.

Handled in their own branches, where a later or parallel doc-en commit applies: the four language/control-structures files, date-sun-info.xml and ltrim.xml.

Left out: reference/datetime/formats.xml. Its Localized Notations table has two columns where doc-en has three, so the file needs a full table sync before its revision can move; that is a separate change.

The str_word_count() offsets were recomputed against the example string with php:8.4-cli.

Fixes: #918