### PR TITLE
[Sync EN] Bulk PDO and mysqli grammar fixes

### DIFF
--- a/appendices/migration72/new-features.xml
+++ b/appendices/migration72/new-features.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6d29533483657c036e49edb5ea88c7103d126681 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 
 <sect1 xml:id="migration72.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -157,11 +157,11 @@ $db->quote('über', PDO::PARAM_STR | PDO::PARAM_STR_NATL);
  <sect2 xml:id="migration72.new-features.additional-emulated-prepares-debugging-info">
   <title>Información adicional de depuración para preparaciones emuladas en <link linkend="book.pdo">PDO</link></title>
 
-  <para>
+  <simpara>
    El método <function>PDOStatement::debugDumpParams</function> ha sido
    actualizado para incluir el SQL que se envía a la base de datos, donde se mostrará la consulta completa y sin procesar
    (incluyendo los marcadores de posición reemplazados con sus valores vinculados). Esto se ha añadido para ayudar en la depuración de preparaciones emuladas (y por lo tanto solo estará disponible cuando las preparaciones emuladas estén activadas).
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration72.new-features.extended-ops-in-ldap">

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration83.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Otros cambios</title>

--- a/reference/mysqli/book.xml
+++ b/reference/mysqli/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 038bdb1d98c2481e291616a310945b38523965da Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <book xml:id="book.mysqli" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundledexternal" ?>
@@ -31,10 +31,10 @@
    xlink:href="&url.mysql.docs;">&url.mysql.docs;</link>.
   </para>
 
-  <para>
+  <simpara>
    Fragmentos del manual de MySQL han sido incluidos en la documentación de PHP
    con el permiso de Oracle Corporation.
-  </para>
+  </simpara>
 
   <para>
    Los ejemplos utilizan ya sea la base de datos

--- a/reference/mysqli/configure.xml
+++ b/reference/mysqli/configure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 050e16021ff71318012fa16322e98d8603d5ab38 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="mysqli.installation" xmlns="http://docbook.org/ns/docbook"
@@ -36,13 +36,14 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
    así como las bibliotecas cliente de cada extensión.
   </para>
 
-  <para>
-   El controlador nativo MySQL es la biblioteca cliente recomendada, ya que ofrece
+  <simpara>
+   El controlador nativo MySQL es la biblioteca cliente recomendada, y desde
+   PHP 8.2.0 la única posible, ya que ofrece
    un aumento de rendimiento y proporciona acceso a características
    que no están disponibles al utilizar la biblioteca cliente MySQL. Consulte la sección
    <link linkend="mysqli.overview.mysqlnd">¿Qué es el controlador nativo MySQL de PHP?</link>
    para una breve descripción de las ventajas del controlador nativo MySQL.
-  </para>
+  </simpara>
 
   <para>
    <literal>/path/to/mysql_config</literal> representa la ruta de acceso del programa
@@ -63,7 +64,14 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
     </thead>
     <tbody>
      <row>
-      <entry>5.4.x y posteriores</entry>
+      <entry>8.2.0 y posteriores</entry>
+      <entry>mysqlnd</entry>
+      <entry><option role="configure">--with-mysqli</option></entry>
+      <entry>libmysqlclient no está soportado</entry>
+      <entry>mysqlnd es la única opción</entry>
+     </row>
+     <row>
+      <entry>5.4.0 hasta 8.1.x</entry>
       <entry>mysqlnd</entry>
       <entry><option role="configure">--with-mysqli</option></entry>
       <entry><option role="configure">--with-mysqli=/path/to/mysql_config</option></entry>
@@ -87,13 +95,6 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
    </tgroup>
   </table>
 
-  <para>
-   Cabe señalar que es posible mezclar las extensiones MySQL así como las
-   bibliotecas cliente. Por ejemplo, es posible activar la extensión
-   MySQL para utilizar la biblioteca cliente MySQL (libmysqlclient) mientras se configura
-   la extensión <literal>mysqli</literal> para utilizar el controlador nativo MySQL.
-   Todas las combinaciones de extensiones y bibliotecas cliente son posibles.
-  </para>
  </section>
 
  <section xml:id="mysqli.installation.windows">

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5208882ce3910d599e339209f967e183b49ba6ef Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="mysqli.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -459,9 +459,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      El campo forma parte de un índice múltiple.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.mysqli-group-flag">

--- a/reference/mysqli/ini.xml
+++ b/reference/mysqli/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 90787fda14dcb0976a9738423e6c6013c037d048 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <section xml:id="mysqli.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -148,10 +148,10 @@
      <type>int</type>
     </term>
     <listitem>
-     <para>
-      Número máximo de conexiones persistentes que pueden realizarse.
+     <simpara>
+      El número máximo de conexiones persistentes que pueden realizarse.
       Establecer a 0 para "ilimitado".
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="ini.mysqli.max-links">
@@ -160,10 +160,10 @@
      <type>int</type>
     </term>
     <listitem>
-     <para>
-      El número máximo de conexiones MySQL por proceso, incluyendo las
+     <simpara>
+      El número máximo de conexiones por proceso, incluyendo las
       conexiones persistentes.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="ini.mysqli.default-port">

--- a/reference/mysqli/mysqli/change-user.xml
+++ b/reference/mysqli/mysqli/change-user.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee14f82484f6289278255f798f1e8b93cdc2cab5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.change-user" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -32,14 +32,14 @@
    A diferencia de <methodname>mysqli::connect</methodname>, este método
    no desconectará la conexión actual si la nueva conexión no puede establecerse.
   </para>
-  <para>
+  <simpara>
    Para que esta función tenga éxito, los parámetros
    <parameter>username</parameter> y <parameter>password</parameter> deben
    ser válidos y el usuario en cuestión debe tener los permisos
    de acceso a la base de datos deseada.
    Si por alguna razón la autorización falla, el usuario
    actual se conservará.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -176,13 +176,13 @@ Base de datos por defecto:
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     El uso de este comando implica siempre que la conexión sea
     considerada como nueva, independientemente de si la función tiene éxito o no.
     Una llamada a esta función anulará por lo tanto todas las transacciones activas,
     cerrará las tablas temporales y desbloqueará las tablas
     bloqueadas.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/dump-debug-info.xml
+++ b/reference/mysqli/mysqli/dump-debug-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.dump-debug-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,12 +20,12 @@
    <type>bool</type><methodname>mysqli_dump_debug_info</methodname>
    <methodparam><type>mysqli</type><parameter>mysql</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Esta función debe ser utilizada por un usuario con el privilegio
    SUPER y se emplea para escribir cierta información de depuración
    en el registro para el servidor MySQL relativo a la conexión especificada por
    el argumento <parameter>link</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/errno.xml
+++ b/reference/mysqli/mysqli/errno.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 614d77598aa2aaa3ddf3e8494812a3b82864d590 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="mysqli.errno" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -36,10 +36,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    El valor del código de error para la última llamada, si falla. <literal>0</literal> significa que no
    ha ocurrido ningún error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli/init.xml
+++ b/reference/mysqli/mysqli/init.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.init" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -26,11 +26,11 @@
    <function>mysqli_options</function> y <function>mysqli_real_connect</function>.
   </para>
   <note>
-   <para>
+   <simpara>
     Todas las llamadas siguientes a cualquier función MySQLi (excepto
     <function>mysqli_options</function> y <function>mysqli_ssl_set</function>)
     fallarán hasta que la función <function>mysqli_real_connect</function> sea llamada.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/multi-query.xml
+++ b/reference/mysqli/mysqli/multi-query.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1beae37b6904f55cfd33dbe99ad83a23eb78b144 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli.multi-query" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e309a62b16c7dc48883b1b426bb8c15918488681 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.options" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -77,7 +77,7 @@
           </row>
           <row>
            <entry><constant>MYSQLI_INIT_COMMAND</constant></entry>
-           <entry>Comando a ejecutar después de la conexión al servidor MySQL</entry>
+           <entry>Comando a ejecutar tras establecer una conexión con el servidor MySQL</entry>
           </row>
           <row>
            <entry><constant>MYSQLI_SET_CHARSET_NAME</constant></entry>

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.ping" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -83,8 +83,8 @@
       <entry>
        Los métodos <methodname>mysqli::ping</methodname> y
        <function>mysqli_ping</function> están ahora obsoletos.
-       La funcionalidad <literal>reconnect</literal> ya no está
-       disponible desde PHP 8.2.0, lo que hace que esta función sea obsoleta.
+       Desde PHP 8.2.0, la funcionalidad <literal>reconnect</literal> ya no
+       está disponible, lo que hace que esta función sea obsoleta.
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli/poll.xml
+++ b/reference/mysqli/mysqli/poll.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c5ccd084c8f830801a939bf1829ddddcaf019730 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli.poll" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -65,10 +65,10 @@
     <varlistentry>
      <term><parameter>reject</parameter></term>
      <listitem>
-      <para>
-       Lista de conexiones rechazadas porque se ejecutaron consultas no asíncronas
-       y para las cuales la función podría devolver resultados.
-      </para>
+      <simpara>
+       Lista de conexiones rechazadas porque no existe ninguna consulta asíncrona
+       pendiente cuyos resultados sondear.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mysqli/mysqli/rollback.xml
+++ b/reference/mysqli/mysqli/rollback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli.rollback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -23,9 +23,9 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Revierte la transacción actual para la base de datos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/select-db.xml
+++ b/reference/mysqli/mysqli/select-db.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli.select-db" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -28,11 +28,11 @@
    <parameter>mysql</parameter>.
   </para>
   <note>
-   <para>
+   <simpara>
     Esta función solo debe utilizarse para cambiar la base de datos por defecto para
     la conexión actual. La base de datos por defecto puede seleccionarse con
     el cuarto argumento de la función <function>mysqli_connect</function>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/sqlstate.xml
+++ b/reference/mysqli/mysqli/sqlstate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d9de192baa45cdf33168eea8a45d14216def4395 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.sqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -25,11 +25,11 @@
    posibles, consulte: <link xlink:href="&url.mysql.docs.error;">&url.mysql.docs.error;</link>.
   </para>
   <note>
-   <para>
+   <simpara>
     Tenga en cuenta que no todos los errores de MySQL tienen aún una correspondencia
     con los errores SQLSTATE. El valor <literal>HY000</literal>
     (error general) se utiliza para los errores sin correspondencia.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/stmt-init.xml
+++ b/reference/mysqli/mysqli/stmt-init.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.stmt-init" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -25,10 +25,10 @@
    <function>mysqli_stmt_prepare</function>.
   </para>
   <note>
-   <para>
+   <simpara>
     Todas las llamadas posteriores a las funciones mysqli_stmt_* fallarán,
     si <function>mysqli_stmt_prepare</function> es llamada.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -43,9 +43,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve un objeto.
-  </para>
+  <simpara>
+   Devuelve un objeto <classname>mysqli_stmt</classname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mysqli/mysqli/use-result.xml
+++ b/reference/mysqli/mysqli/use-result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli.use-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -33,7 +33,7 @@
    a la base de datos.
   </para>
   <note>
-   <para>
+   <simpara>
     La función <function>mysqli_use_result</function> no transfiere
     el conjunto de resultados completo desde la base de datos
     y por lo tanto no se pueden utilizar funciones como
@@ -41,7 +41,7 @@
     registros. Para utilizar esta funcionalidad, se debe
     recuperar el conjunto de resultados utilizando
     <function>mysqli_store_result</function>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.mysqli-driver" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase mysqli_driver</title>
@@ -10,11 +10,11 @@
 <!-- {{{ ClassName intro -->
   <section xml:id="mysqli-driver.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La clase <classname>mysqli_driver</classname> es una instancia del patrón
     monostate, es decir, solo hay un driver que puede ser accedido a través de un
     número arbitrario de instancias <classname>mysqli_driver</classname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5152c78db935ea2463e20a01ae0e3f3573314d78 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli-result.fetch-fields" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c5ccd084c8f830801a939bf1829ddddcaf019730 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli-result.fetch-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -86,10 +86,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Se lanza una <classname>ValueError</classname> cuando
    <parameter>constructor_args</parameter> no está vacío y la clase no tiene constructor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/mysqli/mysqli_result/num-rows.xml
+++ b/reference/mysqli/mysqli_result/num-rows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 181e9c5572ed04ed712b8d7f858f61a94647c6ac Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli-result.num-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -98,11 +98,11 @@ El conjunto de resultados tiene 239 filas.
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     A diferencia de la función <function>mysqli_stmt_num_rows</function>,
     esta función no tiene una variante de método orientado a objetos.
     En el estilo orientado a objetos, se debe utilizar el getter de la propiedad.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_sql_exception/getsqlstate.xml
+++ b/reference/mysqli/mysqli_sql_exception/getsqlstate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli-sql-exception.getsqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -20,10 +20,10 @@
    <link xlink:href="&url.mysql.docs.error;">&url.mysql.docs.error;</link>.
   </para>
   <note>
-   <para>
+   <simpara>
     Cabe señalar que no todos los errores de MySQL están mapeados a SQLSTATE.
     El valor <literal>HY000</literal> (error general) se utiliza para los errores no mapeados.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/affected-rows.xml
+++ b/reference/mysqli/mysqli_stmt/affected-rows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2d5c6bed30ea22d847bf03dad1072f075694b4c3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli-stmt.affected-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -17,15 +17,13 @@
    <type class="union"><type>int</type><type>string</type></type><methodname>mysqli_stmt_affected_rows</methodname>
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Devuelve el número de filas afectadas por una consulta
+  <simpara>
+   Devuelve el número de filas afectadas por la consulta
    <literal>INSERT</literal>, <literal>UPDATE</literal>
    o <literal>DELETE</literal>.
-  </para>
-  <para>
    Funciona como <function>mysqli_stmt_num_rows</function> para
    las consultas <literal>SELECT</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -50,11 +48,11 @@
    <function>mysqli_stmt_store_result</function>.
   </para>
   <note>
-   <para>
+   <simpara>
     Si el número de filas afectadas es mayor que el valor máximo
     de un entero PHP, el número
     de filas afectadas será devuelto como una cadena de caracteres.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/bind-result.xml
+++ b/reference/mysqli/mysqli_stmt/bind-result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e61d37d1d91ec32ecadf2a872e0a4109d02bc68 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli-stmt.bind-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -43,9 +43,9 @@
    </para>
   </note>
   <tip>
-   <para>
+   <simpara>
     Esta función es útil para resultados básicos. Para recuperar un conjunto de resultados iterable, o recuperar cada fila como array u objeto, utilice <function>mysqli_stmt_get_result</function>.
-   </para>
+   </simpara>
   </tip>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec946465e5ee9dc4dc19f1a28510697066a19eac Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli-stmt.execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/mysqli/mysqli_stmt/reset.xml
+++ b/reference/mysqli/mysqli_stmt/reset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli-stmt.reset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,9 +20,9 @@
    <type>bool</type><methodname>mysqli_stmt_reset</methodname>
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Anula una consulta preparada en el cliente y en el servidor después de haber sido preparada.
-  </para>
+  </simpara>
   <para>
    Esta función anula la consulta en el servidor, anula los datos enviados utilizando la función
    <function>mysqli_stmt_send_long_data</function>, anula los conjuntos de resultados no almacenados en buffer,

--- a/reference/mysqli/mysqli_stmt/send-long-data.xml
+++ b/reference/mysqli/mysqli_stmt/send-long-data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli-stmt.send-long-data" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -23,12 +23,12 @@
    <methodparam><type>int</type><parameter>param_num</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Envía los datos al servidor por paquetes, si el tamaño de los datos excede
    el límite de <literal>max_allowed_packet</literal>. Esta función puede
    ser llamada varias veces para enviar los datos de texto o binarios
    de campos como BLOB o TEXT.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli_stmt/sqlstate.xml
+++ b/reference/mysqli/mysqli_stmt/sqlstate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d68e83b719028bb068785cccc3205c23be530564 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mysqli-stmt.sqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -134,11 +134,11 @@ Error: 42S02.
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Tenga en cuenta que no todos los errores MySQL tienen una correspondencia
     en SQLSTATE. El valor <literal>HY000</literal> (error general) se
     utiliza para los errores sin correspondencia.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/overview.xml
+++ b/reference/mysqli/overview.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e8ac70bf549a723cb36465667a6109d9933b8619 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="mysqli.overview" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -72,12 +72,12 @@
     controlador PDO MYSQL, que permite interactuar con MySQL.
   </para>
 
-  <para>
+  <simpara>
     A veces, los desarrolladores utilizan los términos conector y controlador
     de manera intercambiable, lo que puede resultar confuso. En la
     documentación de MySQL, el término <quote>controlador</quote> está reservado
     para los programas que son la interfaz específica con la base de datos del paquete.
-  </para>
+  </simpara>
 
   <para>
     <emphasis role="bold">¿Qué es una extensión?</emphasis>
@@ -277,13 +277,13 @@
     <literal>libmysqlclient</literal> para aplicaciones PHP.
   </para>
 
-  <para>
+  <simpara>
     La extensión <literal>mysqli</literal> y el controlador MySQL nativo pueden
     configurarse individualmente para utilizar <literal>libmysqlclient</literal> o <literal>mysqlnd</literal>. Como
     <literal>mysqlnd</literal> fue diseñado específicamente para el sistema
     PHP, ofrece numerosas ventajas y mejoras con respecto a
     <literal>libmysqlclient</literal>. Se recomienda encarecidamente su uso.
-  </para>
+  </simpara>
 
   <para>
     El MySQL Native Driver está implementado sobre la base del framework

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2088ac3e8ffe9d7b316f0b9a5bf7c3d9eeae5c0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="mysqli.quickstart" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -230,10 +230,10 @@ mysqli.default_socket=/tmp/mysql.sock
    un tubo nombrado. Si no es proporcionado o está vacío, entonces el socket (tubo nombrado)
    valdrá por omisión <literal>\\.\pipe\MySQL</literal>.
   </para>
-  <para>
+  <simpara>
    Si ni un socket de dominio Unix ni un tubo nombrado de Windows es proporcionado, se establecerá una conexión básica y si el valor del puerto no está definido, la biblioteca
    utilizará el puerto <literal>3306</literal>.
-  </para>
+  </simpara>
   <para>
    La biblioteca <link linkend="mysqlnd.overview">mysqlnd</link> y la biblioteca
    cliente MySQL (libmysqlclient) implementan la misma lógica para determinar los valores
@@ -293,7 +293,7 @@ mysqli.default_socket=/tmp/mysql.sock
    restringido con la directiva <link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link>.
    Tenga en cuenta que el servidor web puede generar varios procesos PHP.
   </para>
-  <para>
+  <simpara>
    Una queja común contra las conexiones persistentes es que su estado no es re-initializado antes de la reutilización. Por ejemplo,
    las transacciones abiertas y no terminadas no son automáticamente
    anuladas. Además, las modificaciones autorizadas que ocurren entre el momento
@@ -301,7 +301,7 @@ mysqli.default_socket=/tmp/mysql.sock
    borde no deseado. Por el contrario, el nombre <literal>persistent</literal>
    puede ser comprendido como una promesa sobre el hecho de que el estado persiste
    realmente.
-  </para>
+  </simpara>
   <para>
    La extensión mysqli soporta dos interpretaciones de una conexión persistente :
    estado persistente, y un estado re-initializado antes de la reutilización. Por
@@ -980,9 +980,9 @@ array(2) {
   <para>
    <emphasis role="bold">Emulación del lado-cliente de la preparación de una consulta</emphasis>
   </para>
-  <para>
-   La API no incluye una emulación del lado-cliente de la preparación de una consulta.
-  </para>
+  <simpara>
+   La API no admite la emulación del lado-cliente de la preparación de una consulta.
+  </simpara>
   <para>
    <emphasis role="bold">Ver también</emphasis>
   </para>
@@ -1094,13 +1094,13 @@ Hi!
     </screen>
    </example>
   </para>
-  <para>
+  <simpara>
    Los desarrolladores de aplicaciones y de frameworks pueden proporcionar una API
    más amigable utilizando una mezcla de las variables de sesión y una inspección
    del catálogo de la base de datos. Sin embargo, tenga en cuenta
    el impacto en el rendimiento debido a una solución personalizada basada
    en la inspección del catálogo.
-  </para>
+  </simpara>
   <para>
    <emphasis role="bold">Gestión de los juegos de resultados</emphasis>
   </para>

--- a/reference/mysqli/summary.xml
+++ b/reference/mysqli/summary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e8c90ca8a4a63575341cde6f5fbdc34419d2cff Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <chapter xml:id="mysqli.summary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -204,7 +204,7 @@
      <entry><methodname>mysqli::get_warnings</methodname></entry>
      <entry><function>mysqli_get_warnings</function></entry>
      <entry>N/A</entry>
-     <entry>No documentado</entry>
+     <entry>Recupera el resultado de SHOW WARNINGS</entry>
     </row>
     <row>
      <entry><methodname>mysqli::init</methodname></entry>
@@ -389,7 +389,7 @@
      <entry><link linkend="mysqli-stmt.field-count">$mysqli_stmt::field_count</link></entry>
      <entry><function>mysqli_stmt_field_count</function></entry>
      <entry>N/A</entry>
-     <entry>El número de campos presente en la consulta dada</entry>
+     <entry>El número de campos presente en la consulta</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.insert-id">$mysqli_stmt::insert_id</link></entry>
@@ -401,19 +401,19 @@
      <entry><link linkend="mysqli-stmt.num-rows">$mysqli_stmt::num_rows</link></entry>
      <entry><function>mysqli_stmt_num_rows</function></entry>
      <entry>N/A</entry>
-     <entry>El número de filas de un resultado MySQL</entry>
+     <entry>El número de filas del conjunto de resultados de la consulta</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.param-count">$mysqli_stmt::param_count</link></entry>
      <entry><function>mysqli_stmt_param_count</function></entry>
      <entry>N/A</entry>
-     <entry>El número de parámetros de un comando SQL</entry>
+     <entry>El número de parámetros de la consulta</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.sqlstate">$mysqli_stmt::sqlstate</link></entry>
      <entry><function>mysqli_stmt_sqlstate</function></entry>
      <entry>N/A</entry>
-     <entry>El código SQLSTATE de la última operación MySQL</entry>
+     <entry>El código SQLSTATE de la operación anterior</entry>
     </row>
     <row>
      <entry><emphasis role="bold">&Methods;</emphasis></entry>
@@ -422,7 +422,7 @@
      <entry><methodname>mysqli_stmt::attr_get</methodname></entry>
      <entry><function>mysqli_stmt_attr_get</function></entry>
      <entry>N/A</entry>
-     <entry>Recupera el valor actual de un atributo de consulta</entry>
+     <entry>Recupera el valor actual de un atributo de la consulta</entry>
     </row>
     <row>
      <entry><methodname>mysqli_stmt::attr_set</methodname></entry>

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 78cd8f0ba32f4d9921bb8b7eca066de8de29924d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <section xml:id="pdo.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
@@ -10,14 +10,14 @@
  <procedure xml:id="pdo.install.unix51up">
   <title>Instalar PDO en sistemas Unix</title>
   <step>
-   <para>
+   <simpara>
     PDO y el controlador <link linkend="ref.pdo-sqlite">PDO_SQLITE</link>
     están activados por defecto. Se debe activar
     el controlador PDO de la base de datos de su elección; consulte
     la documentación para los
     <link linkend="pdo.drivers">controladores específicos de su base
      de datos</link> para obtener más información.
-   </para>
+   </simpara>
    <note>
     <para>
      Tenga en cuenta que al compilar PDO como extensión compartida

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e7e4ffe9a10a4dcd9903a7abf125a811d0eda023 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 
 <chapter xml:id="pdo.connections" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -112,7 +112,7 @@ $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass, array(
    </programlisting>
   </example>
  </para>
- <para>
+ <simpara>
   El valor de la opción <constant>PDO::ATTR_PERSISTENT</constant> se convierte
   en &boolean; (activar/desactivar conexiones persistentes), a menos que sea
   una &string; no numérica, en cuyo caso esto permite el uso de
@@ -120,7 +120,7 @@ $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass, array(
   Esto es útil si las conexiones diferentes utilizan parámetros
   incompatibles, por ejemplo, valores diferentes de
   <constant>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</constant>.
- </para>
+ </simpara>
  <note>
   <para>
    Si se desea utilizar conexiones persistentes, se debe

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="pdo.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -429,7 +429,10 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     </term>
     <listitem>
      <simpara>
-      Define el nombre de la clase bajo la cual los datos son devueltos.
+      Define el nombre de la clase y los argumentos del constructor para la
+      extensión del objeto <classname>PDOStatement</classname>. El primer
+      elemento del array es el nombre de la clase, y el segundo elemento es un
+      array de argumentos del constructor.
      </simpara>
     </listitem>
    </varlistentry>
@@ -522,7 +525,8 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
     </term>
     <listitem>
      <simpara>
-      Define el tipo de argumento de string por defecto, esto puede ser <constant>PDO::PARAM_STR_NATL</constant>
+      Define el tipo de argumento de string por defecto, que puede ser
+      <constant>PDO::PARAM_STR_NATL</constant>
       o <constant>PDO::PARAM_STR_CHAR</constant>.
      </simpara>
      <simpara>

--- a/reference/pdo/ini.xml
+++ b/reference/pdo/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="pdo.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/pdo/pdo/connect.xml
+++ b/reference/pdo/pdo/connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -23,9 +23,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)"/>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -36,9 +34,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo/pdo/errorcode.xml
+++ b/reference/pdo/pdo/errorcode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo.errorcode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -24,7 +24,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve un SQLSTATE,
    un identificador alfanumérico de cinco caracteres definido en el estándar ANSI SQL.
    Brevemente, un SQLSTATE consiste en un valor de clase de dos caracteres seguido
@@ -34,7 +34,7 @@
    La clase 'IM' es específica para alertas y errores que provienen de la implementación
    misma de PDO (o quizás ODBC, si se utiliza el driver ODBC).
    El valor de subclase '000' en cualquier clase, indica que no hay subclase para este SQLSTATE.
-  </para>
+  </simpara>
   <para>
    <methodname>PDO::errorCode</methodname> devuelve únicamente los códigos de error
    para operaciones ejecutadas directamente sobre el manejador de la base de datos.

--- a/reference/pdo/pdo/errorinfo.xml
+++ b/reference/pdo/pdo/errorinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo.errorinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdo/getavailabledrivers.xml
+++ b/reference/pdo/pdo/getavailabledrivers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.getavailabledrivers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -35,13 +35,13 @@
    el modo de emulación esté activo.
   </para>
 <note>
-   <para>
+   <simpara>
     Los marcadores de parámetros pueden representar únicamente un literal de
     datos completo.
     Ni una parte de literal, ni una palabra clave, ni un identificador, ni cualquier otra
     consulta arbitraria pueden ser ligados utilizando los parámetros.
     Por ejemplo, no puede asociarse múltiples valores a un solo marcador de nombre entrante, en la cláusula IN() de una consulta SQL.
-   </para>
+   </simpara>
   </note>
   <para>
    Llamar a <methodname>PDO::prepare</methodname> y
@@ -117,11 +117,11 @@
    <link linkend="pdo.error-handling">gestor de errores</link>).
   </para>
   <note>
-   <para>
+   <simpara>
     La emulación de consultas preparadas no comunica con el servidor de base
     de datos. También, la función <methodname>PDO::prepare</methodname> no verifica
     la consulta.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="pdo.quote" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -31,10 +31,10 @@
    más rápidas de ejecutar que interpretar las consultas, ya que los lados cliente y servidor pueden
    almacenar en caché una versión compilada de la consulta.
   </para>
-  <para>
+  <simpara>
    No todos los controladores PDO implementan este método (como PDO_ODBC). Utilice
    consultas preparadas en su lugar.
-  </para>
+  </simpara>
   <caution>
    <title>Seguridad: el juego de caracteres por defecto</title>
    <para>
@@ -76,11 +76,11 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve una cadena protegida, que es teóricamente segura para usar
    en una consulta SQL. Devuelve &false; si el controlador no soporta
    este tipo de protecciones.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo/pdorow.xml
+++ b/reference/pdo/pdorow.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 812ed835faa11b611c112d2a16777aebf70eb020 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <reference xml:id="class.pdorow" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase PDORow</title>
@@ -17,13 +17,13 @@
    <para>
     Los objetos de esta clase no pueden ser instanciados y no son serializables.
    </para>
-   <para>
+   <simpara>
     La clase <classname>PDORow</classname> permite acceder a los
     datos devueltos como si los modos <constant>PDO::FETCH_OBJ</constant>
     y <constant>PDO::FETCH_BOTH</constant> fueran utilizados.
     Esto significa que los datos devueltos pueden ser accedidos como propiedades de objeto,
     y como un array indexado por el nombre de la columna y un número de posición de columna.
-   </para>
+   </simpara>
    <caution>
     <simpara>
      Acceder a una propiedad no definida devuelve &null;

--- a/reference/pdo/pdostatement/debugdumpparams.xml
+++ b/reference/pdo/pdostatement/debugdumpparams.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdostatement.debugdumpparams" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdostatement/errorinfo.xml
+++ b/reference/pdo/pdostatement/errorinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdostatement.errorinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 216c5dc1ef01b98d6ccafe51056e4df68e77cbf6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdostatement.execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -176,10 +176,10 @@ $sth->execute($params);
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
-    Algunos drivers requieren <link linkend="pdostatement.closecursor">cerrar
-    el cursor</link> antes de ejecutar la siguiente consulta.
-   </para>
+   <simpara>
+    Algunos drivers requieren que el <link linkend="pdostatement.closecursor">cursor
+    esté cerrado</link> antes de ejecutar la siguiente consulta.
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="pdostatement.fetch" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -38,70 +38,90 @@
        y por omisión, vale la constante <literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal>
        (que por omisión vale la constante <literal>PDO::FETCH_BOTH</literal>).
        <itemizedlist>
-        <listitem><para>
-         <literal>PDO::FETCH_ASSOC</literal>: devuelve un array indexado por el nombre
-         de la columna como se devuelve en el conjunto de resultados
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_BOTH</literal> (por omisión): devuelve un array indexado
-         por los nombres de columnas y también por los números de columnas,
-         comenzando en el índice 0, como se devuelve en el conjunto de resultados
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_BOUND</literal>: devuelve &true; y asigna los valores
-         de las columnas de su conjunto de resultados en las variables PHP a las que
-         están vinculadas con el método
-         <methodname>PDOStatement::bindColumn</methodname>
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_CLASS</literal>: devuelve una nueva instancia
-         de la clase solicitada. El objeto se inicializa mapeando las columnas del conjunto de resultados a
-         las propiedades de la clase. Este proceso ocurre antes de que se llame al
-         constructor, permitiendo la población de las propiedades, independientemente de su
-         visibilidad o de su marca como <literal>readonly</literal>. Si
-         una propiedad no existe en la clase, se invocará el método mágico
-         <link linkend="object.set">__set()</link>
-         si existe; de lo contrario, se creará una propiedad pública dinámica.
-         Sin embargo, cuando <constant>PDO::FETCH_PROPS_LATE</constant>
-         también está especificado, el constructor se llama <emphasis>antes</emphasis> de
-         que las propiedades sean pobladas. Si <parameter>mode</parameter> incluye
-         <constant>PDO::FETCH_CLASSTYPE</constant> (p.ej.
-         <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), el nombre
-         de la clase se determina a partir del valor de la primera columna.
-        </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_INTO</literal> : actualiza una instancia existente
-         de la clase solicitada, vinculando las columnas del conjunto de resultados a los nombres de las propiedades
-         de la clase
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_LAZY</literal> : combina
-         <literal>PDO::FETCH_BOTH</literal> y <literal>PDO::FETCH_OBJ</literal>,
-         y devuelve un objeto <classname>PDORow</classname>
-         que crea los nombres de propiedad del objeto a medida que se acceden.
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_NAMED</literal> : devuelve un array de la misma
-         forma que <literal>PDO::FETCH_ASSOC</literal>, excepto que si hay
-         múltiples columnas con los mismos nombres, el valor apuntado por esta clave
-         será un array de todas las valores de la línea que tiene ese nombre como columna
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_NUM</literal> : devuelve un array indexado por el
-         número de la columna como se devuelve en su conjunto de resultados,
-         comenzando en 0
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_OBJ</literal> : devuelve un objeto anónimo con los
-         nombres de propiedades que corresponden a los nombres de las columnas devueltas en el
-         conjunto de resultados
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_PROPS_LATE</literal> : cuando se usa con
-         <literal>PDO::FETCH_CLASS</literal>, el constructor de la clase es
-         llamado antes de que las propiedades sean asignadas a partir de los
-         valores de columna respectivos.
-         </para></listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_ASSOC</literal>: devuelve un array indexado por el nombre
+          de la columna como se devuelve en el conjunto de resultados
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_BOTH</literal> (por omisión): devuelve un array indexado
+          por los nombres de columnas y también por los números de columnas,
+          comenzando en el índice 0, como se devuelve en el conjunto de resultados
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_BOUND</literal>: devuelve &true; y asigna los valores
+          de las columnas de su conjunto de resultados en las variables PHP a las que
+          están vinculadas con el método
+          <methodname>PDOStatement::bindColumn</methodname>
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_CLASS</literal>: devuelve una nueva instancia
+          de la clase solicitada. El objeto se inicializa mapeando las columnas del conjunto de resultados a
+          las propiedades de la clase. Este proceso ocurre antes de que se llame al
+          constructor, permitiendo la población de las propiedades, independientemente de su
+          visibilidad o de su marca como <literal>readonly</literal>. Si
+          una propiedad no existe en la clase, se invocará el método mágico
+          <link linkend="object.set">__set()</link>
+          si existe; de lo contrario, se creará una propiedad pública dinámica.
+          Sin embargo, cuando <constant>PDO::FETCH_PROPS_LATE</constant>
+          también está especificado, el constructor se llama <emphasis>antes</emphasis> de
+          que las propiedades sean pobladas. Si <parameter>mode</parameter> incluye
+          <constant>PDO::FETCH_CLASSTYPE</constant> (p.ej.
+          <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), el nombre
+          de la clase se determina a partir del valor de la primera columna.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_INTO</literal> : actualiza una instancia existente
+          de la clase solicitada, vinculando las columnas del conjunto de resultados a los nombres de las propiedades
+          de la clase
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_LAZY</literal> : combina
+          <literal>PDO::FETCH_BOTH</literal> y <literal>PDO::FETCH_OBJ</literal>,
+          y devuelve un objeto <classname>PDORow</classname>
+          que crea los nombres de propiedad del objeto a medida que se acceden.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_NAMED</literal> : devuelve un array de la misma
+          forma que <literal>PDO::FETCH_ASSOC</literal>, excepto que si hay
+          múltiples columnas con los mismos nombres, el valor apuntado por esta clave
+          será un array de todas las valores de la línea que tiene ese nombre como columna
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_NUM</literal> : devuelve un array indexado por el
+          número de la columna como se devuelve en su conjunto de resultados,
+          comenzando en 0
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_OBJ</literal> : devuelve un objeto anónimo con los
+          nombres de propiedades que corresponden a los nombres de las columnas devueltas en el
+          conjunto de resultados
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_PROPS_LATE</literal> : cuando se usa con
+          <literal>PDO::FETCH_CLASS</literal>, el constructor de la clase es
+          llamado antes de que las propiedades sean asignadas a partir de los
+          valores de columna respectivos.
+         </simpara>
+        </listitem>
        </itemizedlist>
       </para>
      </listitem>

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 44bcc82c7d1a0dea5578093833d3172c0c742f5a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdostatement.fetchall" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdostatement.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,13 @@
    Recupera un atributo de la consulta. Actualmente, no existen atributos genéricos, sino
    especificaciones del driver:
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem>
+     <simpara>
+      <literal>PDO::ATTR_CURSOR_NAME</literal>
       (especificación de Firebird y ODBC):
       Recupera el nombre del cursor para <literal>UPDATE ... WHERE CURRENT OF</literal>.
-     </para></listitem>
+     </simpara>
+    </listitem>
    </itemizedlist>
    Tenga en cuenta que los atributos específicos del controlador <emphasis>no deben</emphasis>
    utilizarse con otros controladores.

--- a/reference/pdo/pdostatement/rowcount.xml
+++ b/reference/pdo/pdostatement/rowcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5950d8ae47e8befb9fa5f774ddb96a860833ed5 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdostatement.rowcount" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -29,12 +29,12 @@
    y no debería ser utilizado para aplicaciones portables.
   </para>
   <note>
-   <para>
+   <simpara>
     Este método siempre devuelve "0" (cero) con el controlador PostgreSQL,
     cuando el atributo de declaración
     <constant>PDO::ATTR_CURSOR</constant> está definido como
     <constant>PDO::CURSOR_SCROLL</constant>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdostatement.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,10 +20,13 @@
    Establece un atributo de la consulta. Actualmente, no se definen atributos genéricos, sino
    especificaciones del driver:
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem>
+     <simpara>
+      <literal>PDO::ATTR_CURSOR_NAME</literal>
       (especificidad de Firebird y ODBC):
       Establece el nombre del cursor para <literal>UPDATE ... WHERE CURRENT OF</literal>.
-     </para></listitem>
+     </simpara>
+    </listitem>
    </itemizedlist>
    Tenga en cuenta que los atributos específicos del controlador <emphasis>no deben</emphasis>
    utilizarse con otros controladores.

--- a/reference/pgsql/functions/pg-fetch-object.xml
+++ b/reference/pgsql/functions/pg-fetch-object.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39bb8a868935a56cfce438b0169e13c02c93211c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-fetch-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -77,9 +77,9 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Se lanza una <classname>ValueError</classname> cuando el argumento <parameter>constructor_args</parameter> no está vacío y la clase no tiene constructor.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/tidy/tidy/parsefile.xml
+++ b/reference/tidy/tidy/parsefile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8bcc6238e8017a8a78c23b7256c55617ada5d385 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="tidy.parsefile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/tidy/tidy/parsestring.xml
+++ b/reference/tidy/tidy/parsestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2b84fa46e30d9611e9b5d3af877a7e9ab5c7411a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="tidy.parsestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Port of php/doc-en 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc, for 55 of the 56 files. connect.xml and quote.xml also carry the preceding commits on those files (603435cd84, c62ef37e0d). Where the upstream change only fixed English grammar the Spanish wording is unchanged and only the structure (para to simpara) and the revision follow.

Left out: reference/mysqlinfo/set.xml. The Spanish page is missing the whole 'Comparing prepared statements' example doc-en has, so the file needs that content ported before its revision can move; that is a separate change.

Fixes: #915