### PR TITLE
[Sync-En] Fix grammar in oop5 (#5728)

### DIFF
--- a/language/oop5/anonymous.xml
+++ b/language/oop5/anonymous.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.anonymous" xmlns="http://docbook.org/ns/docbook">
  <title>Clases anónimas</title>
 
@@ -147,9 +146,9 @@ same class
  </informalexample>
 
  <note>
-  <para>
+  <simpara>
    Tenga en cuenta que las clases anónimas son asignadas un nombre por el motor, como se ilustra en el siguiente ejemplo. Este nombre debe considerarse como un detalle de implementación, que no debe ser invocado.
-  </para>
+  </simpara>
   <informalexample>
    <programlisting role="php">
 <![CDATA[

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.autoload" xmlns="http://docbook.org/ns/docbook">
  <title>Autocarga de clases</title>
  <para>
@@ -9,25 +8,25 @@
   de este método es tener que escribir una larga lista de inclusiones de
   ficheros de clases al inicio de cada script: una inclusión por clase.
  </para>
- <para>
+ <simpara>
   La función <function>spl_autoload_register</function> registra un número cualquiera de
   cargadores automáticos, lo que permite a las clases y a las interfaces ser
   automáticamente cargadas si no están definidas actualmente.
   Al registrar autocargadores, PHP da una última oportunidad de incluir una
   definición de clase o interfaz, antes de que PHP falle con un error.
- </para>
+ </simpara>
  <para>
   Cualquier construcción similar a las clases puede ser autocargada de la
   misma manera. Esto incluye las clases, interfaces, traits y enumeraciones.
  </para>
  <caution>
-  <para>
+  <simpara>
    Anterior a PHP 8.0.0, era posible utilizar <function>__autoload</function>
    para autocargar las clases y las interfaces. Sin embargo, es una alternativa
    menos flexible a <function>spl_autoload_register</function> y
    <function>__autoload</function> está obsoleto a partir de PHP 7.2.0,
    y eliminado a partir de PHP 8.0.0.
-  </para>
+  </simpara>
  </caution>
  <note>
   <para>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.changelog" xmlns="http://docbook.org/ns/docbook">
  <title>Modificaciones en POO (Programación orientada a objetos)</title>
  <para>

--- a/language/oop5/cloning.xml
+++ b/language/oop5/cloning.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28529d3539b850e870e3aa97570f4db0e53daa03 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.cloning" xmlns="http://docbook.org/ns/docbook">
   <title>Clonación de objetos</title>
 
-  <para>
+  <simpara>
    La creación de una copia de un objeto con exactamente las mismas
    propiedades no siempre es el comportamiento deseado.
    Un buen ejemplo para ilustrar la necesidad de un constructor de copia:
@@ -12,7 +11,7 @@
    contiene el recurso que representa esa ventana GTK, al crear una copia,
    se puede desear crear una nueva ventana con las mismas propiedades,
    pero que el nuevo objeto contenga un recurso que represente la nueva ventana.
-  </para>
+  </simpara>
 
   <para>
    Una copia de objeto se crea utilizando la palabra clave <literal>clone</literal>
@@ -39,11 +38,11 @@ $copy_of_object = clone $object;
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Una vez realizada la clonación, si se ha definido un método <link linkend="object.clone">__clone()</link>,
    el método <link linkend="object.clone">__clone()</link>
    del nuevo objeto será llamado, para permitir que cada propiedad que deba ser modificada lo sea.
-  </para>
+  </simpara>
 
   <example>
    <title>Ejemplo de duplicación de objetos</title>

--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 922b4b5aeb327d78ea1bb4b932e5db2e9a03ffc5 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.constants" xmlns="http://docbook.org/ns/docbook">
  <title>Constantes de clase</title>
- <para>
+ <simpara>
   Es posible definir <link linkend="language.constants">constantes</link>
   por clases que permanecen idénticas y no modificables.
   La visibilidad por omisión de las constantes de clase es <literal>public</literal>.
- </para>
+ </simpara>
  <note>
   <para>
    Las constantes de clases pueden ser redefinidas por una clase hija.

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 82fc6a1c8670b96f1bd2b40932b6eb19929f4f6f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.decon" xmlns="http://docbook.org/ns/docbook">
   <title>Constructores y destructores</title>
 
@@ -162,12 +161,12 @@ class Point {
      </para>
     </note>
     <note>
-     <para>
+     <simpara>
       Las propiedades de objeto no pueden ser tipadas <type>callable</type> debido a las ambigüedades del motor
       que esto introduciría. Por lo tanto, los argumentos promovidos, tampoco pueden ser tipados
       <type>callable</type>. Sin embargo, cualquier otra
       <link linkend="language.types.declarations">declaración de tipo</link> está permitida.
-     </para>
+     </simpara>
     </note>
     <note>
      <para>
@@ -370,7 +369,7 @@ $obj = new MyDestructableClass();
     llamado una segunda vez cuando el contador de referencias alcance
     nuevamente cero o durante la secuencia de parada.
    </para>
-   <para>
+   <simpara>
     A partir de PHP 8.4.0, cuando la
     <link linkend="features.gc.collecting-cycles">colección de ciclos</link>
     ocurre durante la ejecución de una
@@ -384,7 +383,7 @@ $obj = new MyDestructableClass();
     en otro lugar.
     Los objetos cuyo destructor está suspendido no serán colectados hasta
     que el destructor haya terminado o que la fibra misma sea colectada.
-   </para>
+   </simpara>
    <note>
     <para>
      Los destructores llamados durante la parada del script están en una situación

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.inheritance" xmlns="http://docbook.org/ns/docbook">
  <title>Herencia</title>
  <para>
@@ -29,7 +28,7 @@
   es <literal>private final</literal> en los constructores, ya que es una
   manera común para "desactivar" el constructor cuando se utilizan métodos de fábrica estáticos en su lugar.
  </para>
- <para>
+ <simpara>
   La <link linkend="language.oop5.visibility">visibilidad</link>
   de los métodos, propiedades y constantes puede ser relajada, es decir, un
   método <literal>protected</literal> puede ser marcado como
@@ -38,7 +37,7 @@
   Una excepción son los constructores, para los cuales la visibilidad puede ser restringida,
   por ejemplo, un constructor <literal>public</literal> puede ser anotado
   como <literal>private</literal> en la clase hija.
- </para>
+ </simpara>
 
  <note>
   <para>

--- a/language/oop5/interfaces.xml
+++ b/language/oop5/interfaces.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 565bd8b6cf2cae44ae2bc54ef6dbe6ee70ddfefd Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Interfaces</title>
   <para>

--- a/language/oop5/iterations.xml
+++ b/language/oop5/iterations.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 1fb0ef23d7be0d8ecd9604fce16ee1e0842c6ef6 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.iterations" xmlns="http://docbook.org/ns/docbook">
   <title>Recorrido de objetos</title>
-  <para>
+  <simpara>
     PHP proporciona una manera de definir los objetos de manera que se pueda
     recorrer una lista de miembros, por ejemplo con una estructura
     &foreach;. Por omisión, todas
     las propiedades <link linkend="language.oop5.visibility">visibles</link>
     serán utilizadas para el recorrido.
-  </para>
+  </simpara>
 
   <example>
     <title>Recorrido de objeto simple</title>

--- a/language/oop5/late-static-bindings.xml
+++ b/language/oop5/late-static-bindings.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 009f215fc983eeded6161676bcffdd8cf3b6b080 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.late-static-bindings" xmlns="http://docbook.org/ns/docbook">
   <title>Late Static Bindings (Resolución estática en tiempo de ejecución)</title>
-  <para>
+  <simpara>
    PHP implementa una funcionalidad llamada
    late static binding, en español la resolución
    estática en tiempo de ejecución, que puede ser utilizada para referenciar la clase llamada
    en un contexto de herencia estática.
-  </para>
+  </simpara>
 
   <para>
    Más precisamente, las resoluciones estáticas en tiempo de ejecución funcionan registrando

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8f51247cb4631b29686f867bd904dfe5b2678074 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.magic" xmlns="http://docbook.org/ns/docbook">
   <title>Métodos mágicos</title>
-  <para>
+  <simpara>
    Los métodos mágicos son métodos especiales que sobrescriben la acción
    por omisión de PHP cuando se realizan ciertas acciones sobre un objeto.
-  </para>
+  </simpara>
  <caution>
   <simpara>
    Todos los métodos que comienzan por <literal>__</literal> están reservados por PHP.

--- a/language/oop5/object-comparison.xml
+++ b/language/oop5/object-comparison.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a9edd62d087ab1eb6292c795b7256e14ff9f1234 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
   <sect1 xml:id="language.oop5.object-comparison" xmlns="http://docbook.org/ns/docbook">
    <title>Comparación de objetos</title>
    <para>
@@ -99,10 +97,10 @@ o1 !== o2 : TRUE
     </example>
    </para>
    <note>
-    <para>
+    <simpara>
      Las extensiones pueden definir sus propias reglas para sus
      comparaciones de objetos (<literal>==</literal>).
-    </para>
+    </simpara>
    </note>
   </sect1>
 <!-- Keep this comment at the end of the file

--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.paamayim-nekudotayim" xmlns="http://docbook.org/ns/docbook">
  <title>El operador de resolución de ámbito (::)</title>
 
@@ -88,7 +87,7 @@ OtherClass::doubleColon();
   </programlisting>
  </example>
 
- <para>
+ <simpara>
   Cuando una clase que hereda de otra redefine un método de su clase padre,
   PHP no llamará al método de la clase padre. Es responsabilidad del método derivado
   llamar al método original en caso de necesidad. Esto también es válido
@@ -96,7 +95,7 @@ OtherClass::doubleColon();
   linkend="language.oop5.decon">constructores y destructores</link>,
   la <link linkend="language.oop5.overloading">sobrecarga</link>, y las
   definiciones de <link linkend="language.oop5.magic">métodos mágicos</link>.
- </para>
+ </simpara>
 
  <example>
   <title>Llamada a un método padre</title>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 801e7a15e8c9ee2d16966487dc9058d992450b46 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.properties" xmlns="http://docbook.org/ns/docbook">
  <title>Propiedades</title>
 
@@ -20,10 +19,10 @@
   ser un valor <link linkend="language.constants">constante</link>
  </para>
  <note>
-  <para>
+  <simpara>
    Una manera obsoleta de declarar una propiedad de clase es utilizar
    la palabra clave <literal>var</literal> en lugar de un modificador.
-  </para>
+  </simpara>
  </note>
  <note>
   <simpara>
@@ -166,7 +165,7 @@ class Shape
 
 $triangle = new Shape();
 $triangle->setName("triangle");
-$triangle->setNumberofSides(3);
+$triangle->setNumberOfSides(3);
 var_dump($triangle->getName());
 var_dump($triangle->getNumberOfSides());
 

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.property-hooks" xmlns="http://docbook.org/ns/docbook">
  <title>Hooks de propiedad</title>
 

--- a/language/oop5/references.xml
+++ b/language/oop5/references.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a9edd62d087ab1eb6292c795b7256e14ff9f1234 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.references" xmlns="http://docbook.org/ns/docbook">
   <title>Objetos y referencias</title>
-  <para>
+  <simpara>
    Uno de los pilares de la POO de PHP es el hecho de que los
    "objetos son pasados por referencia por omisión". Esto no es completamente cierto.
    Esta sección corrige esta generalización con algunos ejemplos.
-  </para>
+  </simpara>
 
   <para>
    Una referencia PHP es un alias, que permite a dos variables diferentes

--- a/language/oop5/serialization.xml
+++ b/language/oop5/serialization.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 70f392045a26b176f206013f00fa14b86440efd1 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <!-- TODO Rewrite to remove usage of "you" and talk about __serialize/_unserialize -->
 <sect1 xml:id="language.oop5.serialization" xmlns="http://docbook.org/ns/docbook">
  <title>Serializar objetos - objetos en sesión</title>
@@ -15,7 +13,7 @@
   para guardar un objeto conservará todas sus variables. Sus métodos no serán conservados, solo el nombre de la clase lo será.
  </para>
 
- <para>
+ <simpara>
   Para poder deserializar (<function>unserialize</function>) un objeto,
   la clase del objeto debe estar definida, para permitir su reconstrucción.
   En otras palabras, si se tiene un objeto de la clase A y se serializa,
@@ -26,7 +24,7 @@
   de su representación lineal. Esto puede hacerse, por ejemplo, incluyendo el
   fichero de definición de la clase, o utilizando la función
   <function>spl_autoload_register</function>.
- </para>
+ </simpara>
 
  <informalexample>
   <programlisting role="php">
@@ -67,14 +65,14 @@
   </programlisting>
  </informalexample>
 
- <para>
+ <simpara>
   Si una aplicación serializa objetos, se recomienda encarecidamente, para su uso
   futuro, que la aplicación incluya las definiciones de las clases de los objetos serializados
   en cada página. No hacerlo podría resultar en un objeto deserializado sin su definición
   de clase. PHP asignaría entonces a este objeto una clase de tipo
   <classname>__PHP_Incomplete_Class_Name</classname>, que no tiene métodos, y
   produciría un objeto inútil.
- </para>
+ </simpara>
 
  <para>
   Así, en el ejemplo anterior, si <varname>$a</varname> se registra en la sesión

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: itanea -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.traits" xmlns="http://docbook.org/ns/docbook">
  <title>Traits</title>
  <para>
@@ -205,12 +204,12 @@ Hello World!
   </para>
   <example xml:id="language.oop5.traits.conflict.ex1">
    <title>Resolución de conflictos</title>
-   <para>
+   <simpara>
     En este ejemplo, la clase Talker usa los traits A y B.
     Como A y B tienen métodos conflictivos, se indica que se desea usar
     la variante de smallTalk desde el trait B, y la variante de bigTalk desde el
     trait A.
-   </para>
+   </simpara>
    <para>
     La clase Aliased_Talker usa el operador <literal>as</literal>
     para poder usar la implementación bigTalk de B bajo un alias

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 2e7c00fd314a708ecbd495ef7cc9ae8c8462c33c Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.variance" xmlns="http://docbook.org/ns/docbook">
  <title>Covarianza y Contravarianza</title>
 
@@ -47,11 +45,11 @@
  <sect2 xml:id="language.oop5.variance.covariance">
   <title>Covarianza</title>
 
-  <para>
+  <simpara>
    Para ilustrar el funcionamiento de la covarianza, se crea una simple clase padre abstracta, <varname>Animal</varname>.
    <varname>Animal</varname> será extendida por clases hijas,
   <varname>Cat</varname> y <varname>Dog</varname>.
-  </para>
+  </simpara>
 
   <informalexample>
    <programlisting role="php">


### PR DESCRIPTION
Sync with php/doc-en#5728.

Structural changes applied across 19 files under `language/oop5/`:

- Replace `<para>` with `<simpara>` in the same positions as the English source (anonymous, autoload, cloning, constants, decon, inheritance, iterations, late-static-bindings, magic, object-comparison, paamayim-nekudotayim, properties, references, serialization, traits, variance).
- Fix code sample in `properties.xml`: `setNumberofSides` → `setNumberOfSides`.
- Update EN-Revision in all 19 touched files (changelog, interfaces, property-hooks included for EN text-only fixes).
- Remove `<!-- Reviewed: no/yes -->` and `<!-- $Revision$ -->` lines.

Closes #954