### PR TITLE
CI: check the XML structure of the PR head, not of the merge commit

### DIFF
--- a/.github/workflows/check-xml.yml
+++ b/.github/workflows/check-xml.yml
@@ -19,9 +19,16 @@ jobs:
     name: "Check XML"
     runs-on: ubuntu-22.04
     steps:
+      # The translation at the root, doc-en under en/: this is the layout
+      # check-structure.php expects. The explicit ref takes the real head of
+      # the pull request, not the merge commit actions/checkout builds by
+      # default: that one has master as its second parent, so the diff below
+      # would also list every file landed on master since the last push.
+
       - name: "Checkout translation"
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: "Checkout php/doc-en"


### PR DESCRIPTION
On a `pull_request` event, `actions/checkout` defaults to `refs/pull/N/merge`, whose second parent is the tip of `master`. The `BASE...HEAD` diff below it then lists the pull request *plus* everything landed on `master` since `base.sha` was frozen, and hands all of it to `check-structure.php`.

Measured on a pull request of another translation touching a single `.yaml` file:

| diff | files | of which `.xml` |
| --- | --- | --- |
| `base.sha...merge commit` (current) | 300 | 294 |
| `base.sha...head.sha` (this change) | 1 | 0 |

The job failed on structural drift the pull request did not introduce. Checking out the head sha keeps the diff inside the pull request.

The layout the script expects, translation at the root and doc-en under `en/`, is now stated in the workflow too.
