### PR TITLE
[Sync EN] Set the timezone in the date_sun_info() example (#5740)

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 631587d37135c0bfd7a4f30e37f33e2fb213dc2f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: aac47e05048c3371bfc46d65247d7bf1c4505bf3 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <refentry xml:id="function.date-sun-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -177,6 +177,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+date_default_timezone_set('Asia/Jerusalem');
 $sun_info = date_sun_info(strtotime("2006-12-12"), 31.7667, 35.2333);
 foreach ($sun_info as $key => $val) {
   echo "$key: " . date("H:i:s", $val) . "\n";
@@ -186,15 +187,15 @@ foreach ($sun_info as $key => $val) {
     &example.outputs;
     <screen>
 <![CDATA[
-sunrise: 05:52:11
-sunset: 15:41:21
-transit: 10:46:46
-civil_twilight_begin: 05:24:08
-civil_twilight_end: 16:09:24
-nautical_twilight_begin: 04:52:25
-nautical_twilight_end: 16:41:06
-astronomical_twilight_begin: 04:21:32
-astronomical_twilight_end: 17:12:00
+sunrise: 06:29:21
+sunset: 16:36:00
+transit: 11:32:41
+civil_twilight_begin: 06:02:36
+civil_twilight_end: 17:02:45
+nautical_twilight_begin: 05:32:14
+nautical_twilight_end: 17:33:08
+astronomical_twilight_begin: 05:02:31
+astronomical_twilight_end: 18:02:51
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Fixes #963

Translates EN commit aac47e05048c3371bfc46d65247d7bf1c4505bf3 / PR php/doc-en#5740.

## What changed

The first example in `date_sun_info()` called `date()` on the returned timestamps without setting a timezone, so the output depended on the system timezone of whoever ran it. The recorded values did not match any real timezone.

The coordinates used in the example are Jerusalem (`31.7667, 35.2333`), so `Asia/Jerusalem` is the appropriate zone — consistent with what the polar-night example already does for Prudhoe Bay.

**Changes applied to `reference/datetime/functions/date-sun-info.xml`:**

- Add `date_default_timezone_set('Asia/Jerusalem');` before the `date_sun_info()` call.
- Update the `<screen>` expected output to the timezone-correct values.

The rest of the file (Spanish translation, other examples, changelog) is unchanged.