### PR TITLE
[Sync EN] Add warning for header_register_callback usage (#5760)

### DIFF
--- a/reference/network/functions/header-register-callback.xml
+++ b/reference/network/functions/header-register-callback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5faa7a6747bca628b3bdcc9f93aec5603b65581f Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: abdc23836d3f42399028c1174961107e70ada52d Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <refentry xml:id="function.header-register-callback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -23,6 +23,15 @@
    prepara todos los encabezados que van a ser enviados, y antes de cualquier otra salida es enviado,
    crea una ventana para manipular las cabeceras de salida antes de ser enviado.
   </para>
+  <warning>
+   <simpara>
+    Los callbacks no se apilan. Las llamadas posteriores a
+    <function>header_register_callback</function> desregistrarán silenciosamente
+    cualquier <parameter>callback</parameter> existente, independientemente de dónde
+    se haya establecido. Tenga en cuenta que las dependencias pueden sobrescribir
+    el callback. Diagnosticar este escenario puede ser difícil.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Fixes #974

Translates EN commit abdc23836d3f42399028c1174961107e70ada52d / PR php/doc-en#5760.

## What changed

`header_register_callback` does not stack callbacks: each call silently overwrites the previously registered one. This is a non-obvious footgun, especially when third-party dependencies also register a callback.

A `<warning>` block was added in the English docs to surface this behaviour. This PR translates that warning to Spanish and updates the EN-Revision.

**Changes applied to `reference/network/functions/header-register-callback.xml`:**

- Add `<warning><simpara>` block after the description paragraph, explaining that callbacks are not stacked, that later calls silently de-register earlier ones, and that this can be hard to debug.
- Update EN-Revision: 5faa7a6... to abdc238....