### PR TITLE
[Sync EN] install/unix: Fixed typo (#5761)

### DIFF
--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1c9fb12650addc936f5a0d5d1edc42cd32e9c765 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e07f764c8e4234d1195536ffed2eaf19c849ce50 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="install.unix.source" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Instalación desde las fuentes en sistemas Unix y macOS</title>


### PR DESCRIPTION
Fixes #980

Translates EN commit e07f764c8e4234d1195536ffed2eaf19c849ce50 / PR php/doc-en#5761.

## What changed

The English source corrected a grammatical error: "was been run" -> "has been run" in `install/unix/source.xml`.

The Spanish translation already uses correct grammar ("Después de que el script de configuración se haya ejecutado"), so no content change is needed in the ES file. Only the `EN-Revision` header is updated to reflect that this ES file is in sync with the current EN source.