### PR TITLE
[Sync EN] Example emits warning unrelated to content (#5747)

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fa67e21421448a20fe701a20897c30f93072e64b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e7ec2928daf49d50796dfe74d106eb1068a1c72b Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -119,7 +119,7 @@ echo "Última instrucción\n";
     <title>Escape avanzado usando condiciones</title>
     <programlisting role="php">
 <![CDATA[
-<?php if ($expression == true): ?>
+<?php if (true): ?>
   Esto será mostrado si la expresión es verdadera.
 <?php else: ?>
   De lo contrario, esto será mostrado.


### PR DESCRIPTION
Fixes #961

Translates EN commit e7ec2928daf49d50796dfe74d106eb1068a1c72b / PR php/doc-en#5747.

## What changed

The "Advanced escaping using conditions" example in `language/basic-syntax.xml` used `$expression` as the condition, but `$expression` is never defined. This causes PHP to emit an `E_WARNING` about an undefined variable, which is unrelated to what the example demonstrates (alternative syntax for control structures in HTML output).

The fix replaces `$expression == true` with `true`, making the example self-contained and warning-free.

**Changes applied to `language/basic-syntax.xml`:**

- `<?php if ($expression == true): ?>` -> `<?php if (true): ?>`
- Update EN-Revision.