### PR TITLE
[Sync EN] Fix grammar in language/types (#5746)

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.array">
  <title>Arrays</title>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -476,7 +476,7 @@ $arr[] = <replaceable>valor</replaceable>;
 // <replaceable>clave</replaceable> puede ser un <type>int</type> o <type>string</type>
 // <replaceable>valor</replaceable> puede ser cualquier valor de cualquier tipo</synopsis>
 
-   <para>
+   <simpara>
     Si <varname>$arr</varname> no existe aún o está establecido a &null; o &false;, será creado, por lo que esto es
     también una forma alternativa de crear un <type>array</type>. Sin embargo, esta práctica
     está desaconsejada porque si <varname>$arr</varname> ya contiene
@@ -484,7 +484,7 @@ $arr[] = <replaceable>valor</replaceable>;
     valor permanecerá en su lugar y <literal>[]</literal> podría en realidad representar
     el <link linkend="language.types.string.substr">operador de acceso a string</link>. Siempre es mejor inicializar una variable mediante una
     asignación directa.
-   </para>
+   </simpara>
    <note>
     <simpara>
      A partir de PHP 7.1.0, aplicar el operador de índice vacío en un string lanza un error fatal.
@@ -1048,7 +1048,7 @@ $error_descriptions[8] = "Esto es solo un aviso informal";
    <literal>array($scalarValue)</literal>.
   </para>
 
-  <para>
+  <simpara>
    Si un <type>object</type> es convertido a un <type>array</type>, el resultado
    es un <type>array</type> cuyos elementos son las
    propiedades del <type>object</type>.
@@ -1058,7 +1058,7 @@ $error_descriptions[8] = "Esto es solo un aviso informal";
    valores antepuestos tienen bytes <literal>NUL</literal> a ambos lados.
    Las <link linkend="language.oop5.properties.typed-properties">propiedades tipadas</link>
    no inicializadas se descartan silenciosamente.
-  </para>
+  </simpara>
 
   <example>
    <title>Conversión a un array</title>

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.callable">
  <title>Callables</title>

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -12,14 +12,14 @@
   de lo contrario se lanza un <classname>TypeError</classname>.
  </para>
 
- <para>
+ <simpara>
   Cada tipo soportado por PHP, con la excepción del tipo
   <type>resource</type>, puede ser utilizado en una declaración de tipo
   por el usuario.
   Esta página contiene un registro de cambios de la disponibilidad de
   los diferentes tipos y la documentación sobre su uso en las
   declaraciones de tipo.
- </para>
+ </simpara>
 
  <note>
   <para>

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.declarations">
  <title>Declaraciones de tipo</title>

--- a/language/types/float.xml
+++ b/language/types/float.xml
@@ -6,11 +6,11 @@
 <sect1 xml:id="language.types.float" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Números de punto flotante</title>
 
- <para>
+ <simpara>
   Los números de punto flotante (también conocidos como "floats",
   "doubles" o "números reales")
   pueden ser especificados utilizando las siguientes sintaxis:
- </para>
+ </simpara>
 
  <informalexample>
   <programlisting role="php">
@@ -48,26 +48,26 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
  <warning xml:id="warn.float-precision">
   <title>Precisión de los números de punto flotante</title>
 
-  <para>
+  <simpara>
    Los números de punto flotante tienen una precisión limitada. Aunque dependen del sistema,
    PHP utiliza el formato de precisión decimal IEEE 754, que dará un error relativo máximo del orden de 1.11e-16 (debido a los redondeos). Las operaciones
    aritméticas no elementales pueden dar errores más grandes y, por supuesto, los errores deben ser tenidos en cuenta cuando se realizan múltiples operaciones.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Asimismo, los números racionales exactamente representables como números de punto flotante en base 10, como <literal>0.1</literal> o <literal>0.7</literal>, no tienen
    una representación exacta como números de punto flotante en base 2, utilizada internamente, y esto independientemente del tamaño de la mantisa. Por lo tanto, no pueden
    ser convertidos sin una pequeña pérdida de precisión. Esto puede llevar a resultados confusos: por ejemplo, <literal>floor((0.1+0.7)*10)</literal> normalmente devolverá
    <literal>7</literal> en lugar del <literal>8</literal> esperado, ya que la representación interna será algo como <literal>7.9999999999999991118...</literal>.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Por lo tanto, nunca se debe confiar en los últimos dígitos de un número
    de punto flotante, y tampoco se debe comparar la igualdad de 2 números de punto flotante
    directamente. Si se necesita una mayor precisión, las
    <link linkend="ref.bc">funciones matemáticas de precisión arbitraria</link>
    y las funciones <link linkend="ref.gmp">gmp</link> están disponibles.
-  </para>
+  </simpara>
 
   <para>
    Para una explicación "simple", ver el
@@ -114,17 +114,17 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
  <sect2 xml:id="language.types.float.comparison">
   <title>Comparación de números de punto flotante</title>
 
-  <para>
+  <simpara>
    Como se mencionó anteriormente, la prueba de igualdad de valores de
    números de punto flotante es problemática, debido a la forma en que se representan internamente. Sin embargo, existen formas de
    realizar esta comparación.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Para probar la igualdad de valores de números de punto flotante, se utiliza un límite superior del error relativo al redondeo. Este valor es conocido
    como el epsilon de la máquina, o unit roundoff,
    y es la diferencia más pequeña aceptable en los cálculos.
-  </para>
+  </simpara>
 
   <para>
    <varname>$a</varname> y <varname>$b</varname> son iguales en 5 números

--- a/language/types/float.xml
+++ b/language/types/float.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: PhilDaiguille -->
 <!-- CREDITS: DavidA -->
 

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -30,12 +30,12 @@
    puede ser utilizado para designar un &integer; negativo.
   </simpara>
 
-  <para>
+  <simpara>
    Para utilizar la notación octal, preceda el número de un <literal>0</literal> (cero).
    A partir de PHP 8.1.0, la notación octal puede ser precedida con <literal>0o</literal> o <literal>0O</literal>.
    Para utilizar la notación hexadecimal, preceda el número de <literal>0x</literal>.
    Para utilizar la notación binaria, preceda el número de <literal>0b</literal>.
-  </para>
+  </simpara>
 
   <para>
    A partir de PHP 7.4.0, los enteros literales pueden contener underscores
@@ -127,14 +127,14 @@ var_dump(PHP_INT_MAX + 1);       // sistema de 32 bits: float(2147483648)
  <sect2 xml:id="language.types.integer.division">
   <title>División de entero</title>
 
-  <para>
+  <simpara>
    No hay operador de división de &integer; en PHP, para lograr esto
    utilizar la función <function>intdiv</function>.
    <literal>1/2</literal> produce el &float; (<literal>0.5</literal>).
    El valor puede ser convertido en un &integer; para redondear hacia cero, o
    utilizando la función <function>round</function> para tener un control
    más fino sobre cómo se realiza el redondeo.
-  </para>
+  </simpara>
 
   <example>
    <title>División</title>

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.integer">
  <title>Los enteros</title>

--- a/language/types/iterable.xml
+++ b/language/types/iterable.xml
@@ -4,7 +4,7 @@
 <sect1 xml:id="language.types.iterable">
  <title>Iterables</title>
 
- <para>
+ <simpara>
   Un <type>Iterable</type> es un alias de tipo integrado durante la compilación para
   <!-- Necesidad de mejorar el rendimiento de los elementos de tipo autónomos en PhD <type class="union"><type>array</type><type>Traversable</type></type>. -->
   <literal>array|Traversable</literal>.
@@ -13,7 +13,7 @@
   el alias de tipo mencionado anteriormente y puede ser utilizado como una declaración de tipo.
   Un tipo iterable puede ser utilizado en un ciclo &foreach; y con
   <command>yield from</command> en un <link linkend="language.generators">generador</link>.
- </para>
+ </simpara>
 
  <note>
   <para>

--- a/language/types/iterable.xml
+++ b/language/types/iterable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: PhilDaiguille -->
 <sect1 xml:id="language.types.iterable">
  <title>Iterables</title>

--- a/language/types/mixed.xml
+++ b/language/types/mixed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.mixed">
  <title>Mixed</title>

--- a/language/types/mixed.xml
+++ b/language/types/mixed.xml
@@ -17,10 +17,10 @@
   Disponible a partir de PHP 8.0.0.
  </para>
 
- <para>
+ <simpara>
   <type>mixed</type> es, en el lenguaje de la teoría de tipos, el tipo superior.
   Esto significa que todos los demás tipos son subtipos de este tipo.
- </para>
+ </simpara>
 
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/language/types/never.xml
+++ b/language/types/never.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.never">
  <title>Never</title>

--- a/language/types/never.xml
+++ b/language/types/never.xml
@@ -12,11 +12,11 @@
   <link linkend="language.types.type-system.composite.union">type union</link>
   Disponible a partir de PHP 8.1.0.
  </para>
- <para>
+ <simpara>
   <type>never</type> es, en el lenguaje de la teoría de tipos, el tipo vacío.
   Esto significa que es el subtipo de todos los otros tipos y que puede reemplazar cualquier otro
   tipo de retorno durante la herencia.
- </para>
+ </simpara>
 
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/language/types/null.xml
+++ b/language/types/null.xml
@@ -10,10 +10,10 @@
   &null;.
  </para>
 
- <para>
+ <simpara>
   Las variables no definidas y <function>unset</function> tendrán el
   valor &null;.
- </para>
+ </simpara>
 
  <sect2 xml:id="language.types.null.syntax">
   <title>Sintaxis</title>

--- a/language/types/null.xml
+++ b/language/types/null.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f1dbc451b313fb1ec8058f24c1beccf55fce316 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.null">
  <title>NULL</title>

--- a/language/types/numeric-strings.xml
+++ b/language/types/numeric-strings.xml
@@ -90,11 +90,11 @@ var_dump("2E1" == "020"); // true, "2E1" es 2 * (10 ^ 1), o 20
 
  <sect2 xml:id="language.types.numeric-string.prior">
   <title>Comportamiento anterior a PHP 8.0.0</title>
-  <para>
+  <simpara>
    Antes de PHP 8.0.0, un <type>string</type> se consideraba numérico solo si tenía espacios en blanco al
    <emphasis>inicio</emphasis> del string, si tenía espacios en blanco al
    <emphasis>final</emphasis> del string, el string se consideraba como un string iniciando numéricamente.
-  </para>
+  </simpara>
 
   <para>
    Antes de PHP 8.0.0, cuando un string se utilizaba en un contexto numérico,

--- a/language/types/numeric-strings.xml
+++ b/language/types/numeric-strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <sect1 xml:id="language.types.numeric-strings" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Strings numéricos</title>

--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="language.types.object">

--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -42,7 +42,7 @@ $bar->do_foo();
 
  <sect2 xml:id="language.types.object.casting">
   <title>Conversión en un objeto</title>
-  <para>
+  <simpara>
    Si un <type>object</type> es convertido en un <type>object</type>, no será modificado.
    Si un valor de cualquier otro tipo es convertido en un <type>object</type>,
    se creará una nueva instancia de la clase interna <classname>stdClass</classname>.
@@ -50,7 +50,7 @@ $bar->do_foo();
    Un <type>array</type> se convierte en <type>object</type> con las propiedades
    nombradas en relación con las claves con sus valores correspondientes. Note que
    en este caso, antes de PHP 7.2.0 las claves numéricas fueron inaccesibles a menos que fueran iteradas.
-  </para>
+  </simpara>
 
   <example>
    <title>Conversión en un objeto</title>

--- a/language/types/relative-class-types.xml
+++ b/language/types/relative-class-types.xml
@@ -5,9 +5,9 @@
 <sect1 xml:id="language.types.relative-class-types">
  <title>Tipos de clases relativas</title>
 
- <para>
+ <simpara>
   Estas declaraciones de tipos solo pueden ser utilizadas dentro de las clases.
- </para>
+ </simpara>
 
  <sect2 xml:id="language.types.relative-class-types.self">
   <title><type>self</type></title>

--- a/language/types/relative-class-types.xml
+++ b/language/types/relative-class-types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 339ba3f0f4440af1f8d83e73b2c3be06b3cb2315 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <sect1 xml:id="language.types.relative-class-types">
  <title>Tipos de clases relativas</title>

--- a/language/types/resource.xml
+++ b/language/types/resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95bdd6883b5dde9504701777ba81b3c5f15df52b Maintainer: lboshell Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lboshell Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 
 <sect1 xml:id="language.types.resource">

--- a/language/types/resource.xml
+++ b/language/types/resource.xml
@@ -32,12 +32,12 @@
  <sect2 xml:id="language.types.resource.self-destruct">
   <title>Liberación de recursos</title>
 
-  <para>
+  <simpara>
    Gracias al sistema de conteo de referencias introducido con el Motor
    Zend, un valor de tipo <type>resource</type> sin más referencias es detectado
    automáticamente, y es liberado por el recolector de basura. Por esta
    razón, rara vez se necesita liberar la memoria manualmente.
-  </para>
+  </simpara>
 
   <note>
    <simpara>

--- a/language/types/singleton.xml
+++ b/language/types/singleton.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 828980b619bb4300e196924598b6a5d398f630e4 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.singleton">
  <title>Tipo singleton</title>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 0d964bcaac6618dd80b974eb6fcdf3c67ca07340 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: girgias -->
 <sect1 xml:id="language.types.string">
  <title>Cadenas</title>
@@ -214,8 +214,9 @@ echo 'Las variables no $se\'extienden $tampoco', PHP_EOL;
    </simpara>
 
    <simpara>
-    El identificador de cierre puede estar indentado con espacios o tabulaciones, en cuyo caso
-    la indentación será eliminada de todas las líneas en el string doc.
+    El identificador de cierre puede estar indentado con espacios o tabulaciones. El espacio en
+    blanco equivalente a la indentación del identificador de cierre se elimina del inicio de cada
+    línea del string heredoc.
     Antes de PHP 7.3.0, el identificador de cierre <emphasis>debe</emphasis>
     comenzar en la primera columna de la línea.
    </simpara>
@@ -231,7 +232,7 @@ echo 'Las variables no $se\'extienden $tampoco', PHP_EOL;
     <programlisting role="php">
 <![CDATA[
 <?php
-// sin indentación
+// identificador de cierre no indentado
 echo <<<END
       a
      b
@@ -239,12 +240,12 @@ echo <<<END
 \n
 END;
 
-// 4 espacios de indentación
+// identificador de cierre indentado con 3 espacios; 3 espacios eliminados de cada línea
 echo <<<END
       a
      b
     c
-    END;
+   END;
 ]]>
     </programlisting>
     &example.outputs.73;
@@ -254,9 +255,9 @@ echo <<<END
      b
     c
 
-  a
- b
-c
+   a
+  b
+ c
 ]]>
     </screen>
    </example>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ddc2a2d0966f746b67292b6c0987ef288747e409 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: girgias -->
 <sect1 xml:id="language.types.string">
  <title>Cadenas</title>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -582,11 +582,11 @@ FOOBAR;
   <sect3 xml:id="language.types.string.syntax.nowdoc">
    <title>Nowdoc</title>
 
-   <para>
+   <simpara>
     Los nowdocs son para los strings entre comillas simples lo que los heredocs son para los strings entre comillas dobles. Un nowdoc se especifica de manera similar a un heredoc, pero <emphasis>ninguna interpolación de string es realizada</emphasis> dentro de un nowdoc. La construcción es ideal para integrar código PHP o otros bloques de texto voluminosos sin necesidad de escapar. Comparte algunas características con la construcción SGML
     <literal>&lt;![CDATA[ ]]&gt;</literal>, en el sentido de que declara
     un bloque de texto que no está destinado a ser analizado.
-   </para>
+   </simpara>
 
    <para>
     Un nowdoc es identificado por la misma secuencia <literal>&lt;&lt;&lt;</literal>
@@ -1187,12 +1187,12 @@ string(1) "b"
    los valores <type>bool</type> y <type>string</type>.
   </para>
 
-  <para>
+  <simpara>
    Un <type>int</type> o <type>float</type> es convertido a un
    <type>string</type> representando el número textualmente (incluyendo la
    parte exponencial para los <type>float</type>). Los números de punto flotante pueden ser
    convertidos utilizando la notación exponencial (<literal>4.1E+6</literal>).
-  </para>
+  </simpara>
 
   <note>
    <para>
@@ -1250,7 +1250,7 @@ string(1) "b"
 
   <title>Detalles del tipo string</title>
 
-  <para>
+  <simpara>
    El <type>string</type> en PHP está implementado como un array de octetos y un
    entero indicando la longitud del búfer. No tiene ninguna información sobre cómo
    estos octetos se traducen en caracteres, dejando esta tarea al programador.
@@ -1259,14 +1259,14 @@ string(1) "b"
    en cualquier parte del string (aunque algunas funciones, dichas en este manual de no
    ser «seguras para binarios», pueden pasar los strings a bibliotecas
    que ignoran los datos después de un octeto NUL.)
-  </para>
+  </simpara>
   <para>
    Esta naturaleza del tipo string explica por qué no hay un tipo «octeto» distinto
    en PHP - los strings toman este rol. Las funciones que no devuelven datos
    textuales - por ejemplo, datos arbitrarios leídos desde un socket de red -
    devolverán strings de todos modos.
   </para>
-  <para>
+  <simpara>
    Dado que PHP no dicta una codificación específica para los strings, uno podría
    preguntarse cómo los literales de string están codificados. Por ejemplo, el string
    <literal>"á"</literal> ¿es equivalente a <literal>"\xE1"</literal> (ISO-8859-1),
@@ -1285,7 +1285,7 @@ string(1) "b"
    Tenga en cuenta, sin embargo, que las codificaciones dependientes del estado donde las mismas
    valores de octeto pueden ser utilizados en estados de desplazamiento iniciales y no iniciales
    pueden causar problemas.
-  </para>
+  </simpara>
   <para>
    Por supuesto, para ser útiles, las funciones que operan sobre texto pueden necesitar
    hacer ciertas suposiciones sobre cómo el string está codificado. Desafortunadamente,

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -147,7 +147,7 @@
    o se devuelve desde una función que declara un tipo de retorno.
   </simpara>
 
-  <para>
+  <simpara>
    En este contexto, el valor debe ser de ese tipo. Existen dos excepciones:
    la primera es: si el valor es de tipo <type>int</type> y el tipo declarado
    es <type>float</type>, entonces el entero se convierte en un número de
@@ -158,7 +158,7 @@
    está activo (por omisión), el valor puede convertirse en un valor escalar
    aceptado. Consulte a continuación para obtener una descripción de este
    comportamiento.
-  </para>
+  </simpara>
 
   <warning>
    <simpara>
@@ -248,12 +248,12 @@
    </caution>
 
    <note>
-    <para>
+    <simpara>
      Los tipos que no forman parte de la lista de preferencias anterior no son
      objetivos elegibles para coerción implícita. En particular, no ocurren
      coerciones implícitas a los tipos <type>null</type>, <type>false</type>
      y <type>true</type>.
-    </para>
+    </simpara>
    </note>
 
    <example>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.type-juggling">
  <title>Manipulación de tipos</title>

--- a/language/types/type-system.xml
+++ b/language/types/type-system.xml
@@ -18,10 +18,10 @@
 
  <sect2 xml:id="language.types.type-system.atomic">
   <title>Tipos atómicos</title>
-  <para>
+  <simpara>
    Algunos tipos atómicos son tipos que están estrechamente integrados en el lenguaje
    y no pueden ser reproducidos con tipos definidos por el usuario.
-  </para>
+  </simpara>
 
   <para>
    La lista de tipos básicos es la siguiente:
@@ -161,14 +161,14 @@
 
   <sect3 xml:id="language.types.type-system.composite.intersection">
    <title>Intersección de tipos</title>
-   <para>
+   <simpara>
     Un tipo de intersección acepta valores que satisfacen varias
     declaraciones de tipo de clase, en lugar de una sola.
     Los tipos individuales que forman el tipo de intersección están unidos por el símbolo
     <literal>&amp;</literal>. Por lo tanto, un tipo de intersección compuesto
     por los tipos <literal>T</literal>, <literal>U</literal> y
     <literal>V</literal> se escribe <literal>T&amp;U&amp;V</literal>.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="language.types.type-system.composite.union">
@@ -190,13 +190,13 @@
  <sect2 xml:id="language.types.type-system.alias">
   <title>Alias de tipo</title>
 
-  <para>
+  <simpara>
    PHP soporta dos alias de tipo: <type>mixed</type> y
    <type>iterable</type> que corresponde al tipo
    <link linkend="language.types.type-system.composite.union">tipo de unión</link>
    de <literal>object|resource|array|string|float|int|bool|null</literal>
    y <literal>Traversable|array</literal> respectivamente.
-  </para>
+  </simpara>
 
   <note>
    <simpara>

--- a/language/types/type-system.xml
+++ b/language/types/type-system.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.type-system">
  <title>Sistema de tipos</title>

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.void">
  <title>Void</title>


### PR DESCRIPTION
Fixes #960

Translates EN commit 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb / PR php/doc-en#5746.

## What changed in the English source

The EN commit fixed grammar and wording across all 18 `language/types/` files:

- `<para>` to `<simpara>` conversions throughout
- Hyphenation: "Floating point" -> "Floating-point" (float.xml titles)
- Grammar: "stay in the place" -> "stay in place", "either," -> "either" (callable.xml)
- Typo: "unaccessible" -> "inaccessible" (object.xml)
- Function name: `call_user_function` -> `call_user_func` (callable.xml)
- Minor wording: "straightforward", "the type of the variable passed by reference", etc.

## Impact on the Spanish translation

The Spanish translations do not use any of the corrected English phrases verbatim — they are proper translations, not copied EN text. Specifically:

- `call_user_func` was already correct in the ES callable.xml
- "inaccesible" was already correct in the ES object.xml
- The title uses "Números en coma flotante", not the English "Floating point"

**All 18 files need only an `EN-Revision` header update** to reflect that the ES translation is in sync with the current EN source.