### PR TITLE
[Sync EN] Update EN-Revision for intl/book.xml

### DIFF
--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: a03f9eda2d45b725f75b4d6a1a22e8aec63e157a Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 


### PR DESCRIPTION
Fixes #977

Update EN-Revision to `a03f9eda2d45b725f75b4d6a1a22e8aec63e157a`.

The upstream EN commit only removed a trailing space from English-only text. The ES translation does not contain that text, so no content change is needed.