### PR TITLE
[Sync EN] Update install/unix/debian.xml

### DIFF
--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 2d91caad93e275542dfdc1a99a6fc8a0ed030108 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="install.unix.debian" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -20,7 +20,7 @@
   <title>Uso de APT</title>
   <simpara>
    En primer lugar, tenga en cuenta que otros paquetes pueden ser deseables, como
-   <literal>libapache-mod-php</literal> para la integración con Apache 2, y
+   <literal>libapache2-mod-php</literal> para la integración con Apache httpd 2, y
    <literal>php-pear</literal> para PEAR.
   </simpara>
   <simpara>
@@ -29,7 +29,7 @@
    <command>apt update</command>.
   </simpara>
   <example xml:id="install.unix.debian.apt.example">
-   <title>Ejemplo de instalación en Debian con Apache 2</title>
+   <title>Ejemplo de instalación en Debian con Apache httpd 2</title>
    <programlisting role="shell">
 <![CDATA[
 # apt install php-common libapache2-mod-php php-cli
@@ -37,15 +37,14 @@
    </programlisting>
   </example>
   <simpara>
-   APT instalará y activará automáticamente el módulo PHP para Apache 2, así como todas
-   sus dependencias. Apache deberá ser reiniciado para que los cambios sean efectivos. Por ejemplo:
+   APT instalará y activará automáticamente el módulo PHP para Apache httpd 2, así como todas
+   sus dependencias. Apache httpd deberá ser reiniciado para que los cambios sean efectivos. Por ejemplo:
   </simpara>
   <example xml:id="install.unix.debian.apt.example2">
-   <title>Detener y reiniciar Apache una vez instalado PHP</title>
+   <title>Reiniciar Apache httpd una vez instalado PHP</title>
    <programlisting role="shell">
 <![CDATA[
-# /etc/init.d/apache2 stop
-# /etc/init.d/apache2 start
+# systemctl restart apache2
 ]]>
    </programlisting>
   </example>
@@ -85,10 +84,11 @@
   </example>
   <simpara>
    APT agregará automáticamente las líneas correctas a los ficheros relacionados con &php.ini;, como
-   <filename>/etc/php/7.4/php.ini</filename>,
-   <filename>/etc/php/7.4/conf.d/*.ini</filename>, etc., y según la extensión,
+   <filename>/etc/php/8.x/apache2/php.ini</filename>,
+   <filename>/etc/php/8.x/cli/php.ini</filename>,
+   <filename>/etc/php/8.x/mods-available/*.ini</filename>, etc., y según la extensión,
    agregará entradas similares a <literal>extension=foo.so</literal>.
-   Además, reiniciar el servidor web (Apache, por ejemplo) es necesario para que estos cambios
+   Además, reiniciar el servidor web es necesario para que estos cambios
    sean efectivos.
   </simpara>
  </sect2>


### PR DESCRIPTION
Fixes #979

Update EN-Revision to `2d91caad93e275542dfdc1a99a6fc8a0ed030108`.

Changes mirroring the EN commit:
- Package name corrected: `libapache-mod-php` → `libapache2-mod-php`
- Apache references updated to "Apache httpd 2" throughout
- Replaced obsolete `init.d` stop/start commands with `systemctl restart apache2`
- Updated PHP configuration paths from `7.4` to `8.x` (`apache2/php.ini`, `cli/php.ini`, `mods-available/*.ini`)
- Generalized "reiniciar el servidor web" (removed "Apache, por ejemplo")