### PR TITLE
[Sync EN] Clarify Argon2 memory_cost and time_cost units in password docs

### DIFF
--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66aff414be91c5a0446be585aa6ac78121de1e67 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6cc48aed6f887bdabf09c568f854099f9c74e017 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <appendix xml:id="password.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -58,10 +58,13 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-     </para>
-     <para>
-     </para>
+     <simpara>
+      Costo algorítmico por defecto utilizado por <function>password_hash</function> al
+      hash contraseñas con <constant>PASSWORD_BCRYPT</constant>.
+     </simpara>
+     <simpara>
+      Disponible a partir de PHP 7.0.0.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2i">
@@ -86,11 +89,11 @@
        </para>
       </listitem>
       <listitem>
-       <para>
-        <literal>time_cost</literal> (<type>int</type>) - Tiempo máximo de
-        duración que puede tomar calcular el hash Argon2. Por defecto a
+       <simpara>
+        <literal>time_cost</literal> (<type>int</type>) - Número de iteraciones (pasadas) utilizadas
+        para calcular el hash Argon2. Por defecto a
         <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
-       </para>
+       </simpara>
       </listitem>
       <listitem>
        <para>
@@ -128,13 +131,13 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-      Cantidad de memoria por defecto (en bytes) que será utilizada al
-      intentar calcular un hash.
-     </para>
-     <para>
+     <simpara>
+      Cantidad de memoria por defecto (en kibibytes, KiB) que será utilizada
+      para calcular un hash.
+     </simpara>
+     <simpara>
       Disponible a partir de PHP 7.2.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2-default-time-cost">
@@ -143,13 +146,13 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-      Tiempo por defecto que se tomará para intentar calcular
+     <simpara>
+      Número por defecto de iteraciones (pasadas) utilizadas para calcular
       un hash.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Disponible a partir de PHP 7.2.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2-default-threads">

--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5003a6ea92eb50ac92121782eedfc5ad3fe9d061 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6cc48aed6f887bdabf09c568f854099f9c74e017 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.password-hash" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -104,11 +104,11 @@
      </para>
     </listitem>
     <listitem>
-     <para>
-      <literal>time_cost</literal> (<type>int</type>) - Duración máxima de
-      tiempo que puede tomar para calcular el hash Argon2. Por
+     <simpara>
+      <literal>time_cost</literal> (<type>int</type>) - Número de iteraciones (pasadas)
+      utilizadas para calcular el hash Argon2. Por
       omisión a <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
-     </para>
+     </simpara>
     </listitem>
     <listitem>
      <para>


### PR DESCRIPTION
Fixes #973

Update EN-Revision to `6cc48aed6f887bdabf09c568f854099f9c74e017` for both `reference/password/constants.xml` and `reference/password/functions/password-hash.xml`.

Changes mirroring the EN commit:

**constants.xml:**
- `PASSWORD_BCRYPT_DEFAULT_COST`: fill in previously empty description (uses `<simpara>` as in EN)
- `time_cost` option: clarify as "number of iterations (pasadas)" instead of "maximum duration"
- `PASSWORD_ARGON2_DEFAULT_MEMORY_COST`: correct unit from "bytes" to "kibibytes (KiB)"; convert `<para>` to `<simpara>`
- `PASSWORD_ARGON2_DEFAULT_TIME_COST`: clarify as "number of iterations (pasadas)" instead of "time"; convert `<para>` to `<simpara>`

**password-hash.xml:**
- `time_cost` option: same clarification as above; convert `<para>` to `<simpara>`