### PR TITLE
[Sync EN] Update strtr() examples for clarity

### DIFF
--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1ed119182ad4629064b13301d0e427de47736bfe Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.strtr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -113,15 +113,20 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$addr = "The river å";
 
-// Aquí, strtr() reemplaza octeto por octeto, por lo tanto
-// se asume aquí codificaciones de un solo octeto:
-$addr = strtr($addr, "äåö", "aao");
-echo $addr, PHP_EOL;
-?>
+$original = "He1Lo, w0rld!";
+
+// Con tres argumentos, strtr() realiza una traducción byte a byte.
+$result = strtr($original, "1L0", "llo");
+echo $result;
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello, world!
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -135,9 +140,9 @@ echo $addr, PHP_EOL;
     <programlisting role="php">
 <![CDATA[
 <?php
-$trans = array("h" => "-", "hello" => "hi", "hi" => "hello");
-echo strtr("hi all, I said hello", $trans);
-?>
+
+$replace_pairs = ["h" => "-", "hello" => "hi", "hi" => "hello"];
+echo strtr("hi all, I said hello", $replace_pairs);
 ]]>
     </programlisting>
     &example.outputs;
@@ -157,11 +162,22 @@ hello all, I said hi
     <programlisting role="php">
 <![CDATA[
 <?php
-echo strtr("baab", "ab", "01"),"\n";
 
-$trans = array("ab" => "01");
-echo strtr("baab", $trans);
-?>
+// Caracteres de un solo byte
+$singlebyte_string = "baab";
+echo strtr($singlebyte_string, "ab", "01"), "\n"; // Traducción byte a byte
+
+$replace_pairs = ["ab" => "01"];
+echo strtr($singlebyte_string, $replace_pairs), "\n"; // Traducción de subcadenas
+
+// Caracteres multi-byte
+$multibyte_string = "Ä"; // En UTF-8, codificado como dos bytes: "\xC3\x84"
+
+$result = strtr($multibyte_string, 'Ä', 'A');
+echo bin2hex($result), "\n"; // "4184", donde "c3" pasa a ser "41" ("A"), mientras "84" se mantiene y rompe UTF-8
+
+$replace_pairs = ['Ä' => 'A'];
+echo strtr($multibyte_string, $replace_pairs); // Una traducción de subcadena multi-byte correcta
 ]]>
     </programlisting>
     &example.outputs;
@@ -169,6 +185,8 @@ echo strtr("baab", $trans);
 <![CDATA[
 1001
 ba01
+4184
+A
 ]]>
     </screen>
   </example>


### PR DESCRIPTION
Fixes #966

Update EN-Revision to `1ed119182ad4629064b13301d0e427de47736bfe`.

Changes mirroring the EN commit:
- Replace the first example (Swedish characters) with a clearer ASCII substitution example that explicitly demonstrates byte-by-byte translation
- Update the second example to use short array syntax (`[...]` instead of `array(...)`)
- Expand the third example to show the multibyte character behavior: demonstrates the difference between byte-by-byte (3-arg) and substring (2-arg) translation, including `bin2hex()` output illustrating broken UTF-8 from byte-by-byte replacement