### PR TITLE
[Sync EN] filesystem: Clean up fgetcsv example (#5769)

### DIFF
--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9936f6b7df4f01883b41f60d06fb438e9bf7e667 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.fgetcsv" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -198,19 +198,26 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$row = 1;
-if (($handle = fopen("test.csv", "r")) !== FALSE) {
-    while (($data = fgetcsv($handle, 1000, ",")) !== FALSE) {
-        $num = count($data);
-        echo "<p> $num campos en la línea $row: <br /></p>\n";
-        $row++;
-        for ($c=0; $c < $num; $c++) {
-            echo $data[$c] . "<br />\n";
+
+if (($handle = fopen("test.csv", "r")) !== false) {
+    $row = 1;
+
+    while (($fields = fgetcsv($handle, 1000, ",", "\"", "\\")) !== false) {
+        $num = count($fields);
+
+        echo "\n<p>$num campos en la línea $row:</p>\n<ol>";
+
+        for ($c = 0; $c < $num; $c++) {
+            echo "\n\t<li>", $fields[$c], "</li>";
         }
+
+        echo "\n</ol>";
+
+        $row++;
     }
+
     fclose($handle);
 }
-?>
 ]]>
     </programlisting>
    </example>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5769 (commit 9936f6b).

- `reference/filesystem/functions/fgetcsv.xml`: example rewritten as in EN (`false` instead of `FALSE`, explicit `enclosure`/`escape` arguments, `<ol>`/`<li>` output, no closing `?>`), translated strings kept in Spanish.
- EN-Revision updated.

Fixes: #1001