### PR TITLE
[Sync EN] Clarify that \G and the A modifier do not work with offset in preg_match() (#5652)

### DIFF
--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: aa5a948a110f87b5ca4d2510288e0ad37e21ead0 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.preg-match" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -234,11 +234,12 @@ Array
 )
 ]]>
          </screen>
-         <para>
-          Por lo tanto, para evitar el uso de <function>substr</function>, utilizar
+         <simpara>
+          Como alternativa, para evitar el uso de <function>substr</function>, utilizar
           la aserción <literal>\G</literal> en lugar del ancla <literal>^</literal>, o
-          el modificador <literal>A</literal>, ambos funcionan con el parámetro <parameter>offset</parameter>.
-         </para>
+          el modificador <literal>A</literal>; ninguno de los cuales funciona con
+          el parámetro <parameter>offset</parameter>.
+         </simpara>
         </informalexample>
        </para>
       </note>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5652 (commit aa5a948).

- `reference/pcre/functions/preg-match.xml`: the sentence stated that the `\G` assertion and the `A` modifier work with the `offset` parameter; the EN change fixes it to the opposite, and switches the `para` to a `simpara`.
- EN-Revision updated.

Fixes: #1000