### PR TITLE
[Sync EN] ext/mysqli: Note MYSQLI_TYPE_VECTOR is available as of 8.4.0 (MySQL 9) (#5770)

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 59fd8de0f80a3e4b3d2bc40b91593f70b222a20a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="mysqli.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -818,9 +818,10 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      El campo está definido como <literal>VECTOR</literal>.
-    </para>
+     Disponible a partir de PHP 8.4.0, para MySQL 9.0 y posteriores.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.mysqli-need-data">


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5770 (commit 59fd8de).

- `reference/mysqli/constants.xml`: `MYSQLI_TYPE_VECTOR` now states it is available as of PHP 8.4.0 for MySQL 9.0 and later; `para` turned into `simpara` as in EN.
- EN-Revision updated.

Fixes: #999