### PR TITLE
[Sync EN] ext/gmp: Document that GMP can now be cast to bool (8.4.0) (#5771)

### DIFF
--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 527966eb19d4bbf5f02d0fe82dcb57e417082e25 Maintainer: aeoris Status: ready -->
+<!-- EN-Revision: 021351bd14ec5ce2e25b217d1c7e0ddefa0c3830 Maintainer: aeoris Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.gmp" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -60,6 +60,15 @@
        <entry>8.4.0</entry>
        <entry>
         <classname>GMP</classname> ahora está marcado como <modifier>final</modifier>.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Un objeto <classname>GMP</classname> ahora puede ser convertido a
+        <type>bool</type>; un objeto que representa <literal>0</literal> se convierte
+        en &false;, y cualquier otro valor en &true;. Anteriormente, la conversión a
+        <type>bool</type> emitía un <constant>E_RECOVERABLE_ERROR</constant>.
        </entry>
       </row>
      </tbody>

--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -36,12 +36,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])"/>
    </classsynopsis>
   </section>
 


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5771 (commit 021351b).

- `reference/gmp/gmp.xml`: new changelog row for 8.4.0 about casting a GMP object to bool (0 casts to false, anything else to true; previously an E_RECOVERABLE_ERROR was emitted).
- EN-Revision updated.

Fixes: #998

Also aligns the `xi:include` elements of the touched file with doc-en (self-closing, no `xi:fallback`), which the structure check requires.