### PR TITLE
[Sync EN] Document bool support for allowed_classes in unserialize() (#4768)

### DIFF
--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 64dc79d6c9710dddf196aa28e3c5f63b562e7aef Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b2acdf5697fa3c189f24c3b0147bef57cb8a6c32 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Cambios incompatibles con versiones anteriores</title>
@@ -409,8 +409,8 @@
     La opción <literal>"allowed_classes"</literal> para
     <function>unserialize</function> ahora lanza
     <exceptionname>TypeError</exceptionname> y
-    <exceptionname>ValueError</exceptionname> si no es un
-    <type>array</type> de nombres de clase.
+    <exceptionname>ValueError</exceptionname> si no es ni un
+    <type>array</type> de nombres de clase ni un <type>bool</type>.
    </simpara>
   </sect3>
 

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: b2acdf5697fa3c189f24c3b0147bef57cb8a6c32 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -150,9 +150,9 @@
   </simpara>
   <simpara>
    A partir de PHP 8.4.0, si el elemento <literal>allowed_classes</literal> de
-   <parameter>options</parameter> no es un <type>array</type> de nombres de clases,
-   <function>unserialize</function> lanza <exceptionname>TypeError</exceptionname>
-   y <exceptionname>ValueError</exceptionname>.
+   <parameter>options</parameter> no es ni un <type>array</type> de nombres de clases
+   ni un <type>bool</type>, <function>unserialize</function> lanza
+   <exceptionname>TypeError</exceptionname> y <exceptionname>ValueError</exceptionname>.
   </simpara>
  </refsect1>
 
@@ -173,7 +173,8 @@
        <entry>
         Ahora lanza <exceptionname>TypeError</exceptionname> y
         <exceptionname>ValueError</exceptionname> si el elemento <literal>allowed_classes</literal>
-        de <parameter>options</parameter> no es un <type>array</type> de nombres de clases.
+        de <parameter>options</parameter> no es ni un <type>array</type> de nombres de clases
+        ni un <type>bool</type>.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#4768 (commit b2acdf5).

- `appendices/migration84/incompatible.xml` and `reference/var/functions/unserialize.xml`: the `allowed_classes` option throws TypeError and ValueError when it is neither an array of class names nor a bool (a bool is valid, as documented in the options table).
- EN-Revision updated in both files.

Fixes: #997