### PR TITLE
[Sync EN] Correct memory usage estimation in range() documentation (#4680)

### DIFF
--- a/language/generators.xml
+++ b/language/generators.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 50e6f42c83ac3f6de5e1086b649e06adedd562ff Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: a8c1fc582e4917898980533b90fab4a598aede0f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
@@ -31,15 +31,15 @@
    Al igual que con los iteradores, el acceso aleatorio a los datos no es posible.
   </para>
 
-  <para>
+  <simpara>
    Un ejemplo sencillo de este mecanismo es la reimplementación
    de la función <function>range</function> en forma de generador.
    La función estándar <function>range</function> debe generar un array
    que contenga cada valor y devolverlo, lo cual puede llevar
    a arrays de gran tamaño: por ejemplo, la llamada al código
    <command>range(0, 1000000)</command> puede consumir significativamente más de
-   100 MB de memoria.
-  </para>
+   10 MB de memoria.
+  </simpara>
 
   <para>
    Como alternativa, se puede implementar un generador


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#4680 (commit a8c1fc5).

- `language/generators.xml`: `range(0, 1000000)` memory estimate corrected from 100 MB to 10 MB; the paragraph is now a `simpara` as in EN.
- EN-Revision updated.

Fixes: #996