### PR TITLE
[Sync EN] Fix mb_http_input() ValueError version from 8.4.0 to 8.0.0 (#5252)

### DIFF
--- a/reference/mbstring/functions/mb-http-input.xml
+++ b/reference/mbstring/functions/mb-http-input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d553fa36940639b0889ec4358fa3bbb92f123b69 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 2fab26790083c132d6daeb0a0bfa41d5cc0894e0 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.mb-http-input" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -71,16 +71,11 @@
     </thead>
     <tbody>
      <row>
-      <entry>8.4.0</entry>
+      <entry>8.0.0</entry>
       <entry>
        <function>mb_http_input</function> ahora levanta una
        excepción <exceptionname>ValueError</exceptionname> si <parameter>type</parameter>
        es inválido.
-      </entry>
-     </row>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
        <parameter>type</parameter> ahora es nullable.
       </entry>
      </row>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5252 (commit 2fab267).

- `reference/mbstring/functions/mb-http-input.xml`: the ValueError on an invalid `type` dates back to 8.0.0, not 8.4.0; both changelog rows merged into the 8.0.0 one as in EN.
- EN-Revision updated.

Fixes: #995