### PR TITLE
[Sync EN] Clarify forward_static_call_array() behavior outside a class context (#5241)

### DIFF
--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c6fb604f39a0fa7bf1ae872064b2a3a24f23d855 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 846dfb87daacac70877c332686d60c7dfd0f15d8 Maintainer: seros Status: ready -->
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call_array</refname>
@@ -14,15 +14,24 @@
    <methodparam><type>callable</type><parameter>function</parameter></methodparam>
    <methodparam><type>array</type><parameter>parameters</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Llama a una función o método definido por el usuario, dado por el parámetro
-   <parameter>function</parameter>. Esta función debe ser llamada dentro del contexto de un método, no
-   se puede usar fuera de una clase.
-   Usa el <link linkend="language.oop5.late-static-bindings">Enlace estático
+   <parameter>function</parameter>, con los argumentos pasados como matriz,
+   similar a <function>call_user_func_array</function>.
+   Cuando se llama dentro del contexto de un método, usa el
+   <link linkend="language.oop5.late-static-bindings">Enlace estático
    en tiempo de ejecución</link>.
-   Todos los argumentos del método a llamar se pasan como valores,
-   y como matriz, similar a <function>call_user_func_array</function>.
-  </para>
+   Cuando se llama fuera del contexto de una clase, se comporta como
+   <function>call_user_func_array</function>, sin enlace estático en tiempo de ejecución.
+  </simpara>
+  <note>
+   <simpara>
+    A diferencia de <function>forward_static_call</function>, esta función no
+    requiere un ámbito de clase activo: llamar a
+    <function>forward_static_call</function> fuera de una clase lanza un
+    <exceptionname>Error</exceptionname>, mientras que esta función no.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5241 (commit 846dfb8).

- `reference/funchand/functions/forward-static-call-array.xml`: the description no longer claims the function must be called within a method context; outside a class it behaves like `call_user_func_array()` without late static binding, and a note records the asymmetry with `forward_static_call()`.
- EN-Revision updated.

Note: the Spanish file still uses the pre-8.0 parameter names (`function`/`parameters`) in the synopsis, so the prose keeps `function` for consistency; renaming them to `callback`/`args` is left out of this sync.

Fixes: #994