### PR TITLE
[Sync EN] ext/odbc: document the row default value change to null in fetch_object/array/into (PHP 8.4) (#5768)

### DIFF
--- a/reference/uodbc/functions/odbc-fetch-array.xml
+++ b/reference/uodbc/functions/odbc-fetch-array.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.odbc-fetch-array" xmlns="http://docbook.org/ns/docbook">
@@ -36,9 +36,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       El número de la línea que debe ser leída, opcional.
-      </para>
+      <simpara>
+       El número de la línea a recuperar, comenzando en 1. Si se omite o es &null;,
+       se lee la línea siguiente del conjunto de resultados, como hace
+       <function>odbc_fetch_row</function>. Si el controlador no soporta la
+       lectura de líneas por número, este parámetro es ignorado.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -68,7 +71,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> es ahora nullable.
+       <parameter>row</parameter> es ahora nullable, y su valor por omisión
+       ha cambiado de <literal>-1</literal> a &null;, de forma coherente con
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-into.xml
+++ b/reference/uodbc/functions/odbc-fetch-into.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.odbc-fetch-into" xmlns="http://docbook.org/ns/docbook">
@@ -47,9 +47,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       El número de la línea.
-      </para>
+      <simpara>
+       El número de la línea a leer, comenzando en 1. Si se omite o es &null;,
+       se lee la línea siguiente del conjunto de resultados, como hace
+       <function>odbc_fetch_row</function>. Si el controlador no soporta la
+       lectura de líneas por número, este parámetro es ignorado.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -78,7 +81,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> es ahora nullable.
+       <parameter>row</parameter> es ahora nullable, y su valor por omisión
+       ha cambiado de <literal>0</literal> a &null;, de forma coherente con
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-object.xml
+++ b/reference/uodbc/functions/odbc-fetch-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.odbc-fetch-object" xmlns="http://docbook.org/ns/docbook">
@@ -36,9 +36,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       El número de línea a recuperar, opcional.
-      </para>
+      <simpara>
+       El número de la línea a recuperar, comenzando en 1. Si se omite o es &null;,
+       se lee la línea siguiente del conjunto de resultados, como hace
+       <function>odbc_fetch_row</function>. Si el controlador no soporta la
+       lectura de líneas por número, este parámetro es ignorado.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -68,7 +71,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> es ahora nullable.
+       <parameter>row</parameter> es ahora nullable, y su valor por omisión
+       ha cambiado de <literal>-1</literal> a &null;, de forma coherente con
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5768 (commit 5035039).

- `reference/uodbc/functions/odbc-fetch-array.xml`, `odbc-fetch-into.xml`, `odbc-fetch-object.xml`: the `row` parameter description now states it is 1-based, that omitting it (or passing null) fetches the next row like `odbc_fetch_row()`, and that drivers without row-number support ignore it; the 8.4.0 changelog row records the default value change (-1 / 0 to null). `para` turned into `simpara` as in EN.
- EN-Revision updated in the three files.

Fixes: #982