### PR TITLE
[Sync EN] ext/opcache: document the JIT default change and startup fatal error (PHP 8.4) (#5738)

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f2cdcd5af4558c22db95463b6ccdd25e4cea3cf5 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 36d18e7d4a32ecfdacc1eb086276ffb1baf0393c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="opcache.configuration">
  &reftitle.runtime;
@@ -1175,7 +1175,9 @@ function getA() { return A; }
      <member><literal>off</literal>:  Desactivado, pero puede ser activado durante el tiempo de ejecución.</member>
      <member>
       <literal>tracing</literal>/<literal>on</literal>: Utiliza el tracing JIT.
-      Activado por omisión y recomendado para la mayoría de los usuarios.
+      Recomendado para la mayoría de los usuarios. Antes de PHP 8.4.0, este era el
+      valor por omisión; a partir de PHP 8.4.0 el valor por omisión es
+      <literal>disable</literal>.
      </member>
      <member><literal>function</literal>: Utiliza el function JIT.</member>
     </simplelist>
@@ -1238,6 +1240,12 @@ function getA() { return A; }
      El modo <literal>"tracing"</literal> corresponde a <code>CRTO = 1254</code>,
      el modo <literal>"function"</literal> corresponde a <code>CRTO = 1205</code>.
     </para>
+    <note>
+     <simpara>
+      A partir de PHP 8.4.0, si el JIT está activado, PHP termina con un error fatal
+      durante el arranque cuando la inicialización del JIT falla.
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="ini.opcache.jit-buffer-size">


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5738 (commit 36d18e7).

- `reference/opcache/ini.xml`: the `tracing`/`on` mode is no longer described as enabled by default (the default is `disable` as of PHP 8.4.0), and a note records that PHP exits with a fatal error at startup when JIT initialization fails.
- EN-Revision updated.

Fixes: #978