### PR TITLE
[Sync EN] ext/soap: document PHP 8.4 changes (#5735)

### DIFF
--- a/reference/soap/soapclient.xml
+++ b/reference/soap/soapclient.xml
@@ -246,12 +246,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])"/>
    </classsynopsis>
    <!-- }}} -->
   </section>

--- a/reference/soap/soapclient.xml
+++ b/reference/soap/soapclient.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 89205c88a79fcaad39fd043ed5ef695cd7bf813e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.soapclient" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -74,7 +74,7 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>private</modifier>
-     <type class="union"><type>resource</type><type>null</type></type>
+     <type class="union"><type>array</type><type>null</type></type>
      <varname linkend="soapclient.props.typemap">typemap</varname>
      <initializer>null</initializer>
     </fieldsynopsis>
@@ -493,8 +493,15 @@
     <varlistentry xml:id="soapclient.props.typemap">
      <term><varname>typemap</varname></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       Un array de correspondencias de tipos utilizadas para las conversiones
+       personalizadas de tipos XML a PHP, o &null; si no hay ninguna
+       correspondencia de tipos configurada.
+       A partir de PHP 8.4.0, esta propiedad es de tipo <type>array</type>;
+       anteriormente era de tipo <type>resource</type>.
+       El código que utiliza <function>is_resource</function> para comprobar esta
+       propiedad debe ser actualizado en consecuencia.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="soapclient.props.uri">

--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="soapclient.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -367,6 +367,13 @@
            pero los métodos mágicos <link linkend="object.set">__set()</link> y
            <link linkend="object.get">__get()</link> para las propiedades individuales sí lo serán.
           </para>
+          <simpara>
+           A partir de PHP 8.4.0, las claves también pueden ser especificadas usando la
+           notación de Clark, en la forma <literal>{namespace}type</literal>, para asociar
+           un tipo de un espacio de nombres XML específico, por ejemplo
+           <literal>'{http://example.com}foo'</literal>. Esto es útil cuando el mismo
+           nombre de tipo está definido en más de un espacio de nombres.
+          </simpara>
          </listitem>
         </varlistentry>
         <varlistentry xml:id="soapclient.construct.options.typemap">

--- a/reference/soap/soapserver/construct.xml
+++ b/reference/soap/soapserver/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapserver.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -42,12 +42,16 @@
        un juego de caracteres de codificación interna (<literal>encoding</literal>)
        y una URI actor (<literal>actor</literal>).
       </para>
-      <para>
+      <simpara>
        La opción <literal>classmap</literal> puede ser utilizada para ligar
        algunos tipos WSDL a clases PHP. Esta opción debe ser un
        array con los tipos WSDL como claves y los nombres de las clases PHP
        como valores.
-      </para>
+       A partir de PHP 8.4.0, las claves también pueden ser especificadas usando la
+       notación de Clark, en la forma <literal>{namespace}type</literal>, para asociar
+       un tipo de un espacio de nombres XML específico, por ejemplo
+       <literal>'{http://example.com}foo'</literal>.
+      </simpara>
       <para>
        La opción <literal>typemap</literal> es un array cuyas claves son
        <literal>type_name</literal>, <literal>type_ns</literal> (URI del espacio de nombres),

--- a/reference/soap/soapserver/setpersistence.xml
+++ b/reference/soap/soapserver/setpersistence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 89ae180a851621c308f0ea4604ff2e919aa57a7f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="soapserver.setpersistence" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -71,6 +71,34 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <constant>SOAP_PERSISTENCE_SESSION</constant> ahora funciona cuando la extensión
+       session está compilada como módulo compartido; anteriormente fallaba
+       silenciosamente.
+       <methodname>SoapServer::setPersistence</methodname> ahora también lanza un
+       <exceptionname>Error</exceptionname> cuando se solicita
+       <constant>SOAP_PERSISTENCE_SESSION</constant> mientras que la extensión session
+       no está disponible.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/soap/soapvar/construct.xml
+++ b/reference/soap/soapvar/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="soapvar.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -90,6 +90,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Una instancia de <classname>DateTimeInterface</classname> utilizada como valor
+       de un elemento <literal>xsd:dateTime</literal>, o de un tipo de fecha y hora
+       similar, ahora es serializada en su representación ISO 8601, en lugar de ser
+       serializada como una cadena vacía.
+      </entry>
+     </row>
      <row>
       <entry>8.0.3</entry>
       <entry>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5735 (commit d20d66d).

- `reference/soap/soapclient.xml`: `typemap` property is now array|null instead of resource|null, with a description of the BC break.
- `reference/soap/soapclient/construct.xml` and `reference/soap/soapserver/construct.xml`: classmap keys may use Clark notation ({namespace}type) as of 8.4.0.
- `reference/soap/soapserver/setpersistence.xml`: new changelog section about SOAP_PERSISTENCE_SESSION with a shared session module, and the Error thrown when session is unavailable.
- `reference/soap/soapvar/construct.xml`: new 8.4.0 changelog row about DateTimeInterface values serialized to ISO 8601.
- EN-Revision updated in the five files.

Fixes: #976

Also aligns the `xi:include` elements of the touched files with doc-en (self-closing, no `xi:fallback`), which the structure check requires.