### PR TITLE
[Sync EN] Clarify PECL deprecation (#5622) and document typed class constants for SPL and SQLite3 (#5736)

### DIFF
--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d1fa3096926b6cbaf9da1f831b6fe3302ae2e490 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7b3094477569cda19b14bf61f244b60d24a5e479 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Instalación de extensiones PECL</title>
+ &pecl.moving.to.pie;
 
  <sect1 xml:id="install.pecl.intro">
   <title>Introducción a las instalaciones PECL</title>
@@ -118,6 +119,7 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
 
  <sect1 xml:id="install.pecl.windows">
   <title>Instalación de una extensión PHP en Windows</title>
+  &pecl.moving.to.pie;
   <para>
    Hay dos formas de cargar una extensión PHP en Windows: compilarla en
    PHP o cargar la DLL.
@@ -319,6 +321,7 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
 
  <sect1 xml:id="install.pecl.pear">
   <title>Compilación de extensiones PECL compartidas con el comando pecl</title>
+  &pecl.moving.to.pie;
   <simpara>
    PECL facilita la creación de extensiones PHP compartidas.
    Usando el
@@ -368,6 +371,7 @@ $ pecl install extname-0.1
 
  <sect1 xml:id="install.pecl.phpize">
   <title>Compilación de extensiones PECL compartidas con phpize</title>
+  &pecl.moving.to.pie;
   <simpara>
    A veces, usar el instalador <command>pecl</command> no es una opción.
    Esto podría deberse a que hay un firewall o porque la extensión que se está
@@ -417,7 +421,7 @@ $ make
   <title>
    <command>php-config</command>
   </title>
-
+  &pecl.moving.to.pie;
   <para>
    <command>php-config</command>
    es un script de shell simple para obtener información sobre la configuración instalada de PHP.
@@ -527,6 +531,7 @@ Options:
 
  <sect1 xml:id="install.pecl.static">
   <title>Compilación de extensiones PECL estáticamente en PHP</title>
+  &pecl.moving.to.pie;
   <simpara>
    Puede ser necesario compilar una extensión PECL estáticamente en el binario de PHP.
    Para hacerlo, el código fuente de la extensión deberá colocarse bajo el

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9eb61e3573bc9af825caa0aba34932850aa1b666 Maintainer: argosback Status: ready -->
+<!-- EN-Revision: 7b3094477569cda19b14bf61f244b60d24a5e479 Maintainer: argosback Status: ready -->
 <!-- Reviewed: yes Maintainer: argosback -->
 
 <!ENTITY installation.enabled.disable 'Esta extensión está activada por defecto. Puede ser desactivada utilizando la opción de configuración: '>
@@ -7,6 +7,13 @@
 <!-- Not used in EN anymore -->
 <!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>El generador
 de números aleatorios se inicializa automáticamente.</entry></row>'>
+
+<!ENTITY changelog.class-constants-typed '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  Las constantes de clase ahora son tipadas.
+ </entry>
+</row>'>
 
 <!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
@@ -2036,13 +2043,13 @@ para esta extensión <acronym xmlns="http://docbook.org/ns/docbook">PECL</acrony
 <!ENTITY pecl.moved-ver 'Esta extensión ha sido movida al módulo &link.pecl;
 y no será integrada en PHP a partir de PHP '>
 
-<!ENTITY pecl.moving.to.pie '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pecl.moving.to.pie '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  El instalador de Extensiones para PHP (PHP Installer for Extensions - <acronym>PIE</acronym>) es una nueva herramienta que reemplazará PECL.
-  Recomendamos usar PIE para instalar extensiones.
+  PECL está obsoleto.
+  El instalador de Extensiones para PHP (PHP Installer for Extensions - <acronym>PIE</acronym>) reemplaza a PECL y es el recomendado para instalar extensiones.
   Más información en <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://github.com/php/pie">https://github.com/php/pie</link>
  </simpara>
-</note>'>
+</warning>'>
 
 <!ENTITY warn.pecl.unmaintained '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>Esta extensión es <emphasis>no mantenida</emphasis>.</simpara>

--- a/reference/spl/arrayiterator.xml
+++ b/reference/spl/arrayiterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 077aab2687db07bcf71c2c7e26f677ea61f5916a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <reference xml:id="class.arrayiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase <classname>ArrayIterator</classname></title>
@@ -101,6 +101,23 @@
      </varlistentry>
     </variablelist>
    </section>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/spl/arrayiterator.xml
+++ b/reference/spl/arrayiterator.xml
@@ -65,12 +65,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eff22719b03a83400103686b87d5b470c1d5c785 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <reference xml:id="class.arrayobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase <classname>ArrayObject</classname></title>
@@ -102,6 +102,23 @@
      </varlistentry>
     </variablelist>
    </section>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -63,12 +63,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayObject'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/cachingiterator.xml
+++ b/reference/spl/cachingiterator.xml
@@ -83,17 +83,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CachingIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/cachingiterator.xml
+++ b/reference/spl/cachingiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: PhilDaiguille -->
 <reference xml:id="class.cachingiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase CachingIterator</title>
@@ -172,6 +172,23 @@
         La clase <classname>CachingIterator</classname> implementa ahora <interfacename>Stringable</interfacename>.
        </entry>
       </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
      </tbody>
     </tgroup>
    </informaltable>

--- a/reference/spl/filesystemiterator.xml
+++ b/reference/spl/filesystemiterator.xml
@@ -107,20 +107,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/filesystemiterator.xml
+++ b/reference/spl/filesystemiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <reference xml:id="class.filesystemiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -226,6 +226,23 @@
    </variablelist>
   </section>
   <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/multipleiterator.xml
+++ b/reference/spl/multipleiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <reference xml:id="class.multipleiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -116,6 +116,23 @@
    </variablelist>
   </section>
   <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/multipleiterator.xml
+++ b/reference/spl/multipleiterator.xml
@@ -59,12 +59,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MultipleIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MultipleIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MultipleIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MultipleIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/recursivearrayiterator.xml
+++ b/reference/spl/recursivearrayiterator.xml
@@ -38,9 +38,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -51,17 +49,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivearrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivearrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveArrayIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/recursivearrayiterator.xml
+++ b/reference/spl/recursivearrayiterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.recursivearrayiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase RecursiveArrayIterator</title>
@@ -94,6 +94,23 @@
      </variablelist>
     </section>
   }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/recursiveiteratoriterator.xml
+++ b/reference/spl/recursiveiteratoriterator.xml
@@ -59,12 +59,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveIteratorIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/recursiveiteratoriterator.xml
+++ b/reference/spl/recursiveiteratoriterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Marqitos Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: Marqitos Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <reference xml:id="class.recursiveiteratoriterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -105,6 +105,23 @@
    </variablelist>
   </section>
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/recursivetreeiterator.xml
+++ b/reference/spl/recursivetreeiterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <reference xml:id="class.recursivetreeiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -173,6 +173,23 @@
   </section>
   <!-- }}} -->
 
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/recursivetreeiterator.xml
+++ b/reference/spl/recursivetreeiterator.xml
@@ -32,9 +32,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -92,17 +90,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveTreeIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveTreeIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveTreeIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveTreeIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -83,20 +83,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RegexIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.regexiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase RegexIterator</title>
@@ -209,6 +209,23 @@
      </variablelist>
     </section>
   }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/spldoublylinkedlist.xml
+++ b/reference/spl/spldoublylinkedlist.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: andresdzphp Status: ready -->
 <!-- Reviewed: yes Maintainer: andresdzphp -->
 <reference xml:id="class.spldoublylinkedlist" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase SplDoublyLinkedList</title>
@@ -144,6 +144,23 @@
      </variablelist>
     </section>
   }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/spldoublylinkedlist.xml
+++ b/reference/spl/spldoublylinkedlist.xml
@@ -69,9 +69,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/splfileobject.xml
+++ b/reference/spl/splfileobject.xml
@@ -67,17 +67,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splfileobject.xml
+++ b/reference/spl/splfileobject.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: aeoris Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: aeoris Status: ready -->
 <!-- Reviewed: yes Maintainer: seros -->
 <reference xml:id="class.splfileobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -114,6 +114,23 @@
    </variablelist>
   </section>
   <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/splpriorityqueue.xml
+++ b/reference/spl/splpriorityqueue.xml
@@ -62,9 +62,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splpriorityqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplPriorityQueue'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splpriorityqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplPriorityQueue'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/splpriorityqueue.xml
+++ b/reference/spl/splpriorityqueue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <reference xml:id="class.splpriorityqueue" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clasa SplPriorityQueue</title>
@@ -106,6 +106,23 @@
      </variablelist>
     </section>
   }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -250,12 +250,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 <reference xml:id="class.sqlite3" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase <classname>SQLite3</classname></title>
@@ -523,6 +523,23 @@
      </listitem>
     </varlistentry>
    </variablelist>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5622 (commit 7b30944) and php/doc-en#5736 (commit 6a2ad3e). Both English commits change `language-snippets.ent`, so they are synced together in a single pull request.

php/doc-en#5622:
- `language-snippets.ent`: `pecl.moving.to.pie` becomes a `warning` and states that PECL is deprecated and replaced by PIE.
- `install/pecl.xml`: the notice is repeated in the chapter intro and in the Windows, pecl command, phpize, php-config and static compilation sections, as in EN.

php/doc-en#5736:
- `language-snippets.ent`: new `changelog.class-constants-typed` entity (8.4.0, class constants are now typed).
- The 12 SPL class pages and `reference/sqlite3/sqlite3.xml`: new changelog section using that entity.

EN-Revision updated in every touched file.

Fixes: #972
Fixes: #962

Also aligns the `xi:include` elements of the touched files with doc-en (self-closing, no `xi:fallback`), which the structure check requires.