### PR TITLE
[Sync EN] Add INI_ALL to the .user.ini modes list (#4779)

### DIFF
--- a/install/ini.xml
+++ b/install/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9ab074d32484672f93e5d822f42fb94ae9088207 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5f0cb2451f24071abbfd5f42d96d9210605966b0 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
 xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -223,7 +223,8 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    <varname>$_SERVER['DOCUMENT_ROOT']</varname>). En el caso de que el fichero PHP
    esté fuera de la raíz web, solo su directorio será escaneado.
   </simpara>
-  <simpara>Solo las configuraciones INI con los modos <constant>INI_PERDIR</constant>
+  <simpara>Solo las configuraciones INI con los modos <constant>INI_ALL</constant>,
+   <constant>INI_PERDIR</constant>
    y <constant>INI_USER</constant> serán reconocidas en los ficheros INI
    .user.ini-style.
   </simpara>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#4779 (commit 5f0cb24).

- `install/ini.xml`: `INI_ALL` added to the list of INI modes recognized in .user.ini files, alongside `INI_PERDIR` and `INI_USER`.
- EN-Revision updated.

Fixes: #970