### PR TITLE
[Sync EN] Add user and password to the PDO_MYSQL DSN (#5706)

### DIFF
--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3c1bec9d700807df36994cf368ba291214cd424d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 57a2f4c34cc3c74a7040282dcd60b906738a523d Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
  <reference xml:id="ref.pdo-mysql" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
@@ -106,6 +106,26 @@
         <para>
          El nombre de la base de datos.
         </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><literal>user</literal></term>
+       <listitem>
+        <simpara>
+         El nombre del usuario para la conexión. Un nombre de usuario indicado
+         como segundo argumento del constructor de <classname>PDO</classname>
+         tiene prioridad sobre el especificado en el DSN.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><literal>password</literal></term>
+       <listitem>
+        <simpara>
+         La contraseña del usuario para la conexión. Una contraseña indicada
+         como tercer argumento del constructor de <classname>PDO</classname>
+         tiene prioridad sobre la especificada en el DSN.
+        </simpara>
        </listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5706 (commit 57a2f4c).

- `reference/pdo_mysql/reference.xml`: the DSN description documents the `user` and `password` components, noting that the second and third arguments of the PDO constructor take precedence over them.
- EN-Revision updated.

Fixes: #969