### PR TITLE
[Sync EN] Document padding constants for openssl_sign() and openssl_verify() (#5758)

### DIFF
--- a/reference/openssl/functions/openssl-sign.xml
+++ b/reference/openssl/functions/openssl-sign.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ddcd63907372580151daf69458d6a8268232b703 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-sign" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -76,7 +76,11 @@
     <varlistentry>
      <term><parameter>padding</parameter></term>
      <listitem>
-      <simpara>Relleno RSA PSS a utilizar.</simpara>
+      <simpara>
+       Relleno RSA-PSS a utilizar. Puede ser
+       <constant>OPENSSL_PKCS1_PADDING</constant>,
+       <constant>OPENSSL_PKCS1_PSS_PADDING</constant> o <literal>0</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ddcd63907372580151daf69458d6a8268232b703 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -76,7 +76,11 @@ MIIBCgK...</literal>.
     <varlistentry>
      <term><parameter>padding</parameter></term>
      <listitem>
-      <simpara>Relleno RSA PSS a utilizar.</simpara>
+      <simpara>
+       Relleno RSA-PSS a utilizar. Puede ser
+       <constant>OPENSSL_PKCS1_PADDING</constant>,
+       <constant>OPENSSL_PKCS1_PSS_PADDING</constant> o <literal>0</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5758 (commit ddcd639).

- `reference/openssl/functions/openssl-sign.xml` and `reference/openssl/functions/openssl-verify.xml`: the `padding` parameter now lists the accepted values (OPENSSL_PKCS1_PADDING, OPENSSL_PKCS1_PSS_PADDING or 0).
- EN-Revision updated in both files.

Fixes: #967