### PR TITLE
[Sync EN] Fix Uri\WhatWg\Url screens that ignore URL normalization (#5721)

### DIFF
--- a/reference/uri/uri/whatwg/url/getport.xml
+++ b/reference/uri/uri/whatwg/url/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a00f03a6131b0b74c851b06879c528fc9537da8c Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 0e06411471a898974e114bd57f624781fe3a0b89 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-whatwg-url.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::getPort</refname>
@@ -36,16 +36,20 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$url = new \Uri\WhatWg\Url("https://example.com:443");
+$url = new \Uri\WhatWg\Url("https://example.com:8080");
+var_dump($url->getPort());
 
-echo $url->getPort();
+// 443 es el puerto por omisión de https, por lo que no se almacena.
+$url = new \Uri\WhatWg\Url("https://example.com:443");
+var_dump($url->getPort());
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-443
+int(8080)
+NULL
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 0e06411471a898974e114bd57f624781fe3a0b89 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-whatwg-url.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::parse</refname>
@@ -81,7 +81,7 @@ if ($url !== null) {
    &example.outputs;
    <screen>
 <![CDATA[
-Valid URL: https://example.com
+Valid URL: https://example.com/
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/whatwg/url/withport.xml
+++ b/reference/uri/uri/whatwg/url/withport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 0e06411471a898974e114bd57f624781fe3a0b89 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-whatwg-url.withport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::withPort</refname>
@@ -51,16 +51,21 @@
 <![CDATA[
 <?php
 $url = new \Uri\WhatWg\Url("https://example.com:8080");
-$url = $url->withPort(443);
 
-echo $url->getPort();
+// 443 es el puerto por omisión de https, por lo que no se almacena.
+$url = $url->withPort(443);
+var_dump($url->getPort());
+
+$url = $url->withPort(8443);
+var_dump($url->getPort());
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-443
+NULL
+int(8443)
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5721 (commit 0e06411).

- `getport.xml` and `withport.xml`: a WHATWG URL does not store the scheme's default port, so the examples now use `var_dump()` and contrast a kept port with the dropped 443; the screens show `int(8080)`/`NULL` and `NULL`/`int(8443)`.
- `parse.xml`: the screen shows the normalized `https://example.com/` (an empty path normalizes to `/`).
- EN-Revision updated in the three files.

Fixes: #964