### PR TITLE
[Sync EN] Fix grammar in language/predefined (#5755)

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -27,9 +27,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayAccess'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayAccess'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 <!-- {{{ ArrayAccess intro -->
   <section xml:id="arrayaccess.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Interfaz que permite acceder a los objetos de la misma manera que a los arrays.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -33,9 +33,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <reference xml:id="class.iterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -43,10 +43,10 @@
 
   <section xml:id="iterator.iterators">
    <title>Iteradores Predefinidos</title>
-   <para>
+   <simpara>
     PHP ya ofrece un número de iteradores para muchas de las tareas del día a día.
     Véase la lista de <link linkend="spl.iterators">iteradores SPL</link>.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="iterator.examples">

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -51,9 +51,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Serializable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Serializable'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -15,18 +15,20 @@
     Interfaz que permite personalizar la serialización.
    </para>
 
-   <para>
+   <simpara>
     Las clases que implementan esta interfaz ya no soportan
     <link linkend="object.sleep">__sleep()</link> y
     <link linkend="object.wakeup">__wakeup()</link>.
-    El método de serialización es llamado cada vez que una
-    instancia debe ser serializada. No llama al método
-    __destruct() y no tiene ningún efecto sobre el contenido de este método.
-    Cuando los datos son serializados, la clase es conocida y
-    el método unserialize() apropiado es llamado como constructor
-    en lugar de llamar a __construct(). Si es necesario llamar al constructor
-    estándar, se puede hacer en el método.
-   </para>
+    El método <methodname>serialize</methodname> es llamado cada vez que una
+    instancia debe ser serializada.
+    Esto no invoca a <methodname>__destruct</methodname> ni tiene ningún otro
+    efecto secundario, salvo que se programe dentro del método.
+    Cuando los datos son deserializados, la clase es conocida y
+    el método <methodname>unserialize</methodname> apropiado es llamado como
+    constructor en lugar de llamar a <methodname>__construct</methodname>.
+    El constructor puede ser llamado desde el método
+    <methodname>unserialize</methodname> si se desea.
+   </simpara>
 
    <warning>
     <para>

--- a/language/predefined/stdclass.xml
+++ b/language/predefined/stdclass.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos-->
 <reference xml:id="class.stdclass" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -14,14 +14,14 @@
     Una clase genérica vacía con propiedades dinámicas.
    </para>
 
-   <para>
-    Los objetos de esta clase pueden ser instanciados con
-    <link linkend="language.oop5.basic.new">new</link> operador o creados por
+   <simpara>
+    Los objetos de esta clase pueden ser instanciados con el operador
+    <link linkend="language.oop5.basic.new">new</link> o creados por
     <link linkend="language.types.object.casting">conversión a objeto</link>.
     Varias funciones de PHP también crean instancias de esta clase, por ejemplo
     <function>json_decode</function>, <function>mysqli_fetch_object</function>
     o <methodname>PDOStatement::fetchObject</methodname>.
-   </para>
+   </simpara>
 
    <para>
     A pesar de no implementar
@@ -30,12 +30,12 @@
     <code>#[\AllowDynamicProperties]</code> atributo.
    </para>
 
-   <para>
+   <simpara>
     Esto no es una clase base ya que PHP no tiene el concepto de una clase base universal.
-    Sin embargo, es posible crear una clase personalizada que extienda de
+    Sin embargo, es posible crear una clase personalizada que extienda
     <classname>stdClass</classname> y como resultado herede la funcionalidad
     de propiedades dinámicas.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="stdclass.synopsis">

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: seros Status: ready -->
+<!-- EN-Revision: 14013fe63df29683f759044a46feece2955f4caa Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <reference xml:id="class.traversable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
   <!-- {{{ Traversable intro -->
   <section xml:id="traversable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Interfaz para detectar si una clase puede recorrerse mediante &foreach;.
-   </para>
+   </simpara>
    <para>
     Una interfaz abstracta base no puede ser implementada sola. En su lugar, debe ser
     implementada con <interfacename>IteratorAggregate</interfacename> o con
@@ -52,7 +52,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>7.4.0</entry>
+       <entry>8.0.0</entry>
        <entry>
         La interfaz <interfacename>Traversable</interfacename> ahora puede ser implementada
         por clases abstractas. Las clases que la extiendan deben implementar
@@ -68,19 +68,20 @@
   <section role="notes">
    &reftitle.notes;
    <note>
-    <para>
+    <simpara>
      Las clases internas que implementan esta interfaz pueden ser usadas en
      una construcción &foreach; y no necesitan implementar
      <interfacename>IteratorAggregate</interfacename> o
      <interfacename>Iterator</interfacename>.
-    </para>
+    </simpara>
    </note>
    <note>
-    <para>
-     Antes de PHP 7.4.0, esta interfaz interna del motor no podía ser implementada
-     en scripts PHP. Se debe usar <interfacename>IteratorAggregate</interfacename>
+    <simpara>
+     Antes de PHP 8.0.0, esta interfaz interna del motor no podía ser implementada
+     directamente en scripts PHP, ni siquiera por clases abstractas.
+     <interfacename>IteratorAggregate</interfacename>
      o <interfacename>Iterator</interfacename> deben usarse en su lugar.
-    </para>
+    </simpara>
    </note>
   </section>
 

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: seros Status: ready -->
 <!-- Reviewed: no Maintainer: seros -->
 <reference xml:id="class.traversable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -33,10 +33,10 @@
    </classsynopsis>
    <!-- }}} -->
 
-   <para>
-    Esta interfaz no tiene métodos, su único propósito es ser la base
+   <simpara>
+    Esta interfaz no tiene métodos; su único propósito es ser la base
     para todas las clases atravesables.
-   </para>
+   </simpara>
 
   </section>
 

--- a/language/predefined/valueerror.xml
+++ b/language/predefined/valueerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.valueerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ValueError</title>
@@ -11,12 +11,12 @@
 <!-- {{{ Error intro -->
   <section xml:id="valueerror.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Una <classname>ValueError</classname> se lanza cuando el tipo de un argumento es correcto
     pero su valor es incorrecto.
     Por ejemplo, si se pasa un entero negativo cuando la función espera un entero positivo,
     o si se pasa una cadena o un array vacío cuando la función espera que no esté vacío.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/language/predefined/valueerror.xml
+++ b/language/predefined/valueerror.xml
@@ -35,17 +35,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/language/predefined/weakmap.xml
+++ b/language/predefined/weakmap.xml
@@ -52,9 +52,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakmap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakMap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakmap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakMap'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/language/predefined/weakmap.xml
+++ b/language/predefined/weakmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.weakmap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -12,14 +12,14 @@
   <!-- {{{ WeakMap intro -->
   <section xml:id="weakmap.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Un <classname>WeakMap</classname> es un array asociativo (o diccionario) que acepta objetos como claves. Sin embargo, a diferencia
     del similar <classname>SplObjectStorage</classname>, un objeto en una clave de <classname>WeakMap</classname>
     no contribuye al número de referencias del objeto. En otras palabras, si, en un momento dado, la única referencia restante
     a un objeto es la clave de un <classname>WeakMap</classname>, el objeto será recolectado y eliminado del <classname>WeakMap</classname>.
     Su principal caso de uso es la construcción de cachés de datos derivados de un objeto que no necesitan ser conservados
     más tiempo que el objeto.
-   </para>
+   </simpara>
    <para>
     <classname>WeakMap</classname> implementa <interfacename>ArrayAccess</interfacename>,
     <interfacename>Traversable</interfacename> (vía <interfacename>IteratorAggregate</interfacename>),
@@ -64,7 +64,7 @@
    &reftitle.examples;
    <para>
     <example>
-     <title>Ejemplo de uso de un <classname>Weakmap</classname></title>
+     <title>Ejemplo de uso de un <classname>WeakMap</classname></title>
      <programlisting role="php">
       <![CDATA[
 <?php

--- a/language/predefined/weakreference.xml
+++ b/language/predefined/weakreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.weakreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,15 +11,15 @@
 <!-- {{{ WeakReference intro -->
   <section xml:id="weakreference.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Las referencias débiles permiten al programador mantener una referencia a un objeto sin impedir su destrucción.
-    Son útiles para implementar estructuras como cachés.
+    Son útiles para implementar estructuras de tipo caché.
     Si el objeto original ha sido destruido, &null; será devuelto
     al llamar al método <methodname>WeakReference::get</methodname>.
     El objeto original será destruido cuando el
     <link linkend="features.gc.refcounting-basics">contador de referencias</link> llegue a cero;
     la creación de referencias débiles no incrementa el <literal>contador de referencias</literal> del objeto referenciado.
-   </para>
+   </simpara>
    <simpara>
     Las <classname>WeakReference</classname>s no pueden ser serializadas.
    </simpara>

--- a/language/predefined/weakreference.xml
+++ b/language/predefined/weakreference.xml
@@ -37,12 +37,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='WeakReference'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakReference'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='WeakReference'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakReference'])"/>
    </classsynopsis>
 <!-- }}} -->
 


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5755 (commit 029f19d).

- The eight touched intro paragraphs become `simpara`, as in EN.
- `serializable.xml`: paragraph rewritten to match the English wording (method names tagged with `methodname`, and the constructor can be called from within the `unserialize` method).
- `stdclass.xml`: "con el operador new" instead of "con new operador".
- `traversable.xml`: semicolon instead of comma, as in EN.
- `weakmap.xml`: example title fixed to `WeakMap`.
- `weakreference.xml`: "estructuras de tipo caché" (cache-like structures).
- EN-Revision updated in the eight files.

Fixes: #968

Also included, because the structure and EN-Revision checks require it on the touched files: the `xi:include` elements are aligned with doc-en (self-closing, no `xi:fallback`), and `traversable.xml` is synced with php/doc-en#5773 (commit 14013fe): changelog row 7.4.0 corrected to 8.0.0, notes turned into `simpara` and reworded (prior to PHP 8.0.0 the interface could not be implemented directly, not even by abstract classes).