### PR TITLE
[Sync EN] Fix grammar in control structures (#5750)

### DIFF
--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.elseif" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
@@ -144,7 +144,7 @@ Arrays dinámicos:
     <simpara>
      Tenga en cuenta que
      <link linkend="language.types.array.syntax.destructuring">destructuración de arrays</link>
-     mediante <literal>[]</literal> solo es posible a partir de PHP 7.1.0
+     mediante <literal>[]</literal> solo es posible a partir de PHP 7.1.0.
     </simpara>
    </note>
   </para>
@@ -292,9 +292,9 @@ array(4) {
   </para>
   <warning>
    <simpara>
-    La referencia a un <literal>$value</literal> del último elemento del array
+    La referencia al <literal>$value</literal> del último elemento del array
     permanece incluso después del bucle <literal>foreach</literal>. Se recomienda
-    destruir estas referencias utilizando <function>unset</function>.
+    destruirla utilizando <function>unset</function>.
     De lo contrario, ocurrirá el siguiente comportamiento:
    </simpara>
    <informalexample>

--- a/language/control-structures/include-once.xml
+++ b/language/control-structures/include-once.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 89d80c92a1154a2903fff371f0d056bf2ac8ba27 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="function.include-once" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>include_once</title>
  <?phpdoc print-version-for="include_once"?>
- <para>
+ <simpara>
   La expresión <literal>include_once</literal> incluye y
   evalúa el fichero especificado durante la ejecución del script.
-  El comportamiento es similar a
+  Este comportamiento es similar al de
   <function>include</function>,
   pero la diferencia es que si el código ya ha sido incluido, no lo será una segunda vez, y include_once devuelve &true;. Como su nombre indica, el fichero será incluido solo una vez.
- </para>
+ </simpara>
  <para>
   La estructura <literal>include_once</literal> se utiliza
   preferentemente cuando el fichero va a ser

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no Maintainer: Marqitos -->
 
 <sect1 xml:id="function.include" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -160,7 +160,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
  </para>
  <warning>
   <title>Alerta de seguridad</title>
-  <para>
+  <simpara>
    Un fichero remoto puede ser tratado en el servidor remoto
    (dependiendo de la extensión del fichero y si el servidor remoto
    ejecuta PHP o no) pero debe producir siempre un script PHP válido
@@ -169,7 +169,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
    <function>readfile</function> es una función mucho más apropiada.
    De otra manera, debería tener cuidado de asegurar el script remoto
    para que produzca un código válido y deseado.
-   </para>
+  </simpara>
  </warning>
  <para>
   Ver también

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -260,7 +260,7 @@ echo $bar; // muestra 1
   Si el fichero no puede ser incluido, &false; es devuelto y un error
   de nivel <constant>E_WARNING</constant> es enviado.
  </simpara>
- <para>
+ <simpara>
   Si hay funciones definidas en el fichero incluido, pueden ser
   utilizadas en el fichero principal si están antes del
   <function>return</function> o después.
@@ -269,7 +269,7 @@ echo $bar; // muestra 1
   Se recomienda utilizar <function>include_once</function>
   en lugar de verificar si el fichero ya ha sido incluido y por lo tanto devolver
   condicionalmente la inclusión del fichero.
- </para>
+ </simpara>
  <simpara>
   Otra forma de incluir un fichero PHP en una variable es capturar
   la salida utilizando las funciones de

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -145,11 +145,11 @@ $result = match ($x) {
   </informalexample>
  </para>
 
- <para>
+ <simpara>
   Los brazos de la expresión de <literal>match</literal> pueden contener múltiples expresiones
-  separadas por una coma. Se trata de un OU lógico y de una abreviación para múltiples brazos
+  separadas por una coma. Se trata de un O lógico y de una abreviación para múltiples brazos
   que utilizan la misma expresión como resultado.
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php" annotations="non-interactive">
@@ -191,11 +191,11 @@ $expressionResult = match ($condition) {
   </note>
  </para>
 
- <para>
+ <simpara>
   Una expresión <literal>match</literal> debe ser exhaustiva. Si la expresión
   no es tratada por ningún brazo de <literal>match</literal>, se lanza un error
- <classname>UnhandledMatchError</classname>.
- </para>
+  <classname>UnhandledMatchError</classname>.
+ </simpara>
 
  <example>
  <title>Ejemplo de una expresión match no manejada</title>

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: PhilDaiguille Status: ready -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>switch</title>
  <?phpdoc print-version-for="switch"?>
  <simpara>
   La instrucción <literal>switch</literal> equivale a una serie de instrucciones
-  <literal>if</literal>. En numerosas ocasiones, se necesitará comparar la misma variable (o expresión) con un gran número de valores
+  <literal>if</literal> sobre la misma expresión. En las situaciones en las que es
+  necesario comparar la misma variable o expresión con un gran número de valores
   diferentes, y ejecutar diferentes partes de código según el valor
-  al que sea igual. Esto es exactamente para lo que sirve la instrucción
-  <literal>switch</literal>.
+  al que sea igual, la instrucción <literal>switch</literal> suele ser más
+  cómoda y más fácil de leer.
  </simpara>
  <note>
   <simpara>
@@ -23,10 +24,10 @@
   </simpara>
  </note>
  <note>
-  <para>
+  <simpara>
    Téngase en cuenta que switch/case provoca una
    <link linkend="types.comparisions-loose">comparación amplia</link>.
-  </para>
+  </simpara>
  </note>
 
  <para>
@@ -247,7 +248,8 @@ B
  </para>
  <para>
   Para comparaciones más complejas, el valor &true; puede ser utilizado como valor de switch.
-  O, alternativamente, bloques <literal>if</literal>-<literal>else</literal> en lugar de <literal>switch</literal>.
+  O, alternativamente, pueden utilizarse bloques
+  <literal>if</literal>-<literal>else</literal> en lugar de <literal>switch</literal>.
   <informalexample>
    <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
Syncs the Spanish translation with php/doc-en#5750 (commit e674990).

- `include-once.xml`, `include.xml`, `match.xml`, `switch.xml`: the touched paragraphs become `simpara`, as in EN.
- `foreach.xml`: the warning now refers to a single reference to the `$value` of the last element ("destruirla"), and the note about array destructuring ends with a period.
- `switch.xml`: the introduction follows the reworded English text (a series of `if` statements on the same expression; switch is often more convenient and easier to read), and the alternative `if`-`else` blocks form a complete sentence.
- `match.xml`: "OU lógico" typo fixed to "O lógico", indentation of the UnhandledMatchError paragraph fixed.
- `do-while.xml`, `elseif.xml`, `for.xml`: English-only grammar fixes, the Spanish text already matched, so only EN-Revision is bumped.
- EN-Revision updated in the eight files.

Fixes: #965

Also aligns one paragraph of `include.xml` (functions defined in the included file) with the `simpara` used in doc-en, which the structure check requires.