### PR TITLE
[Sync-En] Iterator::rewind: remove link to wrong rewind function, replace with self reference (#5764)

### DIFF
--- a/language/predefined/iterator/rewind.xml
+++ b/language/predefined/iterator/rewind.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7fbb16f538011636999459326a55d5f153ef2c61 Maintainer: yago Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: f0a5e4f7d35f0af1a7e93b383445657bc459914b Maintainer: yago Status: ready -->
 <refentry xml:id="iterator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Iterator::rewind</refname>
@@ -23,7 +22,7 @@
     ejecutado <emphasis>despues</emphasis> &foreach; bucle.
    </para>
    <simpara>
-    Como &foreach; siempre llama a <methodname>rewind</methodname> antes de iniciar
+    Como &foreach; siempre llama a este método antes de iniciar
     la iteración, avanzar manualmente la posición del iterador (por ejemplo mediante
     <methodname>SplFileObject::seek</methodname>) será reiniciado.
    </simpara>


### PR DESCRIPTION
Fixes #1023