### PR TITLE
[Sync-En] Clarify closing identifier indentation behaviour of Heredoc (#5763)

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 0d964bcaac6618dd80b974eb6fcdf3c67ca07340 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: girgias -->
 <sect1 xml:id="language.types.string">
  <title>Cadenas</title>
 


### PR DESCRIPTION
Fixes #984