### PR TITLE
[Sync-En] xml: remove bundled expat and add configure changelog

### DIFF
--- a/reference/intl/intlgregoriancalendar/getgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/getgregorianchange.xml
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <simpara>&style.procedural;</simpara>
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>float</type><methodname>intlgregcal_get_gregorian_change</methodname>
    <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
   </methodsynopsis>

--- a/reference/intl/intlgregoriancalendar/getgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/getgregorianchange.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: a9a5a377cfbff431de8bbdca1a2b7a51c7500ca1 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="intlgregoriancalendar.getgregorianchange" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlGregorianCalendar::getGregorianChange</refname>
@@ -9,21 +8,34 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>float</type><methodname>IntlGregorianCalendar::getGregorianChange</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis role="procedural">
+   <type>float</type><methodname>intlgregcal_get_gregorian_change</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Obtiene la fecha de cambio gregoriana.
+  </simpara>
 
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &no.function.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>
+      Una instancia de <classname>IntlGregorianCalendar</classname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/intl/intlgregoriancalendar/isleapyear.xml
+++ b/reference/intl/intlgregoriancalendar/isleapyear.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: a9a5a377cfbff431de8bbdca1a2b7a51c7500ca1 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="intlgregoriancalendar.isleapyear" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlGregorianCalendar::isLeapYear</refname>
@@ -9,15 +8,20 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>bool</type><methodname>IntlGregorianCalendar::isLeapYear</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis role="procedural">
+   <type>bool</type><methodname>intlgregcal_is_leap_year</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>year</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Determina si el año dado es un año bisiesto.
+  </simpara>
 
  </refsect1>
 
@@ -25,11 +29,19 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>
+      Una instancia de <classname>IntlGregorianCalendar</classname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
     <term><parameter>year</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      El año a comprobar.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/intl/intlgregoriancalendar/isleapyear.xml
+++ b/reference/intl/intlgregoriancalendar/isleapyear.xml
@@ -14,7 +14,7 @@
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
   </methodsynopsis>
   <simpara>&style.procedural;</simpara>
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>intlgregcal_is_leap_year</methodname>
    <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>

--- a/reference/intl/intlgregoriancalendar/setgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/setgregorianchange.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: a9a5a377cfbff431de8bbdca1a2b7a51c7500ca1 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="intlgregoriancalendar.setgregorianchange" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlGregorianCalendar::setGregorianChange</refname>
@@ -9,15 +8,20 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>bool</type><methodname>IntlGregorianCalendar::setGregorianChange</methodname>
    <methodparam><type>float</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis role="procedural">
+   <type>bool</type><methodname>intlgregcal_set_gregorian_change</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>float</type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Establece la fecha de cambio gregoriana.
+  </simpara>
 
  </refsect1>
 
@@ -25,11 +29,19 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>
+      Una instancia de <classname>IntlGregorianCalendar</classname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
     <term><parameter>timestamp</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Instante del cambio, expresado como una marca de tiempo Unix en milisegundos.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/intl/intlgregoriancalendar/setgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/setgregorianchange.xml
@@ -14,7 +14,7 @@
    <methodparam><type>float</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>
   <simpara>&style.procedural;</simpara>
-  <methodsynopsis role="procedural">
+  <methodsynopsis>
    <type>bool</type><methodname>intlgregcal_set_gregorian_change</methodname>
    <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
    <methodparam><type>float</type><parameter>timestamp</parameter></methodparam>

--- a/reference/xml/configure.xml
+++ b/reference/xml/configure.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cdab70215c31e34b90a5f941a33cdf47eeaa12e2 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: c1b9c92d863bd1b4f82b13b4d13b8ab27caa66f0 Maintainer: PhilDaiguille Status: ready -->
 
 <section xml:id="xml.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
@@ -9,19 +8,32 @@
   &installation.enabled.disable;
   <option role="configure">--disable-xml</option>
  </para>
- <para>
-  Estas funciones están activadas por omisión y utilizan la
-  biblioteca expat proporcionada con la distribución. El soporte de XML puede ser desactivado
-  utilizando la opción de compilación
-  <option role="configure">--disable-xml</option>.
-  Si se compila PHP como módulo para Apache 1.3.9 o superior,
-  PHP utilizará automáticamente la biblioteca
-  <productname>expat</productname> proporcionada por Apache. Si no se desea utilizar la biblioteca expat integrada,
-  es necesario compilar PHP con la opción
-  <option role="configure">--with-expat-dir=DIR</option>, donde DIR es el
-  directorio de instalación de la biblioteca expat.
- </para>
  &windows.builtin;
+ <simplesect role="changelog">
+ &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        La opción <option role="configure">--with-libexpat-dir</option> fue renombrada a
+        <option role="configure">--with-expat</option> y ya no acepta un argumento de directorio.
+        La biblioteca expat integrada ha sido eliminada.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </simplesect>
 </section>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Syncs `reference/xml/configure.xml` with php/doc-en commit c1b9c92d863bd1b4f82b13b4d13b8ab27caa66f0.

- Removes the outdated paragraph about bundled expat and `--with-expat-dir=DIR`
- Adds a `<simplesect role="changelog">` with the PHP 7.4.0 entry documenting:
  - `--with-libexpat-dir` renamed to `--with-expat`
  - No longer accepts a directory argument
  - Bundled expat library removed

Fixes #1049