### PR TITLE
[Sync-En] curl: update curl_multi_exec refpurpose

### DIFF
--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6aa7900b52cdf99998a9367ee06f1155850b92b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 13682c8c7717db18862829bfc3ce9dc4a006079d Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.curl-multi-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_exec</refname>
@@ -13,10 +13,10 @@
    <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
    <methodparam><type>int</type><parameter role="reference">still_running</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ejecuta cada gestor de la pila. Este método puede ser llamado
    incluso si un gestor necesita leer o escribir datos.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,10 +38,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un código cURL, definido en las <link linkend="curl.constants">constantes predefinidas</link>
    de cURL.
-  </para>
+  </simpara>
   <note>
    <para>
     Esta función solo retorna errores relacionados con la pila. Problemas

--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 2ebb9660d47e648a28007960bf059d1f691c7f21 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d6aa7900b52cdf99998a9367ee06f1155850b92b Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.curl-multi-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_exec</refname>
-  <refpurpose>Ejecuta las subpeticiones de la sesión cURL</refpurpose>
+  <refpurpose>Ejecuta cada uno de los gestores de la pila</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">


### PR DESCRIPTION
Syncs `reference/curl/functions/curl-multi-exec.xml` with php/doc-en commit d6aa7900b52cdf99998a9367ee06f1155850b92b.

- Updates `refpurpose` from "Ejecuta las subpeticiones de la sesión cURL" to match the new EN description "Processes each of the handles in the stack"
- Removes `<!-- Reviewed: no -->` and `<!-- $Revision$ -->`

Fixes #1073