### PR TITLE
[Sync-En] pcre: replace 'see below' with xref for atomic groups

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c083c88c8e7ed7eb0d14662c0471693dcac42daf Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3e1cd2462664adb2495cff5887671ba8a9909cf9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <!-- splitted from ./en/functions/pcre.xml, last change in rev 1.2 -->
 <chapter xml:id="reference.pcre.pattern.syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -1017,11 +1017,12 @@
    carácter compuesto, independientemente de cuántos caracteres individuales se
    utilicen realmente para renderizarlo.
   </para>
-  <para>
+  <simpara>
    En versiones de PCRE anteriores a 8.32 (que corresponde a versiones de PHP anteriores a 5.4.14 cuando se usa la biblioteca PCRE incluida), <literal>\X</literal>
    es equivalente a <literal>(?>\PM\pM*)</literal>. Es decir, coincide con un carácter sin la propiedad "marca", seguido de cero o más caracteres
-   con la propiedad "marca", y trata la secuencia como un grupo atómico (ver más abajo). Los caracteres con la propiedad "marca" son típicamente acentos que afectan al carácter anterior.
-  </para>
+   con la propiedad "marca", y trata la secuencia como un grupo atómico (ver
+   <xref linkend="regexp.reference.onlyonce"/>). Los caracteres con la propiedad "marca" son típicamente acentos que afectan al carácter anterior.
+  </simpara>
   <para>
    Coincidir con caracteres por propiedad Unicode no es rápido, porque PCRE tiene
    que buscar una estructura que contiene datos para más de quince mil
@@ -1818,6 +1819,9 @@
 
  <section xml:id="regexp.reference.onlyonce">
   <title>Subpatrones de una sola vez</title>
+  <simpara>
+   Los subpatrones de una sola vez también se conocen como <emphasis>grupos atómicos</emphasis>.
+  </simpara>
   <para>
    Con la repetición de maximización y minimización, el fracaso de lo que sigue normalmente hace que el elemento repetido se reevalúe para ver si un número diferente de repeticiones permite que el resto del patrón coincida. A veces es útil
    evitar esto, ya sea para cambiar la naturaleza de la coincidencia, o


### PR DESCRIPTION
Syncs `reference/pcre/pattern.syntax.xml` with php/doc-en commit 3e1cd2462664adb2495cff5887671ba8a9909cf9.

Changes applied:
- `\X` section: `<para>` → `<simpara>`, "see below" → `<xref linkend="regexp.reference.onlyonce"/>`
- Subpattern names section: add `<simpara>` documenting PHP 8.4.0 max name length (128 chars)
- Lookbehind assertions: update to reflect variable-length support in PHP 8.4.0, move old restriction into a historical `<simpara>`
- Once-only subpatterns: add `<simpara>` noting they are also known as "atomic groups"

Fixes #1075