### PR TITLE
[Sync-En] zmq: fix unresolved exception entity references

### DIFF
--- a/reference/zmq/book.xml
+++ b/reference/zmq/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a5b92a30888d6423db112f07a9b344cf6fc4891 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: PhilDaiguille Status: ready -->
 <!-- State: experimental -->
 <book xml:id="book.zmq" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -21,10 +20,19 @@
  &reference.zmq.setup;
 
  &reference.zmq.zmq;
+ &reference.zmq.zmqexception;
+
  &reference.zmq.zmqcontext;
+ &reference.zmq.zmqcontextexception;
+
  &reference.zmq.zmqsocket;
+ &reference.zmq.zmqsocketexception;
+
  &reference.zmq.zmqpoll;
+ &reference.zmq.zmqpollexception;
+
  &reference.zmq.zmqdevice;
+ &reference.zmq.zmqdeviceexception;
 
 </book>
 

--- a/reference/zmq/zmqcontextexception.xml
+++ b/reference/zmq/zmqcontextexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqcontextexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -40,11 +39,9 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqcontextexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -87,7 +84,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqcontextexception;
 
 </reference>
 

--- a/reference/zmq/zmqdeviceexception.xml
+++ b/reference/zmq/zmqdeviceexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqdeviceexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -40,11 +39,9 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqdeviceexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -87,7 +84,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqdeviceexception;
 
 </reference>
 

--- a/reference/zmq/zmqexception.xml
+++ b/reference/zmq/zmqexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -39,9 +38,6 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
@@ -87,7 +83,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqexception;
 
 </reference>
 

--- a/reference/zmq/zmqpollexception.xml
+++ b/reference/zmq/zmqpollexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqpollexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -40,11 +39,9 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqpollexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -87,7 +84,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqpollexception;
 
 </reference>
 

--- a/reference/zmq/zmqsocketexception.xml
+++ b/reference/zmq/zmqsocketexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqsocketexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -40,11 +39,9 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqsocketexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -87,7 +84,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqsocketexception;
 
 </reference>
 


### PR DESCRIPTION
Syncs zmq exception files with php/doc-en commit c517a71287d79c65ea42dff4c6973e22ef5c3bee.

- `book.xml`: adds `&reference.zmq.zmqexception;`, `&reference.zmq.zmqcontextexception;`, `&reference.zmq.zmqsocketexception;`, `&reference.zmq.zmqpollexception;`, `&reference.zmq.zmqdeviceexception;`
- `zmqexception.xml`, `zmqcontextexception.xml`, `zmqdeviceexception.xml`, `zmqpollexception.xml`, `zmqsocketexception.xml`:
  - Removes `&Methods;` classsynopsisinfo and self-referencing `xi:include`
  - Changes `&InheritedMethods;` xi:include from `class.zmq*exception` to `class.exception`
  - Removes `&reference.zmq.entities.zmq*exception;` from bottom of each file

Fixes #1068