### PR TITLE
[Sync-En] outcontrol: clarify ob_get_status buffer_size and ob_start chunk_size

### DIFF
--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af7044e82ac0abe745ce3dfe2169e69a7e8e342f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ob-get-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_get_status</refname>
@@ -106,7 +105,14 @@
     <seglistitem>
      <seg>buffer_size</seg>
      <seg>
-      Tamaño del búfer de salida en bytes
+      Tamaño actualmente asignado del búfer de salida en bytes.
+      Comienza en <literal>16384</literal> bytes con el
+      <parameter>chunk_size</parameter> por defecto, o en
+      <parameter>chunk_size</parameter> redondeado al siguiente múltiplo de
+      <literal>4096</literal> cuando se proporciona uno, y crece en múltiplos de
+      <literal>4096</literal> a medida que se almacena más salida.
+      No es la cantidad de datos en el búfer (véase
+      <literal>buffer_used</literal>).
      </seg>
     </seglistitem>
     <seglistitem>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e58094c4537a9ac89a6a0a7e64a4256d63e05514 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ob-start" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_start</refname>
@@ -111,14 +110,22 @@
     <varlistentry>
      <term><parameter>chunk_size</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si el parámetro opcional <parameter>chunk_size</parameter> es pasado,
-       la función de devolución de llamada es llamada cada nueva línea después
-       de <parameter>chunk_size</parameter> bytes de salida.
+       el búfer se vaciará después de cualquier bloque de código que produzca salida
+       que haga que la longitud del búfer sea igual
+       o superior a <parameter>chunk_size</parameter>.
        El valor por omisión <literal>0</literal> significa
        que toda la salida es almacenada en búfer hasta que el búfer sea desactivado.
+       Un valor de <literal>1</literal> significa que el búfer se vaciará
+       después de cada operación de salida, desactivando efectivamente el almacenamiento en búfer.
+       <parameter>chunk_size</parameter> también determina el tamaño inicial del
+       búfer reportado por <function>ob_get_status</function>:
+       <literal>16384</literal> bytes cuando es <literal>0</literal>, y
+       <parameter>chunk_size</parameter> redondeado al siguiente múltiplo de
+       <literal>4096</literal> en caso contrario.
        Consulte <xref linkend="outcontrol.buffer-size"/> para más detalles.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Closes #1079

Syncs with https://github.com/php/doc-en/commit/1ebafd8a44786824396f95102576426462835869

- `ob-get-status.xml`: expand `buffer_size` description to document initial allocation size, growth in multiples of 4096, and clarify it differs from `buffer_used`
- `ob-start.xml`: update `chunk_size` description (`<para>` → `<simpara>`), document `chunk_size=1` behavior, and document how `chunk_size` determines initial buffer size