### PR TITLE
[Sync-En] curl: document curl_errno/curl_error behavior with multi handles

### DIFF
--- a/reference/curl/functions/curl-errno.xml
+++ b/reference/curl/functions/curl-errno.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: ff7a0054b19ab80290b365d1417550807f82755a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.curl-errno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_errno</refname>
@@ -33,6 +31,15 @@
   <para>
    Devuelve el número de error o <literal>0</literal> si no ha ocurrido ningún error.
   </para>
+  <note>
+   <simpara>
+    Cuando un <type>CurlHandle</type> es ejecutado mediante
+    <function>curl_multi_exec</function>, esta función siempre devuelve
+    <literal>0</literal>. El código de error para cada manejador individual está
+    disponible como la clave <literal>result</literal> devuelta por
+    <function>curl_multi_info_read</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -84,6 +91,7 @@ if(curl_errno($ch))
   <para>
    <simplelist>
     <member><function>curl_error</function></member>
+    <member><function>curl_multi_info_read</function></member>
     <member><link xlink:href="&url.curl.error;">los códigos de error cURL</link></member>
    </simplelist>
   </para>

--- a/reference/curl/functions/curl-error.xml
+++ b/reference/curl/functions/curl-error.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: ff7a0054b19ab80290b365d1417550807f82755a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.curl-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_error</refname>
@@ -34,6 +32,16 @@
    Devuelve el mensaje de error o <literal>''</literal> (string vacío) si no
    ha ocurrido ningún error.
   </para>
+  <note>
+   <simpara>
+    Cuando un <type>CurlHandle</type> es ejecutado mediante
+    <function>curl_multi_exec</function>, esta función siempre devuelve
+    <literal>''</literal> (el string vacío). Para obtener el string de error de
+    cada manejador individual, pase la clave <literal>result</literal> devuelta por
+    <function>curl_multi_info_read</function> a
+    <function>curl_strerror</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -85,6 +93,8 @@ else
   <para>
    <simplelist>
     <member><function>curl_errno</function></member>
+    <member><function>curl_strerror</function></member>
+    <member><function>curl_multi_info_read</function></member>
     <member><link xlink:href="&url.curl.error;">Códigos de error Curl</link></member>
    </simplelist>
   </para>

--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af7044e82ac0abe745ce3dfe2169e69a7e8e342f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ob-get-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_get_status</refname>
@@ -106,7 +105,14 @@
     <seglistitem>
      <seg>buffer_size</seg>
      <seg>
-      Tamaño del búfer de salida en bytes
+      Tamaño actualmente asignado del búfer de salida en bytes.
+      Comienza en <literal>16384</literal> bytes con el
+      <parameter>chunk_size</parameter> por defecto, o en
+      <parameter>chunk_size</parameter> redondeado al siguiente múltiplo de
+      <literal>4096</literal> cuando se proporciona uno, y crece en múltiplos de
+      <literal>4096</literal> a medida que se almacena más salida.
+      No es la cantidad de datos en el búfer (véase
+      <literal>buffer_used</literal>).
      </seg>
     </seglistitem>
     <seglistitem>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e58094c4537a9ac89a6a0a7e64a4256d63e05514 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ob-start" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_start</refname>
@@ -111,14 +110,22 @@
     <varlistentry>
      <term><parameter>chunk_size</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si el parámetro opcional <parameter>chunk_size</parameter> es pasado,
-       la función de devolución de llamada es llamada cada nueva línea después
-       de <parameter>chunk_size</parameter> bytes de salida.
+       el búfer se vaciará después de cualquier bloque de código que produzca salida
+       que haga que la longitud del búfer sea igual
+       o superior a <parameter>chunk_size</parameter>.
        El valor por omisión <literal>0</literal> significa
        que toda la salida es almacenada en búfer hasta que el búfer sea desactivado.
+       Un valor de <literal>1</literal> significa que el búfer se vaciará
+       después de cada operación de salida, desactivando efectivamente el almacenamiento en búfer.
+       <parameter>chunk_size</parameter> también determina el tamaño inicial del
+       búfer reportado por <function>ob_get_status</function>:
+       <literal>16384</literal> bytes cuando es <literal>0</literal>, y
+       <parameter>chunk_size</parameter> redondeado al siguiente múltiplo de
+       <literal>4096</literal> en caso contrario.
        Consulte <xref linkend="outcontrol.buffer-size"/> para más detalles.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Closes #1078

Syncs with https://github.com/php/doc-en/commit/ff7a0054b19ab80290b365d1417550807f82755a

- `curl-errno.xml`: add note that `curl_errno()` always returns 0 when handle was executed via `curl_multi_exec()`; add `curl_multi_info_read` to seealso
- `curl-error.xml`: add note that `curl_error()` always returns empty string when handle was executed via `curl_multi_exec()`; add `curl_strerror` and `curl_multi_info_read` to seealso