### PR TITLE
[Sync-En] info: fix assert/dl/getrusage return docs, E_ALL value

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2916fa4160bdf53bb316a5c7c018fc91df7cd951 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.assert" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>assert</refname>
@@ -14,32 +13,32 @@
    <methodparam><type>mixed</type><parameter>assertion</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>Throwable</type><type>string</type><type>null</type></type><parameter>description</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>assert</function>
    permite definir expectativas: aserciones que tienen efecto
    en los entornos de desarrollo y prueba, pero que están optimizadas
    para no tener costo en producción.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Las aserciones pueden ser utilizadas para ayudar en la depuración.
    Un caso de uso para las aserciones es servir como verificaciones de coherencia
    para precondiciones que deberían siempre ser &true;, y si no lo son,
    esto indica errores de programación.
    Otro caso de uso es garantizar la presencia de ciertas funcionalidades tales como
    funciones de extensión o ciertos límites y funcionalidades del sistema.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Como las aserciones pueden ser configuradas para ser eliminadas, no deben
    <emphasis>ser</emphasis> utilizadas para operaciones normales en tiempo de ejecución,
    tales como verificaciones de parámetros de entrada. En general, el código debe comportarse
    como se espera incluso si la verificación de aserciones está desactivada.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <function>assert</function> verificará que la expectativa dada en
    <parameter>assertion</parameter> sea satisfecha.
    Si no lo es y por lo tanto el resultado es &false;, tomará la acción apropiada
    según la configuración de <function>assert</function>.
-  </para>
+  </simpara>
   <para>
    El comportamiento de <function>assert</function> está dictado por los siguientes parámetros INI:
    <table>
@@ -118,7 +117,7 @@
        <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
        <entry>&true;</entry>
        <entry>
-        Si &true;, lanzará una <classname>AssertionError</classname> si la expectativa no es cumplida.
+        Si &true;, lanzará una <exceptionname>AssertionError</exceptionname> si la expectativa no es cumplida.
        </entry>
        <entry>
         Deprecado a partir de PHP 8.3.0.
@@ -160,20 +159,20 @@
     <varlistentry>
      <term><parameter>assertion</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Esta es cualquier expresión que devuelve un valor, que será ejecutada
        y cuyo resultado será utilizado para indicar si la aserción tuvo éxito o falló.
-      </para>
+      </simpara>
 
       <warning>
-       <para>
+       <simpara>
         Anterior a PHP 8.0.0, si <parameter>assertion</parameter> era una
         <type>string</type>, era interpretada como código PHP y ejecutada vía
         <function>eval</function>.
         Esta cadena era pasada a la función de devolución de llamada como tercer argumento.
         Este comportamiento estaba <emphasis>DEPRECADO</emphasis> en PHP 7.2.0,
         y es <emphasis>ELIMINADO</emphasis> a partir de PHP 8.0.0
-       </para>
+       </simpara>
       </warning>
      </listitem>
     </varlistentry>
@@ -182,40 +181,40 @@
      <listitem>
       <para>
        Si <parameter>description</parameter> es una instancia de
-       <classname>Throwable</classname>, será lanzada únicamente si
+       <exceptionname>Throwable</exceptionname>, será lanzada únicamente si
        <parameter>assertion</parameter> es ejecutada y falla.
        <note>
-        <para>
+        <simpara>
          A partir de PHP 8.0.0, esto se hace <emphasis>antes</emphasis> de llamar
          a la función de devolución de llamada de aserción eventualmente definida
-        </para>
+        </simpara>
        </note>
        <note>
-        <para>
+        <simpara>
          A partir de PHP 8.0.0, el objeto &object; será lanzado independientemente de la configuración de
          <link linkend="ini.assert.exception">assert.exception</link>.
-        </para>
+        </simpara>
        </note>
        <note>
-        <para>
+        <simpara>
          A partir de PHP 8.0.0, el parámetro
          <link linkend="ini.assert.bail">assert.bail</link>
          no tiene ningún efecto en este caso.
-        </para>
+        </simpara>
        </note>
       </para>
-      <para>
+      <simpara>
        Si <parameter>description</parameter> es una &string;, este mensaje
        será utilizado si se emite una excepción o advertencia.
        Una descripción opcional, que será incluida en el mensaje de fallo si
        la <parameter>assertion</parameter> falla.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Si <parameter>description</parameter> es omitido.
        <!-- Esto no ocurre si &null; es pasado ... -->
        Se crea una descripción por defecto equivalente al código fuente de la llamada a
        <function>assert</function> en tiempo de compilación.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -224,21 +223,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <function>assert</function> siempre devolverá &true; si al menos una de las siguientes condiciones es verdadera:
-  </para>
+  </simpara>
   <simplelist>
    <member><literal>zend.assertions=0</literal></member>
    <member><literal>zend.assertions=-1</literal></member>
    <member><literal>assert.active=0</literal></member>
-   <member><literal>assert.exception=1</literal></member>
-   <member><literal>assert.bail=1</literal></member>
-   <member>Un objeto de excepción personalizado es pasado a <parameter>description</parameter>.</member>
   </simplelist>
-  <para>
+  <simpara>
    Si ninguna de las condiciones es verdadera, <function>assert</function> devolverá &true; si
    <parameter>assertion</parameter> es verdadero, y &false; de lo contrario.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -273,7 +269,7 @@
        <entry>8.0.0</entry>
        <entry>
         Si <parameter>description</parameter> es una instancia de
-        <classname>Throwable</classname>, el objeto es lanzado si la aserción falla, independientemente del valor de
+        <exceptionname>Throwable</exceptionname>, el objeto es lanzado si la aserción falla, independientemente del valor de
         <link linkend="ini.assert.exception">assert.exception</link>.
        </entry>
       </row>
@@ -281,7 +277,7 @@
        <entry>8.0.0</entry>
        <entry>
         Si <parameter>description</parameter> es una instancia de
-        <classname>Throwable</classname>, ninguna función de devolución de llamada de usuario
+        <exceptionname>Throwable</exceptionname>, ninguna función de devolución de llamada de usuario
         es llamada incluso si está definida.
        </entry>
       </row>
@@ -330,10 +326,10 @@ echo '¡Hola!';
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Si las aserciones están activadas (<link linkend="ini.zend.assertions"><literal>zend.assertions=1</literal></link>)
      el ejemplo anterior mostraría:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught AssertionError: assert(1 > 2) in example.php:2
@@ -343,10 +339,10 @@ Stack trace:
   thrown in example.php on line 2
 ]]>
     </screen>
-    <para>
+    <simpara>
      Si las aserciones están desactivadas (<literal>zend.assertions=0</literal> o <literal>zend.assertions=-1</literal>)
      el ejemplo anterior mostraría:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 ¡Hola!
@@ -363,10 +359,9 @@ echo '¡Hola!';
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Si las aserciones están activadas, el ejemplo anterior mostraría:
-     el ejemplo anterior mostraría:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught AssertionError: Se esperaba que uno fuera mayor que dos in example.php:2
@@ -376,10 +371,9 @@ Stack trace:
   thrown in example.php on line 2
 ]]>
     </screen>
-    <para>
+    <simpara>
      Si las aserciones están desactivadas, el ejemplo anterior mostraría:
-     el ejemplo anterior mostraría:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 ¡Hola!
@@ -397,10 +391,9 @@ Stack trace:
       echo '¡Hola!';
       ]]>
      </programlisting>
-    <para>
+    <simpara>
      Si las aserciones están activadas, el ejemplo anterior mostraría:
-     el ejemplo anterior mostraría:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught ArithmeticAssertionError: Se esperaba que uno fuera mayor que dos in example.php:4
@@ -409,9 +402,9 @@ Stack trace:
   thrown in example.php on line 4
 ]]>
     </screen>
-     <para>
+     <simpara>
       Si las aserciones están desactivadas, el ejemplo anterior mostraría:
-     </para>
+     </simpara>
      <screen>
 <![CDATA[
 ¡Hola!

--- a/reference/info/functions/dl.xml
+++ b/reference/info/functions/dl.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a89c6d71c7b65e3de84f26230fbf72c9b8948adf Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.dl" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>dl</refname>
@@ -94,16 +92,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success; Si la funcionalidad de carga de módulos no está
    disponible, o ha sido desactivada (desactivando la directiva
    <link linkend="ini.enable-dl">enable_dl</link>
-   en el &php.ini;) se emitirá un <constant>E_ERROR</constant> y
-   la ejecución del script será detenida. Si la función
+   en el &php.ini;) se emitirá un <constant>E_WARNING</constant>
+   y se devolverá &false;. Si la función
    <function>dl</function> falla porque la biblioteca no pudo ser encontrada,
-   <function>dl</function> retornará &false; y emitirá un mensaje de advertencia
+   además de &false; se emitirá un mensaje de advertencia
    <constant>E_WARNING</constant>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xml:id="function.get-defined-constants" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -59,7 +58,7 @@ Array
             [E_USER_ERROR] => 256
             [E_USER_WARNING] => 512
             [E_USER_NOTICE] => 1024
-            [E_ALL] => 2047
+            [E_ALL] => 30719
             [TRUE] => 1
         )
 
@@ -127,7 +126,7 @@ Array
     [E_USER_ERROR] => 256
     [E_USER_WARNING] => 512
     [E_USER_NOTICE] => 1024
-    [E_ALL] => 2047
+    [E_ALL] => 30719
     [TRUE] => 1
 )
 ]]>

--- a/reference/info/functions/getrusage.xml
+++ b/reference/info/functions/getrusage.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a277389c9d2d5a940fcd6dbe62da7e109282379d Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.getrusage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>getrusage</refname>
@@ -105,12 +103,11 @@ echo $dat["ru_stime.tv_sec"]; // tiempo de sistema utilizado (en segundos)
      </member>
     </simplelist>
    </para>
-   <para>
+   <simpara>
     Si <function>getrusage</function> es llamado con el argumento <parameter>mode</parameter>
     valiendo <literal>1</literal> (<constant>RUSAGE_CHILDREN</constant>), entonces la utilización
-    de los recursos para los hilos son recolectados (lo que significa que, internamente,
-    la función es llamada con <constant>RUSAGE_THREAD</constant>).
-   </para>
+    de los recursos para los procesos hijos son recolectados.
+   </simpara>
   </note>
   <note>
    <para>


### PR DESCRIPTION
Closes #1077

Syncs with https://github.com/php/doc-en/commit/5367d2fcdf4b710a81806aba52a71c522f082713

- `assert.xml`: multiple `<para>` → `<simpara>` in description, parameters, returnvalues, and examples sections; `<classname>` → `<exceptionname>` for AssertionError and Throwable; remove extra list members from returnvalues that don't match EN
- `dl.xml`: returnvalues `<para>` → `<simpara>`; fix error level: `E_ERROR` + execution stopped → `E_WARNING` + false returned
- `get-defined-constants.xml`: fix `E_ALL` value from `2047` to `30719`
- `getrusage.xml`: RUSAGE_CHILDREN note: `<para>` → `<simpara>`; fix description (threads → child processes, remove incorrect RUSAGE_THREAD mention)