### PR TITLE
[Sync-En] mysqli: document wait-timeout error code change 2006->4031 (8.4.0)

### DIFF
--- a/reference/mysqli/mysqli/query.xml
+++ b/reference/mysqli/mysqli/query.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d470f625f96a83d65464619297cccad7ce46e743 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: fa76e55f2ea8892e8898f20bb9467ace49b0e91e Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="mysqli.query" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::query</refname>
@@ -126,6 +125,33 @@
  <refsect1 role="errors">
   &reftitle.errors;
   &mysqli.conditionalexception;
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Al conectar a MySQL 8.0.24 o posterior, el código de error reportado
+        para un tiempo de espera del servidor ahora es <literal>4031</literal>
+        (<literal>ER_CLIENT_INTERACTION_TIMEOUT</literal>) en lugar de
+        <literal>2006</literal> (<literal>CR_SERVER_GONE_ERROR</literal>).
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Closes #1076

Syncs with https://github.com/php/doc-en/commit/fa76e55f2ea8892e8898f20bb9467ace49b0e91e

- `mysqli/mysqli/query.xml`: add changelog entry documenting that as of PHP 8.4.0, connecting to MySQL 8.0.24+, the error code for a server wait timeout changes from 2006 (CR_SERVER_GONE_ERROR) to 4031 (ER_CLIENT_INTERACTION_TIMEOUT)