### PR TITLE
[Sync-En] pcntl: fix reference pages and document 8.4 failure return

### DIFF
--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 71fa455c5670ea4a3a3a0c60e34d906d1061a6c8 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: PhilDaiguille Status: ready -->
 <appendix xml:id="pcntl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  <para>
@@ -628,16 +626,6 @@
   <varlistentry xml:id="constant.si-timer">
    <term>
     <constant>SI_TIMER</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.si-msggq">
-   <term>
-    <constant>SI_MSGGQ</constant>
     (<type>int</type>)
    </term>
    <listitem>

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.pcntl-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_exec</refname>
@@ -63,9 +61,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve &false;.
-  </para>
+  <simpara>
+   Devuelve &false; en caso de error. En caso de éxito, la función no retorna
+   ya que la imagen del proceso actual es reemplazada por el programa ejecutado.
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigprocmask.xml
+++ b/reference/pcntl/functions/pcntl-sigprocmask.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.pcntl-sigprocmask" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_sigprocmask</refname>
@@ -85,28 +83,29 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el <parameter>signal</parameter>
-       está vacío.
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el <parameter>signals</parameter>
+       está vacío, excepto si <parameter>mode</parameter> es
+       <constant>SIG_SETMASK</constant>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>TypeError</classname> si el valor de <parameter>signal</parameter>
+       Se lanza una excepción <exceptionname>TypeError</exceptionname> si el valor de <parameter>signals</parameter>
        no es un <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el valor de <parameter>signal</parameter>
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el valor de <parameter>signals</parameter>
        es inválido.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el valor de <parameter>mode</parameter>
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el valor de <parameter>mode</parameter>
        no es <constant>SIG_BLOCK</constant>, <constant>SIG_UNBLOCK</constant> o
        <constant>SIG_SETMASK</constant>.
       </entry>
@@ -136,12 +135,10 @@ pcntl_sigprocmask(SIG_UNBLOCK, array(SIGHUP), $oldset);
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigwaitinfo</function></member>
-    <member><function>pcntl_sigtimedwait</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigwaitinfo</function></member>
+   <member><function>pcntl_sigtimedwait</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigtimedwait.xml
+++ b/reference/pcntl/functions/pcntl-sigtimedwait.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.pcntl-sigtimedwait" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_sigtimedwait</refname>
@@ -90,42 +88,49 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el <parameter>signal</parameter>
+       En caso de fallo, ahora se devuelve &false;; anteriormente
+       se devolvía <literal>-1</literal> en algunos casos.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el <parameter>signals</parameter>
        está vacío.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>TypeError</classname> si el valor de <parameter>signal</parameter>
+       Se lanza una excepción <exceptionname>TypeError</exceptionname> si el valor de <parameter>signals</parameter>
        no es un <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el valor de <parameter>signal</parameter>
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el valor de <parameter>signals</parameter>
        es inválido.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el valor de <parameter>seconds</parameter>
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el valor de <parameter>seconds</parameter>
        es inferior a <literal>0</literal>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el valor de <parameter>nanoseconds</parameter>
-       es inferior a <literal>0</literal>.
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el valor de <parameter>nanoseconds</parameter>
+       no está entre <literal>0</literal> y <literal>1e9</literal>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si los valores de <parameter>seconds</parameter> y
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si los valores de <parameter>seconds</parameter> y
        de <parameter>nanoseconds</parameter> son ambos iguales a <literal>0</literal>.
       </entry>
      </row>
@@ -136,12 +141,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigprocmask</function></member>
-    <member><function>pcntl_sigwaitinfo</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigprocmask</function></member>
+   <member><function>pcntl_sigwaitinfo</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigwaitinfo.xml
+++ b/reference/pcntl/functions/pcntl-sigwaitinfo.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.pcntl-sigwaitinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_sigwaitinfo</refname>
@@ -106,21 +104,28 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el <parameter>signal</parameter>
+       En caso de fallo, ahora se devuelve &false;; anteriormente
+       se devolvía <literal>-1</literal> en algunos casos.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el <parameter>signals</parameter>
        está vacío.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>TypeError</classname> si el valor de <parameter>signal</parameter>
+       Se lanza una excepción <exceptionname>TypeError</exceptionname> si el valor de <parameter>signals</parameter>
        no es un <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Se lanza una excepción <classname>ValueError</classname> si el valor de <parameter>signal</parameter>
+       Se lanza una excepción <exceptionname>ValueError</exceptionname> si el valor de <parameter>signals</parameter>
        es inválido.
       </entry>
      </row>
@@ -155,12 +160,10 @@ pcntl_sigwaitinfo(array(SIGHUP), $info);
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigprocmask</function></member>
-    <member><function>pcntl_sigtimedwait</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigprocmask</function></member>
+   <member><function>pcntl_sigtimedwait</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-unshare.xml
+++ b/reference/pcntl/functions/pcntl-unshare.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d7c1097cca089f4571977b41855e63d3c3638433 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id='function.pcntl-unshare' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_unshare</refname>
@@ -48,20 +47,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve <literal>0</literal> en caso de éxito, <literal>-1</literal> en caso contrario.
+  <simpara>
+   Devuelve &true; en caso de éxito o &false; en caso de error.
    En caso de fallo, define un código de error, que puede ser recuperado con <function>pcntl_get_last_error</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><link linkend="pcntl.constants.clone">Constante PCNTL</link></member>
-    <member><function>pcntl_get_last_error</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><link linkend="pcntl.constants.clone">Constante PCNTL</link></member>
+   <member><function>pcntl_get_last_error</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Closes #1074

Syncs with https://github.com/php/doc-en/commit/253f4bdd29fc3938030dce22882611ceefa9f74a

- `constants.xml`: remove `SI_MSGGQ` constant (does not exist; `SI_MESGQ` is the correct one and is already documented)
- `pcntl-exec.xml`: returnvalues `<para>` → `<simpara>`; clarify that on success the function does not return
- `pcntl-sigprocmask.xml`: `<classname>` → `<exceptionname>` in changelog; `signal` → `signals` parameter name; note that empty signals is accepted when mode is `SIG_SETMASK`; move simplelist out of para in seealso
- `pcntl-sigtimedwait.xml`: same classname→exceptionname, signal→signals; add 8.4.0 row for false return; fix nanoseconds range (≥0 → between 0 and 1e9); move simplelist out of para in seealso
- `pcntl-sigwaitinfo.xml`: same fixes; add 8.4.0 row for false return; move simplelist out of para in seealso
- `pcntl-unshare.xml`: returnvalues: "0 or -1" → true/false; `<para>` → `<simpara>`; move simplelist out of para in seealso