### PR TITLE
[Sync-En] Modernize Apache httpd 2.x installation guide

### DIFF
--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -1,46 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a38e360ae1ce4169b331013958c519d17f19114e Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: fd1f9d85122cd85854f4afdf5a57ab7da38ff69c Maintainer: PhilDaiguille Status: ready -->
 
 <sect1 xml:id="install.unix.apache2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Apache 2.x en sistemas Unix</title>
- <para>
+ <title>Apache httpd 2.x en sistemas Unix</title>
+ <simpara>
   Esta sección contiene las notas y consejos de instalación de PHP con el servidor
-  Apache 2.x en sistemas Unix.
- </para>
+  Apache HTTP Server 2.x en sistemas Linux y similares a Unix.
+ </simpara>
 
- &warn.apache2.compat;
+ <warning>
+  <title>Usar PHP-FPM en su lugar</title>
+  <simpara>
+   <emphasis role="strong">No utilice <literal>mod_php</literal> para nuevas
+   instalaciones.</emphasis> Las instrucciones de esta página se mantienen
+   como referencia histórica y para los casos excepcionales en que se requiere
+   incrustar PHP directamente en el proceso de Apache httpd.
+  </simpara>
+  <simpara>
+   Para todos los despliegues modernos, use
+   <link linkend="install.fpm">PHP-FPM</link> (FastCGI Process Manager)
+   con el módulo <literal>mod_proxy_fcgi</literal> de Apache httpd. PHP-FPM
+   ofrece una mejor gestión de recursos, aislamiento de procesos, reinicio
+   independiente de PHP sin reiniciar Apache httpd, y compatibilidad con el
+   MPM <literal>event</literal> de Apache httpd (el predeterminado desde
+   Apache httpd 2.4). Las principales distribuciones Linux lo incluyen como
+   configuración por defecto.
+  </simpara>
+  <simpara>
+   El método <literal>mod_php</literal> incrusta PHP directamente en cada
+   proceso worker de Apache httpd. A menos que PHP se compile con seguridad
+   de hilos (<literal>--enable-zts</literal>), <literal>mod_php</literal>
+   requiere el MPM <literal>prefork</literal>, lo que limita significativamente
+   la concurrencia. Si se procede con <literal>mod_php</literal>, se deben
+   comprender plenamente las implicaciones de rendimiento y seguridad.
+  </simpara>
+ </warning>
 
- <para>
+ <simpara>
   La <link xlink:href="&url.apache2.docs;">Documentación Apache</link>
-  es la mejor fuente de información sobre el servidor Apache 2.x.
-  La mayoría de la información sobre las opciones de instalación de Apache
+  es la mejor fuente de información sobre el servidor Apache httpd 2.x.
+  La mayoría de la información sobre las opciones de instalación de Apache httpd
   puede encontrarse allí.
- </para>
+ </simpara>
 
- <para>
-  La versión más reciente del servidor HTTP Apache puede obtenerse
+ <simpara>
+  La versión más reciente de Apache httpd puede obtenerse
   desde la <link xlink:href="&url.apache;">página de descarga de Apache</link>,
   y una versión adaptada de PHP desde los enlaces anteriores.
-  Esta guía cubre únicamente las bases de funcionamiento de Apache 2.x con PHP.
+  Esta guía cubre únicamente las bases de funcionamiento de Apache httpd 2.x con PHP.
   Para más información, leer la
   <link xlink:href="&url.apache2.docs;">documentación Apache</link>.
   Los números de versión se omiten aquí, para asegurarse de que las instrucciones no sean
   incorrectas. En los ejemplos a continuación, 'NN' deberá ser reemplazado
-  por la versión específica de Apache a utilizar.
- </para>
+  por la versión específica de Apache httpd a utilizar.
+ </simpara>
 
- <para>
-  Actualmente hay 2 versiones de Apache 2.x - 2.4 y 2.2.
-  Hay varias razones para elegir una sobre la otra; sin embargo, la versión
-  2.4 es actualmente la última versión disponible y también la que recomendamos. Sin embargo, las instrucciones
-  contenidas en esta guía deberían funcionar para la versión 2.4 así como para la versión 2.2. Nota: Apache httpd 2.2 está oficialmente en Fin de Vida, no habrá más desarrollo ni parches para esta versión.
- </para>
+ <simpara>
+  Estas instrucciones se aplican a Apache httpd 2.4, que es la única rama de
+  versión compatible de Apache httpd. Las versiones anteriores (2.2 y anteriores)
+  están en fin de vida y no deben utilizarse.
+ </simpara>
 
  <orderedlist>
   <listitem>
-   <para>
-    Descargue el servidor HTTP Apache desde el sitio anterior y descomprímalo :
-   </para>
+   <simpara>
+    Descargue Apache httpd desde el sitio anterior y descomprímalo:
+   </simpara>
 
    <informalexample>
     <screen>
@@ -52,9 +77,9 @@ tar -xzf httpd-2.x.NN.tar.gz
   </listitem>
 
   <listitem>
-   <para>
-    De la misma manera, descargue y descomprima las fuentes de PHP :
-   </para>
+   <simpara>
+    De la misma manera, descargue y descomprima las fuentes de PHP:
+   </simpara>
 
    <informalexample>
     <screen>
@@ -66,16 +91,22 @@ tar -xzf php-NN.tar.gz
   </listitem>
 
   <listitem>
-   <para>
-    Compile e instale Apache. Consulte la documentación sobre la instalación
-    de Apache para más detalles sobre la compilación de este software.
-   </para>
+   <simpara>
+    Compile e instale Apache httpd. Consulte la documentación sobre la instalación
+    de Apache httpd para más detalles sobre la compilación de este software.
+    Tenga en cuenta que <literal>mod_php</literal> requiere el MPM
+    <literal>prefork</literal> a menos que PHP sea compilado con seguridad de
+    hilos (<literal>--enable-zts</literal>). Si tiene intención de usar PHP-FPM
+    (recomendado), puede usar el MPM <literal>event</literal> predeterminado y
+    pasar directamente a las
+    <link linkend="install.fpm">instrucciones de instalación de PHP-FPM</link>.
+   </simpara>
 
    <informalexample>
     <screen>
 <![CDATA[
 cd httpd-2_x_NN
-./configure --enable-so
+./configure --enable-so --with-mpm=prefork
 make
 make install
 ]]>
@@ -85,10 +116,10 @@ make install
 
   <listitem>
    <para>
-    Ahora que se tiene Apache 2.x.NN disponible bajo /usr/local/apache2,
-    configúrelo con soporte para la carga de módulos, así como el
-    MPM prefork estándar. Para probar la instalación, utilice el procedimiento
-    normal para iniciar el servidor Apache, es decir:
+    Ahora que se tiene Apache httpd 2.x.NN disponible bajo /usr/local/apache2,
+    configurado con soporte para la carga de módulos y el MPM prefork.
+    Para probar la instalación, utilice el procedimiento
+    normal para iniciar el servidor Apache httpd, es decir:
 
     <informalexample>
      <screen>
@@ -97,7 +128,7 @@ make install
 ]]>
      </screen>
     </informalexample>
-    y deténgalo para continuar con la configuración de PHP :
+    y deténgalo para continuar con la configuración de PHP:
 
     <informalexample>
      <screen>
@@ -111,19 +142,20 @@ make install
 
   <listitem>
 
-   <para>
+   <simpara>
     Ahora, configure y compile PHP. Será en este momento
     cuando se podrá personalizar PHP con las diversas opciones disponibles,
     como la lista de extensiones a activar. Ejecute
     <command>./configure --help</command> para obtener la lista de opciones disponibles. En nuestro ejemplo, realizaremos
-    una configuración simple, con Apache 2 y soporte MySQL.
-   </para>
+    una configuración simple, con Apache httpd y soporte MySQL.
+   </simpara>
 
-   <para>
-    Si se ha construido Apache desde las fuentes, tal como se describe anteriormente,
+   <simpara>
+    Si se ha construido Apache httpd desde las fuentes, tal como se describe anteriormente,
     el siguiente ejemplo debería ser correcto en cuanto a las rutas hacia <command>apxs</command>, pero si
-    se ha instalado Apache de otra manera, se deberán tener en cuenta las especificidades y ajustar las rutas <command>apxs</command> en consecuencia. Tenga en cuenta que, según las distribuciones, podría ser necesario renombrar <command>apxs</command> a <command>apxs2</command>.
-   </para>
+    se ha instalado Apache httpd de otra manera, se deberán tener en cuenta las especificidades y ajustar las rutas <command>apxs</command> en consecuencia. Tenga en cuenta que, según las distribuciones, podría ser necesario renombrar <command>apxs</command> a <command>apxs2</command>.
+   </simpara>
+
    <informalexample>
     <screen>
 <![CDATA[
@@ -135,13 +167,13 @@ make install
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Si se decide modificar las opciones de configuración después de la instalación,
     se deberán ejecutar nuevamente las etapas <command>configure</command>, <command>make</command>
     y <command>make install</command>.
     Entonces solo se necesitará reiniciar Apache para que el nuevo módulo surta efecto.
-    Una recompilación de Apache no es necesaria.
-   </para>
+    Una recompilación de Apache httpd no es necesaria.
+   </simpara>
 
    <para>
     Tenga en cuenta que, salvo indicaciones contrarias, <command>make install</command> también instalará
@@ -153,9 +185,9 @@ make install
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Configurar el archivo <filename>php.ini</filename>
-   </para>
+   </simpara>
 
    <informalexample>
     <screen>
@@ -165,33 +197,30 @@ cp php.ini-development /usr/local/lib/php.ini
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Se debe editar el archivo <literal>.ini</literal> para definir las opciones PHP.
     Si se prefiere colocar <filename>php.ini</filename> en otro directorio, utilice
     la opción <literal>--with-config-file-path=/some/path</literal> en la etapa 5.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     Si se elige el archivo <filename>php.ini-production</filename>, asegúrese de leer la lista
     de modificaciones correspondiente ya que puede afectar considerablemente la forma
     en que PHP funcionará.
-   </para>
+   </simpara>
 
   </listitem>
 
   <listitem>
 
-   <para>
+   <simpara>
     Edite el archivo <filename>httpd.conf</filename> para cargar el módulo PHP. La ruta especificada
-    a la derecha de la cadena LoadModule, debe corresponder a la ruta del sistema del módulo
-    PHP. <command>make install</command> anterior debería haber realizado esta operación
+    a la derecha de la cadena <literal>LoadModule</literal>, debe corresponder a la ruta del sistema del módulo
+    PHP. El comando <command>make install</command> anterior debería haber realizado esta operación
     por usted, pero una simple verificación permitirá asegurarse.
-   </para>
+   </simpara>
 
    <informalexample>
-    <para>
-     Para PHP 8:
-    </para>
     <programlisting role="apache-conf">
 <![CDATA[
 LoadModule php_module modules/libphp.so
@@ -199,31 +228,20 @@ LoadModule php_module modules/libphp.so
     </programlisting>
    </informalexample>
 
-   <informalexample>
-    <para>
-     Para PHP 7:
-    </para>
-    <programlisting role="apache-conf">
-<![CDATA[
-LoadModule php7_module modules/libphp5.so
-]]>
-    </programlisting>
-   </informalexample>
-
   </listitem>
 
   <listitem>
 
-   <para>
-    Indique a Apache que analice ciertas extensiones como scripts PHP.
-    Por ejemplo, deje que Apache pase a PHP los archivos cuya extensión es
+   <simpara>
+    Indique a Apache httpd que analice ciertas extensiones como scripts PHP.
+    Por ejemplo, deje que Apache httpd pase a PHP los archivos cuya extensión es
     <literal>.php</literal>.
     En lugar de utilizar solo la directiva <literal>AddType</literal> de Apache,
     se desea evitar cualquier riesgo potencialmente peligroso, cuando
     se descarga y crea un archivo como <filename>exploit.php.jpg</filename>,
     de ejecución PHP. Utilizando este ejemplo, se puede tener cualquier
     extensión analizada por PHP. Se ha añadido <literal>.php</literal> para el ejemplo.
-   </para>
+   </simpara>
 
    <informalexample>
     <programlisting role="apache-conf">
@@ -235,17 +253,17 @@ LoadModule php7_module modules/libphp5.so
     </programlisting>
    </informalexample>
 
-   <para>
+   <simpara>
     O, si se desea permitir que los archivos <literal>.php</literal>, <literal>.php2</literal>,
     <literal>.php3</literal>, <literal>.php4</literal>, <literal>.php5</literal>,
     <literal>.php6</literal>, y <literal>.phtml</literal> sean
-    analizados por PHP, pero nada más, se utilizará esto :
-   </para>
+    analizados por PHP, pero nada más, se utilizará esto:
+   </simpara>
 
    <informalexample>
     <programlisting role="apache-conf">
 <![CDATA[
-<FilesMatch "\.ph(p[2-6]?|tml)$">
+<FilesMatch "\.(php[2-6]?|phtml)$">
     SetHandler application/x-httpd-php
 </FilesMatch>
 ]]>
@@ -255,7 +273,7 @@ LoadModule php7_module modules/libphp5.so
    <para>
     Y para permitir que los archivos <literal>.phps</literal> sean manejados por el filtro del código
     fuente de PHP, y así, ser mostrados como código fuente con coloración
-    sintáctica, utilice esto :
+    sintáctica, utilice esto:
    </para>
 
    <informalexample>
@@ -272,7 +290,6 @@ LoadModule php7_module modules/libphp5.so
     Para permitir el uso de un archivo PHP como manejador por defecto cuando no se
     encuentra ningún otro manejador, por ejemplo al utilizar un motor de enrutamiento, se
     puede usar la directiva <literal>FallbackResource</literal>.
-    Está disponible en Apache 2.4.4 y versiones posteriores.
    </simpara>
 
    <simpara>
@@ -300,7 +317,7 @@ FallbackResource /index.php
 
    <para>
     <literal>mod_rewrite</literal> puede ser utilizado para permitir que cualquier archivo <literal>.php</literal>
-    sea mostrado como código fuente con coloración sintáctica, sin necesidad de renombrarlo o copiarlo con una extensión <literal>.phps</literal>. :
+    sea mostrado como código fuente con coloración sintáctica, sin necesidad de renombrarlo o copiarlo con una extensión <literal>.phps</literal>:
    </para>
 
    <informalexample>
@@ -321,9 +338,9 @@ RewriteRule (.*\.php)s$ $1 [H=application/x-httpd-php-source]
   </listitem>
 
   <listitem>
-   <para>
-    Utilice el procedimiento normal para iniciar el servidor Apache, es decir:
-   </para>
+   <simpara>
+    Utilice el procedimiento normal para iniciar el servidor Apache httpd, es decir:
+   </simpara>
 
    <informalexample>
     <screen>
@@ -346,47 +363,40 @@ service httpd restart
   </listitem>
  </orderedlist>
 
- <para>
+ <simpara>
   Si se han seguido los pasos anteriores, ahora se tiene un servidor web
-  Apache2 funcional con soporte PHP como módulo <literal>SAPI</literal>.
+  Apache httpd funcional con soporte PHP como módulo <literal>SAPI</literal>.
   Por supuesto, hay una multitud de otras opciones de configuración disponibles
-  con Apache y PHP. Para más información, introduzca el comando
+  con Apache httpd y PHP. Para más información, introduzca el comando
   <command>./configure --help</command> en el árbol de fuentes correspondiente.
- </para>
- <para>
-  Apache puede ser compilado en modo multithread, seleccionando
-  el MPM <filename>worker</filename>, en lugar del estándar
-  MPM <filename>prefork</filename>. Esto se hace añadiendo la siguiente opción al argumento de <command>./configure</command>, en la etapa 3 anterior:
- </para>
- <informalexample>
-  <screen>
-<![CDATA[
---with-mpm=worker
-]]>
-  </screen>
- </informalexample>
- <para>
-  Esto no debería emprenderse sin ser consciente de las consecuencias,
-  y teniendo al menos una justa comprensión de lo que implica.
-  La documentación de Apache sobre
-  <link xlink:href="&url.apache2.mpm;">MPM-Modules</link>
-  proporcionará información importante que permitirá tomar
-  la decisión.
- </para>
+ </simpara>
+
  <note>
-  <para>
+  <title>Compatibilidad MPM</title>
+  <simpara>
+   A menos que PHP sea compilado con Zend Thread Safety
+   (<literal>--enable-zts</literal>), <literal>mod_php</literal> requiere
+   el MPM <literal>prefork</literal>.
+   Para más información, leer la entrada FAQ correspondiente sobre el uso de
+   <link linkend="faq.installation.apache2">Apache httpd con un MPM
+   multi-hilo</link>.
+  </simpara>
+
+  <simpara>
+   La mayoría de los paquetes de distribución de
+   <literal>mod_php</literal> no se compilan con ZTS, por lo que
+   <literal>prefork</literal> suele ser necesario. Si se necesita un MPM
+   multi-hilo (recomendado para mejor rendimiento bajo carga), use
+   <link linkend="install.fpm">PHP-FPM</link> con
+   <literal>mod_proxy_fcgi</literal> en su lugar.
+  </simpara>
+ </note>
+
+ <note>
+  <simpara>
    La <link linkend="faq.installation.apache.multiviews">FAQ Apache
    MultiViews</link> trata sobre el uso de MultiViews con PHP.
-  </para>
- </note>
- <note>
-  <para>
-   Para compilar una versión multithread de Apache, el sistema de destino
-   debe soportar threads. En este caso, PHP también debe ser construido
-   con Zend Thread Safety (ZTS). Bajo esta configuración, no todas las extensiones
-   estarán disponibles. Recomendamos compilar Apache con el
-   <filename>prefork</filename> MPM-Module.
-  </para>
+  </simpara>
  </note>
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2299,11 +2299,6 @@ Por ejemplo: <literal>tcp://[fe80::1]:80</literal>.</simpara></note>'>
 <!ENTITY tidy.object 'El objeto <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>'>
 
 <!-- Snippets for the installation section -->
-<!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>No se recomienda el uso de PHP
-en un entorno thread MPM, con Apache 2. Utilice el modo prefork MPM, que es
-el MPM predeterminado para Apache 2.0 y 2.2. Para
-saber por qué, lea la entrada de la FAQ correspondiente a la
-<link linkend="faq.installation.apache2">utilización de Apache 2 en un entorno thread MPM</link>.</simpara></warning>'>
 <!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <simpara>
   Las versiones provenientes de terceros son consideradas no oficiales y

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7b3094477569cda19b14bf61f244b60d24a5e479 Maintainer: argosback Status: ready -->
+<!-- EN-Revision: fd1f9d85122cd85854f4afdf5a57ab7da38ff69c Maintainer: argosback Status: ready -->
 <!-- Reviewed: yes Maintainer: argosback -->
 
 <!ENTITY installation.enabled.disable 'Esta extensión está activada por defecto. Puede ser desactivada utilizando la opción de configuración: '>
-
-<!-- Not used in EN anymore -->
-<!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>El generador
-de números aleatorios se inicializa automáticamente.</entry></row>'>
 
 <!ENTITY changelog.class-constants-typed '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
@@ -89,10 +85,6 @@ utilice <function>proc_open</function> definiendo la opción <parameter>bypass_s
 Windows no soportan ciertos caracteres en los nombres de fichero, como <literal>&lt;|&gt;*?":</literal>. Los nombres de fichero con un
 punto final no son soportados. A diferencia de algunas herramientas de extracción, este método no reemplaza estos caracteres con
 un guión bajo, sino que falla al extraer tales ficheros.</simpara></note>'>
-
-<!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara> En lugar de un nombre de función, un
-array que contenga una referencia de objeto y un nombre de método también puede ser
-utilizado.</simpara></note>'>
 
 <!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>Las devoluciónes de
 llamada registradas con funciones como <function>call_user_func</function> y <function>call_user_func_array</function> no serán llamadas si
@@ -242,11 +234,6 @@ Esta extensión debe ser utilizada bajo su propio riesgo.</simpara></warning>'>
 <!ENTITY deprecated.function 'Esta función está obsoleta.'>
 <!ENTITY removed.function 'Esta función ha sido eliminada.'>
 
-<!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 5.3.0 y ha sido <emphasis>ELIMINADA</emphasis>
-a partir de PHP 5.4.0.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-6-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 5.6.0. Depender de esta funcionalidad
@@ -267,11 +254,6 @@ está altamente desaconsejado.</simpara></warning>'>
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta función está
 <emphasis>OBSOLETA</emphasis> a partir de PHP 7.1.0 y ha sido
 <emphasis>ELIMINADA</emphasis> a partir de PHP 7.2.0. Depender de esta función
-está altamente desaconsejado.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-7-2-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara> Esta funcionalidad está
-<emphasis>OBSOLETA</emphasis> a partir de PHP 7.2.0. Depender de esta funcionalidad
 está altamente desaconsejado.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.feature-7-2-0.removed-8-0-0 '<warning
@@ -359,9 +341,6 @@ ciertamente <emphasis xmlns="http://docbook.org/ns/docbook">eliminada</emphasis>
 <!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
 <simpara>Este alias está <emphasis>OBSOLETO</emphasis> a partir de PHP 5.4.0.
 Depender de este alias está fuertemente desaconsejado.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara> Este alias está
-<emphasis>OBSOLETO</emphasis> a partir de PHP 5.4.0. y ha sido <emphasis>ELIMINADO</emphasis> a partir de PHP 7.0.0.</simpara></warning>'>
 
 <!ENTITY warn.removed.function-7-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara> Esta función ha sido
@@ -474,10 +453,6 @@ evitar su uso.</simpara></warning>
 <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">El ejemplo anterior mostrará:</simpara>'>
 
 <!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5:</simpara>'>
-
-<!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.3:</simpara>'>
-
-<!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.4:</simpara>'>
 
 <!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">Resultado del ejemplo anterior en PHP 5.5:</simpara>'>
 
@@ -1434,10 +1409,6 @@ zonas horarias pueden ser eliminadas de la base de datos IANA de zonas horarias 
 Cada llamada a una función de fecha/hora generará un diagnóstico de tipo <constant>E_WARNING</constant>
 si la zona horaria no es válida. Ver también <function>date_default_timezone_set</function></simpara>'>
 
-<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
-Emite un mensaje de tipo <constant>E_STRICT</constant> y <constant>E_NOTICE</constant>
-durante errores de zonas horarias.</simpara></entry></row>'>
-
 <!ENTITY date.timestamp.description '
 <varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
 El parámetro opcional <parameter>timestamp</parameter> es un
@@ -1959,8 +1930,6 @@ o <link linkend="functions.named-arguments">argumentos nombrados</link>.</simpar
 
 <!-- Common pieces in partintro-sections -->
 <!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna directiva de configuración.</simpara>'>
-<!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ningún recurso.</simpara>'>
-<!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">Esta extensión no define ninguna constante.</simpara>'>
 <!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">No se requiere ninguna biblioteca externa para compilar esta extensión.</simpara>'>
 <!ENTITY no.install '<simpara xmlns="http://docbook.org/ns/docbook">No hay instalación necesaria para usar estas
 funciones, son parte del núcleo de PHP.</simpara>'>


### PR DESCRIPTION
Sync with EN commit fd1f9d85122cd85854f4afdf5a57ab7da38ff69c.

- Rename title to "Apache httpd 2.x en sistemas Unix"
- Replace `&warn.apache2.compat;` with a `<warning>` block recommending PHP-FPM for new installations
- Drop Apache 2.2 and PHP 7 references (end of life)
- Update step 3 to mention prefork MPM requirement and PHP-FPM alternative
- Remove worker MPM section; add MPM Compatibility note
- Multiple `<para>` to `<simpara>` conversions throughout
- Fix FilesMatch regex: `\.ph(p[2-6]?|tml)$` → `\.(php[2-6]?|phtml)$`
- Remove "available in Apache 2.4.4 and later" from FallbackResource simpara
- Remove orphaned `warn.apache2.compat` entity from `language-snippets.ent`

Closes #1070

Also removes ten entities dropped from EN by php/doc-en#5628 (commit de78d65ef7785a167268b3cb5d5268b13bb9f358) and unused in doc-es: `changelog.randomseed`, `note.func-callback`, `warn.deprecated.feature-5-3-0.removed-5-4-0`, `warn.deprecated.feature-7-2-0`, `warn.deprecated.alias-5-3-0.removed-7-0-0`, `example.outputs.53`, `example.outputs.54`, `date.timezone.errors.changelog`, `no.resource`, `no.constants`. This is folded in here rather than sent as its own pull request because it touches the same file.

`warn.deprecated.function-7-4-0` is kept for now: it is still used by `reference/reflection/reflection/export.xml`, which needs to move to `warn.deprecated.function-7-4-0.removed-8-0-0` first, as EN did.

Fixes: #1048
