### PR TITLE
[Sync-En] Update curl_multi_exec() refpurpose

### DIFF
--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.curl-multi-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_exec</refname>
-  <refpurpose>Ejecuta cada uno de los gestores de la pila</refpurpose>
+  <refpurpose>Procesa cada uno de los gestores de la pila</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>int</type><parameter role="reference">still_running</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Ejecuta cada gestor de la pila. Este método puede ser llamado
+   Procesa cada uno de los gestores de la pila. Este método puede ser llamado
    incluso si un gestor necesita leer o escribir datos.
   </simpara>
  </refsect1>


### PR DESCRIPTION
Sync with EN commit d6aa7900b52cdf99998a9367ee06f1155850b92b.

Update `refpurpose` from "Ejecuta las subpeticiones de la sesión cURL" to "Procesa cada uno de los gestores de la pila", matching the new EN wording "Processes each of the handles in the stack".

Remove `<!-- $Revision$ -->` and `<!-- Reviewed: no -->` tags.

Closes #1073