### PR TITLE
[Sync-En] Document potential Windows deadlock in flock()

### DIFF
--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75a76afb61d91f04feebc83931c5412b13682d2b Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: f3112c43e303fcd63c0df89798b45bfef9d49e15 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.flock" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>flock</refname>
@@ -191,12 +190,33 @@ fclose($fp);
     anticuados como <literal>FAT</literal> y sus derivados, y por lo tanto
     siempre devolverá &false; en estos entornos.
    </para>
+   <para>
+    En Windows, si PHP intenta ejecutar un fichero de código fuente PHP bloqueado con
+    <constant>LOCK_EX</constant>, el proceso quedará suspendido hasta que el fichero
+    sea desbloqueado. El siguiente ejemplo provocará un bloqueo mutuo (deadlock):
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+if ($argv[1] ?? null === 'child') { die(); }
+$fp = fopen(__FILE__, "rb");
+flock($fp, LOCK_EX);
+shell_exec("php " . escapeshellarg(__FILE__) . " child");
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
   </warning>
   <note>
    <para>
     En Windows, si el proceso de bloqueo abre el fichero una segunda vez, no podrá
     acceder al fichero a través de este segundo manejador hasta que desbloquee el fichero.
    </para>
+   <simpara>
+    En Windows, si se intenta incluir con require un fichero bloqueado con LOCK_EX,
+    fallará con ErrorException: require(): Read of X bytes failed with errno=13 Permission denied
+   </simpara>
   </note>
  </refsect1>
 


### PR DESCRIPTION
Sync with EN commit f3112c43e303fcd63c0df89798b45bfef9d49e15.

- Add example showing how `LOCK_EX` + `shell_exec("php ...")` causes a deadlock on Windows (PHP hangs waiting for the file to be unlocked)
- Add `<simpara>` to the Windows note explaining that `require` on a `LOCK_EX`'ed file fails with `errno=13 Permission denied`

Closes #1069