### PR TITLE
[Sync-En] ext/zmq: Fix unresolved exception entity references

### DIFF
--- a/reference/zmq/book.xml
+++ b/reference/zmq/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a5b92a30888d6423db112f07a9b344cf6fc4891 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: PhilDaiguille Status: ready -->
 <!-- State: experimental -->
 <book xml:id="book.zmq" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -21,10 +20,19 @@
  &reference.zmq.setup;
 
  &reference.zmq.zmq;
+ &reference.zmq.zmqexception;
+
  &reference.zmq.zmqcontext;
+ &reference.zmq.zmqcontextexception;
+
  &reference.zmq.zmqsocket;
+ &reference.zmq.zmqsocketexception;
+
  &reference.zmq.zmqpoll;
+ &reference.zmq.zmqpollexception;
+
  &reference.zmq.zmqdevice;
+ &reference.zmq.zmqdeviceexception;
 
 </book>
 

--- a/reference/zmq/zmqcontextexception.xml
+++ b/reference/zmq/zmqcontextexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqcontextexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -39,12 +38,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqcontextexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -87,7 +82,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqcontextexception;
 
 </reference>
 

--- a/reference/zmq/zmqdeviceexception.xml
+++ b/reference/zmq/zmqdeviceexception.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
-<reference xml:id="class.zmqdeviceexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.zmqdeviceexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase ZMQDeviceException</title>
  <titleabbrev>ZMQDeviceException</titleabbrev>
@@ -39,12 +38,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqdeviceexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -87,7 +82,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqdeviceexception;
 
 </reference>
 

--- a/reference/zmq/zmqexception.xml
+++ b/reference/zmq/zmqexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -38,10 +37,6 @@
     </classsynopsisinfo>
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
@@ -87,7 +82,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqexception;
 
 </reference>
 

--- a/reference/zmq/zmqpollexception.xml
+++ b/reference/zmq/zmqpollexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqpollexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -39,12 +38,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqpollexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -87,7 +82,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqpollexception;
 
 </reference>
 

--- a/reference/zmq/zmqsocketexception.xml
+++ b/reference/zmq/zmqsocketexception.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c517a71287d79c65ea42dff4c6973e22ef5c3bee Maintainer: seros Status: ready -->
 
 <reference xml:id="class.zmqsocketexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -39,12 +38,8 @@
     <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqsocketexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
    <!-- }}} -->
@@ -87,7 +82,6 @@
 
  </partintro>
 
- &reference.zmq.entities.zmqsocketexception;
 
 </reference>
 


### PR DESCRIPTION
Sync with EN commit c517a71287d79c65ea42dff4c6973e22ef5c3bee.

- `book.xml`: add references to exception class files (zmqexception, zmqcontextexception, zmqsocketexception, zmqpollexception, zmqdeviceexception)
- All exception XML files (`zmqexception`, `zmqcontextexception`, `zmqdeviceexception`, `zmqpollexception`, `zmqsocketexception`):
  - Remove the erroneous `&Methods;` classsynopsisinfo and its self-referencing `xi:include`
  - Fix `InheritedMethods` xi:include to reference `class.exception` instead of `class.zmqexception`
  - Remove `&reference.zmq.entities.*;` entity references (no methods to include)
- `zmqdeviceexception.xml`: remove unused `xmlns:xlink` attribute

Closes #1068