### PR TITLE
[Sync-En] pcre: describe PREG_UNMATCHED_AS_NULL for trailing groups

### DIFF
--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e62b1e3989a5049c052bc547bb6bf175ada8e48d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cdbe6f9826baecd4a6c05f1c95ea47d1d8f32551 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <appendix xml:id="pcre.constants" xmlns="http://docbook.org/ns/docbook">
@@ -102,6 +102,11 @@
       incluir los subpatrones sin coincidencia en <varname>$matches</varname> con un valor a &null;.
       Sin esta constante, los subpatrones sin coincidencia son devueltos con una cadena vacía, como si la coincidencia estuviera vacía.
       Definir esta constante permite distinguir estos dos casos.
+      Con <function>preg_match</function>, los subpatrones sin coincidencia
+      finales son omitidos por completo de <varname>$matches</varname> a menos
+      que se utilice esta bandera; a partir de PHP 7.4.0, la bandera los reporta
+      como &null;, de modo que <varname>$matches</varname> siempre tenga el
+      mismo tamaño.
      </entry>
      <entry>7.2.0</entry>
     </row>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: aa5a948a110f87b5ca4d2510288e0ad37e21ead0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: cdbe6f9826baecd4a6c05f1c95ea47d1d8f32551 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.preg-match" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -122,8 +122,12 @@ Array
          <term><constant>PREG_UNMATCHED_AS_NULL</constant></term>
          <listitem>
           <para>
-           Si este flag es pasado, los subpatrones no coincidentes son reportados como &null;;
-           de lo contrario son reportados como una <type>string</type> vacía.
+           Si este flag es pasado, los subpatrones no coincidentes son reportados
+           como &null; y son siempre incluidos en los resultados (incluyendo los
+           finales). Sin este flag, los subpatrones no coincidentes que son
+           seguidos por un subpatrón coincidente son reportados como una
+           <type>string</type> vacía, mientras que los subpatrones no
+           coincidentes finales son omitidos por completo de los resultados.
            <informalexample>
             <programlisting role="php">
 <![CDATA[
@@ -131,6 +135,12 @@ Array
 preg_match('/(a)(b)*(c)/', 'ac', $matches);
 var_dump($matches);
 preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_UNMATCHED_AS_NULL);
+var_dump($matches);
+
+// Subpatrones no coincidentes finales:
+preg_match('/(a)(b)?(c)?/', 'a', $matches);
+var_dump($matches);
+preg_match('/(a)(b)?(c)?/', 'a', $matches, PREG_UNMATCHED_AS_NULL);
 var_dump($matches);
 ?>
 ]]>
@@ -157,6 +167,22 @@ array(4) {
   NULL
   [3]=>
   string(1) "c"
+}
+array(2) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+}
+array(4) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+  [2]=>
+  NULL
+  [3]=>
+  NULL
 }
 ]]>
             </screen>
@@ -275,6 +301,18 @@ Array
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        Cuando se utiliza el flag <constant>PREG_UNMATCHED_AS_NULL</constant>,
+        los grupos de captura no coincidentes finales ahora también son
+        incluidos en el resultado con el valor &null; (o
+        <literal>[null, -1]</literal> cuando
+        <constant>PREG_OFFSET_CAPTURE</constant> también es utilizado), de modo
+        que <varname>$matches</varname> siempre tenga el mismo tamaño.
+        Anteriormente, eran omitidos.
+       </entry>
+      </row>
       <row>
        <entry>7.2.0</entry>
        <entry>


### PR DESCRIPTION
Sync with EN commit cdbe6f9826baecd4a6c05f1c95ea47d1d8f32551 (php/doc-en#5272).

- Document that trailing unmatched subpatterns are omitted from `$matches` unless the flag is set
- Extend the `preg_match()` example and its output accordingly
- Add the 7.4.0 changelog row

Fixes: #1061