### PR TITLE
[Sync-En] document the --enable-zend-max-execution-timers configure option

### DIFF
--- a/appendices/configure/misc.xml
+++ b/appendices/configure/misc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4c676dacf58ff5d779eed96739ab4660204cbe7f Maintainer: argosback Status: ready -->
+<!-- EN-Revision: 667093532547bcfe6224765f038c151c61f30f48 Maintainer: argosback Status: ready -->
 <!-- Reviewed: yes Maintainer: argosback -->
  <sect3 xml:id="configure.options.misc" xmlns="http://docbook.org/ns/docbook">
   <title>Otras opciones</title>
@@ -47,6 +47,28 @@
     </listitem>
    </varlistentry>
 
+   <varlistentry xml:id="configure.enable-zend-max-execution-timers">
+    <term>
+     <option role="configure">--enable-zend-max-execution-timers</option>
+    </term>
+    <listitem>
+     <simpara>
+      Usar temporizadores POSIX por hilo para el seguimiento de
+      <link linkend="ini.max-execution-time">max_execution_time</link>
+      en lugar de la función <literal>setitimer()</literal>, que actúa
+      sobre todo el proceso. Estos temporizadores miden el tiempo
+      transcurrido (<literal>CLOCK_BOOTTIME</literal>, o
+      <literal>CLOCK_MONOTONIC</literal> en FreeBSD), mientras que
+      <literal>setitimer(ITIMER_PROF)</literal>, el valor predeterminado,
+      mide el tiempo de CPU, de modo que el tiempo empleado en pausas o
+      en la espera de E/S cuenta para el límite.
+      Requiere soporte de <literal>timer_create()</literal>: disponible en
+      Linux, y en FreeBSD a partir de PHP 8.4.0.
+      Disponible a partir de PHP 8.1.0. Habilitado de forma predeterminada
+      en las compilaciones ZTS a partir de PHP 8.3.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="configure.enable-sigchild">
     <term>
      <option role="configure">--enable-sigchild</option>

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 667093532547bcfe6224765f038c151c61f30f48 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="info.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -252,6 +252,15 @@
       Consulte la función <function>set_time_limit</function>
       para más detalles.
      </para>
+     <simpara>
+      Cuando PHP se compila con
+      <link linkend="configure.enable-zend-max-execution-timers">--enable-zend-max-execution-timers</link>
+      (el valor predeterminado en las compilaciones ZTS a partir de PHP 8.3.0),
+      el límite se controla mediante temporizadores POSIX por hilo que miden
+      el tiempo transcurrido, de modo que el tiempo empleado en pausas o en la
+      espera de E/S cuenta para el mismo. El seguimiento predeterminado, basado
+      en <literal>setitimer(ITIMER_PROF)</literal>, mide en cambio el tiempo de CPU.
+     </simpara>
      <para>
       El servidor web puede tener otras configuraciones de tiempo límite
       de ejecución que también pueden interrumpir PHP. Apache tiene una directiva


### PR DESCRIPTION
Sync with EN commit 667093532547bcfe6224765f038c151c61f30f48 (php/doc-en#5269).

- Add the `--enable-zend-max-execution-timers` entry to the configure options
- Mention it in the `max_execution_time` directive description

Fixes: #1060