### PR TITLE
[Sync-En] install: fix naming, paths and add php-fpm to the dnf install example

### DIFF
--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 88d5409cd9668b28ecb879522750807322a816dd Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="install.unix.dnf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Instalación a partir de paquetes en distribuciones GNU/Linux que utilizan DNF</title>
@@ -29,7 +29,7 @@
    <title>Ejemplo de instalación DNF</title>
    <programlisting role="shell">
 <![CDATA[
-# dnf install php php-common
+# dnf install php php-common php-fpm
 ]]>
    </programlisting>
   </example>
@@ -39,7 +39,7 @@
    Por ejemplo :
   </simpara>
   <example xml:id="install.unix.dnf.example2">
-   <title>Reiniciar Apache una vez instalado PHP</title>
+   <title>Reiniciar Apache httpd una vez instalado PHP</title>
    <programlisting role="shell">
 <![CDATA[
 # sudo systemctl restart httpd
@@ -86,10 +86,11 @@
   </example>
   <simpara>
    DNF añadirá automáticamente las líneas apropiadas a los distintos archivos
-   vinculados a &php.ini;, como <filename>/etc/php/8.3/php.ini</filename>,
-   <filename>/etc/php/8.3/conf.d/*.ini</filename>, etc. y dependiendo de
+   vinculados a &php.ini;, como <filename>/etc/php.ini</filename>,
+   <filename>/etc/php.d/*.ini</filename>, etc. y dependiendo de
    la extensión añadirá entradas similares a <literal>extension=foo.so</literal>.
-   Sin embargo, es necesario reiniciar el servidor web (como Apache) para que estos cambios surtan efecto.
+   Sin embargo, es necesario reiniciar el servidor web y PHP-FPM para que
+   estos cambios surtan efecto.
   </simpara>
  </sect2>
 </sect1>


### PR DESCRIPTION
Sync with EN commit 88d5409cd9668b28ecb879522750807322a816dd (php/doc-en#5745).

- Add `php-fpm` to the install example
- Fix the configuration paths (`/etc/php.ini`, `/etc/php.d/*.ini`)
- Say "Apache httpd" and mention restarting PHP-FPM

Fixes: #1059