### PR TITLE
[Sync-En] fpm: document environment variable expansion in configuration

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1f01e2a8e478c63bd6598cde09235ec027b23dd5 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7cd12cc82bc0a778241189596022acdda016d857 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>Configuration</title>
@@ -484,7 +484,7 @@
       </term>
       <listitem>
        <para>
-        The number of seconds after which an idle process will be killed. 
+        The number of seconds after which an idle process will be killed.
         Used only when <literal>pm</literal> is set to <literal>ondemand</literal>.
         Available units: s(econds)(default), m(inutes), h(ours), or d(ays).
         Default value: 10s.
@@ -1004,6 +1004,22 @@
       </listitem>
      </varlistentry>
     </variablelist>
+    <para>
+     Los valores de configuración pueden definirse utilizando la expansión de
+     variables de entorno. La definición de valores por defecto cuando la variable
+     de entorno no está definida o es nula también está soportada a partir de
+     PHP 8.3.0. Por ejemplo:
+        <example>
+        <title>Uso de la expansión de variables de entorno</title>
+        <programlisting role="ini">
+<![CDATA[
+listen = /var/run/php-fpm-${POOL_NAME}.sock
+user = ${USER_NAME:-www-data}
+group = ${USER_NAME:-www-data}
+]]>
+        </programlisting>
+       </example>
+    </para>
     <para>
      It's possible to pass additional environment variables and update PHP settings of a certain pool.
      To do this, you need to add the following options to the pool configuration file.


### PR DESCRIPTION
Sync with EN commit 7cd12cc82bc0a778241189596022acdda016d857 (php/doc-en#5181).

- Add the paragraph and example about environment variable expansion in pool configuration

Fixes: #1058