### PR TITLE
[Sync-En] errorfunc: document the DEBUG_BACKTRACE_PROVIDE_OBJECT option

### DIFF
--- a/reference/errorfunc/functions/debug-print-backtrace.xml
+++ b/reference/errorfunc/functions/debug-print-backtrace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1fd69376c6c90066f086c99a32621f0b3fd47ba0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 41911b489877ce67e1a9c47b43b1cc37aa21b6e2 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.debug-print-backtrace" xmlns="http://docbook.org/ns/docbook">
@@ -43,6 +43,15 @@
            <entry>
             Si se deben omitir el índice "args" y, por lo tanto, todos los argumentos
             del método/función para preservar la memoria.
+           </entry>
+          </row>
+          <row>
+           <entry>DEBUG_BACKTRACE_PROVIDE_OBJECT</entry>
+           <entry>
+            Aceptado por compatibilidad con <function>debug_backtrace</function>,
+            pero no tiene ningún efecto: la pila de ejecución generada se
+            representa como una cadena de caracteres y la entrada "object"
+            nunca es mostrada.
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
Sync with EN commit 41911b489877ce67e1a9c47b43b1cc37aa21b6e2 (php/doc-en#5217).

- Add the `DEBUG_BACKTRACE_PROVIDE_OBJECT` row to the `options` table

Fixes: #1056