### PR TITLE
[Sync-En] language: document the PHP 8.4 comparison and readonly clone BC breaks

### DIFF
--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 62e61e543c2d2b8519952efa246ed708026cfb16 Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.properties" xmlns="http://docbook.org/ns/docbook">
  <title>Propiedades</title>
 
@@ -373,6 +373,14 @@ var_dump($test2->prop); // NULL
     </programlisting>
    </example>
   </para>
+  <note>
+   <simpara>
+    A partir de PHP 8.4.0, la modificación indirecta de una propiedad readonly
+    dentro de <link linkend="object.clone">__clone()</link>, como obtener una
+    referencia a ella (<code>$ref = &amp;$this->prop</code>), ya no está
+    permitida. Esto ya estaba prohibido durante la inicialización readonly.
+   </simpara>
+  </note>
  </sect2>
 
  <sect2 xml:id="language.oop5.properties.dynamic-properties">

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 62e61e543c2d2b8519952efa246ed708026cfb16 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.operators.comparison">
  <title>Operadores de comparación</title>
@@ -343,6 +343,15 @@ function standard_array_compare($op1, $op2)
    &integer;s con &string;s. Por lo tanto, generalmente se recomienda utilizar los
    operadores de comparación <literal>===</literal> y <literal>!==</literal> en lugar de
    <literal>==</literal> y <literal>!=</literal> en la mayoría de los casos.
+  </simpara>
+ </note>
+
+ <note>
+  <simpara>
+   Encontrar una recursión durante la comparación, por ejemplo al comparar un
+   array o un objeto que contiene una referencia a sí mismo, lanza un
+   <exceptionname>Error</exceptionname> a partir de PHP 8.4.0; anteriormente,
+   esto provocaba un error fatal.
   </simpara>
  </note>
 


### PR DESCRIPTION
Sync with EN commit 62e61e543c2d2b8519952efa246ed708026cfb16 (php/doc-en#5775).

- Note that indirect modification of a readonly property in `__clone()` is no longer allowed as of PHP 8.4.0
- Note that recursion during a comparison throws an `Error` as of PHP 8.4.0

Fixes: #1055