### PR TITLE
[Sync-En] gmp: improve the gmp_export() documentation

### DIFF
--- a/reference/gmp/functions/gmp-export.xml
+++ b/reference/gmp/functions/gmp-export.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 548548299328e56739eb2832a5c22ba2de745038 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ba0a95ac9ad601e5ef05a0f3ab937d9749395982 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.gmp-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,16 @@
    <methodparam choice="opt"><type>int</type><parameter>word_size</parameter><initializer>1</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>GMP_MSW_FIRST | GMP_NATIVE_ENDIAN</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Exporta un número GMP hacia un string binario.
-  </para>
+  <simpara>
+   Exporta un número GMP hacia un string binario. Esta función puede
+   manejar números arbitrariamente grandes, más allá del rango del tipo
+   entero nativo de PHP, con un tamaño de palabra y un orden de bytes
+   configurables, de manera similar a <function>pack</function>.
+  </simpara>
+  <simpara>
+   El signo del número se ignora; exportar un número negativo produce el
+   mismo resultado que exportar su valor absoluto.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,27 +34,36 @@
     <varlistentry>
      <term><parameter>num</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El número GMP a exportar.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>word_size</parameter></term>
      <listitem>
-      <para>
-       El valor por omisión es 1. El número de bytes en cada
-       parte de datos binarios. Principalmente utilizado con
-       el argumento options.
-      </para>
+      <simpara>
+       El número de bytes por palabra en la salida. La longitud total
+       del string retornado será un múltiplo de este valor.
+       Valor por omisión: <literal>1</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
-       El valor por omisión es <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
-      </para>
+      <simpara>
+       Una máscara de bits que controla el orden de las palabras y el
+       orden de los bytes. Orden de las palabras:
+       <constant>GMP_MSW_FIRST</constant> (palabra más significativa
+       primero, por omisión) o <constant>GMP_LSW_FIRST</constant>
+       (palabra menos significativa primero). Orden de los bytes dentro
+       de cada palabra: <constant>GMP_NATIVE_ENDIAN</constant> (por
+       omisión), <constant>GMP_BIG_ENDIAN</constant> o
+       <constant>GMP_LITTLE_ENDIAN</constant>.
+       Valor por omisión:
+       <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -56,9 +72,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retorna un string.
-  </para>
+  <simpara>
+   Retorna un string que contiene la representación binaria del número
+   GMP. El string está vacío si el número es cero.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Sync with EN commit ba0a95ac9ad601e5ef05a0f3ab937d9749395982 (php/doc-en#5265).

- Rewrite the description, the `word_size` and `flags` parameters and the return value
- Drop the obsolete mention of an `options` parameter

Fixes: #1053