### PR TITLE
[Sync-En] exec: clarify executable lookup for proc_open() with an array command

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f50098447455250c9f92eed119248aaa30920100 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5600a279c7904a92dca710222de2289613a47aad Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.proc-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -58,6 +58,15 @@
        un &array; de argumentos de comandos.
        En este caso el proceso será abierto directamente (sin pasar por un shell) y PHP se encargará de escapar los argumentos necesarios.
       </para>
+      <simpara>
+       Cuando <parameter>command</parameter> es proporcionado como un array y el primer
+       elemento es un simple nombre de fichero sin separadores de directorio, el ejecutable
+       es buscado utilizando la variable de entorno <envar>PATH</envar> actual.
+      </simpara>
+      <simpara>
+       Si <envar>PATH</envar> no está definida, son utilizadas las rutas de búsqueda
+       predeterminadas del sistema, tal como son definidas por el sistema operativo.
+      </simpara>
       <note>
        <para>
         En Windows, el escape de los argumentos de los elementos del &array; asume


### PR DESCRIPTION
Sync with EN commit 5600a279c7904a92dca710222de2289613a47aad (php/doc-en#5220).

- Document the `PATH` lookup when the first array element is a plain file name, and the fallback to the system default search paths

Fixes: #1052