### PR TITLE
[Sync-En] funchand: clarify the forward_static_call() documentation

### DIFF
--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -1,28 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 846dfb87daacac70877c332686d60c7dfd0f15d8 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 17ddeefd6592d09dd9abcf185f56b5befc7b2d6d Maintainer: seros Status: ready -->
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call_array</refname>
-  <refpurpose>Llamar a un método estático y pasar los argumentos como matriz</refpurpose>
+  <refpurpose>Llama a una función de devolución de llamada con una matriz de
+  parámetros, preservando la clase llamada actual</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>mixed</type><methodname>forward_static_call_array</methodname>
-   <methodparam><type>callable</type><parameter>function</parameter></methodparam>
-   <methodparam><type>array</type><parameter>parameters</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>array</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    Llama a una función o método definido por el usuario, dado por el parámetro
-   <parameter>function</parameter>, con los argumentos pasados como matriz,
+   <parameter>callback</parameter>, con los argumentos pasados como matriz,
    similar a <function>call_user_func_array</function>.
-   Cuando se llama dentro del contexto de un método, usa el
-   <link linkend="language.oop5.late-static-bindings">Enlace estático
-   en tiempo de ejecución</link>.
-   Cuando se llama fuera del contexto de una clase, se comporta como
-   <function>call_user_func_array</function>, sin enlace estático en tiempo de ejecución.
+   Cuando se llama dentro del contexto de un método y se llama a una función de
+   devolución de llamada de método, realiza una
+   <link linkend="language.oop5.late-static-bindings">llamada reenviada</link>,
+   de modo que <literal>static::</literal> dentro del método se resuelve a la
+   misma clase llamada que en el llamador. Esto es útil para funciones de
+   devolución de llamada de métodos estáticos que deberían comportarse como
+   <literal>self::</literal> o <literal>parent::</literal>.
   </simpara>
   <note>
    <simpara>
@@ -39,7 +42,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>function</parameter></term>
+     <term><parameter>callback</parameter></term>
      <listitem>
       <para>
        La función o método a ser llamado. Este parámetro puede ser un &array;,
@@ -51,14 +54,15 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Un parámetro, reuniendo todos los parámetros del método en una matriz.
-      </para>
+      <simpara>
+       Los parámetros a pasar a la función de devolución de llamada, como una
+       matriz.
+      </simpara>
       <note>
-       <para>
-        Observe que los parámetros para <function>forward_static_call_array</function> no
-        son pasados por referencia.
-       </para>
+       <simpara>
+        Para pasar un parámetro por referencia, el elemento correspondiente en
+        <parameter>args</parameter> debe ser una referencia.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/funchand/functions/forward-static-call.xml
+++ b/reference/funchand/functions/forward-static-call.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: seros Status: ready -->
+<!-- EN-Revision: 17ddeefd6592d09dd9abcf185f56b5befc7b2d6d Maintainer: seros Status: ready -->
 <refentry xml:id="function.forward-static-call" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call</refname>
-  <refpurpose>Llamar a un método estático</refpurpose>
+  <refpurpose>Llama a una función de devolución de llamada preservando la clase llamada actual</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,13 +14,17 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Llama a una función o método definido por el usuario, dado por el parámetro
-   <parameter>function</parameter>, con los siguientes argumentos. Esta función debe ser llamada dentro
+   <parameter>callback</parameter>, con los siguientes argumentos. Esta función debe ser llamada dentro
    del contexto de un método, no se puede usar fuera de una clase.
-   Usa el <link linkend="language.oop5.late-static-bindings">Enlace estático
-   en tiempo de ejecución</link>.
-  </para>
+   Al llamar a una función de devolución de llamada de método, realiza una
+   <link linkend="language.oop5.late-static-bindings">llamada reenviada</link>,
+   de modo que <literal>static::</literal> dentro del método se resuelve a la
+   misma clase llamada que en el llamador. Esto es útil para funciones de
+   devolución de llamada de métodos estáticos que deberían comportarse como
+   <literal>self::</literal> o <literal>parent::</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,9 +44,9 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Cero o más parámetros a ser pasados a la función.
-      </para>
+      <simpara>
+       Cero o más parámetros a ser pasados a la función de devolución de llamada.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Sync with EN commit 17ddeefd6592d09dd9abcf185f56b5befc7b2d6d (php/doc-en#5784).

- Rewrite the description in terms of a forwarding call and how `static::` resolves
- Update the `args` parameter description

Also fixes a pre-existing inconsistency in `forward-static-call-array.xml`, where the synopsis declared `function`/`parameters` while the parameter list documented `callback`/`args`.

Fixes: #1051