### PR TITLE
[Sync-En] zip: document ZipArchive deferred write behavior

### DIFF
--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5cb356334f35b9ae452e3af47d2d9f0b1cd16b63 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,6 +16,16 @@
    Cierra fichero abierto o creado y guarda los cambios. Este método es
    automáticamente llamado al finalizar el script.
   </simpara>
+  <note>
+   <simpara>
+    Todas las modificaciones del archivo (añadir, eliminar o renombrar
+    entradas) se realizan en memoria y solo se escriben en el disco cuando
+    se llama a este método. Como consecuencia, los errores relacionados con
+    las operaciones del sistema de ficheros (como un permiso denegado o
+    directorios inexistentes) solo aparecerán en el momento del cierre, y no
+    cuando se llaman los métodos de modificación.
+   </simpara>
+  </note>
   <simpara>
    Si el archivo no contiene ningún fichero, el fichero es completamente eliminado por defecto
    (no se escribe ningún archivo vacío) según el valor de la

--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5cb356334f35b9ae452e3af47d2d9f0b1cd16b63 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xml:id="ziparchive.open" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -19,6 +19,17 @@
   <simpara>
    Desde libzip 1.6.0, un archivo vacío ya no es un archivo válido.
   </simpara>
+  <note>
+   <simpara>
+    Al crear un nuevo archivo con <constant>ZipArchive::CREATE</constant>,
+    el fichero no se escribe realmente en el disco hasta que se llama a
+    <methodname>ZipArchive::close</methodname>. Por lo tanto, los errores
+    relacionados con el sistema de ficheros (como un permiso denegado o un
+    directorio padre inexistente) solo se reportarán al llamar a
+    <methodname>ZipArchive::close</methodname>, y no al llamar a este
+    método.
+   </simpara>
+  </note>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;


### PR DESCRIPTION
Sync with EN commit 5cb356334f35b9ae452e3af47d2d9f0b1cd16b63 (php/doc-en#5274).

- Note that archive changes are held in memory and only written on `ZipArchive::close()`, so filesystem errors surface there

Fixes: #1050