### PR TITLE
[Sync-En] fix typos and spelling mistakes

### DIFF
--- a/reference/svm/svm/crossvalidate.xml
+++ b/reference/svm/svm/crossvalidate.xml
@@ -20,7 +20,7 @@
    problema así como n "plis", la función separará el conjunto del problema en
    n subconjuntos, y comenzará entrenamientos sucesivos en los subconjuntos.
    Aunque la precisión sea generalmente más baja que la de un SVM entrenado
-   con los conjuntos de datos proporcionados, el porcentaje correcto retornado
+   con el conjunto de datos completo, el porcentaje correcto retornado
    debería ser suficientemente útil para probar diferentes argumentos de entrenamiento.
   </simpara>
 

--- a/reference/ui/ui/window/isfullscreen.xml
+++ b/reference/ui/ui/window/isfullscreen.xml
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <simpara>
-   Detectará si esta ventana se utiliza toda la pantalla
+   Detectará si esta ventana utiliza toda la pantalla
   </simpara>
 
  </refsect1>


### PR DESCRIPTION
Sync with EN commit 330a38c4d45556b49e06ebe6d39e0e311534cd8c (php/doc-en#5582).

Of the 61 files listed in the issue, only two carried the English typo through into the translation:

- `svm/crossvalidate.xml`: "enter data set" had been translated as "los conjuntos de datos proporcionados" instead of the entire data set
- `ui/window/isfullscreen.xml`: "this Window us using" had produced an ungrammatical sentence

The other 59 files are already correct in Spanish, either because the misspelled identifier is written properly or because the English typo leaves no trace in the translation.

Fixes: #686