### PR TITLE
[Sync-En] SplFixedArray: non-integer key throws TypeError as of PHP 8.1.0

### DIFF
--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -46,12 +46,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFixedArray'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFixedArray'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFixedArray'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFixedArray'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: yes Maintainer: seros -->
+<!-- EN-Revision: a833060594749e44ff296fee01fd587d6395cff7 Maintainer: andresdzphp Status: ready -->
 <reference xml:id="class.splfixedarray" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase SplFixedArray</title>
  <titleabbrev>SplFixedArray</titleabbrev>
@@ -91,6 +90,14 @@
       <row>
        <entry>8.1.0</entry>
        <entry>
+        El uso de una clave no entera en un <classname>SplFixedArray</classname>
+        ahora lanza un <exceptionname>TypeError</exceptionname> en lugar de una
+        <exceptionname>RuntimeException</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>8.1.0</entry>
+       <entry>
         <classname>SplFixedArray</classname> ahora implementa
         <interfacename>JsonSerializable</interfacename>.
        </entry>
@@ -136,23 +143,25 @@ $array[9] = "asdf";
 // Reducir el tamaño de un array a 2
 $array->setSize(2);
 
-// Las siguientes líneas lanzan una RuntimeException: Index invalid or out of range (Índice inválido o fuera de rango)
-try {
-    var_dump($array["non-numeric"]);
-} catch(RuntimeException $re) {
-    echo "RuntimeException: ".$re->getMessage()."\n";
-}
-
+// Los dos bloques siguientes lanzan una RuntimeException: Index invalid or out of range (Índice inválido o fuera de rango)
 try {
     var_dump($array[-1]);
-} catch(RuntimeException $re) {
-    echo "RuntimeException: ".$re->getMessage()."\n";
+} catch(RuntimeException $e) {
+    echo "RuntimeException: ".$e->getMessage()."\n";
 }
 
 try {
     var_dump($array[5]);
-} catch(RuntimeException $re) {
-    echo "RuntimeException: ".$re->getMessage()."\n";
+} catch(RuntimeException $e) {
+    echo "RuntimeException: ".$e->getMessage()."\n";
+}
+
+// A partir de PHP 8.1.0, el uso de una clave no entera lanza un TypeError.
+// Antes de PHP 8.1.0, se lanzaba una RuntimeException en su lugar.
+try {
+    var_dump($array["non-numeric"]);
+} catch(TypeError $e) {
+    echo "TypeError: ".$e->getMessage()."\n";
 }
 ?>
 ]]>
@@ -165,11 +174,18 @@ int(2)
 string(3) "foo"
 RuntimeException: Index invalid or out of range
 RuntimeException: Index invalid or out of range
-RuntimeException: Index invalid or out of range
+TypeError: Illegal offset type
 ]]>
      </screen>
     </example>
    </para>
+   <note>
+    <simpara>
+     Antes de PHP 8.1.0, acceder a un <classname>SplFixedArray</classname> con
+     una clave no entera lanzaba una <exceptionname>RuntimeException</exceptionname>
+     en lugar de un <exceptionname>TypeError</exceptionname>.
+    </simpara>
+   </note>
   </section>
   <!-- }}} -->
 


### PR DESCRIPTION
Sync with EN commit a833060594749e44ff296fee01fd587d6395cff7.

Adds the 8.1.0 changelog entry (non-integer key throws `TypeError` instead of `RuntimeException`), reorders and fixes the `SplFixedArray` example accordingly, updates the `<screen>` output and adds the trailing note.

Removes the obsolete `<!-- Reviewed -->` marker.

Fixes: #1132