### PR TITLE
[Sync-En] pcre: clarify that delimiters must be single-byte characters

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e1cd2462664adb2495cff5887671ba8a9909cf9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: PhilDaiguille Status: ready -->
 <!-- splitted from ./en/functions/pcre.xml, last change in rev 1.2 -->
 <chapter xml:id="reference.pcre.pattern.syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Sintaxis de patrones</title>
@@ -29,12 +28,20 @@
  </section>
  <section xml:id="regexp.reference.delimiters">
   <title>Delimitadores</title>
-  <para>
+  <simpara>
    Al usar las funciones PCRE, es obligatorio que el patrón esté encerrado
    por <emphasis>delimitadores</emphasis>. Un delimitador puede ser cualquier carácter no alfanumérico,
-   no barra invertida, no espacio en blanco.
+   no barra invertida, no espacio en blanco, de un solo byte.
    Los espacios en blanco iniciales antes de un delimitador válido se ignoran silenciosamente.
-  </para>
+  </simpara>
+  <note>
+   <simpara>
+    Los caracteres multibyte (como los caracteres codificados en UTF-8, por ejemplo <literal>§</literal>)
+    no pueden ser utilizados como delimitadores. PHP lee exactamente un byte como delimitador;
+    utilizar un carácter multibyte provocaría que los bytes restantes fueran
+    interpretados erróneamente como modificadores de patrón desconocidos.
+   </simpara>
+  </note>
   <para>
    Los delimitadores comúnmente utilizados son las barras inclinadas hacia adelante (<literal>/</literal>), signos de número
    (<literal>#</literal>) y tildes (<literal>~</literal>). Los siguientes son ejemplos de patrones delimitados válidos.


### PR DESCRIPTION
Sync with EN commit b55141fe2d4f601e32555c33fb00e1f9225c4638.

Translates the clarification that a PCRE delimiter must be a single-byte character, together with the note explaining that multibyte characters (UTF-8, e.g. `§`) cannot be used as delimiters. The affected `<para>` becomes `<simpara>`, matching EN.

Removes the obsolete `<!-- Reviewed -->` marker.

Fixes: #1131