### PR TITLE
[Sync-En] install: note apache2handler requires Apache 2.4 as of PHP 8.4.0

### DIFF
--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fd1f9d85122cd85854f4afdf5a57ab7da38ff69c Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: ee7185a089f266a9475b069aa199314811fad8a8 Maintainer: PhilDaiguille Status: ready -->
 
 <sect1 xml:id="install.unix.apache2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Apache httpd 2.x en sistemas Unix</title>
@@ -60,6 +60,13 @@
   versión compatible de Apache httpd. Las versiones anteriores (2.2 y anteriores)
   están en fin de vida y no deben utilizarse.
  </simpara>
+
+ <note>
+  <simpara>
+   A partir de PHP 8.4.0, la SAPI apache2handler requiere al menos Apache 2.4;
+   el soporte de Apache 2.0 y 2.2, que están en fin de vida, ha sido eliminado.
+  </simpara>
+ </note>
 
  <orderedlist>
   <listitem>


### PR DESCRIPTION
Sync with EN commit ee7185a089f266a9475b069aa199314811fad8a8.

Adds the translated note stating that, as of PHP 8.4.0, the apache2handler SAPI requires at least Apache 2.4, support for the end-of-life 2.0/2.2 branches having been removed.

Fixes: #1127