### PR TITLE
[Sync-En] cli: document built-in server index lookup for file-like paths (8.4.0)

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 07b2f1dcff1d8beb846f5671e5f4bf2ab8d33ebf Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 14f641dc7a2eb3ab1f97062f0a74f7cdb59ae708 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Utilización de la línea de comandos</title>
@@ -1374,6 +1373,15 @@ php >
   <para>
    Las solicitudes URI se sirven desde el directorio de trabajo actual donde se inició PHP, a menos que se utilice la opción -t para especificar explícitamente un documento raíz. Si una solicitud URI no especifica un archivo, entonces el archivo index.php o el archivo index.html del directorio actual será devuelto. Si ninguno de estos archivos existe, la búsqueda de un archivo index.php e index.html continuará en el directorio padre y así sucesivamente hasta que se encuentre uno de estos archivos o se alcance el directorio raíz. Si se encuentra un archivo index.php o index.html, se devolverá y $_SERVER['PATH_INFO'] se establecerá como la última parte de la URI. De lo contrario, se devolverá un código de respuesta 404.
   </para>
+
+  <note>
+   <simpara>
+    A partir de PHP 8.4.0, esta búsqueda del archivo de índice se realiza incluso
+    cuando la ruta solicitada parece un archivo, es decir, cuando su último
+    componente contiene un punto, pero no se puede localizar. Anteriormente, tales
+    solicitudes omitían la búsqueda y devolvían inmediatamente una respuesta 404.
+   </simpara>
+  </note>
 
   <para>
    Si se proporciona un archivo PHP en la línea de comandos cuando se inicia el servidor web, se tratará como un script "ruteador". El script se ejecutará al inicio de cada solicitud HTTP. Si este script devuelve &false;, entonces el recurso solicitado se devolverá tal cual. De lo contrario, la salida del script se devolverá al navegador.


### PR DESCRIPTION
Sync with EN commit 14f641dc7a2eb3ab1f97062f0a74f7cdb59ae708.

Adds the translated note documenting that, as of PHP 8.4.0, the built-in web server also performs the index file lookup for paths that look like a file (last component containing a dot) but cannot be found, instead of returning a 404 straight away.

Removes the obsolete `<!-- Reviewed -->` marker.

Fixes: #1126