### PR TITLE
[Sync-En] imagick: amend Imagick::sigmoidalContrastImage() parameter names

### DIFF
--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: d9fec5dc8a61c5bbee1d7f70a7bea50c2388e0fd Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.sigmoidalcontrastimage" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,21 +16,24 @@
    <methodparam><type>float</type><parameter>beta</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ajusta el contraste de la imagen con un algoritmo de contraste sigmoide
    no lineal. Aumenta el contraste de la imagen utilizando una función
    de transferencia sigmoide sin saturar las luces altas y las sombras.
-   El contraste indica cuánto debe aumentarse (0 para no hacer nada, 3 es
-   un valor típico, 20 es un valor alto); el punto medio indica dónde
-   estarán los tonos medios en la imagen resultante (0 corresponde a blanco,
-   50 a gris y 100 a negro). Establezca el parámetro <parameter>sharpen</parameter>
-   en &true; para aumentar el contraste de la imagen; de lo contrario,
-   el contraste se reducirá.
-  </para>
-  <para>
-   Consulte también los <link xlink:href="&url.imagemagick.usage.color_mods.sigmoidal;">ejemplos
-   de ImageMagick V6 - Transformaciones de imágenes - Contraste no lineal</link>
-  </para>
+   <parameter>alpha</parameter> indica cuánto debe aumentarse el contraste:
+   <literal>0.00</literal> para no hacer nada; <literal>3.00</literal> es
+   un valor típico; <literal>20.00</literal> es un valor extremo.
+   <parameter>beta</parameter> indica dónde estarán los tonos medios en la
+   imagen resultante, como una fracción del rango del quantum:
+   <literal>0.0</literal> corresponde a blanco, <literal>0.5</literal> a
+   gris medio y <literal>1.0</literal> a negro (se debe multiplicar por
+   <code>getQuantumRange()['quantumRangeLong']</code> para obtener el valor
+   a pasar).
+  </simpara>
+  <simpara>
+   Consúltense también los <link xlink:href="&url.imagemagick.usage.color_mods.sigmoidal;">ejemplos
+    de ImageMagick -- Modificaciones de color — Contraste no lineal sigmoide</link>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,18 +43,19 @@
     <varlistentry>
      <term><parameter>sharpen</parameter></term>
      <listitem>
-      <para>
-       Si es &true;, el contraste aumentará; de lo contrario, el contraste disminuirá.
-      </para>
+      <simpara>
+       Si es &true;, el contraste aumentará; si es &false;, el contraste disminuirá.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>alpha</parameter></term>
      <listitem>
-      <para>
-       La cantidad de contraste a aplicar. -1 representa una cantidad muy pequeña,
-       5 una cantidad significativa y 20 el máximo.
-      </para>
+      <simpara>
+       La cantidad de contraste a aplicar. <literal>1.00</literal> representa una cantidad
+       muy pequeña, <literal>5.00</literal> una cantidad significativa y
+       <literal>20.00</literal> un valor extremo.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -59,16 +63,17 @@
      <listitem>
       <simpara>
        Dónde debe situarse el punto medio del gradiente. Este valor debe estar
-       en el intervalo 0-1, multiplicado por el valor del quantum para ImageMagick.
+       en el intervalo de <literal>0.00</literal> a <literal>1.00</literal>,
+       multiplicado por el valor del quantum para ImageMagick.
       </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>channel</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Canales de color sobre los cuales debe aplicarse el contraste.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -91,32 +96,29 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>
-     Crea un degradado de imagen utilizando el método
-     <function>Imagick::sigmoidalContrastImage</function>
-     para mezclar dos imágenes suavemente, donde la mezcla
-     está definida por las variables $contrast y $midpoint.
-    </title>
-    <programlisting role="php">
+  <example>
+   <title>
+    Crea un degradado de imagen utilizando el método
+    <function>Imagick::sigmoidalContrastImage</function>
+    para mezclar dos imágenes suavemente, donde la mezcla
+    está definida por <parameter>alpha</parameter> y <parameter>beta</parameter>
+   </title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
-function generateBlendImage($width, $height, $contrast = 10, $midpoint = 0.5) {
+function generateBlendImage($width, $height, $alpha = 10, $beta = 0.5)
+{
     $imagick = new Imagick();
     $imagick->newPseudoImage($width, $height, 'gradient:black-white');
     $quanta = $imagick->getQuantumRange();
-    $imagick->sigmoidalContrastImage(true, $contrast, $midpoint * $quanta["quantumRangeLong"]);
+    $imagick->sigmoidalContrastImage(true, $alpha, $beta * $quanta["quantumRangeLong"]);
 
     return $imagick;
 }
-
-?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Sync with EN commit d9fec5dc8a61c5bbee1d7f70a7bea50c2388e0fd.

Rewrites the description in terms of `alpha`/`beta`, fixes the wrong `-1` value for `alpha` (`1.00`), adds `&false;` for `sharpen`, updates the ImageMagick colour modification link, moves the example out of the wrapping `<para>` and renames the example variables accordingly.

Fixes: #1125