### PR TITLE
[Sync-En] phar: document privateKey parameter in PharData::setSignatureAlgorithm()

### DIFF
--- a/reference/phar/Phar/setSignatureAlgorithm.xml
+++ b/reference/phar/Phar/setSignatureAlgorithm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 2cbc37d710751c33862709e622d0e928c9015c45 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="phar.setsignaturealgorithm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Phar::setSignatureAlgorithm</refname>
@@ -53,6 +52,7 @@
        <programlisting role="php">
 <![CDATA[
 <?php
+$p = new Phar('archive.phar');
 $private = openssl_get_privatekey(file_get_contents('private.pem'));
 $pkey = '';
 openssl_pkey_export($private, $pkey);

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 2cbc37d710751c33862709e622d0e928c9015c45 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="phardata.setsignaturealgorithm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>PharData::setSignatureAlgorithm</refname>
@@ -35,6 +34,30 @@
        Un algoritmo entre <literal>Phar::MD5</literal>,
        <literal>Phar::SHA1</literal>, <literal>Phar::SHA256</literal>,
        <literal>Phar::SHA512</literal>, o <literal>Phar::OPENSSL</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>privateKey</parameter></term>
+     <listitem>
+      <para>
+       El contenido de una clave privada OpenSSL, tal como se extrae de un
+       certificado o de un archivo de clave OpenSSL:
+       <programlisting role="php">
+        <![CDATA[
+<?php
+$p = new PharData('archive.tar');
+$private = openssl_get_privatekey(file_get_contents('private.pem'));
+$pkey = '';
+openssl_pkey_export($private, $pkey);
+$p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
+?>
+        ]]>
+       </programlisting>
+       Consulte
+       <link linkend="phar.using">la introducción de phar</link>
+       para las instrucciones de nombramiento y ubicación del
+       archivo de clave pública.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Sync with EN commit 2cbc37d710751c33862709e622d0e928c9015c45.

Documents the `privateKey` parameter on the `PharData::setSignatureAlgorithm()` page and makes the OPENSSL example runnable by instantiating the archive in both pages.

Removes the obsolete `<!-- Reviewed -->` markers.

Fixes: #1122