### PR TITLE
[Sync-En] json: move JSON_ERROR_NON_BACKED_ENUM availability to a changelog section

### DIFF
--- a/reference/json/functions/json-last-error.xml
+++ b/reference/json/functions/json-last-error.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 058ea1e8420b9c1b24402af52545e8313428e1d1 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3733e082ad183251e0b63d08b52c448a243f9710 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xml:id="function.json-last-error" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -28,89 +27,113 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Devuelve un entero, cuyo valor puede ser una de las siguientes
+   constantes:
+  </simpara>
   <para>
-   Devuelve una de las siguientes constantes:
+   <variablelist>
+   <varlistentry>
+    <term><constant>JSON_ERROR_NONE</constant></term>
+    <listitem>
+     <simpara>No ha ocurrido ningún error</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_DEPTH</constant></term>
+    <listitem>
+     <simpara>Se ha excedido la profundidad máxima de la pila</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_STATE_MISMATCH</constant></term>
+    <listitem>
+     <simpara>JSON inválido o mal formado</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_CTRL_CHAR</constant></term>
+    <listitem>
+     <simpara>Error de carácter de control, posiblemente mal codificado</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_SYNTAX</constant></term>
+    <listitem>
+     <simpara>Error de sintaxis</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UTF8</constant></term>
+    <listitem>
+     <simpara>Caracteres UTF-8 mal formados, posiblemente mal codificados</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_RECURSION</constant></term>
+    <listitem>
+     <simpara>Una o más referencias recursivas en el valor a codificar</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_INF_OR_NAN</constant></term>
+    <listitem>
+     <simpara>
+      Uno o más valores
+      <link linkend="language.types.float.nan"><constant>NAN</constant></link>
+      o <link linkend="function.is-infinite"><constant>INF</constant></link>
+      en el valor a codificar
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UNSUPPORTED_TYPE</constant></term>
+    <listitem>
+     <simpara>Se ha proporcionado un valor de un tipo que no puede ser codificado</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_INVALID_PROPERTY_NAME</constant></term>
+    <listitem>
+     <simpara>Se ha proporcionado un nombre de propiedad que no puede ser codificado</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UTF16</constant></term>
+    <listitem>
+     <simpara>Caracteres UTF-16 mal formados, posiblemente mal codificados</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_NON_BACKED_ENUM</constant></term>
+    <listitem>
+     <simpara>El valor contiene un enum no respaldado que no se puede serializar</simpara>
+    </listitem>
+   </varlistentry>
+   </variablelist>
   </para>
-  <table>
-   <title>Códigos de error JSON</title>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Constante</entry>
-      <entry>Significado</entry>
-      <entry>Disponibilidad</entry>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
      </row>
     </thead>
     <tbody>
      <row>
-      <entry><constant>JSON_ERROR_NONE</constant></entry>
-      <entry>No ha ocurrido ningún error</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_DEPTH</constant></entry>
-      <entry>Se ha alcanzado la profundidad máxima de la pila</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_STATE_MISMATCH</constant></entry>
-      <entry>JSON inválido o mal formado</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_CTRL_CHAR</constant></entry>
-      <entry>Error durante el control de caracteres; probablemente un codificación incorrecta</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_SYNTAX</constant></entry>
-      <entry>Error de sintaxis</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UTF8</constant></entry>
-      <entry>Caracteres UTF-8 malformados, posiblemente mal codificados</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_RECURSION</constant></entry>
-      <entry>Una o más referencias recursivas están presentes
-       en el valor a codificar</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_INF_OR_NAN</constant></entry>
+      <entry>8.1.0</entry>
       <entry>
-       Una o más valores
-       <link linkend="language.types.float.nan"><constant>NAN</constant></link>
-       o <link linkend="function.is-infinite"><constant>INF</constant></link>
-       están presentes en el valor a codificar.
+       Se añadió <constant>JSON_ERROR_NON_BACKED_ENUM</constant>.
       </entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UNSUPPORTED_TYPE</constant></entry>
-      <entry>Se ha proporcionado un valor de un tipo que no puede ser codificado</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_INVALID_PROPERTY_NAME</constant></entry>
-      <entry>Se ha proporcionado un nombre de propiedad que no puede ser codificado</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UTF16</constant></entry>
-      <entry>Caracteres UTF-16 mal formados, probablemente mal codificados</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_NON_BACKED_ENUM</constant></entry>
-      <entry>El valor contiene un enum sin valores (non-backed enum) que no se puede serializar. Disponible a partir de PHP 8.1.0.</entry>
-      <entry></entry>
      </row>
     </tbody>
    </tgroup>
-  </table>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -122,11 +145,11 @@
 <![CDATA[
 <?php
 // Una cadena JSON válida
-$json[] = '{"Organisation": "Équipe de Documentation PHP"}';
+$json[] = '{"Organización": "Equipo de Documentación de PHP"}';
 
 // Una cadena json inválida que va a generar un error de sintaxis,
 // aquí, uso de ' en lugar de "
-$json[] = "{'Organisation': 'Équipe de Documentation PHP'}";
+$json[] = "{'Organización': 'Equipo de Documentación de PHP'}";
 
 foreach ($json as $string) {
     echo 'Decodificación: ' . $string;
@@ -164,8 +187,8 @@ foreach ($json as $string) {
     &example.outputs;
     <screen>
 <![CDATA[
-Decodificación: {"Organisation": "Équipe de Documentation PHP"} - Sin errores
-Decodificación: {'Organisation': 'Équipe de Documentation PHP'} - Error de sintaxis; JSON malformado
+Decodificación: {"Organización": "Equipo de Documentación de PHP"} - Sin errores
+Decodificación: {'Organización': 'Equipo de Documentación de PHP'} - Error de sintaxis; JSON malformado
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Sync with EN commit 3733e082ad183251e0b63d08b52c448a243f9710.

Replaces the JSON error codes table with a `<variablelist>` matching EN, and moves the `JSON_ERROR_NON_BACKED_ENUM` availability information into a dedicated changelog section.

Also translates two leftover French strings in the examples and realigns the corresponding `<screen>` output. Removes the obsolete `<!-- Reviewed -->` marker.

Fixes: #1119