### PR TITLE
[Sync-En] array: add example on updating values with array_walk_recursive()

### DIFF
--- a/reference/array/functions/array-walk-recursive.xml
+++ b/reference/array/functions/array-walk-recursive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63f09f4d816aa29c3f8fba9d12a8c6ce2f1755de Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 0d8ee2131b4da66a4d274c576da9137c2a7963d5 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.array-walk-recursive" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_walk_recursive</refname>
@@ -131,6 +131,44 @@ La clave sour contiene el elemento lemon
      nunca es mostrada. Cualquier clave que esté asociada
      a un <type>array</type> no es pasada a la función de retrollamada.
     </para>
+   </example>
+  </para>
+  <simpara>
+   <function>array_walk_recursive</function> también puede utilizarse para
+   actualizar los valores in situ pasando el parámetro de la retrollamada por referencia.
+  </simpara>
+  <para>
+   <example>
+    <title>Actualización de los valores in situ</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$sweet = ['a' => 'apple', 'b' => 'banana'];
+$fruits = ['sweet' => $sweet, 'sour' => 'lemon'];
+
+function test_update(&$item)
+{
+    $item = strtoupper($item);
+}
+
+function test_print($item, $key)
+{
+    echo "La clave $key contiene el elemento $item\n";
+}
+
+array_walk_recursive($fruits, 'test_update');
+array_walk_recursive($fruits, 'test_print');
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+La clave a contiene el elemento APPLE
+La clave b contiene el elemento BANANA
+La clave sour contiene el elemento LEMON
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>


### PR DESCRIPTION
Sync with EN commit 0d8ee2131b4da66a4d274c576da9137c2a7963d5.

Adds the translated "Updating values in place" example (callback taking `&$item` by reference), with the `<screen>` output checked against php:8.4-cli.

Fixes: #1118