### PR TITLE
[Sync-En] errorfunc: document the exception handler stack behavior (8.3.0, 8.3.5)

### DIFF
--- a/reference/errorfunc/functions/restore-exception-handler.xml
+++ b/reference/errorfunc/functions/restore-exception-handler.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4a6671fe697ead5b27603b56face01a2c4e7ebe5 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
-
+<!-- EN-Revision: 1cc803aaa07ac94ce8e3bfdf56f4b9ddd23326d3 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.restore-exception-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>restore_exception_handler</refname>
@@ -24,6 +21,29 @@
    gestor de excepciones (que puede ser la función interna o una función
    definida por el usuario).
   </para>
+  <note>
+   <simpara>
+    Mientras se ejecuta un gestor de excepciones, ningún gestor de excepciones
+    está activo: a partir de PHP 8.3.0 el motor lo desactiva antes de invocarlo,
+    de modo que una excepción lanzada por el gestor no le sea transmitida de
+    nuevo.
+   </simpara>
+   <simpara>
+    A partir de PHP 8.3.5 el motor también apila el gestor que va a invocar en la
+    pila de gestores. Por lo tanto, una llamada a
+    <function>restore_exception_handler</function> realizada desde dentro de un
+    gestor de excepciones desapila esa entrada y reinstala el gestor que se está
+    ejecutando actualmente; se necesita una segunda llamada para instalar el
+    gestor que estaba activo antes de él.
+   </simpara>
+   <simpara>
+    El gestor en ejecución se reinstala automáticamente cuando retorna, pero solo
+    si en ese momento no hay ningún gestor de excepciones activo: un gestor que
+    llama a <function>set_exception_handler</function> o a
+    <function>restore_exception_handler</function> queda a cargo de la pila de
+    gestores.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -35,6 +55,40 @@
   &reftitle.returnvalues;
   <para>
    &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.5</entry>
+       <entry>
+        El gestor de excepciones que va a ser invocado ahora se apila en la pila
+        de gestores, por lo que <function>restore_exception_handler</function>
+        llamada desde dentro de un gestor de excepciones reinstala el gestor que
+        se está ejecutando actualmente; restaurar el gestor que estaba activo
+        antes de él ahora requiere dos llamadas.
+       </entry>
+      </row>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        El gestor de excepciones activo ahora se desactiva mientras se ejecuta.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 
@@ -77,15 +131,13 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>set_exception_handler</function></member>
-    <member><function>get_exception_handler</function></member>
-    <member><function>set_error_handler</function></member>
-    <member><function>restore_error_handler</function></member>
-    <member><function>error_reporting</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>set_exception_handler</function></member>
+   <member><function>get_exception_handler</function></member>
+   <member><function>set_error_handler</function></member>
+   <member><function>restore_error_handler</function></member>
+   <member><function>error_reporting</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/errorfunc/functions/set-exception-handler.xml
+++ b/reference/errorfunc/functions/set-exception-handler.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4a6671fe697ead5b27603b56face01a2c4e7ebe5 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc803aaa07ac94ce8e3bfdf56f4b9ddd23326d3 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.set-exception-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>set_exception_handler</refname>
@@ -21,6 +20,35 @@
    de prueba/atrapa. La ejecución se detendrá después de la llamada a la
    función <parameter>callback</parameter>.
   </para>
+
+  <note>
+   <simpara>
+    Mientras se ejecuta un gestor de excepciones, ningún gestor de excepciones
+    está activo: a partir de PHP 8.3.0 el motor lo desactiva antes de invocarlo,
+    de modo que una excepción lanzada por el gestor no le sea transmitida de
+    nuevo. Por lo tanto, llamada desde dentro de un gestor,
+    <function>set_exception_handler</function> indica que no hay ningún gestor
+    previamente definido.
+   </simpara>
+   <simpara>
+    A partir de PHP 8.3.5 el motor también apila el gestor que va a invocar en la
+    pila de gestores, por lo que <function>restore_exception_handler</function>
+    llamada desde dentro de un gestor reinstala el gestor que se está ejecutando
+    actualmente en lugar del que estaba activo antes de él.
+   </simpara>
+   <simpara>
+    El gestor en ejecución se reinstala automáticamente cuando retorna, pero solo
+    si en ese momento no hay ningún gestor de excepciones activo. En cuanto el
+    gestor llama a <function>set_exception_handler</function> o a
+    <function>restore_exception_handler</function>, esta restauración automática
+    se omite y el gestor activo es el que el propio gestor haya dejado
+    instalado.
+   </simpara>
+   <simpara>
+    Por lo tanto, se desaconseja modificar el gestor de excepciones desde dentro
+    de sí mismo.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -63,6 +91,41 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.5</entry>
+       <entry>
+        El gestor de excepciones que va a ser invocado ahora se apila en la pila
+        de gestores y se reinstala una vez que retorna, a menos que el propio
+        gestor haya modificado la pila.
+       </entry>
+      </row>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        El gestor de excepciones activo ahora se desactiva mientras se ejecuta,
+        por lo que <function>set_exception_handler</function> llamada desde
+        dentro de un gestor indica que no hay ningún gestor previamente
+        definido.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -88,15 +151,13 @@ echo "No ejecutado\n";
 
  <refsect1 role="seealso"><!-- {{{ -->
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>get_exception_handler</function></member>
-    <member><function>restore_exception_handler</function></member>
-    <member><function>restore_error_handler</function></member>
-    <member><function>error_reporting</function></member>
-    <member>Las <link linkend="language.exceptions">excepciones</link></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>get_exception_handler</function></member>
+   <member><function>restore_exception_handler</function></member>
+   <member><function>restore_error_handler</function></member>
+   <member><function>error_reporting</function></member>
+   <member>Las <link linkend="language.exceptions">excepciones</link></member>
+  </simplelist>
  </refsect1><!-- }}} -->
 
 </refentry>


### PR DESCRIPTION
Sync with EN commit 1cc803aaa07ac94ce8e3bfdf56f4b9ddd23326d3.

Adds the note describing the exception handler stack behavior (8.3.0: the handler is disabled while running; 8.3.5: it is stacked and reinstated on return) and the matching changelog section. The `seealso` `<simplelist>` is taken out of its `<para>`, as in EN.

Removes the obsolete `<!-- Reviewed -->` markers.

Fixes: #1117