### PR TITLE
[Sync-En] sodium: AES-256-GCM aarch64 support; filesystem: auto_detect_line_endings deprecation

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fd1f9d85122cd85854f4afdf5a57ab7da38ff69c Maintainer: argosback Status: ready -->
-<!-- Reviewed: yes Maintainer: argosback -->
+<!-- EN-Revision: 9e5166dc6a5ff650b649298470d19eb7c3637a63 Maintainer: argosback Status: ready -->
 
 <!ENTITY installation.enabled.disable 'Esta extensión está activada por defecto. Puede ser desactivada utilizando la opción de configuración: '>
 
@@ -101,11 +100,13 @@ y los argumentos faltantes son reemplazados con sus valores
 por defecto. Esta función ignora la colección de argumentos variádicos nombrados
 desconocidos. Los argumentos nombrados que son recolectados solo son accesibles a través del parámetro variádico.</simpara></note>'>
 
-<!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara> Si PHP no reconoce correctamente los finales de
-línea al leer ficheros que han sido creados o leídos en un Macintosh, la activación de
-la opción de configuración
+<!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>Antes de PHP 8.1.0, la
+opción de configuración en tiempo de ejecución
 <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link>
-puede resolver el problema.</simpara></note>'>
+se podía activar para ayudar a PHP a reconocer correctamente los finales de línea
+al leer ficheros creados en sistemas Macintosh. Esta opción está obsoleta a partir
+de PHP 8.1.0. Si es necesario, en su lugar se deben gestionar manualmente los saltos
+de línea <literal>"\r"</literal>.</simpara></note>'>
 
 <!ENTITY note.no-remote '<note xmlns="http://docbook.org/ns/docbook"><simpara> Esta función no funciona con los
 <link linkend="features.remote-files">archivos remotos</link>, ya que el archivo
@@ -4515,6 +4516,29 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Esta función ha sido
     contexto <link linkend="context.ssl.verify-peer-name"><parameter>verify_peer_name</parameter></link>
     a &false;.
    </simpara>
+'>
+
+<!-- Sodium -->
+<!ENTITY sodium.changelog.aes256gcm-aarch64 '
+  <informaltable xmlns="http://docbook.org/ns/docbook">
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Esta función ahora también está definida en aarch64.
+       Anteriormente solo estaba definida en x86 y x86_64.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
 '>
 
 <!-- Keep this comment at the end of the file

--- a/reference/filesystem/ini.xml
+++ b/reference/filesystem/ini.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: Marqitos Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 9e5166dc6a5ff650b649298470d19eb7c3637a63 Maintainer: Marqitos Status: ready -->
 <section xml:id="filesystem.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
@@ -149,18 +147,23 @@
      <type>bool</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Cuando se activa, PHP examinará la información leída por
       <function>fgets</function> y <function>file</function> para ver si se
       está usando las convenciones de final de línea de Unix, MS-Dos o Macintosh.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Esto permite a PHP inter-operar con los sistemas Macintosh,
       pero por defecto está en Off, ya que hay una pérdida muy pequeña de rendimiento
       cuando se detectan las convenciones de EOL para la primera línea, y también
-      porque la gente que usa retornos de carro como elementos serparadores bajo
+      porque la gente que usa retornos de carro como elementos separadores bajo
       sistemas Unix podrían experimentar un comportamiento que no es compatible con versiones anteriores.
-     </para>
+     </simpara>
+     <warning>
+      <simpara>
+       Esta opción está obsoleta a partir de PHP 8.1.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 

--- a/reference/sodium/constants.xml
+++ b/reference/sodium/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 2214cd3277cf065a3abf395e9bbde73ed61d7d12 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: PhilDaiguille Status: ready -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sodium.constants">
  &reftitle.constants;
  &extension.constants;
@@ -171,6 +169,9 @@
    </term>
    <listitem>
     <simpara>
+     Solo está definida en las plataformas donde el soporte de AES-256-GCM
+     está compilado.
+     Definida en aarch64 a partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -181,6 +182,9 @@
    </term>
    <listitem>
     <simpara>
+     Solo está definida en las plataformas donde el soporte de AES-256-GCM
+     está compilado.
+     Definida en aarch64 a partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -191,6 +195,9 @@
    </term>
    <listitem>
     <simpara>
+     Solo está definida en las plataformas donde el soporte de AES-256-GCM
+     está compilado.
+     Definida en aarch64 a partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -201,6 +208,9 @@
    </term>
    <listitem>
     <simpara>
+     Solo está definida en las plataformas donde el soporte de AES-256-GCM
+     está compilado.
+     Definida en aarch64 a partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-decrypt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-aes256gcm-decrypt">
  <refnamediv>
   <refname>sodium_crypto_aead_aes256gcm_decrypt</refname>
@@ -69,6 +68,12 @@
    Devuelve el texto en claro en caso de éxito, &return.falseforfailure;.
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
+ </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-aes256gcm-encrypt">
  <refnamediv>
   <refname>sodium_crypto_aead_aes256gcm_encrypt</refname>
@@ -68,6 +67,12 @@
    Devuelve el texto cifrado y la etiqueta de autenticación en forma de cadena de bytes binarios sin tratar. (Formato: texto cifrado, luego etiqueta.)
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
+ </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-is-available.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-is-available.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-aes256gcm-is-available">
  <refnamediv>
   <refname>sodium_crypto_aead_aes256gcm_is_available</refname>
@@ -30,6 +29,32 @@
    Devuelve &true; si es seguro cifrar con AES-256-GCM, y &false; en caso contrario.
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Esta función ahora puede devolver &true; en CPU aarch64 que dispongan de
+       las extensiones criptográficas de ARM.
+       Anteriormente, AES-256-GCM acelerado por hardware solo se detectaba en
+       x86 y x86_64, y esta función siempre devolvía &false; en aarch64.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-keygen.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-aes256gcm-keygen">
  <refnamediv>
   <refname>sodium_crypto_aead_aes256gcm_keygen</refname>
@@ -31,6 +30,12 @@
    Devuelve una clave aleatoria de 256 bits.
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
+ </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Two sync issues are handled together because both touch `language-snippets.ent`.

Sync with EN commits 4c85baa92d7c99df238876d20d77ecb952472f11 (sodium) and 9e5166dc6a5ff650b649298470d19eb7c3637a63 (filesystem).

- sodium: new `sodium.changelog.aes256gcm-aarch64` entity (8.4.0 changelog table), changelog section added to the four AES-256-GCM function pages, and descriptions filled in for the four `SODIUM_CRYPTO_AEAD_AES256GCM_*` constants.
- filesystem: `note.line-endings` rewritten (deprecation of `auto_detect_line_endings` in 8.1.0, manual handling of `"\\r"`) and a deprecation `<warning>` added to the INI directive; the two inline-only paragraphs become `<simpara>`.

Removes the obsolete `<!-- Reviewed -->` markers and fixes a typo ("serparadores").

Fixes: #1115
Fixes: #1120