### PR TITLE
[Sync-En] array: note SORT_REGULAR with numeric strings in array_unique()

### DIFF
--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 47cbf365f535be1517473eee446e94d096778ca8 Maintainer: PhilDaiguille Status: ready -->
 <!-- CREDITS: DavidA. -->
 <refentry xml:id="function.array-unique" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -60,6 +58,15 @@
         <listitem>
          <simpara><constant>SORT_REGULAR</constant> - compara los elementos normalmente
          (no modifica los tipos)</simpara>
+         <note>
+          <simpara>
+           Al combinar <constant>SORT_REGULAR</constant> con arrays que mezclan
+           strings numéricos y no numéricos, el algoritmo de ordenar y comparar
+           podría no colocar los elementos iguales de forma adyacente, lo que
+           puede dejar duplicados en el resultado. Se debe utilizar
+           <constant>SORT_STRING</constant> para evitarlo.
+          </simpara>
+         </note>
         </listitem>
         <listitem>
          <simpara><constant>SORT_NUMERIC</constant> - compara los elementos


### PR DESCRIPTION
Sync with EN commit 47cbf365f535be1517473eee446e94d096778ca8.

Adds the translated note under the `SORT_REGULAR` list item, warning that mixing numeric and non-numeric strings with `SORT_REGULAR` may leave duplicates, and that `SORT_STRING` should be used instead.

Removes the obsolete `<!-- Reviewed -->` and `<!-- $Revision$ -->` markers.

Fixes: #1113