### PR TITLE
[Sync-En] yac: sync the Yac extension documentation with EN

### DIFF
--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 68c2c871505aadf983f16113c5b077b335ce8d76 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: andresdzphp Status: ready -->
 
 <book xml:id="book.yac" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -10,9 +8,55 @@
 
  <preface xml:id="intro.yac">
   &reftitle.intro;
-  <para>
-   Yac (Otro caché), es un caché de datos de usuario de memoria compartida sin bloqueo, podría utilizarse para reemplazar el APC, el memcache local.
-  </para>
+  <simpara>
+   Yac (Yet Another Cache) es una caché de datos de usuario en memoria
+   compartida y sin bloqueos, que puede utilizarse para reemplazar a APC
+   o a un memcached local.
+  </simpara>
+  <simpara>
+   Yac almacena los datos en memoria compartida, lo que los hace visibles
+   para todos los procesos de trabajo de PHP de la misma máquina sin
+   ninguna comunicación entre procesos. En lugar de bloqueos, Yac se basa
+   en actualizaciones atómicas de las ranuras junto con unos pocos sondeos
+   de colisión, de modo que un fallo de caché nunca bloquea una petición y
+   una escritura concurrente puede provocar, en el peor de los casos, un
+   almacenamiento fallido o una lectura perdida que quien la invoca puede
+   simplemente reintentar.
+  </simpara>
+  <simpara>
+   Al no haber bloqueos ni comunicación entre procesos en la ruta de
+   acceso, una lectura es esencialmente una búsqueda hash en memoria
+   compartida. Como resultado, Yac es extremadamente rápida, con una
+   latencia de lectura del orden de microsegundos, y su rendimiento puede
+   escalar con el número de procesos de trabajo mientras las escrituras se
+   repartan entre distintas claves.
+  </simpara>
+  <simpara>
+   Dado que Yac sacrifica garantías de corrección a cambio de velocidad y
+   rendimiento, resulta más adecuada para datos que son costosos de
+   producir pero fáciles de recrear: fragmentos de página, instantáneas de
+   configuración, respuestas pequeñas de servicios y otras cachés locales.
+   No debería utilizarse como almacén de referencia para datos
+   irremplazables.
+  </simpara>
+  <simpara>
+   A partir de yac 2.4.0, los valores escalares pequeños —
+   <constant>NULL</constant>, booleanos, enteros, cadenas cortas de hasta
+   7 bytes y arrays vacíos — se almacenan directamente dentro de la ranura
+   hash en lugar de en un bloque de valor separado («valores
+   incrustados»), lo que elimina la reserva de memoria del valor y la
+   copia del bloque en cada acceso, mejorando significativamente el
+   rendimiento al tiempo que reduce el uso de memoria. La versión 2.4.0
+   también cambió el motor de compresión de FastLZ a LZ4, haciendo que las
+   lecturas comprimidas sean varias veces más rápidas.
+  </simpara>
+  <note>
+   <simpara>
+    La memoria compartida solo es visible dentro de una misma máquina.
+    Para compartir una caché entre varios servidores, se debe utilizar en
+    su lugar una caché en red como Memcached o Redis.
+   </simpara>
+  </note>
  </preface>
 
  &reference.yac.setup;

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: andresdzphp Status: ready -->
 
 <section xml:id="yac.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -76,9 +74,14 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
-
-      </para>
+      <simpara>
+       Los valores serializados que superan este número de bytes se
+       comprimen antes de almacenarse (actualmente con LZ4). Se debe
+       establecer a <literal>-1</literal> (el valor predeterminado) para
+       desactivar por completo la compresión. Comprimir valores grandes
+       ahorra memoria compartida a costa de algo de CPU tanto al almacenar
+       como al recuperar.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.debug">
@@ -87,9 +90,10 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
-
-      </para>
+      <simpara>
+       Reservada para depuración. A partir de Yac 2.4.0 esta directiva
+       está registrada pero no tiene ningún efecto.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.enable">
@@ -98,9 +102,10 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
-
-      </para>
+      <simpara>
+       Indica si Yac está activado. Si está desactivado, crear una
+       instancia de <classname>Yac</classname> lanza una excepción.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.enable-cli">
@@ -109,9 +114,13 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
-
-      </para>
+      <simpara>
+       Indica si Yac está activado al ejecutarse bajo la SAPI
+       <literal>CLI</literal>. Está desactivado de forma predeterminada
+       porque los scripts de línea de comandos suelen iniciarse y
+       detenerse de inmediato, y el segmento de memoria compartida se
+       crearía en vano.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.keys-memory-size">
@@ -120,9 +129,15 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
-
-      </para>
+      <simpara>
+       Cantidad de memoria compartida utilizada para las ranuras de la
+       tabla hash que contienen las claves y la información de control.
+       Cada ranura es una estructura de tamaño fijo, de modo que este
+       valor determina cuántos elementos pueden gestionarse a la vez. El
+       valor predeterminado es <literal>4M</literal>. Yac divide esta
+       zona en segmentos; el tamaño de segmento es 4M, por lo que este
+       valor debe ser un múltiplo de <literal>4M</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.serializer">
@@ -131,9 +146,17 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
-
-      </para>
+      <simpara>
+       Serializador utilizado para convertir valores PHP arbitrarios en
+       bytes antes de almacenarlos. Los valores permitidos son
+       <literal>php</literal> (el predeterminado),
+       <literal>json</literal>, <literal>igbinary</literal> y
+       <literal>msgpack</literal>. Los tres últimos requieren que la
+       extensión se haya compilado con el soporte correspondiente. Los
+       serializadores binarios, como <literal>igbinary</literal> y
+       <literal>msgpack</literal>, suelen ser más rápidos y producen
+       datos más pequeños que <literal>php</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.values-memory-size">
@@ -142,9 +165,15 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
-
-      </para>
+      <simpara>
+       Cantidad de memoria compartida utilizada para almacenar los
+       valores propiamente dichos. El valor predeterminado es
+       <literal>64M</literal>. Yac reserva esta zona en segmentos de 4M
+       cada uno, por lo que este valor debe ser un múltiplo de
+       <literal>4M</literal>. Cuando la zona está llena, las entradas
+       usadas menos recientemente se eliminan para hacer sitio a las
+       nuevas.
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/yac/setup.xml
+++ b/reference/yac/setup.xml
@@ -1,31 +1,104 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9dbf3a558f49ddc5b2e0097abd3f06cf5413f25d Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: andresdzphp Status: ready -->
 
 <chapter xml:id="yac.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
  <section xml:id="yac.requirements">
   &reftitle.required;
-  <para>
-
-  </para>
+  <simpara>
+   No se requiere ninguna biblioteca externa.
+  </simpara>
  </section>
 
  <!-- {{{ Installation -->
  <section xml:id="yac.installation">
   &reftitle.install;
-  <para>
+  <simpara>
+   Yac se puede instalar de tres maneras: mediante PECL, mediante PIE o
+   compilándolo a partir del código fuente.
+  </simpara>
+  <simpara>
    &pecl.moved;
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;yac">&url.pecl.package;yac</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.windows.download.avail;
-  </para>
+  </simpara>
+  <example>
+   <title>Instalación de Yac con PECL</title>
+   <programlisting role="shell">
+<![CDATA[
+pecl install yac
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   A partir de Yac 2.3.2, la extensión se puede instalar con
+   &link.pie;, el instalador de extensiones de PHP, ejecutando lo
+   siguiente en la línea de comandos.
+  </simpara>
+  <example>
+   <title>Instalación de Yac con PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yac
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Los serializadores opcionales se pueden activar en el momento de la instalación:
+  </simpara>
+  <example>
+   <title>Instalación de Yac con PIE y un serializador</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yac --enable-json
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   El código fuente está alojado en
+   <link xlink:href="&url.git.hub;laruence/yac">GitHub</link>. Para
+   compilar la extensión a partir del código fuente, se debe ejecutar lo
+   siguiente en la línea de comandos, sustituyendo las rutas por las de la
+   instalación local de PHP.
+  </simpara>
+  <example>
+   <title>Compilación de Yac a partir del código fuente</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Están disponibles las siguientes opciones de <literal>configure</literal>:
+  </simpara>
+  <simpara>
+   Los valores se comprimen con LZ4 antes de ser almacenados. El motor de
+   compresión LZ4 se introdujo en Yac 2.4.0, en sustitución del anterior
+   FastLZ. De forma predeterminada, Yac utiliza la copia de LZ4 incluida con la
+   extensión; no se necesita ningún indicador adicional. Para enlazar en su lugar
+   con la biblioteca LZ4 del sistema, se utiliza la opción
+   <option role="configure">--with-system-lz4</option>, que
+   requiere que estén instalados la cabecera <literal>lz4.h</literal> y
+   <literal>liblz4</literal>.
+  </simpara>
+  <simpara>
+   Se pueden compilar serializadores alternativos con
+   <option role="configure">--enable-json</option>,
+   <option role="configure">--enable-msgpack</option> o
+   <option role="configure">--enable-igbinary</option>, que registran la
+   extensión correspondiente como una dependencia opcional. El serializador
+   utilizado en tiempo de ejecución se selecciona con la directiva ini
+   <link linkend="ini.yac.serializer">yac.serializer</link>.
+  </simpara>
  </section>
  <!-- }}} -->
 
@@ -35,9 +108,9 @@
 
  <section xml:id="yac.resources">
   &reftitle.resources;
-  <para>
-
-  </para>
+  <simpara>
+   Esta extensión no define ningún tipo de recurso.
+  </simpara>
  </section>
 
 </chapter>

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -1,29 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::add</refname>
-  <refpurpose>Guardar en caché</refpurpose>
+  <refpurpose>Almacena un valor sin sobrescribir uno existente</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>array</type><parameter>key_vals</parameter></methodparam>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
-    Añadir un artículo al caché.
-  </para>
+  <simpara>
+   Almacena un valor en la caché. A diferencia de <methodname>Yac::set</methodname>,
+   no sobrescribe una entrada existente que siga siendo válida; en ese caso el
+   almacenamiento es rechazado.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,25 +33,30 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
-       &string; clave
-     </para>
+     <simpara>
+      Una clave de tipo <type>string</type>, o un <type>array</type> de pares
+      <literal>clave =&gt; valor</literal> que se almacenan en una sola llamada.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-      valor mixto, Todo tipo de valor php podría ser almacenado excepto &resource;
-     </para>
+     <simpara>
+      El valor a almacenar. Puede almacenarse cualquier tipo de PHP excepto
+      <type>resource</type>. Solo se utiliza en la forma de clave única; cuando
+      <parameter>keys</parameter> es un array, este argumento es en su lugar el
+      parámetro opcional <parameter>ttl</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>ttl</parameter></term>
     <listitem>
-     <para>
-      tiempo de expiración
-     </para>
+     <simpara>
+      Tiempo de vida en segundos. <literal>0</literal> significa que la entrada
+      nunca expira por tiempo.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -58,25 +64,64 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &boolean;, &true; en caso de éxito, &false; en caso de fallar.
-   <note>
-    <para>
-     <methodname>Yac::add</methodname> puede fallar si el casillero no se puede obtener,
-     así que, si necesitas que el valor se almacene correctamente, puedes escribir códigos como:
-     <example>
-      <title>Asegúrate de que el artículo se almacene</title>
-      <programlisting role="php">
-       <![CDATA[
-       while(!$yac->set("key", "value"));
-       ]]>
-      </programlisting>
-     </example>
-    </para>
-   </note>
-  </para>
+  <simpara>
+   Devuelve &true; en caso de éxito, &false; en caso de fallo. El almacenamiento
+   también es rechazado (devolviendo &false;) cuando la clave ya existe y no ha
+   expirado.
+  </simpara>
+  <note>
+   <para>
+    Yac almacena las entradas sin bloqueos. Bajo una fuerte contención, un
+    almacenamiento puede fallar de forma transitoria; si el valor debe acabar
+    siendo almacenado, hay que reintentarlo:
+    <programlisting role="php">
+<![CDATA[
+<?php
+while (!$yac->add("key", "value")) {
+    // reintento en caso de fallo transitorio
+}
+?>
+]]>
+    </programlisting>
+   </para>
+  </note>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::add</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+var_dump($yac->add("foo", "bar"));          // bool(true)
+var_dump($yac->add("foo", "baz"));          // bool(false): "foo" ya existe
+
+// ttl en segundos; 0 (el valor predeterminado) significa que la entrada nunca expira
+$yac->add("short-lived", "value", 5);
+sleep(6);
+var_dump($yac->get("short-lived"));        // bool(false): expirado
+
+// almacena varios pares clave => valor en una sola llamada, con un ttl
+$yac->add(array("a" => 1, "b" => 2), 60);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::delete</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 74155fb94bef0d0e0c6edd5994fc33ab40781701 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xml:id="yac.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +13,12 @@
    <modifier>public</modifier> <methodname>Yac::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>prefix</parameter><initializer>""</initializer></methodparam>
   </constructorsynopsis>
-  <para>
-    se utiliza un prefijo para preparar las claves, esto podría utilizarse para evitar conflictos entre aplicaciones.
-  </para>
-
+  <simpara>
+   Crea una nueva instancia de <classname>Yac</classname>. El
+   <parameter>prefix</parameter> opcional se antepone a cada clave que almacena
+   esta instancia, lo que permite que varias aplicaciones o cachés en la misma
+   máquina utilicen nombres de clave coincidentes sin que colisionen.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,31 +27,49 @@
    <varlistentry>
     <term><parameter>prefix</parameter></term>
     <listitem>
-     <para>
-       Prefijo &string;
-     </para>
+     <simpara>
+      Un prefijo de clave, de hasta 48 bytes (<constant>YAC_MAX_KEY_LEN</constant>).
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
 
- <!-- Return values commented out, as constructors generally don't return a
-      value. Uncomment this if you do need a return values section (for
-      example, because there's also a procedural version of the method).
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-
-  </para>
- </refsect1>
- -->
-
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   Lanza una <exceptionname>Exception</exceptionname> si la caché está
+   deshabilitada (<literal>yac.enable=0</literal>), o si
+   <parameter>prefix</parameter> supera los 48 bytes de longitud.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::__construct</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+$other = new Yac("app2_");
+var_dump($other->get("foo"));    // bool(false): espacio de nombres diferente
+$other->set("foo", "baz");       // almacenado como "app2_foo"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   Lanza una <classname>Exception</classname> si Yac no está habilitado. Lanza
-   <classname>Exception</classname> si <parameter>prefix</parameter> excede
-   la longitud máxima de clave de 48 (<constant>YAC_MAX_KEY_LEN</constant>) bytes.
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::delete</refname>
-  <refpurpose>Eliminar los artículos de la memoria caché</refpurpose>
+  <refpurpose>Elimina elementos de la caché</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,11 +12,26 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::delete</methodname>
    <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>delay</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   retira los artículos de la memoria caché
-  </para>
+  <simpara>
+   Elimina uno o varios elementos de la caché.
+  </simpara>
+  <note>
+   <simpara>
+    La eliminación se implementa marcando la entrada como caducada en lugar
+    de liberar su ranura: la entrada deja de poder leerse de inmediato, pero
+    la ranura permanece ocupada hasta que se almacena de nuevo la misma clave
+    o hasta que una escritura posterior recupera dicha ranura. Como
+    consecuencia, el número de ranuras usadas que informa
+    <methodname>Yac::info</methodname> no disminuye tras una eliminación, y
+    <methodname>Yac::dump</methodname> sigue mostrando la entrada eliminada
+    hasta que su ranura se recicla; un valor <literal>ttl</literal> distinto
+    de cero situado en el pasado indica una entrada eliminada o caducada, por
+    lo que, al examinar la salida de <methodname>Yac::dump</methodname>, tales
+    entradas deben ser filtradas por el llamador.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,17 +40,21 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
-      clave string, o array de multiples claves para ser removidas.
-     </para>
+     <simpara>
+      Una clave de tipo <type>string</type>, o un <type>array</type> de claves
+      que serán eliminadas.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>ttl</parameter></term>
+    <term><parameter>delay</parameter></term>
     <listitem>
-     <para>
-      si se establece un retraso, la eliminación marcará los elementos como inválidos en ttl segundo.
-     </para>
+     <simpara>
+      Número de segundos antes de que el elemento deje de ser válido. Si se
+      omite o vale <literal>0</literal>, el elemento se invalida de inmediato.
+      Un valor positivo mantiene el elemento legible durante ese número de
+      segundos antes de que caduque.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,11 +62,65 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Devuelve &true; en caso de éxito, o &false; si la clave no estaba presente
+   en la caché. Dado que una eliminación solo marca la entrada como caducada,
+   una clave que ha sido eliminada pero aún no sobrescrita se sigue
+   considerando presente: eliminar de nuevo la misma clave devuelve &true;.
+  </simpara>
+  <simpara>
+   Cuando se proporciona un <type>array</type> de claves, se devuelve &true;
+   únicamente si todas las claves estaban presentes; si falta alguna clave, se
+   devuelve &false;.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::delete</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+var_dump($yac->delete("foo"));      // bool(true): marcada como caducada
+var_dump($yac->get("foo"));         // bool(false): a partir de ahora, un fallo
+var_dump($yac->delete("foo"));      // bool(true) de nuevo: la ranura aún no
+                                     // ha sido sobrescrita
+var_dump($yac->delete("never"));    // bool(false): nunca fue almacenada
+
+// una eliminación no libera la ranura: slots_used no disminuye, y
+// la entrada caducada sigue apareciendo en el volcado
+var_dump($yac->info()["slots_used"]); // int(1)
+print_r($yac->dump());                // "foo" sigue apareciendo; su ttl
+                                       // está en el pasado
+
+// eliminación retardada: mantiene la entrada legible durante 60 segundos más
+$yac->set("tmp", "value");
+var_dump($yac->delete("tmp", 60));    // bool(true)
+
+// eliminar varias claves a la vez devuelve true solo cuando todas las
+// claves estaban presentes
+var_dump($yac->delete(array("tmp", "nope"))); // bool(false): falta "nope"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::flush</methodname></member>
+    <member><methodname>Yac::info</methodname></member>
+    <member><methodname>Yac::dump</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,34 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::dump</refname>
-  <refpurpose>Volcar cache</refpurpose>
+  <refpurpose>Vuelca las entradas de la caché para su inspección</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>mixed</type><methodname>Yac::dump</methodname>
-   <methodparam><type>int</type><parameter>num</parameter></methodparam>
+   <modifier>public</modifier> <type>array</type><methodname>Yac::dump</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>limit</parameter><initializer>100</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Volcar valores almacenados en caché
-  </para>
+  <simpara>
+   Vuelca los metadatos de las entradas almacenadas actualmente en la caché.
+   Los valores en sí no son devueltos.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>num</parameter></term>
+    <term><parameter>limit</parameter></term>
     <listitem>
-     <para>
-       El número máximo de artículos debe ser devuelto
-     </para>
+     <simpara>
+      Número máximo de entradas a devolver.
+     </simpara>
+     <simpara>
+      Pasar <literal>-1</literal> como <parameter>limit</parameter> vuelca
+      todas las entradas que la caché contiene en ese momento. Es de tener en
+      cuenta que construir la lista completa puede consumir una cantidad
+      considerable de memoria en una caché grande; cuando la memoria importa,
+      es preferible recorrer las entradas por páginas con
+      <parameter>limit</parameter> y <parameter>offset</parameter>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      Número de entradas a omitir antes de empezar a recopilar. Este parámetro
+      está disponible a partir de PECL yac 2.4.0; las versiones anteriores
+      siempre comienzan por la primera entrada. Combinado con
+      <parameter>limit</parameter>, permite recorrer por páginas una caché que
+      contiene más entradas de las que una sola llamada puede devolver.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,11 +56,220 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   mixed
-  </para>
+  <simpara>
+   Un <type>array</type> con un elemento por cada entrada volcada. Cada
+   elemento es a su vez un array que describe la entrada:
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>index</literal></term>
+    <listitem><simpara>
+     El índice de la ranura de la entrada en la tabla hash.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hash</literal></term>
+    <listitem><simpara>
+     El hash de 64 bits de la clave, utilizado para el sondeo de ranuras.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>crc</literal></term>
+    <listitem><simpara>
+     La suma de comprobación CRC32 del valor almacenado, utilizada para
+     detectar lecturas inconsistentes. <literal>0</literal> para las entradas
+     empotradas, que no tienen bloque de valor.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>ttl</literal></term>
+    <listitem><simpara>
+     La marca de tiempo de expiración (tiempo Unix). <literal>0</literal>
+     significa que la entrada nunca expira por tiempo. Es de tener en cuenta
+     que <methodname>Yac::delete</methodname> solamente marca una entrada como
+     expirada, por lo que las entradas eliminadas pueden seguir apareciendo en
+     el volcado; un <literal>ttl</literal> distinto de cero situado en el
+     pasado indica una entrada expirada o eliminada.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>k_len</literal></term>
+    <listitem><simpara>
+     La longitud de la clave, en bytes.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>v_len</literal></term>
+    <listitem><simpara>
+     La longitud del valor, en bytes. Para las entradas comprimidas se trata de
+     la longitud del valor <emphasis>original</emphasis> antes de la compresión
+     (a partir de yac 2.4.0; las versiones anteriores informaban de la longitud
+     almacenada, ya comprimida).
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>c_len</literal></term>
+    <listitem><simpara>
+     Presente únicamente para las entradas comprimidas (a partir de yac 2.4.0):
+     la longitud de la carga útil comprimida realmente almacenada en la memoria
+     compartida, en bytes. Comparar <literal>c_len</literal> con
+     <literal>v_len</literal> muestra cuánto ahorra la compresión en cada
+     entrada.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>size</literal></term>
+    <listitem><simpara>
+     El tamaño asignado al bloque de valor en la memoria compartida, en bytes.
+     <literal>0</literal> para las entradas empotradas.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>atime</literal></term>
+    <listitem><simpara>
+     La hora del último acceso (tiempo Unix), actualizada en cada
+     <methodname>Yac::get</methodname> con éxito. Cuando la caché está llena, la
+     entrada con el <literal>atime</literal> más antiguo de entre las ranuras
+     candidatas es la primera en ser desalojada (a partir de yac 2.4.0).
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hits</literal></term>
+    <listitem><simpara>
+     Un contador de aciertos por entrada, incrementado en cada
+     <methodname>Yac::get</methodname> con éxito, y reiniciado cuando la entrada
+     es sobrescrita, eliminada o expira (a partir de yac 2.4.0).
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>embedded</literal></term>
+    <listitem><simpara>
+     Indica si el valor se almacena directamente dentro de la ranura en lugar de
+     en un bloque de valor separado (a partir de yac 2.4.0). Los valores
+     pequeños — <constant>NULL</constant>, booleanos, enteros pequeños, cadenas
+     de hasta 7 bytes y arrays vacíos — se incrustan de esta forma y no reservan
+     memoria de valor alguna; para ellos <literal>crc</literal> y
+     <literal>size</literal> se indican como <literal>0</literal>.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>key</literal></term>
+    <listitem><simpara>
+     La clave de la caché, sin ningún prefijo de instancia.
+    </simpara></listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::dump</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+$yac->set("baz", "qux");
+
+print_r($yac->dump());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [0] => Array
+        (
+            [index] => 12345
+            [hash] => 14463105906481965911
+            [crc] => 0
+            [ttl] => 0
+            [k_len] => 3
+            [v_len] => 3
+            [size] => 0
+            [atime] => 1725955200
+            [hits] => 0
+            [embedded] => 1
+            [key] => foo
+        )
+
+    [1] => Array
+        (
+            [index] => 12987
+            [hash] => 15132029420525657053
+            [crc] => 0
+            [ttl] => 0
+            [k_len] => 3
+            [v_len] => 3
+            [size] => 0
+            [atime] => 1725955200
+            [hits] => 0
+            [embedded] => 1
+            [key] => baz
+        )
+
+)
+]]>
+   </screen>
+   <simpara>
+    Las entradas se listan en el orden de las ranuras, no en el orden en que
+    fueron almacenadas. Las entradas empotradas (escalares cortos conservados
+    dentro de la propia ranura) tienen <literal>crc</literal> y
+    <literal>size</literal> a cero; las entradas almacenadas en un bloque de
+    valor separado llevan su suma de comprobación y el tamaño del bloque, y las
+    entradas comprimidas llevan además <literal>c_len</literal>.
+   </simpara>
+  </example>
+  <example>
+   <title>Recorrido por páginas de una caché grande</title>
+   <simpara>
+    <parameter>limit</parameter> limita cuántas entradas devuelve una sola
+    llamada, y <parameter>offset</parameter> omite esa cantidad de entradas
+    antes de empezar a recopilar, de modo que ambos pueden combinarse para
+    recorrer por páginas una caché que contiene más entradas de las que una sola
+    llamada puede devolver.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$page_size = 100;
+$page_num  = 2;
+
+// omite las 100 primeras entradas y devuelve las 100 siguientes (página 2)
+$page = $yac->dump($page_size, $page_size * ($page_num - 1));
+
+var_dump(count($page));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(100)
+]]>
+   </screen>
+   <simpara>
+    Se devuelven menos entradas de las solicitadas cuando la caché contiene
+    menos entradas de las que abarca la página pedida, y se devuelve un array
+    vacío en cuanto el desplazamiento apunta más allá de la última ranura
+    ocupada.
+   </simpara>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/flush.xml
+++ b/reference/yac/yac/flush.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b8be4b126c545a0b452be29b6b5ce185471814a1 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.flush" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::flush</refname>
-  <refpurpose>Limpiar el caché</refpurpose>
+  <refpurpose>Vacía la caché</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +13,12 @@
    <modifier>public</modifier> <type>bool</type><methodname>Yac::flush</methodname>
    <void />
   </methodsynopsis>
-  <para>
-    Eliminar todos los valores almacenados
-  </para>
+  <simpara>
+    Elimina todos los valores almacenados en caché. Dado que la caché es
+    compartida por todos los procesos de la misma máquina, esto vacía la
+    caché de forma global; el prefijo de clave proporcionado a
+    <methodname>Yac::__construct</methodname> no limita lo que se elimina.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,11 +28,45 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   bool, siempre true
-  </para>
+  <simpara>
+   Devuelve &true;.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::flush</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+$other = new Yac("app2_");
+$other->set("baz", "qux");
+
+// flush vacía la caché completa: las entradas de todas las instancias,
+// independientemente del prefijo utilizado al almacenarlas
+$yac->flush();
+
+var_dump($yac->get("foo"));   // bool(false)
+var_dump($other->get("baz")); // bool(false)
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::delete</methodname></member>
+    <member><methodname>Yac::info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -1,43 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::get</refname>
-  <refpurpose>Recuperar los valores de caché</refpurpose>
+  <refpurpose>Recupera valores de la caché</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::get</methodname>
-   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter role="reference">cas</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-    Recuperar los valores de caché
-  </para>
+  <simpara>
+    Recupera valores de la caché
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>key</parameter></term>
+    <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
-      claves &string;, o &array; de multiples claves.
-     </para>
+     <simpara>
+      Una clave de tipo <type>string</type>, o un <type>array</type> de claves.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>cas</parameter></term>
+    <term><parameter>default</parameter></term>
     <listitem>
-     <para>
-      Si no es &null;, se ajustará al caso del artículo recuperado.
-     </para>
+     <simpara>
+      El valor que se devuelve cuando la clave (o las claves) solicitada no
+      está presente en la caché, disponible a partir de yac 2.4.0. Si se
+      omite, un fallo de caché devuelve &false;.
+     </simpara>
+     <note>
+      <simpara>
+       Antes de yac 2.4.0, esta posición de argumento contenía un token
+       <literal>$cas</literal> por referencia en lugar de un valor por
+       defecto. El código que pasaba ese token o dependía de él debe
+       actualizarse al migrar a la versión 2.4.0.
+      </simpara>
+     </note>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,11 +53,64 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   mixed en caso de éxito, false en caso de error
-  </para>
+  <simpara>
+   Para una clave de tipo <type>string</type>, devuelve el valor almacenado en
+   caché si se encuentra, y en caso contrario el valor de
+   <parameter>default</parameter> (o &false; si no se indicó ningún valor por
+   defecto).
+  </simpara>
+  <simpara>
+   Para un <type>array</type> de claves, devuelve un array que contiene los
+   valores encontrados indexados por sus claves. Las claves que no están
+   presentes en la caché se omiten del resultado a partir de yac 2.4.0, o se
+   rellenan con el valor de <parameter>default</parameter> si se indicó uno;
+   antes de la versión 2.4.0, se insertaba un marcador &false; por cada clave
+   ausente.
+  </simpara>
  </refsect1>
 
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::get</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");
+var_dump($yac->get("foo"));                 // string(3) "bar"
+var_dump($yac->get("missing"));             // bool(false): un fallo de caché
+
+// un fallo de caché y un false almacenado son indistinguibles sin un valor
+// por defecto; un valor centinela (disponible a partir de yac 2.4.0) permite
+// diferenciarlos
+$yac->set("flag", false);
+var_dump($yac->get("flag"));                // bool(false): el valor almacenado
+var_dump($yac->get("missing", false));      // bool(false): un fallo de caché, misma forma
+var_dump($yac->get("flag", "__NONE__"));    // bool(false): el valor almacenado
+var_dump($yac->get("missing", "__NONE__")); // string(8) "__NONE__": un fallo de caché
+
+// con un array de claves, solo las claves encontradas están presentes en el resultado
+$yac->set("foo2", "bar2");
+var_dump($yac->get(array("foo", "foo2", "missing")));
+// array(2) { ["foo"]=> string(3) "bar" ["foo2"]=> string(4) "bar2" }
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::__get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/getter.xml
+++ b/reference/yac/yac/getter.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 338bf692d6d24357c4a3b36b098131bc30372378 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.getter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::__get</refname>
-  <refpurpose>Getter</refpurpose>
+  <refpurpose>Recupera un valor usando la sintaxis de propiedades</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +13,11 @@
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::__get</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    Recupera los valores del caché
-  </para>
+  <simpara>
+   Recupera un valor de la caché; se invoca al leer una propiedad de una
+   instancia de <classname>Yac</classname>: <literal>$yac->foo</literal> es
+   equivalente a <literal>$yac->get("foo")</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
    <varlistentry>
     <term><parameter>key</parameter></term>
     <listitem>
-     <para>
-       clave &string;
-     </para>
+     <simpara>
+      El nombre de la propiedad, utilizado como clave de la caché.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,11 +36,46 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   mixed en caso de éxito, &null; en caso de error.
-  </para>
+  <simpara>
+   El valor almacenado en caso de acierto, &null; cuando la clave no está
+   presente en la caché.
+  </simpara>
+  <note>
+   <simpara>
+    A diferencia de <methodname>Yac::get</methodname>, la sintaxis de
+    propiedades no puede distinguir un &null; almacenado de una clave
+    ausente, y solo admite claves individuales.
+   </simpara>
+  </note>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::__get</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+var_dump($yac->foo);       // string(3) "bar"
+var_dump($yac->missing);   // NULL
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::__set</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/info.xml
+++ b/reference/yac/yac/info.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d286e6182179363c926e03ced71d03f3b2879ad6 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,9 +13,9 @@
    <modifier>public</modifier> <type>array</type><methodname>Yac::info</methodname>
    <void />
   </methodsynopsis>
-  <para>
-    Obtener el estado del sistema de caché
-  </para>
+  <simpara>
+    Obtiene el estado del sistema de caché
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,13 +25,149 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve un array, consistente con:
-   "memory_size", "slots_memory_size", "values_memory_size", "segment_size", "segment_num",
-   "miss", "hits", "fails", "kicks", "recycles", "slots_size", "slots_used"
-  </para>
+  <simpara>
+   Devuelve un <type>array</type> con las siguientes claves:
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>memory_size</literal></term>
+    <listitem><simpara>
+     Memoria compartida total en uso, en bytes: la tabla de slots más los
+     bloques de valores.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_memory_size</literal></term>
+    <listitem><simpara>
+     Memoria reservada para la tabla de slots hash, en bytes.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>values_memory_size</literal></term>
+    <listitem><simpara>
+     Memoria reservada para los valores almacenados, en bytes.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>segment_size</literal></term>
+    <listitem><simpara>
+     Tamaño de un segmento de memoria de valores, en bytes.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>segment_num</literal></term>
+    <listitem><simpara>
+     Número de segmentos de memoria de valores.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>miss</literal></term>
+    <listitem><simpara>
+     Número de fallos de caché: búsquedas que no encontraron nada o que
+     encontraron una entrada expirada.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hits</literal></term>
+    <listitem><simpara>
+     Número de aciertos de caché: búsquedas satisfactorias.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>fails</literal></term>
+    <listitem><simpara>
+     Número de almacenamientos fallidos: almacenamientos que no pudieron
+     asignar un bloque de valor.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>kicks</literal></term>
+    <listitem><simpara>
+     Número de expulsiones: cuántas veces hubo que expulsar una entrada
+     existente porque la ruta de slots candidata estaba llena.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>recycles</literal></term>
+    <listitem><simpara>
+     Número de veces que el asignador llegó al final de un segmento y
+     volvió a su comienzo.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>start_time</literal></term>
+    <listitem><simpara>
+     La marca de tiempo Unix en la que se inicializó el caché en memoria
+     compartida.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_size</literal></term>
+    <listitem><simpara>
+     Número total de slots hash.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_used</literal></term>
+    <listitem><simpara>
+     Número de slots hash ocupados actualmente.
+    </simpara></listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::info</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+print_r($yac->info());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [memory_size] => 46137344
+    [slots_memory_size] => 4194304
+    [values_memory_size] => 41943040
+    [segment_size] => 4194304
+    [segment_num] => 10
+    [miss] => 0
+    [hits] => 0
+    [fails] => 0
+    [kicks] => 0
+    [recycles] => 0
+    [start_time] => 1725955200
+    [slots_size] => 32768
+    [slots_used] => 1
+)
+]]>
+   </screen>
+   <simpara>
+    La tasa de aciertos puede calcularse como
+    <literal>hits / (hits + miss)</literal>; un contador
+    <literal>kicks</literal> o <literal>fails</literal> creciente indica
+    que el caché está bajo presión de memoria.
+   </simpara>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::dump</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/set.xml
+++ b/reference/yac/yac/set.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 338bf692d6d24357c4a3b36b098131bc30372378 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::set</refname>
-  <refpurpose>Guardar en el caché</refpurpose>
+  <refpurpose>Almacena un valor en la caché</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>array</type><parameter>key_vals</parameter></methodparam>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
-    Añade un elemento a la caché, si la clave ya existe, se sobreescribe.
-  </para>
+  <simpara>
+   Almacena un valor en la caché. Si la clave ya existe, la entrada
+   existente se sobrescribe, independientemente de si ha expirado.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,25 +32,30 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
-       clave &string;
-     </para>
+     <simpara>
+      Una clave de tipo <type>string</type>, o un <type>array</type> de
+      pares <literal>clave =&gt; valor</literal> que almacenar en una sola llamada.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-      valor mixed, Todo tipo de valor php podría ser almacenado excepto &resource;
-     </para>
+     <simpara>
+      El valor que almacenar. Se puede almacenar cualquier tipo de PHP excepto
+      <type>resource</type>. Solo se utiliza en la forma de clave única; cuando
+      <parameter>keys</parameter> es un array, este argumento es en su lugar el
+      parámetro opcional <parameter>ttl</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>ttl</parameter></term>
     <listitem>
-     <para>
-      tiempo de expiración
-     </para>
+     <simpara>
+      Tiempo de vida en segundos. <literal>0</literal> significa que la entrada
+      nunca expira por tiempo.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -58,8 +63,44 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Devuelve &true; en caso de éxito, &false; en caso de error.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::set</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");                    // almacena un único valor
+$yac->set("foo", "baz");                    // sobrescribe la entrada existente
+
+// ttl en segundos: la entrada expira transcurridos 5 segundos
+$yac->set("short-lived", "value", 5);
+sleep(6);
+var_dump($yac->get("short-lived"));        // bool(false): ha expirado
+
+// almacena varios pares clave => valor con una sola llamada
+$yac->set(array("a" => 1, "b" => 2));
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   el valor de sí mismo
+   <simplelist>
+    <member><methodname>Yac::add</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::__set</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/yac/yac/setter.xml
+++ b/reference/yac/yac/setter.xml
@@ -1,43 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 5733f2023a2aa3112b2e6a560b130523dd8fce03 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="yac.setter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::__set</refname>
-  <refpurpose>Setter</refpurpose>
+  <refpurpose>Almacena un valor utilizando la sintaxis de propiedades</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::__set</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    almacena un elemento en el caché
-  </para>
+  <simpara>
+   Almacena un valor en la caché; se invoca al escribir una propiedad de una
+   instancia de <classname>Yac</classname>: <literal>$yac->foo = "bar"</literal>
+   es equivalente a <literal>$yac->set("foo", "bar")</literal>, sin
+   ttl.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>keys</parameter></term>
+    <term><parameter>key</parameter></term>
     <listitem>
-     <para>
-       clave &string;
-     </para>
+     <simpara>
+      El nombre de la propiedad, utilizado como clave de la caché.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-      valor mixed, Todo tipo de valor php podría ser almacenado excepto &resource;
-     </para>
+     <simpara>
+      El valor a almacenar. Se puede almacenar cualquier tipo de PHP excepto
+      <type>resource</type>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,8 +47,35 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Devuelve el valor almacenado.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yac::__set</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->foo = "bar";          // almacenado sin ttl
+var_dump($yac->get("foo")); // string(3) "bar"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   Siempre devuelve el valor de sí mismo
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::__get</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 


### PR DESCRIPTION
Sync with EN commits 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 and d3a03f8f542cd083d793bbd8ef3d7756aae7711f.

Translates the EN revision of the Yac extension: introduction (lock-free semantics, embedded values and LZ4 in yac 2.4.0), default values for every INI directive, configure/PIE options in setup, corrected signatures (`get(string|array $keys, mixed $default)` without `&$cas`, `delete($keys, $delay)`, `set(): bool`, `setter` with `$key`), plus new examples and "See also" sections on the ten method pages.

The second EN commit (php/doc-en#5810) touches four of these files, so each file carries its own latest EN hash. `reference/yac/versions.xml` and `reference/yac/yac.xml` are outside the scope of this issue and stay untouched.

Removes the obsolete `<!-- Reviewed -->` and `<!-- $Revision$ -->` markers.

Fixes: #1130