### PR TITLE
[Sync-En] yar: sync the Yar extension documentation with EN

### DIFF
--- a/reference/yar/book.xml
+++ b/reference/yar/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <book xml:id="book.yar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -10,11 +8,25 @@
 
  <preface xml:id="intro.yar">
   &reftitle.intro;
-  <para>
-   Yar es un «framework» de RPC que pretende simplificar y facilitar la manera
-   en que se comunican las aplicaciones de PHP entre ellas.
-   Tiene la capacidad de llamar concurrentemente a varios servicios remotos.
-  </para>
+  <simpara>
+   Yar (Yet another RPC framework) es un framework RPC ligero y concurrente
+   cuyo objetivo es proporcionar una manera simple y sencilla de establecer
+   la comunicación entre aplicaciones PHP. También puede emitir varias
+   llamadas a servicios remotos de forma concurrente.
+  </simpara>
+  <simpara>
+   Yar es una extensión nativa de PHP, no una biblioteca de espacio de
+   usuario. Utiliza un protocolo binario compacto sobre HTTP, HTTPS o TCP y
+   se distribuye con tres empaquetadores integrados (<literal>php</literal>,
+   <literal>json</literal> y, cuando se compila con
+   <option role="configure">--enable-msgpack</option>,
+   <literal>msgpack</literal>), por lo que no se requiere ningún paquete
+   adicional ni proceso proxy.
+  </simpara>
+  <simpara>
+   El protocolo es independiente del lenguaje: existen implementaciones
+   compatibles para C, Java y Lua.
+  </simpara>
  </preface>
 
  &reference.yar.setup;

--- a/reference/yar/configure.xml
+++ b/reference/yar/configure.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <section xml:id="yar.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
- <para>
+ <simpara>
   &pecl.info;
   <link xlink:href="&url.pecl.package;yar">&url.pecl.package;yar</link>
- </para>
+ </simpara>
 
 </section>
 

--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -1,166 +1,318 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4966eedcbc8d5ae4dd7043ee14cec170e321406b Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <appendix xml:id="yar.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
- <para>
-  <variablelist>
-   <varlistentry xml:id="constant.yar-version">
-    <term>
-     <constant>YAR_VERSION</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-client-protocol-http">
-    <term>
-     <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-packager">
-    <term>
-     <constant>YAR_OPT_PACKAGER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-timeout">
-    <term>
-     <constant>YAR_OPT_TIMEOUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-connect-timeout">
-    <term>
-     <constant>YAR_OPT_CONNECT_TIMEOUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-header">
-    <term>
-     <constant>YAR_OPT_HEADER</constant>
-     (<type>array</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Desde 2.0.4
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-packager-php">
-    <term>
-     <constant>YAR_PACKAGER_PHP</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-packager-json">
-    <term>
-     <constant>YAR_PACKAGER_JSON</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-okey">
-    <term>
-     <constant>YAR_ERR_OKEY</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-output">
-    <term>
-     <constant>YAR_ERR_OUTPUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-transport">
-    <term>
-     <constant>YAR_ERR_TRANSPORT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-request">
-    <term>
-     <constant>YAR_ERR_REQUEST</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-protocol">
-    <term>
-     <constant>YAR_ERR_PROTOCOL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-packager">
-    <term>
-     <constant>YAR_ERR_PACKAGER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-exception">
-    <term>
-     <constant>YAR_ERR_EXCEPTION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </para>
+ <variablelist>
+  <varlistentry xml:id="constant.yar-version">
+   <term>
+    <constant>YAR_VERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La versión de la extensión Yar, por ejemplo
+     <literal>"2.4.0"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-has-msgpack">
+   <term>
+    <constant>YAR_HAS_MSGPACK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <literal>1</literal> cuando Yar se compiló con
+     <option role="configure">--enable-msgpack</option>, en caso contrario
+     <literal>0</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-http">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifica el protocolo HTTP, expuesto a través de la propiedad de solo
+     lectura <varname>_protocol</varname> de
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-tcp">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_TCP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifica el protocolo TCP, expuesto a través de la propiedad de solo
+     lectura <varname>_protocol</varname> de
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-unix">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_UNIX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifica el protocolo de sockets Unix, expuesto a través de la propiedad
+     de solo lectura <varname>_protocol</varname> de
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-packager">
+   <term>
+    <constant>YAR_OPT_PACKAGER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente que reemplaza la directiva
+     <link linkend="ini.yar.packager">yar.packager</link>
+     para un único cliente. El valor debe ser uno de
+     <literal>php</literal>, <literal>json</literal> o
+     <literal>msgpack</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-persistent">
+   <term>
+    <constant>YAR_OPT_PERSISTENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente que activa las conexiones persistentes. Cuando se
+     establece a un valor verdadero, se utiliza el keep-alive de HTTP, de modo
+     que las llamadas repetidas al mismo servidor reutilizan la conexión
+     durante el resto del ciclo de vida de la petición PHP.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-timeout">
+   <term>
+    <constant>YAR_OPT_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente que reemplaza la directiva
+     <link linkend="ini.yar.timeout">yar.timeout</link>, en
+     milisegundos.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-connect-timeout">
+   <term>
+    <constant>YAR_OPT_CONNECT_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente que reemplaza la directiva
+     <link linkend="ini.yar.connect-timeout">yar.connect_timeout</link>,
+     en milisegundos.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-header">
+   <term>
+    <constant>YAR_OPT_HEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente para añadir cabeceras HTTP personalizadas. El valor
+     debe ser un array de cadenas como
+     <literal>"X-Custom: valor"</literal>. Solo es efectiva con los
+     protocolos HTTP y HTTPS. Disponible a partir de Yar 2.0.4.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-resolve">
+   <term>
+    <constant>YAR_OPT_RESOLVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente que reemplaza la resolución de nombres de host para las
+     llamadas HTTP. El valor debe ser un array de cadenas con el formato
+     <literal>HOST:PORT:ADDRESS</literal>, siguiendo la sintaxis de
+     <constant>CURLOPT_RESOLVE</constant> de curl. Requiere libcurl
+     &gt;= 7.21.3. Disponible a partir de Yar 2.1.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-proxy">
+   <term>
+    <constant>YAR_OPT_PROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente para encaminar las llamadas HTTP a través de un proxy
+     HTTP. El valor debe ser una cadena como <literal>127.0.0.1:8888</literal>.
+     Disponible a partir de Yar 2.2.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-provider">
+   <term>
+    <constant>YAR_OPT_PROVIDER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente que transporta la identidad del proveedor enviada con
+     cada petición. El valor debe ser una cadena de 32 bytes como máximo, que
+     se pasa al método mágico <literal>__auth</literal> del lado del servidor.
+     Disponible a partir de Yar 2.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-token">
+   <term>
+    <constant>YAR_OPT_TOKEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Opción del cliente que transporta el token de autenticación enviado con
+     cada petición. El valor debe ser una cadena de 32 bytes como máximo, que
+     se pasa al método mágico <literal>__auth</literal> del lado del servidor.
+     Disponible a partir de Yar 2.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-php">
+   <term>
+    <constant>YAR_PACKAGER_PHP</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El identificador del empaquetador <literal>php</literal>,
+     <literal>"PHP"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-json">
+   <term>
+    <constant>YAR_PACKAGER_JSON</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El identificador del empaquetador <literal>json</literal>,
+     <literal>"JSON"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-msgpack">
+   <term>
+    <constant>YAR_PACKAGER_MSGPACK</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El identificador del empaquetador <literal>msgpack</literal>,
+     <literal>"MSGPACK"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-okey">
+   <term>
+    <constant>YAR_ERR_OKEY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Ningún error; la petición se procesó correctamente.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-packager">
+   <term>
+    <constant>YAR_ERR_PACKAGER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Un error del empaquetador, por ejemplo un cuerpo que no se ha podido
+     desempaquetar.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-protocol">
+   <term>
+    <constant>YAR_ERR_PROTOCOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Un error de protocolo, por ejemplo una cabecera Yar mal formada.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-request">
+   <term>
+    <constant>YAR_ERR_REQUEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Un error de petición, por ejemplo una llamada a un método no definido o no
+     público.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-output">
+   <term>
+    <constant>YAR_ERR_OUTPUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Un error de salida, por ejemplo el servidor no ha podido iniciar su búfer
+     de salida.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-transport">
+   <term>
+    <constant>YAR_ERR_TRANSPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Un error de transporte, por ejemplo un fallo de conexión o un tiempo de
+     espera agotado.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-exception">
+   <term>
+    <constant>YAR_ERR_EXCEPTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El servicio remoto lanzó una excepción durante el procesamiento de la
+     petición.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 </appendix>
 
 <!-- Keep this comment at the end of the file

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
  <example>
-  <title>Ejemplo de servidor de Yar</title>
+  <title>Ejemplo de servidor Yar</title>
   <programlisting role="php">
 <![CDATA[
 <?php
 
-/* Se asume que a esta página se puede acceder mediante http://example.com/operator.php */
+/* se supone que esta página es accesible en http://example.com/operator.php */
 
 class Operator {
 
     /**
-     * Add two operands
+     * Suma dos operandos
      * @param integer
      * @return integer
      */
@@ -25,21 +23,21 @@ class Operator {
     }
 
     /**
-     * Sub
+     * Resta
      */
     public function sub($a, $b) {
         return $a - $b;
     }
 
     /**
-     * Mul
+     * Multiplicación
      */
     public function mul($a, $b) {
         return $a * $b;
     }
 
     /**
-     * Protected methods will not be exposed
+     * Los métodos protegidos no se exponen
      * @param integer
      * @return integer
      */
@@ -48,18 +46,25 @@ class Operator {
     }
 }
 
-$servidor = new Yar_Server(new Operator());
-$servidor->handle();
+$server = new Yar_Server(new Operator());
+$server->handle();
 ?>
 ]]>
   </programlisting>
  </example>
 
  <example>
-  <title>Acceder al servidor desde el navegador (petición GET)</title>
+  <title>Acceso al servidor desde el navegador (petición GET)</title>
+  <simpara>
+   Cuando se emite una petición GET al URI del servicio, Yar muestra una
+   página de información que lista todos los métodos públicos del objeto
+   ejecutor junto con su comentario de documentación. Esto se controla con
+   la directiva
+   <link linkend="ini.yar.expose-info">yar.expose_info</link>.
+  </simpara>
   &example.outputs.similar;
   <mediaobject>
-   <alt>Información del servidor de Yar</alt>
+   <alt>Yar Server Info</alt>
    <imageobject>
     <imagedata fileref="en/reference/yar/image/yar.png" scalefit="1" width="700px" />
    </imageobject>
@@ -67,21 +72,20 @@ $servidor->handle();
  </example>
 
  <example>
-  <title>Ejemplo de cliente de Yar</title>
+  <title>Ejemplo de cliente Yar</title>
   <programlisting role="php">
 <![CDATA[
 <?php
-$cliente = new yar_client("http://example.com/operator.php");
+$client = new Yar_Client("http://example.com/operator.php");
 
-/* llamar directamente */
-var_dump($cliente->add(1, 2));
+/* llamada directa */
+var_dump($client->add(1, 2));
 
-/* llamar mediante el método 'call' */
-var_dump($cliente->call("add", array(3, 2)));
+/* llamada mediante call() */
+var_dump($client->call("add", array(3, 2)));
 
-
-/* _add no puede ser llamado */
-var_dump($cliente->_add(1, 2));
+/* _add no se puede llamar: no es público */
+var_dump($client->_add(1, 2));
 ?>
 ]]>
   </programlisting>
@@ -90,38 +94,61 @@ var_dump($cliente->_add(1, 2));
 <![CDATA[
 int(3)
 int(5)
-PHP Fatal error:  Uncaught exception 'Yar_Server_Exception' with message 'call to api Operator::_add() failed' in *
+PHP Fatal error:  Uncaught Yar_Server_Request_Exception: call to undefined api Operator::_add() in *
 ]]>
   </screen>
  </example>
 
  <example>
-  <title>Ejemplo de cliente concurrente de Yar</title>
+  <title>Ejemplo de cliente concurrente Yar</title>
   <programlisting role="php">
 <![CDATA[
 <?php
 function callback($ret, $callinfo) {
-    echo $callinfo['method'] , " result: ", $ret , "\n";
+    echo $callinfo['method'], " resultado: ", $ret, "\n";
 }
 
-/* registrar las llamadas asíncronas a servicios remotos */
+function error_callback($type, $error, $callinfo) {
+    error_log("[$type] $error");
+}
+
+/* registra llamadas asíncronas a servicios remotos */
 Yar_Concurrent_Client::call("http://example.com/operator.php", "add", array(1, 2), "callback");
 Yar_Concurrent_Client::call("http://example.com/operator.php", "sub", array(2, 1), "callback");
 Yar_Concurrent_Client::call("http://example.com/operator.php", "mul", array(2, 2), "callback");
 
-/* enviar todas las peticiones y esperar una respuesta */
-Yar_Concurrent_Client::loop();
+/* envía todas las peticiones y espera las respuestas */
+Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>
 ]]>
   </programlisting>
   &example.outputs.similar;
   <screen>
 <![CDATA[
-mul result: 4
-sub result: 1
-add result: 3
+mul resultado: 4
+sub resultado: 1
+add resultado: 3
 ]]>
   </screen>
+ </example>
+
+ <example>
+  <title>Ejemplo de cliente TCP Yar</title>
+  <simpara>
+   Además de HTTP, <classname>Yar_Client</classname> puede comunicarse con
+   servidores compatibles con Yar a través de TCP o de sockets Unix, por
+   ejemplo con un servicio implementado con el framework Yar en C. El
+   servidor remoto debe implementar el mismo protocolo binario de Yar.
+  </simpara>
+  <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("tcp://127.0.0.1:8600");
+
+var_dump($client->add(1, 2));
+?>
+]]>
+  </programlisting>
  </example>
 
 </chapter>

--- a/reference/yar/ini.xml
+++ b/reference/yar/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <section xml:id="yar.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -19,9 +18,15 @@
     </thead>
     <tbody>
      <row>
-      <entry><link linkend="ini.yar.packager">yar.packager</link></entry>
-      <entry>php</entry>
-      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></entry>
+      <entry>1000</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.content-type">yar.content_type</link></entry>
+      <entry>application/octet-stream</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
@@ -31,8 +36,20 @@
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
-      <entry><link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></entry>
-      <entry>1000</entry>
+      <entry><link linkend="ini.yar.expose-info">yar.expose_info</link></entry>
+      <entry>On</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.packager">yar.packager</link></entry>
+      <entry>php</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.ssl-verify">yar.ssl_verify</link></entry>
+      <entry>Off</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -40,12 +57,6 @@
       <entry><link linkend="ini.yar.timeout">yar.timeout</link></entry>
       <entry>5000</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
-     </row>
-     <row>
-      <entry><link linkend="ini.yar.expose-info">yar.expose_info</link></entry>
-      <entry>On</entry>
-      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>
@@ -57,61 +68,124 @@
 
  <para>
   <variablelist>
-   <varlistentry xml:id="ini.yar.packager">
-    <term>
-     <parameter>yar.packager</parameter>
-     <type>string</type>
-    </term>
-    <listitem>
-     <para>
-      Podría ser php, json, y msgpack (requiere construcción con soporte para msgpack)
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="ini.yar.debug">
-    <term>
-     <parameter>yar.debug</parameter>
-     <type>string</type>
-    </term>
-    <listitem>
-     <para>
-
-     </para>
-    </listitem>
-   </varlistentry>
    <varlistentry xml:id="ini.yar.connect-timeout">
-    <term>
-     <parameter>yar.connect_timeout</parameter>
-     <type>int</type>
-    </term>
-    <listitem>
-     <para>
-      Tiempo de espera en ms
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="ini.yar.timeout">
-    <term>
-     <parameter>yar.timeout</parameter>
-     <type>int</type>
-    </term>
-    <listitem>
-     <para>
-      Tiempo de espera en ms
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="ini.yar.expose-info">
-    <term>
-     <parameter>yar.expose_info</parameter>
-     <type>bool</type>
-    </term>
-    <listitem>
-     <para>
-      Si exponer la información del servicio (al acceder al servidor mediante GET)
-     </para>
-    </listitem>
-   </varlistentry>
+     <term>
+      <parameter>yar.connect_timeout</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       Tiempo de espera de conexión, en milisegundos, para las llamadas HTTP
+       emitidas por <classname>Yar_Client</classname> y
+       <classname>Yar_Concurrent_Client</classname>.
+      </simpara>
+      <note>
+       <simpara>
+        Este valor se interpreta en milisegundos. Antes de Yar 1.2.1 se medía
+        en segundos (el valor predeterminado era
+        <literal>1</literal>).
+       </simpara>
+      </note>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.content-type">
+     <term>
+      <parameter>yar.content_type</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       El valor de la cabecera de respuesta <literal>Content-Type</literal>
+       enviada por <classname>Yar_Server</classname>. Yar utiliza un protocolo
+       binario, por lo que el valor predeterminado es
+       <literal>application/octet-stream</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.debug">
+     <term>
+      <parameter>yar.debug</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       Activa el modo de depuración. Cuando está activo, Yar emite mensajes
+       <constant>E_WARNING</constant> con detalles a nivel de protocolo para
+       cada petición y cada respuesta, precedidos de
+       <literal>[Debug Yar_Server]</literal> o
+       <literal>[Debug Yar_Client]</literal> y de una marca de tiempo.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.expose-info">
+     <term>
+      <parameter>yar.expose_info</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       Indica si <methodname>Yar_Server::handle</methodname> muestra la página
+       de información del servicio para las peticiones que no son POST
+       (habitualmente GET). Cuando esta directiva está desactivada, dichas
+       peticiones lanzan en su lugar una
+       <exceptionname>Yar_Server_Exception</exceptionname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.packager">
+     <term>
+      <parameter>yar.packager</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       El empaquetador predeterminado utilizado para serializar los cuerpos de
+       las peticiones y de las respuestas. Los valores válidos son
+       <literal>php</literal> (serialización de PHP),
+       <literal>json</literal> y
+       <literal>msgpack</literal> (únicamente cuando Yar se ha compilado con
+       <option role="configure">--enable-msgpack</option>).
+      </simpara>
+      <simpara>
+       Cuando Yar se compila con soporte de msgpack, el valor predeterminado
+       pasa a ser <literal>msgpack</literal>.
+      </simpara>
+      <simpara>
+       Este valor puede reemplazarse en cada cliente mediante la opción
+       <constant>YAR_OPT_PACKAGER</constant>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.ssl-verify">
+     <term>
+      <parameter>yar.ssl_verify</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       Indica si se verifica el certificado TLS de los servidores HTTPS. Cuando
+       está activa, el transporte curl establece
+       <constant>CURLOPT_SSL_VERIFYPEER</constant> y
+       <constant>CURLOPT_SSL_VERIFYHOST</constant>, y las peticiones a
+       servidores con certificados no válidos fallan. Desactivada de forma
+       predeterminada por compatibilidad hacia atrás. Disponible a partir de
+       Yar 2.4.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.timeout">
+     <term>
+      <parameter>yar.timeout</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       Tiempo de espera, en milisegundos, para las llamadas RPC emitidas por
+       <classname>Yar_Client</classname> y
+       <classname>Yar_Concurrent_Client</classname>.
+      </simpara>
+     </listitem>
+    </varlistentry>
 
   </variablelist>
  </para>

--- a/reference/yar/setup.xml
+++ b/reference/yar/setup.xml
@@ -1,36 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 307e7d78baacfcd228eef8f384e96659b67d9adb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: PhilDaiguille Status: ready -->
 
 <chapter xml:id="yar.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
  <section xml:id="yar.requirements">
   &reftitle.required;
-  <para>
-   Si se desea utilizar msgpack como empaquetador, es necesario compilar
-   Yar con la opción de configuración ./configure --enable-msgpack
-  </para>
+  <simpara>
+   La biblioteca cURL es necesaria para los transportes HTTP y HTTPS. El
+   transporte TCP está implementado con sockets simples y no necesita
+   ninguna biblioteca adicional.
+  </simpara>
+  <simpara>
+   Se requiere la extensión <link linkend="book.json">JSON</link>, que se
+   incluye con PHP y está siempre disponible a partir de PHP 8.0.0.
+  </simpara>
+  <simpara>
+   Para utilizar el empaquetador <literal>msgpack</literal>, la extensión
+   <link xlink:href="&url.pecl.package;msgpack">msgpack</link> debe estar
+   instalada y Yar debe compilarse con la opción de configuración
+   <option role="configure">--enable-msgpack</option>.
+  </simpara>
  </section>
 
+ <!-- {{{ Installation -->
  <section xml:id="yar.installation">
   &reftitle.install;
-  <para>
+  <simpara>
    &pecl.moved;
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;yar">&url.pecl.package;yar</link>.
+  </simpara>
+  <simpara>
+   &pecl.windows.download.avail;
+  </simpara>
+  <para>
+   El código fuente está alojado en
+   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. Para compilar
+   la extensión a partir del código fuente:
+   <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/yar.git
+$ cd yar
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+   </screen>
+  </para>
+  <para>
+   Están disponibles las siguientes opciones de <literal>configure</literal>:
+   <variablelist>
+    <varlistentry>
+     <term>
+      <option role="configure">--with-curl</option>
+     </term>
+     <listitem>
+      <simpara>
+       Ubicación de la instalación de cURL, si no se encuentra en las rutas
+       de inclusión predeterminadas.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <option role="configure">--enable-msgpack</option>
+     </term>
+     <listitem>
+      <simpara>
+       Activa el empaquetador <literal>msgpack</literal> y convierte la
+       extensión <literal>msgpack</literal> en una dependencia opcional.
+       Cuando Yar se compila con esta opción, el valor predeterminado de
+       <link linkend="ini.yar.packager">yar.packager</link> pasa a ser
+       <literal>msgpack</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <option role="configure">--enable-epoll</option>
+     </term>
+     <listitem>
+      <simpara>
+       Utiliza <literal>epoll</literal> de Linux en lugar de
+       <literal>select()</literal> para la multiplexación de E/S, disponible
+       a partir de Yar 2.1.2. Esto puede mejorar el rendimiento de
+       <classname>Yar_Concurrent_Client</classname> con una concurrencia
+       elevada. Solo tiene efecto en Linux; en las demás plataformas se
+       ignora silenciosamente.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </para>
  </section>
+ <!-- }}} -->
 
+ <!-- {{{ Configuration -->
  &reference.yar.ini;
+ <!-- }}} -->
 
  <section xml:id="yar.resources">
   &reftitle.resources;
-  <para>
-
-  </para>
+  <simpara>
+   Esta extensión no define ningún tipo de recurso.
+  </simpara>
  </section>
 
 </chapter>

--- a/reference/yar/yar-client-exception.xml
+++ b/reference/yar/yar-client-exception.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-client-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Client_Exception</title>
  <titleabbrev>Yar_Client_Exception</titleabbrev>
@@ -13,9 +11,12 @@
 <!-- {{{ Yar_Client_Exception intro -->
   <section xml:id="yar-client-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Clase base de las excepciones lanzadas cuando una petición falla antes,
+    durante o después de alcanzar el servicio remoto: se lanza una subclase
+    u otra según el lugar en el que se haya producido el fallo. El código de
+    la excepción es una de las constantes <literal>YAR_ERR_*</literal>.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -23,68 +24,29 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Client_Exception properties -->
-  <section xml:id="yar-client-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client-packager-exception.xml
+++ b/reference/yar/yar-client-packager-exception.xml
@@ -1,88 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-client-packager-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-packager-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Client_Packager_Exception</title>
  <titleabbrev>Yar_Client_Packager_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Packager_Exception intro -->
   <section xml:id="yar-client-packager-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Se lanza cuando el cuerpo de la respuesta no se puede desempaquetar con el empaquetador solicitado (código de excepción <constant>YAR_ERR_PACKAGER</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-packager-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Packager_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Packager_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Packager_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Client_Packager_Exception properties -->
-  <section xml:id="yar-client-packager-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-packager-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client-protocol-exception.xml
+++ b/reference/yar/yar-client-protocol-exception.xml
@@ -1,88 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 07275f5d03cf34c5a2218e0c103978f8024da153 Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-client-protocol-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-protocol-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Client_Protocol_Exception</title>
  <titleabbrev>Yar_Client_Protocol_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Protocol_Exception intro -->
   <section xml:id="yar-client-protocol-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Se lanza cuando la respuesta del servicio RPC viola el protocolo Yar, por ejemplo una dirección de protocolo no soportada o una cabecera de respuesta mal formada (código de excepción <constant>YAR_ERR_PROTOCOL</constant>).
+   </simpara>
+   <simpara>
+    A partir de Yar 2.4.0 esto incluye también una respuesta cuyo id de
+    transacción no coincide con el id de la petición a la que responde. El
+    cliente valida el campo <literal>i</literal> de cada respuesta; una
+    respuesta que lleve un id de transacción distinto y no nulo (por ejemplo,
+    una desviada por un proxy) se rechaza. Las respuestas con un id de
+    transacción igual a cero o ausente se siguen aceptando por compatibilidad
+    con servidores más antiguos.
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-protocol-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Protocol_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Protocol_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Protocol_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Client_Protocol_Exception properties -->
-  <section xml:id="yar-client-protocol-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-protocol-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client-transport-exception.xml
+++ b/reference/yar/yar-client-transport-exception.xml
@@ -1,88 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-client-transport-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-transport-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Client_Transport_Exception</title>
  <titleabbrev>Yar_Client_Transport_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Transport_Exception intro -->
   <section xml:id="yar-client-transport-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Se lanza cuando falla la conexión con el servicio RPC: conexión rechazada, tiempo de espera agotado o respuesta vacía (código de excepción <constant>YAR_ERR_TRANSPORT</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-transport-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Transport_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Transport_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Transport_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Client_Transport_Exception properties -->
-  <section xml:id="yar-client-transport-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-transport-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client.xml
+++ b/reference/yar/yar-client.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <reference xml:id="class.yar-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,9 +11,12 @@
 <!-- {{{ Yar_Client intro -->
   <section xml:id="yar-client.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    El lado cliente del framework RPC Yar. Un cliente está vinculado a una
+    única dirección de servicio; invocar sobre él cualquier método no
+    definido emite una llamada remota con ese nombre de método y los
+    argumentos indicados.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -23,42 +24,40 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Client</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>int</type>
      <varname linkend="yar-client.props.protocol">_protocol</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>string</type>
      <varname linkend="yar-client.props.uri">_uri</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type class="union"><type>array</type><type>null</type></type>
      <varname linkend="yar-client.props.options">_options</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>bool</type>
      <varname linkend="yar-client.props.running">_running</varname>
     </fieldsynopsis>
 
-
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Yar_Client'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-
 
 <!-- {{{ Yar_Client properties -->
   <section xml:id="yar-client.props">
@@ -67,31 +66,44 @@
     <varlistentry xml:id="yar-client.props.protocol">
      <term><varname>_protocol</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Solo lectura. El protocolo derivado de la dirección del servicio: una
+       de las constantes <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>,
+       <constant>YAR_CLIENT_PROTOCOL_TCP</constant> o
+       <constant>YAR_CLIENT_PROTOCOL_UNIX</constant>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.uri">
      <term><varname>_uri</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Solo lectura. La dirección de servicio con la que se creó el cliente.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.options">
      <term><varname>_options</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Solo lectura. Un &array; con las opciones establecidas en este
+       cliente, indexado por las constantes <literal>YAR_OPT_*</literal>, o
+       &null; si no se estableció ninguna.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.running">
      <term><varname>_running</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Solo lectura. Indica si hay una llamada emitida por este cliente
+       actualmente en curso.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-concurrent-client.xml
+++ b/reference/yar/yar-concurrent-client.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <reference xml:id="class.yar-concurrent-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,9 +11,17 @@
 <!-- {{{ Yar_Concurrent_Client intro -->
   <section xml:id="yar-concurrent-client.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Un ayudante estático que agrupa llamadas RPC remotas. Las llamadas
+    registradas con <methodname>Yar_Concurrent_Client::call</methodname> no
+    se envían inmediatamente; todas se despachan a la vez, en paralelo,
+    mediante <methodname>Yar_Concurrent_Client::loop</methodname>.
+   </simpara>
+   <note>
+    <simpara>
+     Solo se admiten servicios HTTP(S) para las llamadas concurrentes.
+    </simpara>
+   </note>
   </section>
 <!-- }}} -->
 
@@ -23,65 +29,17 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Concurrent_Client</classname></ooclass>
-
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Concurrent_Client</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.callstack">_callstack</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.callback">_callback</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.error-callback">_error_callback</varname>
-    </fieldsynopsis>
-
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Concurrent_Client</classname>
+    </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-concurrent-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-concurrent-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Concurrent_Client'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Concurrent_Client properties -->
-  <section xml:id="yar-concurrent-client.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-concurrent-client.props.callstack">
-     <term><varname>_callstack</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-concurrent-client.props.callback">
-     <term><varname>_callback</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-concurrent-client.props.error-callback">
-     <term><varname>_error_callback</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-exception.xml
+++ b/reference/yar/yar-server-exception.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-server-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Server_Exception</title>
  <titleabbrev>Yar_Server_Exception</titleabbrev>
@@ -13,10 +11,13 @@
 <!-- {{{ Yar_Server_Exception intro -->
   <section xml:id="yar-server-exception.intro">
    &reftitle.intro;
-   <para>
-     Si un servicio lanza excepciones, se lanzará una Yar_Server_Exception en
-     el lado del cliente.
-   </para>
+   <simpara>
+    Se lanza en el lado del cliente cuando la petición RPC ha fallado en el
+    servidor. Si el propio método del servicio remoto lanzó una excepción,
+    su mensaje, código, fichero, línea y nombre de clase se transmiten, y
+    <methodname>Yar_Server_Exception::getType</methodname> devuelve el
+    nombre de clase de la excepción original.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -24,78 +25,56 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>string</type>
      <varname linkend="yar-server-exception.props.type">_type</varname>
+     <initializer>"Yar_Exception_Server"</initializer>
     </fieldsynopsis>
 
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-
 <!-- {{{ Yar_Server_Exception properties -->
   <section xml:id="yar-server-exception.props">
    &reftitle.properties;
    <variablelist>
-    <varlistentry xml:id="yar-server-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
     <varlistentry xml:id="yar-server-exception.props.type">
      <term><varname>_type</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       El nombre de clase de la excepción lanzada por el servicio remoto, o
+       <literal>"Yar_Exception_Server"</literal> si el error no fue causado
+       por una excepción del código de usuario. Se lee mediante
+       <methodname>Yar_Server_Exception::getType</methodname>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-output-exception.xml
+++ b/reference/yar/yar-server-output-exception.xml
@@ -1,88 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-server-output-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-output-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Server_Output_Exception</title>
  <titleabbrev>Yar_Server_Output_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Output_Exception intro -->
   <section xml:id="yar-server-output-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Se lanza cuando el servidor no puede capturar la salida del método del servicio (código de excepción <constant>YAR_ERR_OUTPUT</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-output-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Output_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Output_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Output_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Server_Output_Exception properties -->
-  <section xml:id="yar-server-output-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-output-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-packager-exception.xml
+++ b/reference/yar/yar-server-packager-exception.xml
@@ -1,88 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-server-packager-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-packager-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Server_Packager_Exception</title>
  <titleabbrev>Yar_Server_Packager_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Packager_Exception intro -->
   <section xml:id="yar-server-packager-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Se lanza cuando el cuerpo de la petición no se puede desempaquetar con el empaquetador anunciado en la petición (código de excepción <constant>YAR_ERR_PACKAGER</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-packager-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Packager_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Packager_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Packager_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Server_Packager_Exception properties -->
-  <section xml:id="yar-server-packager-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-packager-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-protocol-exception.xml
+++ b/reference/yar/yar-server-protocol-exception.xml
@@ -1,88 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-server-protocol-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-protocol-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Server_Protocol_Exception</title>
  <titleabbrev>Yar_Server_Protocol_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Protocol_Exception intro -->
   <section xml:id="yar-server-protocol-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Se lanza cuando la petición entrante viola el protocolo Yar, por ejemplo una cabecera de petición mal formada (código de excepción <constant>YAR_ERR_PROTOCOL</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-protocol-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Protocol_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Protocol_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Protocol_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Server_Protocol_Exception properties -->
-  <section xml:id="yar-server-protocol-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-protocol-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-request-exception.xml
+++ b/reference/yar/yar-server-request-exception.xml
@@ -1,88 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
-<reference xml:id="class.yar-server-request-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-request-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La clase Yar_Server_Request_Exception</title>
  <titleabbrev>Yar_Server_Request_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Request_Exception intro -->
   <section xml:id="yar-server-request-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Se lanza cuando el método remoto solicitado no existe en el objeto del servidor, o no es público (código de excepción <constant>YAR_ERR_REQUEST</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-request-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Request_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Request_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Request_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Server_Request_Exception properties -->
-  <section xml:id="yar-server-request-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-request-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server.xml
+++ b/reference/yar/yar-server.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <reference xml:id="class.yar-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,9 +11,11 @@
 <!-- {{{ Yar_Server intro -->
   <section xml:id="yar-server.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Envuelve un objeto y expone todos sus métodos públicos como un servicio
+    remoto, servido a través de HTTP por
+    <methodname>Yar_Server::handle</methodname>.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -23,30 +23,26 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Server</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>object</type>
      <varname linkend="yar-server.props.executor">_executor</varname>
+     <initializer>null</initializer>
     </fieldsynopsis>
 
-
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Yar_Server'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-
 
 <!-- {{{ Yar_Server properties -->
   <section xml:id="yar-server.props">
@@ -55,13 +51,14 @@
     <varlistentry xml:id="yar-server.props.executor">
      <term><varname>_executor</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       El objeto cuyos métodos públicos se exponen como servicios RPC.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar_client/call.xml
+++ b/reference/yar/yar_client/call.xml
@@ -1,24 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>Yar_Client::__call</refname>
-  <refpurpose>Llamar a un servicio</refpurpose>
+  <refname>Yar_Client::call</refname>
+  <refpurpose>Llama a un servicio remoto</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>Yar_Client::__call</methodname>
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type>mixed</type><methodname>Yar_Client::call</methodname>
    <methodparam><type>string</type><parameter>method</parameter></methodparam>
-   <methodparam><type>array</type><parameter>parameters</parameter></methodparam>
+   <methodparam><type>array</type><parameter>arguments</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Emite una llamada a un método RPC remoto.
-  </para>
+  <simpara>
+   Emite una llamada RPC al método remoto <literal>method</literal>. Esto
+   es exactamente lo que ocurre cuando se invoca un método inexistente sobre
+   un objeto <classname>Yar_Client</classname> (véase
+   <methodname>Yar_Client::__call</methodname>);
+   <methodname>Yar_Client::call</methodname> solo existe para que los métodos
+   remotos llamados literalmente <literal>call</literal> o
+   <literal>__call</literal> sigan siendo accesibles.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,17 +31,17 @@
    <varlistentry>
     <term><parameter>method</parameter></term>
     <listitem>
-     <para>
-       Nombre del método RPC remoto.
-     </para>
+     <simpara>
+      El nombre del método del servicio remoto.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>parameters</parameter></term>
+    <term><parameter>arguments</parameter></term>
     <listitem>
-     <para>
-       Parámetros.
-     </para>
+     <simpara>
+      La lista de argumentos pasados al método remoto.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,38 +49,26 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Devuelve el valor de retorno del método del servicio remoto.
+  </simpara>
  </refsect1>
 
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title>Ejemplo de <function>Yar_Client::__call</function></title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-$cliente = new Yar_Client("http://host/api/");
-
-/* llamar al servicio remoto */
-$resultado = $cliente->some_method("parameter");
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
-  </example>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Cuando el método <literal>call</literal> no existe en el lado del
+   servidor, se lanza una
+   <exceptionname>Yar_Server_Request_Exception</exceptionname>. Véase
+   <methodname>Yar_Client::__call</methodname> para la lista completa de
+   fallos y sus clases de excepción.
+  </simpara>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
+   <member><methodname>Yar_Client::__call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/construct.xml
+++ b/reference/yar/yar_client/construct.xml
@@ -1,36 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 167c48c1c76f7f29be2f44fd72ea72a43ae5e1e1 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client::__construct</refname>
-  <refpurpose>Crear un cliente</refpurpose>
+  <refpurpose>Crea un cliente</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="Yar_Client">
    <modifier>final</modifier> <modifier>public</modifier> <methodname>Yar_Client::__construct</methodname>
-   <methodparam><type>string</type><parameter>url</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
-  </methodsynopsis>
-  <para>
-    Crea un <classname>Yar_Client</classname> hacia un
-    <classname>Yar_Server</classname>.
-  </para>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Crea un <classname>Yar_Client</classname> para el servicio RPC situado
+   en <literal>uri</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>url</parameter></term>
+    <term><parameter>uri</parameter></term>
     <listitem>
-     <para>
-       El URL del servidor de Yar.
-     </para>
+     <simpara>
+      Dirección del servicio RPC. El protocolo se deriva del esquema:
+      <literal>http://</literal> y <literal>https://</literal> seleccionan el
+      transporte HTTP, <literal>tcp://</literal> selecciona el transporte TCP
+      y <literal>unix://</literal> selecciona el transporte por socket Unix.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; de opciones del cliente, indexado por las constantes
+      <literal>YAR_OPT_*</literal>, equivalente a llamar a
+      <methodname>Yar_Client::setOpt</methodname> para cada entrada. Las
+      opciones no válidas se omiten silenciosamente.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -38,30 +50,38 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-    Una instancia de <classname>Yar_Client</classname>.
-  </para>
+  <simpara>
+   Una nueva instancia de <classname>Yar_Client</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si la URI no comienza por un esquema soportado, se lanza una
+   <exceptionname>Yar_Client_Protocol_Exception</exceptionname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo de <function>Yar_Client::__construct</function></title>
+   <title>Ejemplo de <methodname>Yar_Client::__construct</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$cliente = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://host/api/");
+
+/* con opciones */
+$client = new Yar_Client("http://host/api/", [
+    YAR_OPT_TIMEOUT => 1000,
+    YAR_OPT_PACKAGER => "json",
+]);
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/yar/yar_client/getopt.xml
+++ b/reference/yar/yar_client/getopt.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+
+<refentry xml:id="yar-client.getopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yar_Client::getOpt</refname>
+  <refpurpose>Lee una opción del cliente</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type>mixed</type><methodname>Yar_Client::getOpt</methodname>
+   <methodparam><type>int</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Devuelve el valor establecido previamente con
+   <methodname>Yar_Client::setOpt</methodname>, o con el parámetro
+   <literal>options</literal> de
+   <methodname>Yar_Client::__construct</methodname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      Una de las constantes <literal>YAR_OPT_*</literal>, véase
+      <methodname>Yar_Client::setOpt</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   El valor de la opción, o &false; si la opción no se ha establecido en este
+   cliente o el nombre de la opción es desconocido.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yar_Client::getOpt</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("http://host/api/");
+$client->setOpt(YAR_OPT_TIMEOUT, 1000);
+
+var_dump($client->getOpt(YAR_OPT_TIMEOUT));
+var_dump($client->getOpt(YAR_OPT_PACKAGER));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(1000)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Yar_Client::setOpt</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yar/yar_client/setopt.xml
+++ b/reference/yar/yar_client/setopt.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fade73b9ec1424cbbfcd5d075a21d30445ce8a23 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client.setopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client::setOpt</refname>
-  <refpurpose>Establecer los contextos de una llamada</refpurpose>
+  <refpurpose>Establece opciones del cliente</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type class="union"><type>Yar_Client</type><type>false</type></type><methodname>Yar_Client::setOpt</methodname>
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type class="union"><type>Yar_Client</type><type>bool</type></type><methodname>Yar_Client::setOpt</methodname>
    <methodparam><type>int</type><parameter>name</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Establece una opción en el cliente. Las opciones se evalúan cuando se
+   emite una llamada, por lo que pueden cambiarse entre llamadas.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,23 +26,29 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-      El nombre puede ser:
-      <constant>YAR_OPT_PACKAGER</constant>,
-      <constant>YAR_OPT_PERSISTENT</constant> (Necesita soporte en el servidor),
-      <constant>YAR_OPT_TIMEOUT</constant>,
-      <constant>YAR_OPT_CONNECT_TIMEOUT</constant>,
-      <constant>YAR_OPT_HEADER</constant> (desde 2.0.4),
-      <constant>YAR_OPT_PROXY</constant> (desde 2.2.0)
-     </para>
+     <simpara>
+      Una de las constantes <literal>YAR_OPT_*</literal>:
+     </simpara>
+     <simplelist>
+      <member><constant>YAR_OPT_PACKAGER</constant> — un nombre de empaquetador: <literal>php</literal>, <literal>json</literal> o, si se ha compilado con soporte para msgpack, <literal>msgpack</literal></member>
+      <member><constant>YAR_OPT_PERSISTENT</constant> — un indicador booleano de conexión persistente (keep-alive de HTTP)</member>
+      <member><constant>YAR_OPT_TIMEOUT</constant> — un tiempo de espera en milisegundos, que prevalece sobre <link linkend="ini.yar.timeout">yar.timeout</link></member>
+      <member><constant>YAR_OPT_CONNECT_TIMEOUT</constant> — un tiempo de espera de conexión en milisegundos, que prevalece sobre <link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></member>
+      <member><constant>YAR_OPT_HEADER</constant> (a partir de 2.0.4) — un &array; de líneas de cabecera HTTP adicionales</member>
+      <member><constant>YAR_OPT_RESOLVE</constant> (a partir de 2.1.0) — un &array; de entradas de resolución de nombres de host</member>
+      <member><constant>YAR_OPT_PROXY</constant> (a partir de 2.2.0) — una dirección de proxy HTTP</member>
+      <member><constant>YAR_OPT_PROVIDER</constant> (a partir de 2.3.0) — la identidad del proveedor, hasta 32 bytes</member>
+      <member><constant>YAR_OPT_TOKEN</constant> (a partir de 2.3.0) — el token de autenticación, hasta 32 bytes</member>
+     </simplelist>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      El valor de la opción. Un valor no válido genera una advertencia y hace
+      que la llamada devuelva &false;.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -51,50 +56,80 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve <varname>$this</varname> en caso de éxito &return.falseforfailure;.
-  </para>
+  <simpara>
+   Devuelve el propio objeto cliente, lo que permite una interfaz fluida, o
+   &false; cuando el nombre de la opción es desconocido, el valor no es
+   válido o la opción no se aplica al protocolo con el que se creó el
+   cliente.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Las condiciones que hacen que la llamada devuelva &false; generan también
+   una advertencia:
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <constant>YAR_OPT_HEADER</constant>,
+     <constant>YAR_OPT_RESOLVE</constant> y
+     <constant>YAR_OPT_PROXY</constant> solo funcionan con el protocolo HTTP;
+     usarlas con un cliente <literal>tcp://</literal> o
+     <literal>unix://</literal> genera una advertencia.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>YAR_OPT_RESOLVE</constant> requiere además libcurl
+     &gt;= 7.21.3.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     Cada opción espera un tipo de valor concreto (cadena, booleano, entero o
+     array), descrito en la página de
+     <link linkend="yar.constants">constantes</link>.
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo de <function>Yar_Client::setOpt</function></title>
+   <title>Ejemplo de <methodname>Yar_Client::setOpt</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
-$cliente = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://host/api/");
 
-//Establecer el tiempo de espera a 1s
-$cliente->SetOpt(YAR_OPT_CONNECT_TIMEOUT, 1000);
+/* Establece el tiempo de espera en 1s */
+$client->setOpt(YAR_OPT_TIMEOUT, 1000);
 
-//Establecer el empaquetador a JSON
-$cliente->SetOpt(YAR_OPT_PACKAGER, "json");
+/* Establece el empaquetador en JSON */
+$client->setOpt(YAR_OPT_PACKAGER, "json");
 
-//Establecer cabeceras personalizadas
-$client->SetOpt(YAR_OPT_HEADER, array("hr1: val1", "hd2: val2"));
+/* Establece cabeceras personalizadas */
+$client->setOpt(YAR_OPT_HEADER, ["X-Api-Key: value"]);
 
-// Establecer Http Proxy
-$client->SetOpt(YAR_OPT_PROXY, "127.0.0.1:8888");
+/* Enruta a través de un proxy HTTP */
+$client->setOpt(YAR_OPT_PROXY, "127.0.0.1:8888");
 
-/* llamar al servicio remoto */
-$result = $cliente->some_method("parameter");
+/* llama al servicio remoto */
+$result = $client->some_method("parameter");
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
+   <member><methodname>Yar_Client::getOpt</methodname></member>
    <member><methodname>Yar_Client::__call</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client_exception/gettype.xml
+++ b/reference/yar/yar_client_exception/gettype.xml
@@ -1,23 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 167c48c1c76f7f29be2f44fd72ea72a43ae5e1e1 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client_Exception::getType</refname>
-  <refpurpose>Recuperar el tipo de excepción</refpurpose>
+  <refpurpose>Obtiene el tipo de la excepción</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="Yar_Client_Exception">
    <modifier>public</modifier> <type>string</type><methodname>Yar_Client_Exception::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Devuelve el tipo de la excepción. Las excepciones del lado del cliente
+   las lanza el propio cliente (fallos de transporte, errores de protocolo,
+   etc.), por lo que el tipo es siempre la cadena fija
+   <literal>"Yar_Exception_Client"</literal>. Se puede usar
+   <methodname>Exception::getCode</methodname> para distinguir cada fallo
+   concreto; el código es una de las constantes
+   <literal>YAR_ERR_*</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,38 +31,43 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Devuelve <literal>"Yar_Exception_Client"</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo de <function>Yar_Client_Exception::getType</function></title>
+   <title>Ejemplo de <methodname>Yar_Client_Exception::getType</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
+$client = new Yar_Client("http://host/api/");
 
-/* ... */
-
+try {
+    $client->some_method("parameter");
+} catch (Yar_Client_Exception $e) {
+    var_dump($e->getType());
+    var_dump($e->getCode());
+}
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-...
+string(20) "Yar_Exception_Client"
+int(16)
 ]]>
    </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yaf_Server_Exception::getType</methodname></member>
+   <member><methodname>Yar_Server_Exception::getType</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,29 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c50df321d2cccb1044219a98d4c5c7677d4b29cf Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::call</refname>
-  <refpurpose>Registrar una llamada concurrente</refpurpose>
+  <refpurpose>Registra una llamada concurrente</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>int</type><methodname>Yar_Concurrent_Client::call</methodname>
+  <methodsynopsis role="Yar_Concurrent_Client">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>false</type><type>null</type></type><methodname>Yar_Concurrent_Client::call</methodname>
    <methodparam><type>string</type><parameter>uri</parameter></methodparam>
    <methodparam><type>string</type><parameter>method</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>parameters</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>parameters</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>error_callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Registra una llamada RPC, aunque no la envía inmediatamente. Se enviará al
-   llamar a <methodname>Yar_Concurrent_Client::loop</methodname>.
-  </para>
+  <simpara>
+   Registra una llamada RPC remota. La petición no se envía inmediatamente;
+   todas las llamadas registradas se envían juntas mediante
+   <methodname>Yar_Concurrent_Client::loop</methodname>, y las respuestas se
+   tratan a medida que llegan.
+  </simpara>
+  <note>
+   <simpara>
+    Solo se admiten URIs HTTP y HTTPS. Los transportes TCP y de sockets Unix
+    no están disponibles para las llamadas concurrentes.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,40 +38,52 @@
    <varlistentry>
     <term><parameter>uri</parameter></term>
     <listitem>
-     <para>
-       El URI del servidor de RPC (HTTP, TCP).
-     </para>
+     <simpara>
+      Dirección del servicio RPC, que comienza por
+      <literal>http://</literal> o <literal>https://</literal>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>method</parameter></term>
     <listitem>
-     <para>
-      El nombre del servicio (es decir, el nombre del método).
-     </para>
+     <simpara>
+      El nombre del método del servicio remoto.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>parameters</parameter></term>
     <listitem>
-     <para>
-      Parámetros.
-     </para>
+     <simpara>
+      La lista de argumentos pasados al método remoto.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-      Una retrollamada a una función, la cual será invocada mientras se devuelve la respuesta.
-     </para>
+     <simpara>
+      Un <type>callable</type> invocado cuando llega la respuesta de esta
+      llamada, con dos argumentos: el valor de la respuesta y un
+      &array; <literal>callinfo</literal> con las claves
+      <literal>sequence</literal>, <literal>uri</literal> y
+      <literal>method</literal>. Si se omite, se utiliza el
+      <literal>callback</literal> de
+      <methodname>Yar_Concurrent_Client::loop</methodname>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>error_callback</parameter></term>
     <listitem>
      <simpara>
-      Si se establece esta retrollamada, Yar la invocará cuando ocurra un error.
+      Un <type>callable</type> invocado cuando esta llamada falla, con tres
+      argumentos: el tipo de error (uno de los códigos
+      <literal>YAR_ERR_*</literal>), el mensaje de error y el
+      &array; <literal>callinfo</literal>. Si se omite, se utiliza el
+      <literal>error_callback</literal> de
+      <methodname>Yar_Concurrent_Client::loop</methodname>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -73,8 +91,10 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Un &array; de opciones.
-      Ver la lista de <link linkend="yar.constants">constantes</link>.
+      Un &array; de opciones del cliente, indexado por las constantes
+      <literal>YAR_OPT_*</literal>, véase
+      <methodname>Yar_Client::setOpt</methodname>. Se aplica únicamente a
+      esta llamada.
      </simpara>
     </listitem>
    </varlistentry>
@@ -84,7 +104,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Un ID único que se puede utilizar para identificar la llamada que es.
+   Devuelve el número de secuencia de la llamada registrada, un ID único que
+   empieza en <literal>1</literal> y que identifica la llamada. Devuelve
+   &false; cuando el cliente concurrente ya se encuentra dentro de
+   <methodname>Yar_Concurrent_Client::loop</methodname> o cuando se alcanza
+   el máximo de <literal>128</literal> llamadas registradas; en ambos casos
+   se emite una advertencia. Devuelve &null; si la URI o el nombre del
+   método están vacíos, o si la URI no es una dirección HTTP(S), con una
+   advertencia.
   </simpara>
  </refsect1>
 
@@ -107,23 +134,18 @@ function error_callback($type, $error, $callinfo)
 
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
 
-// Si no se especifica la retrollamada, se usará la retrollamada en bucle
+/* Si no se especifica el callback, se utilizará el callback de loop() */
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
 
-// Este servidor acepta empaquetador JSON
+/* Este servidor acepta el empaquetador JSON */
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
 
-// Tiempo de espera personalizado
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1));
+/* Tiempo de espera personalizado */
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
 
-// Las peticiones aún no se han enviado
+/* Las peticiones todavía no se han enviado */
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </informalexample>
  </refsect1>
 
@@ -132,8 +154,6 @@ Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::loop</methodname></member>
    <member><methodname>Yar_Concurrent_Client::reset</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -1,22 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::loop</refname>
-  <refpurpose>Enviar todas las llamadas</refpurpose>
+  <refpurpose>Envía todas las llamadas registradas y espera su respuesta</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yar_Concurrent_Client::loop</methodname>
-   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
+  <methodsynopsis role="Yar_Concurrent_Client">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>bool</type><type>null</type></type><methodname>Yar_Concurrent_Client::loop</methodname>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>error_callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-    Envía todas las llamadas RPC remotas registradas.
+   Envía en paralelo todas las llamadas registradas con
+   <methodname>Yar_Concurrent_Client::call</methodname> y bloquea hasta que
+   todas las respuestas hayan llegado y hayan sido tratadas. La lista de
+   llamadas se vacía cuando este método retorna.
   </simpara>
  </refsect1>
 
@@ -26,24 +29,34 @@
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-      Si se establece esta retrollamada, Yar la invocará después de haber
-      enviado todas las llamadas y antes de cualquier respuesta, con un $callinfo NULL.
-     </para>
-     <para>
-      Entonces, si un usuario no especifica la retrollamada al registrar una llamada concurretne,
-      esta retrollamada se utilizará para manejar la resupesta, o si no, se utilizará la
-      retrollamada especificada durante el registro.
-     </para>
+     <simpara>
+      Un <type>callable</type> utilizado para tratar las respuestas de las
+      llamadas que se registraron sin su propio callback. Justo después de
+      que se hayan enviado todas las peticiones, se le llama además una vez
+      con dos argumentos &null;, antes de que llegue ninguna respuesta.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>error_callback</parameter></term>
     <listitem>
-     <para>
-      Si se establece esta retrollamada, Yar la invocará cuando suceda un
-      error.
-     </para>
+     <simpara>
+      Un <type>callable</type> utilizado para tratar los errores de las
+      llamadas que se registraron sin su propio callback de error. Recibe
+      tres argumentos: el tipo de error (uno de los códigos
+      <literal>YAR_ERR_*</literal>), el mensaje de error y el
+      &array; <literal>callinfo</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; de opciones del cliente, indexado por las constantes
+      <literal>YAR_OPT_*</literal>, que se aplica a cada llamada registrada
+      que no las sobrescriba.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -51,26 +64,29 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Devuelve &true; cuando todas las llamadas registradas han sido tratadas,
+   o cuando no se ha registrado ninguna llamada. Devuelve &false; si el
+   cliente concurrente ya se está ejecutando dentro de otro bucle; en ese
+   caso se emite una advertencia.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo de <function>Yar_Concurrent_Client::loop</function></title>
+   <title>Ejemplo de <methodname>Yar_Concurrent_Client::loop</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 function callback($retval, $callinfo) {
-     if ($callinfo == NULL) {
-        echo "Now, all requests are sent, and no response available\n";
-     } else {
-        echo "This is a remote call response, the method name is", $callinfo["method"],
-             ". calling sequence is " , $callinfo["sequence"] , "\n";
+    if ($callinfo == NULL) {
+        echo "Ahora todas las peticiones han sido enviadas, y no hay ninguna respuesta disponible\n";
+    } else {
+        echo "Esta es una respuesta de una llamada remota, el nombre del método es ", $callinfo["method"],
+             ". La secuencia de llamada es ", $callinfo["sequence"], "\n";
         var_dump($retval);
-     }
+    }
 }
 
 function error_callback($type, $error, $callinfo) {
@@ -78,43 +94,32 @@ function error_callback($type, $error, $callinfo) {
 }
 
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));   // if the callback is not specificed,
-                                                                               // callback in loop will be used
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
-                                                                               //this server accept json packager
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
-                                                                               //custom timeout
 
-Yar_Concurrent_Client::loop("callback", "error_callback"); //send the requests,
-                                                           //the error_callback is optional
+/* si no se especifica el callback, se utilizará el callback de loop() */
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+
+Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Now, all requests are sent, and no response available
-This is a remote call response, the method name issome_method. calling sequence is 4
+Ahora todas las peticiones han sido enviadas, y no hay ninguna respuesta disponible
+Esta es una respuesta de una llamada remota, el nombre del método es some_method. La secuencia de llamada es 2
 string(11) "some_method"
-This is a remote call response, the method name issome_method. calling sequence is 1
-string(11) "some_method"
-This is a remote call response, the method name issome_method. calling sequence is 2
-string(11) "some_method"
-This is a remote call response, the method name issome_method. calling sequence is 3
+Esta es una respuesta de una llamada remota, el nombre del método es some_method. La secuencia de llamada es 1
 string(11) "some_method"
 ]]>
    </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::call</methodname></member>
    <member><methodname>Yar_Concurrent_Client::reset</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 62126c55f1c6ed444043e7272c4f9e233818a44b Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::reset</refname>
-  <refpurpose>Limpiar todas las llamadas registradas</refpurpose>
+  <refpurpose>Limpia todas las llamadas registradas</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="Yar_Concurrent_Client">
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yar_Concurrent_Client::reset</methodname>
    <void />
   </methodsynopsis>
-  <para>
-   Limpia todas las llamadas registradas
-  </para>
+  <simpara>
+   Descarta todas las llamadas registradas con
+   <methodname>Yar_Concurrent_Client::call</methodname> que todavía no se
+   han enviado.
+  </simpara>
+  <note>
+   <simpara>
+    <methodname>Yar_Concurrent_Client::loop</methodname> vacía la lista de
+    llamadas automáticamente una vez que ha terminado, por lo que reset solo
+    es necesario para abortar un lote que nunca se envió.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,8 +34,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-  </para>
+  <simpara>
+   Devuelve &true;, o &false; cuando el cliente concurrente se encuentra
+   actualmente dentro de
+   <methodname>Yar_Concurrent_Client::loop</methodname>, en cuyo caso se
+   emite un error de nivel <constant>E_WARNING</constant>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -36,13 +48,18 @@
    <title>Ejemplo de <function>Yar_Concurrent_Client::reset</function></title>
    <programlisting role="php">
 <![CDATA[
+<?php
+function callback($retval, $callinfo) {
+    var_dump($retval);
+}
+
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+
+/* nunca enviada: se descarta la llamada registrada */
+Yar_Concurrent_Client::reset();
+?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
 
@@ -51,8 +68,6 @@
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::call</methodname></member>
    <member><methodname>Yar_Concurrent_Client::loop</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_server/construct.xml
+++ b/reference/yar/yar_server/construct.xml
@@ -1,36 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server::__construct</refname>
-  <refpurpose>Registrar un servidor</refpurpose>
+  <refpurpose>Crea un servidor RPC</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="Yar_Server">
    <modifier>final</modifier> <modifier>public</modifier> <methodname>Yar_Server::__construct</methodname>
-   <methodparam><type>Object</type><parameter>obj</parameter></methodparam>
-  </methodsynopsis>
-  <para>
-   Configurar un Servidor Yar HTTP RPC. Todos los métodos públicos de $obj serán
-   registrados como un servicio RPC.
-  </para>
+   <methodparam><type>object</type><parameter>executor</parameter></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Crea un servidor RPC HTTP de Yar. Todos los métodos públicos de
+   <parameter>executor</parameter> se registran como servicios RPC.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>obj</parameter></term>
+    <term><parameter>executor</parameter></term>
     <listitem>
-     <para>
-      Un objeto, todos sus métodos publicos serán registrados como
-      servicioes RPC.
-     </para>
+     <simpara>
+      Cualquier objeto cuyos métodos públicos deban exponerse como
+      servicios RPC. Los métodos protegidos y privados, y los métodos cuyo
+      nombre empieza por un guion bajo, no se exponen.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -38,23 +37,23 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Una instancia de <classname>Yar_Server</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo de <function>Yar_Server::__construct</function></title>
+   <title>Ejemplo de <methodname>Yar_Server::__construct</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 class API {
     /**
-     * the doc info will be generated automatically into service info page.
-     * @params
-     * @return
+     * El bloque de documentación se muestra en la página de información del servicio.
+     * @param string $parameter
+     * @return string
      */
     public function some_method($parameter, $option = "foo") {
          return "some_method";
@@ -69,20 +68,16 @@ $service->handle();
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <simplelist>
-   <member><methodname>Yar_Server::handle</methodname></member>
-  </simplelist>
+  <para>
+   <simplelist>
+    <member><methodname>Yar_Server::handle</methodname></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -1,30 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 07275f5d03cf34c5a2218e0c103978f8024da153 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-server.handle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server::handle</refname>
-  <refpurpose>Iniciar un servidor RPC</refpurpose>
+  <refpurpose>Inicia el servidor RPC</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type> <methodname>Yar_Server::handle</methodname>
-   <void/>
+  <methodsynopsis role="Yar_Server">
+   <modifier>public</modifier> <type>bool</type><methodname>Yar_Server::handle</methodname>
+   <void />
   </methodsynopsis>
-  <para>
-   Inicia un servidor de HTTP de RPC listo para aceptar peticiones RPC.
-   <note>
-    <para>
-     Las llamadas RPC usuales serán emitidas como peticiones POST de HTTP. Si se emite
-     una petición GET de HTTP al URI, se imprimierá en la página la información
-     del servicio (la sección comentada anteriormente).
-    </para>
-   </note>
-  </para>
+  <simpara>
+   Empieza a atender la petición RPC entrante.
+  </simpara>
+  <note>
+   <simpara>
+    Las llamadas RPC habituales se emiten como peticiones HTTP POST. Si en
+    su lugar se emite una petición HTTP GET, se muestra la página de
+    información del servicio, generada a partir de los métodos públicos y
+    de sus bloques de documentación del objeto ejecutor. Este
+    comportamiento se puede desactivar con la directiva
+    <link linkend="ini.yar.expose-info">yar.expose_info</link>,
+    en cuyo caso una petición GET lanza una
+    <exceptionname>Yar_Server_Exception</exceptionname>.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    A partir de Yar 2.3.0, la página de información del servicio se puede
+    personalizar definiendo un método <literal>protected</literal> llamado
+    <literal>__info</literal> en el objeto ejecutor. Cuando llega una
+    petición GET, Yar llama a este método pasándole el marcado de la página
+    que mostraría en otro caso; si el método devuelve una &string;, esa
+    cadena se envía al cliente en lugar de la página predeterminada.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -34,25 +47,98 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Devuelve &true;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
   <para>
-   boolean
+   <table>
+    <title>Errores de <methodname>Yar_Server::handle</methodname></title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Condición</entry>
+       <entry>Excepción</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>
+        El método remoto lanzó una excepción.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Exception</exceptionname> (con el nombre
+        de clase original en su propiedad <literal>_type</literal>).
+       </entry>
+      </row>
+      <row>
+       <entry>
+        El método remoto no se encontró o no es público.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Request_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        El cuerpo de la petición no se pudo desempaquetar.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Packager_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        La petición está mal formada a nivel de protocolo.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Protocol_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        La salida del servidor no se pudo capturar.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Output_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        La autenticación falló, o se solicitó la página de información
+        mientras
+        <link linkend="ini.yar.expose-info">yar.expose_info</link> está
+        desactivada.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Exception</exceptionname> con el código
+        <constant>YAR_ERR_FORBIDDEN</constant>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo de <function>Yar_Server::handle</function></title>
+   <title>Ejemplo de <methodname>Yar_Server::handle</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 class API {
     /**
-     * the doc info will be generated automatically into service info page.
-     * @params
-     * @return
+     * El bloque de documentación se muestra en la página de información del servicio.
+     * @param string $parameter
+     * @return string
      */
     public function some_method($parameter, $option = "foo") {
+        return "some_method";
     }
 
     protected function client_can_not_see() {
@@ -64,20 +150,43 @@ $service->handle();
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
+  </example>
+  <example>
+   <title>Personalización de la página de información del servicio con
+   <literal>__info</literal> (a partir de Yar 2.3.0)</title>
+   <programlisting role="php">
 <![CDATA[
+<?php
+class API {
+    public function some_method($parameter, $option = "foo") {
+        return "some_method";
+    }
+
+    /*
+     * Debe ser protected. Se llama en las peticiones GET con el marcado de
+     * la página que Yar mostraría en otro caso, y el valor de cadena que
+     * devuelve se envía al cliente en su lugar.
+     */
+    protected function __info($markup) {
+        return "Hola mundo";
+    }
+}
+
+$service = new Yar_Server(new API());
+$service->handle();
+?>
 ]]>
-   </screen>
+   </programlisting>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <simplelist>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-  </simplelist>
+  <para>
+   <simplelist>
+    <member><methodname>Yar_Server::__construct</methodname></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yar/yar_server_exception/gettype.xml
+++ b/reference/yar/yar_server_exception/gettype.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 8cc7e649de5889a9029139587962320e2794addd Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-server-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server_Exception::getType</refname>
-  <refpurpose>Recuperar el tipo de excepción</refpurpose>
+  <refpurpose>Obtiene el tipo de la excepción</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>Yar_Server_Exception::getType</methodname>
+  <methodsynopsis role="Yar_Server_Exception">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>int</type></type><methodname>Yar_Server_Exception::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
-   Obtener el tipo original de la excepción lanzada por el servidor
-  </para>
+  <simpara>
+   Cuando un método remoto lanza una excepción, el servidor incrusta la
+   excepción original en la respuesta y el cliente la relanza como una
+   <exceptionname>Yar_Server_Exception</exceptionname>. Este método devuelve
+   el nombre de clase de esa excepción original.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,19 +28,21 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   string
-  </para>
+  <simpara>
+   El nombre de clase de la excepción lanzada por el servicio remoto, o
+   <literal>"Yar_Exception_Server"</literal> cuando la excepción del lado
+   del servidor no llevaba ningún nombre de clase.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo de <function>Yar_Server_Exception::getType</function></title>
+   <title>Ejemplo de <methodname>Yar_Server_Exception::getType</methodname></title>
    <programlisting role="php">
 <![CDATA[
-//Server.php
 <?php
+/* Server.php */
 class Custom_Exception extends Exception {};
 
 class API {
@@ -51,9 +54,12 @@ class API {
 $service = new Yar_Server(new API());
 $service->handle();
 ?>
-
-//Client.php
+]]>
+   </programlisting>
+   <programlisting role="php">
+<![CDATA[
 <?php
+/* Client.php */
 $client = new Yar_Client("http://host/api.php");
 
 try {
@@ -62,6 +68,7 @@ try {
     var_dump($e->getType());
     var_dump($e->getMessage());
 }
+?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -74,11 +81,10 @@ string(6) "client"
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member></member>
+   <member><methodname>Yar_Client_Exception::getType</methodname></member>
   </simplelist>
  </refsect1>
 


### PR DESCRIPTION
Two sync issues are handled together because both touch `yar-client-protocol-exception.xml` and `yar_server/handle.xml`.

Sync with EN commits 75d48299ef85693f10eee31af1be88488fb84c6f and 07275f5d03cf34c5a2218e0c103978f8024da153.

- Full revision of the Yar documentation: the nine `YAR_OPT_*` options, exception hierarchy with `role="exception"`/`<ooexception>`, INI page rewritten with `yar.ssl_verify`, `<simpara>`, `<exceptionname>` and "See also" sections; the `Yar_Client::getOpt()` page is added.
- `yar-client-protocol-exception.xml` gains the paragraph on response transaction id validation (Yar 2.4.0) and `yar_server/handle.xml` the note and example for the `__info` magic method (Yar 2.3.0).

`reference/yar/versions.xml` is EN-only and stays out of scope. Removes the obsolete `<!-- Reviewed -->` and `<!-- $Revision$ -->` markers.

Fixes: #1124
Fixes: #1123