### PR TITLE
[Sync-En] array: drop the stale Reviewed marker on language/types/array.xml

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
 <sect1 xml:id="language.types.array">
  <title>Arrays</title>
 


### PR DESCRIPTION
The content of this sync issue was already applied: the note of example 10 matches the current EN wording and `EN-Revision` is already at 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb, the latest EN commit for this file (synced by 9b7b95b99).

Only the obsolete `<!-- Reviewed -->` marker was left; this removes it and closes the issue.

Fixes: #685