### PR TITLE
[Sync-En] finalize sync of the copy-pasted description fixes

### DIFF
--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-cache-info">
  <refnamediv>
   <refname>apcu_cache_info</refname>

--- a/reference/apcu/functions/apcu-key-info.xml
+++ b/reference/apcu/functions/apcu-key-info.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos-->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-key-info">
  <refnamediv>
   <refname>apcu_key_info</refname>
@@ -27,7 +26,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
-      Nombre de la clave.
+      La clave de la que se desea obtener la información.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/cubrid/functions/cubrid-lob2-import.xml
+++ b/reference/cubrid/functions/cubrid-lob2-import.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-lob2-import">
  <refnamediv>
   <refname>cubrid_lob2_import</refname>

--- a/reference/cubrid/functions/cubrid-pconnect.xml
+++ b/reference/cubrid/functions/cubrid-pconnect.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-pconnect">
  <refnamediv>
   <refname>cubrid_pconnect</refname>

--- a/reference/cubrid/functions/cubrid-seq-insert.xml
+++ b/reference/cubrid/functions/cubrid-seq-insert.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-seq-insert">
  <refnamediv>
   <refname>cubrid_seq_insert</refname>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-chown">
  <refnamediv>
   <refname>eio_chown</refname>

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fchown">
  <refnamediv>
   <refname>eio_fchown</refname>

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fstat">
  <refnamediv>
   <refname>eio_fstat</refname>

--- a/reference/eio/functions/eio-nready.xml
+++ b/reference/eio/functions/eio-nready.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-nready">
  <refnamediv>
   <refname>eio_nready</refname>

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-truncate">
  <refnamediv>
   <refname>eio_truncate</refname>

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-suggest">
  <refnamediv>
   <refname>enchant_dict_suggest</refname>

--- a/reference/ev/evchild/createstopped.xml
+++ b/reference/ev/evchild/createstopped.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evchild.createstopped">
  <refnamediv>
   <refname>EvChild::createStopped</refname>

--- a/reference/ev/evsignal/construct.xml
+++ b/reference/ev/evsignal/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evsignal.construct">
  <refnamediv>
   <refname>EvSignal::__construct</refname>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
 
 <reference xml:id="class.event" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Event</title>

--- a/reference/event/eventhttprequest/getbufferevent.xml
+++ b/reference/event/eventhttprequest/getbufferevent.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
 
 <refentry xml:id="eventhttprequest.getbufferevent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/fann/functions/fann-get-activation-function.xml
+++ b/reference/fann/functions/fann-get-activation-function.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-activation-function" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/fann/functions/fann-get-rprop-decrease-factor.xml
+++ b/reference/fann/functions/fann-get-rprop-decrease-factor.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-rprop-decrease-factor" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
 
 <refentry xml:id="zmqdevice.settimercallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -34,7 +32,7 @@
     <listitem>
      <simpara>
       Función de retrollamada a invocar cuando se dispara el temporizador. La devolución de false
-      o de un valor que se evalú como false por parte de esta función causará la detención
+      o de un valor que se evalúe como false por parte de esta función causará la detención
       del dispositivo.
      </simpara>
     </listitem>


### PR DESCRIPTION
Sync with EN commit 184764a63e01525315f54897f3bd38eaa1242b42.

The translation of that EN commit was already applied across the 18 files (each of the 18 changed spots was checked line by line, and every `EN-Revision` already pointed at 184764a6). What was left is finalized here:

- the obsolete `<!-- Reviewed -->` and `<!-- $Revision$ -->` markers are removed from the 18 files;
- `apcu-key-info.xml`: the `key` parameter description is aligned on the new EN wording;
- `zmqdevice/settimercallback.xml`: agreement fix in the paragraph rewritten by the EN commit ("se evalú" -> "se evalúe").

Fixes: #684