### PR TITLE
[Sync-En] ReflectionClass::setStaticPropertyValue: document visibility-independent behavior

### DIFF
--- a/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
+++ b/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c4aabaa0b97ef1ecc00cf2cd539ea186c6a855ae Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: c74adac363c4ad18bfb648b8962663b26de3828b Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="reflectionclass.setstaticpropertyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::setStaticPropertyValue</refname>
-  <refpurpose>Define el valor de una propiedad estática pública</refpurpose>
+  <refpurpose>Establece el valor de una propiedad estática</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,12 +14,12 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Define el valor de una propiedad estática pública.
-   Si la propiedad es privada o protegida, el método fallará.
+   Establece el valor de una propiedad estática de esta clase, independientemente
+   de la visibilidad de la propiedad.
   </simpara>
   <simpara>
-   <methodname>ReflectionProperty::setValue</methodname> permite definir
-   el valor de las propiedades públicas, privadas y protegidas.
+   <methodname>ReflectionProperty::setValue</methodname> también puede usarse
+   para establecer el valor de propiedades estáticas.
   </simpara>
  </refsect1>
 
@@ -67,11 +66,11 @@
     </thead>
     <tbody>
      <row>
-      <entry>7.4.0</entry>
+      <entry>7.4.9, 8.0.0</entry>
       <entry>
-       El uso de <methodname>ReflectionClass::setStaticPropertyValue</methodname> para definir
-       una propiedad privada o protegida ahora produce un error fatal. Anteriormente, esto
-       lanzaba una <classname>ReflectionException</classname>.
+       <methodname>ReflectionClass::setStaticPropertyValue</methodname> ahora puede
+       establecer propiedades estáticas privadas y protegidas. Anteriormente, se lanzaba
+       una <exceptionname>ReflectionException</exceptionname>.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Sync with EN commit c74adac363c4ad18bfb648b8962663b26de3828b.

Updates the description and changelog to reflect that `setStaticPropertyValue` ignores property visibility since 7.4.9/8.0.0 (previously only worked on public properties and threw a `ReflectionException` for private/protected ones).

Fixes: #1165