### PR TITLE
[Sync-En] Document that readonly properties cannot be initialized by reference

### DIFF
--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 62e61e543c2d2b8519952efa246ed708026cfb16 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 4e77868e15fea65175b87a38d6d31b61d63f7f8e Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.oop5.properties" xmlns="http://docbook.org/ns/docbook">
  <title>Propiedades</title>
 
@@ -261,6 +261,35 @@ $test1->prop = "foobar";
     </programlisting>
    </example>
   </para>
+  <note>
+   <para>
+    Las propiedades de solo lectura solo pueden inicializarse mediante una asignación directa.
+    Una propiedad de solo lectura no inicializada no puede inicializarse por referencia, ni siquiera
+    desde el ámbito en el que ha sido declarada: pasarla a un parámetro de función que espera
+    ser pasado por referencia, o asignarla por referencia, produce una excepción
+    <exceptionname>Error</exceptionname>.
+    <informalexample>
+     <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+
+class Test {
+    public readonly array $matches;
+
+    public function __construct(string $subject) {
+        // Inicialización ilegal por referencia.
+        preg_match('/\d+/', $subject, $this->matches);
+        // Error: Cannot indirectly modify readonly property Test::$matches
+    }
+}
+
+new Test('abc 42');
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </note>
   <note>
    <para>
     Especificar un valor por defecto explícito a una propiedad de solo lectura


### PR DESCRIPTION
Sync with EN commit 4e77868e15fea65175b87a38d6d31b61d63f7f8e.

Adds a note explaining that an uninitialized readonly property cannot be initialized by reference (passing it to a by-reference parameter or assigning it by reference results in an `Error` exception), with a code example.

Fixes: #1159