### PR TITLE
[Sync-En] mb_scrub: add examples and seealso section

### DIFF
--- a/reference/mbstring/functions/mb-scrub.xml
+++ b/reference/mbstring/functions/mb-scrub.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 77a60306bc47d2151ebca7e6983897a0371a9671 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: eb10503592351cf78c25be21c60a9049784d57bb Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.mb-scrub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_scrub</refname>
@@ -71,6 +70,85 @@
    </tgroup>
   </informaltable>
  </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Reemplazo a nivel de byte realizado por <function>mb_scrub</function></title>
+   <simpara>
+    Aquí se utiliza <function>bin2hex</function> porque los terminales, navegadores y
+    fuentes pueden renderizar una secuencia de bytes mal formada con un carácter de
+    sustitución propio, ocultando lo que la cadena contiene realmente.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+// El byte 0xFF no puede aparecer en una cadena UTF-8 válida.
+$input = "A\xFFB";
+echo bin2hex($input), "\n";
+
+// El carácter de sustitución por defecto es "?" (0x3F).
+echo bin2hex(mb_scrub($input, 'UTF-8')), "\n";
+
+// U+FFFD REPLACEMENT CHARACTER se codifica como EF BF BD en UTF-8.
+mb_substitute_character(0xFFFD);
+echo bin2hex(mb_scrub($input, 'UTF-8')), "\n";
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+41ff42
+413f42
+41efbfbd42
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Usar <function>mb_scrub</function> antes de un procesamiento consciente de UTF-8</title>
+   <simpara>
+    Los patrones PCRE con el modificador <literal>u</literal> rechazan los sujetos que
+    no son UTF-8 bien formado. Limpiar la entrada primero la hace aceptable.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$input = "A\xFFB";
+
+var_dump(preg_match_all('/./us', $input));
+echo preg_last_error_msg(), "\n";
+
+$clean = mb_scrub($input, 'UTF-8');
+
+var_dump(preg_match_all('/./us', $clean));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+Malformed UTF-8 characters, possibly incorrectly encoded
+int(3)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>mb_substitute_character</function></member>
+   <member><function>mb_check_encoding</function></member>
+   <member><function>mb_convert_encoding</function></member>
+  </simplelist>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Mirrors php/doc-en commit eb10503 for `mb_scrub`: adds two examples (byte-level replacement, scrubbing before PCRE processing) and a seealso section.

Fixes: #1152