### PR TITLE
[Sync-En] Modernize PDO installation documentation

### DIFF
--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: Marqitos -->
+<!-- EN-Revision: 6e58d11156926ea75109693d63306092320b63fe Maintainer: PhilDaiguille Status: ready -->
 <section xml:id="pdo.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
  <para>
@@ -45,11 +44,11 @@ extension=pdo
   <step>
    <para>
     PDO está activado por defecto.
-    Seleccione los otros archivos DLL específicos de su base de datos
-    y utilice la función <function>dl</function> para cargarlos en tiempo de ejecución o actívelos en el archivo &php.ini;.
+    Active los controladores específicos de base de datos en &php.ini; según sea necesario.
     Por ejemplo, esto carga el controlador
     <link linkend="ref.pdo-sqlite">PDO_SQLITE</link> pero
-    deja el controlador <link linkend="ref.pdo-odbc">PDO_ODBC</link> comentado:
+    deja el controlador <link linkend="ref.pdo-odbc">PDO_ODBC</link>
+    comentado:
     <screen>
 <![CDATA[
 ;extension=pdo_odbc
@@ -57,10 +56,10 @@ extension=pdo_sqlite
 ]]>
     </screen>
    </para>
-   <para>
-    Estas librerías DLL deben existir en el directorio del sistema
+   <simpara>
+    Los archivos de extensión correspondientes deben existir en el directorio
     <link linkend="ini.extension-dir">extension_dir</link>.
-   </para>
+   </simpara>
   </step>
  </procedure>
  <note>


### PR DESCRIPTION
Mirrors php/doc-en commit 6e58d11 for `reference/pdo/configure.xml`: drops the obsolete `dl()` advice in favour of enabling drivers in `php.ini`, and switches the trailing `<para>` to `<simpara>`.

Fixes: #1160