### PR TITLE
[Sync-En] Document named arguments support in Reflection ...Args methods

### DIFF
--- a/reference/reflection/reflectionclass/newinstanceargs.xml
+++ b/reference/reflection/reflectionclass/newinstanceargs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="reflectionclass.newinstanceargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::newInstanceArgs</refname>
@@ -27,10 +26,22 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Acepta un número variable de argumentos pasados al constructor,
-       como en la función <function>call_user_func</function>.
-      </para>
+      <simpara>
+       Los parámetros a pasar al constructor de la clase, como un <type>array</type>.
+      </simpara>
+      <simpara>
+       Si todas las claves de <parameter>args</parameter> son numéricas, estas se ignoran
+       y cada elemento se pasa al constructor como argumento posicional, en orden.
+      </simpara>
+      <simpara>
+       Si alguna de las claves de <parameter>args</parameter> es una cadena, esos elementos
+       se pasan al constructor como argumentos con nombre, usando la clave como nombre.
+      </simpara>
+      <simpara>
+       Se lanza un <exceptionname>Error</exceptionname> si una clave numérica en
+       <parameter>args</parameter> aparece después de una clave de cadena, o si una clave
+       de cadena no coincide con el nombre de ningún parámetro del constructor.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -53,6 +64,29 @@
    Una <classname>ReflectionException</classname> si la clase no tiene constructor
    y el parámetro <parameter>args</parameter> contiene al menos un dato.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Las claves de <parameter>args</parameter> ahora se interpretan como nombres de parámetro,
+       en lugar de ser ignoradas silenciosamente.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionfunction/invokeargs.xml
+++ b/reference/reflection/reflectionfunction/invokeargs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="reflectionfunction.invokeargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFunction::invokeArgs</refname>
@@ -26,10 +25,23 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Los argumentos a utilizar durante la invocación, de manera similar al
-       funcionamiento de <function>call_user_func_array</function>.
-      </para>
+      <simpara>
+       Los parámetros a pasar a la función, como un <type>array</type>,
+       de manera similar al funcionamiento de <function>call_user_func_array</function>.
+      </simpara>
+      <simpara>
+       Si todas las claves de <parameter>args</parameter> son numéricas, estas se ignoran
+       y cada elemento se pasa a la función como argumento posicional, en orden.
+      </simpara>
+      <simpara>
+       Si alguna de las claves de <parameter>args</parameter> es una cadena, esos elementos
+       se pasan a la función como argumentos con nombre, usando la clave como nombre.
+      </simpara>
+      <simpara>
+       Se lanza un <exceptionname>Error</exceptionname> si una clave numérica en
+       <parameter>args</parameter> aparece después de una clave de cadena, o si una clave
+       de cadena no coincide con el nombre de ningún parámetro de la función.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/reflection/reflectionmethod/invokeargs.xml
+++ b/reference/reflection/reflectionmethod/invokeargs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="reflectionmethod.invokeargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionMethod::invokeArgs</refname>
@@ -36,9 +35,22 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Los argumentos a pasar al método, en forma de array.
-      </para>
+      <simpara>
+       Los parámetros a pasar al método, como un <type>array</type>.
+      </simpara>
+      <simpara>
+       Si todas las claves de <parameter>args</parameter> son numéricas, estas se ignoran
+       y cada elemento se pasa al método como argumento posicional, en orden.
+      </simpara>
+      <simpara>
+       Si alguna de las claves de <parameter>args</parameter> es una cadena, esos elementos
+       se pasan al método como argumentos con nombre, usando la clave como nombre.
+      </simpara>
+      <simpara>
+       Se lanza un <exceptionname>Error</exceptionname> si una clave numérica en
+       <parameter>args</parameter> aparece después de una clave de cadena, o si una clave
+       de cadena no coincide con el nombre de ningún parámetro del método.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Mirrors php/doc-en commit 0f4bc7c for `reference/reflection`: documents that string keys in `$args` are passed as named arguments and numeric keys as positional ones since PHP 8.0.0, in `newInstanceArgs`, `invokeArgs` (function) and `invokeArgs` (method).

Fixes: #1161