### PR TITLE
[Sync-En] sqlite3: document OK/DENY/IGNORE constants and add lastErrorCode seealso

### DIFF
--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: 32916e1adeb2b92179db162f422c63a69d9c9036 Maintainer: PhilDaiguille Status: ready -->
 <reference xml:id="class.sqlite3" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase <classname>SQLite3</classname></title>
  <titleabbrev>SQLite3</titleabbrev>
@@ -263,21 +262,30 @@
     <varlistentry xml:id="sqlite3.constants.ok">
      <term><constant>SQLite3::OK</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Retornado desde un callback de autorización para permitir la acción.
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="sqlite3.constants.deny">
      <term><constant>SQLite3::DENY</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Retornado desde un callback de autorización para rechazar toda la instrucción
+       SQL con un error.
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="sqlite3.constants.ignore">
      <term><constant>SQLite3::IGNORE</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Retornado desde un callback de autorización para denegar la acción específica
+       mientras se sigue permitiendo que se compile la instrucción SQL. Véase
+       <methodname>SQLite3::setAuthorizer</methodname> para el efecto sobre cada acción.
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/sqlite3/sqlite3/lasterrorcode.xml
+++ b/reference/sqlite3/sqlite3/lasterrorcode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 855bfee2f3db70d7dbb4c60c7c4a4efa567f1c60 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 32916e1adeb2b92179db162f422c63a69d9c9036 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="sqlite3.lasterrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SQLite3::lastErrorCode</refname>
@@ -30,6 +29,15 @@
   <para>
    Devuelve un entero que representa el código de error de la última consulta que ha fallado.
   </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::lastExtendedErrorCode</methodname></member>
+   <member><methodname>SQLite3::enableExtendedResultCodes</methodname></member>
+   <member><methodname>SQLite3::lastErrorMsg</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Mirrors php/doc-en commit 32916e1 for `reference/sqlite3`: fills in the empty descriptions of the `SQLite3::OK`, `DENY` and `IGNORE` constants and adds a seealso to `SQLite3::lastErrorCode`. Note that two files it links to are still EN-only.

Fixes: #1162