### PR TITLE
[Sync-En] mb_strlen: document invalid encoding ValueError and add shared snippets

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e5166dc6a5ff650b649298470d19eb7c3637a63 Maintainer: argosback Status: ready -->
+<!-- EN-Revision: 8465ca6ec4bbcf79583ecd057860164dd9c7e385 Maintainer: argosback Status: ready -->
 
 <!ENTITY installation.enabled.disable 'Esta extensión está activada por defecto. Puede ser desactivada utilizando la opción de configuración: '>
 
@@ -1199,6 +1199,22 @@ de la codificación de caracteres interna.</simpara>'>
  <entry>8.0.0</entry>
  <entry>
   <parameter>encoding</parameter> ahora acepta &null;.
+ </entry>
+</row>'>
+
+<!ENTITY mbstring.errors.encoding-invalid '<para xmlns="http://docbook.org/ns/docbook">
+ A partir de PHP 8.0.0, se lanza una <exceptionname>ValueError</exceptionname> si
+ <parameter>encoding</parameter> es una codificación no válida.
+ Antes de PHP 8.0.0, se emitía una advertencia <constant>E_WARNING</constant> en su lugar.
+</para>'>
+
+<!ENTITY mbstring.changelog.encoding-invalid '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.0.0</entry>
+ <entry>
+  Ahora lanza una <exceptionname>ValueError</exceptionname> si
+  <parameter>encoding</parameter> es una codificación no válida.
+  Anteriormente, se emitía una advertencia <constant>E_WARNING</constant>
+  y se devolvía &false;.
  </entry>
 </row>'>
 

--- a/reference/mbstring/functions/mb-encoding-aliases.xml
+++ b/reference/mbstring/functions/mb-encoding-aliases.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96bc008584eaea7d899b13234a88b1d84f82032b Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8465ca6ec4bbcf79583ecd057860164dd9c7e385 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.mb-encoding-aliases" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -44,10 +44,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Genera un <classname>ValueError</classname> si
-   <parameter>encoding</parameter> es desconocido.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -61,13 +58,7 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       Si el argumento <parameter>encoding</parameter> es desconocido, ahora se genera un <classname>ValueError</classname>;
-       previamente, se emitía un <constant>E_WARNING</constant> y la función devolvía &false;.
-      </entry>
-     </row>
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/mbstring/functions/mb-internal-encoding.xml
+++ b/reference/mbstring/functions/mb-internal-encoding.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5b3fc18be040c1d552da1497415b20296163012f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8465ca6ec4bbcf79583ecd057860164dd9c7e385 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <refentry xml:id="function.mb-internal-encoding" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,11 +51,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   A partir de PHP 8.0.0, se lanza una <classname>ValueError</classname> si el valor
-   de <parameter>encoding</parameter> es una codificación inválida.
-   Anterior a PHP 8.0.0, se emitía una <constant>E_WARNING</constant> en su lugar.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -70,14 +66,7 @@
     </thead>
     <tbody>
      &mbstring.changelog.encoding-nullable;
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       Ahora lanza una <classname>ValueError</classname> si
-       <parameter>encoding</parameter> es una codificación inválida.
-       Anteriormente, se emitía una <constant>E_WARNING</constant> en su lugar.
-      </entry>
-     </row>
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/mbstring/functions/mb-strlen.xml
+++ b/reference/mbstring/functions/mb-strlen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 8465ca6ec4bbcf79583ecd057860164dd9c7e385 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.mb-strlen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -54,10 +54,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Si la codificación es desconocida, se genera un error de nivel
-   <constant>E_WARNING</constant>.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -72,6 +69,7 @@
     </thead>
     <tbody>
      &mbstring.changelog.encoding-nullable;
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>


### PR DESCRIPTION
Syncs with EN commit 8465ca6ec4bbcf79583ecd057860164dd9c7e385 by adding the shared `mbstring.errors.encoding-invalid` and `mbstring.changelog.encoding-invalid` entities to `language-snippets.ent` and using them in `mb_strlen`, `mb_encoding_aliases` and `mb_internal_encoding`.

This also corrects `mb_strlen`, which still documented an `E_WARNING` instead of the `ValueError` thrown since PHP 8.0.0.

Fixes: #1156
