### PR TITLE
[Sync-En] Add Alpine Linux and Arch Linux (pacman) installation documentation

### DIFF
--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4cb53ecbd763db2db808e90d7eda63afb380e6df Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5a5899391ef91a4d42bca9495c8a1d323d38f23a Maintainer: PhilDaiguille Status: ready -->
 <chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
  <title>Instalación en sistemas Unix</title>
  <simpara>
@@ -28,6 +27,8 @@
  <!-- nodos específicos de la distribución -->
  &install.unix.debian;
  &install.unix.dnf;
+ &install.unix.alpine;
+ &install.unix.pacman;
  &install.unix.openbsd;
  <!-- instrucciones generales de las fuentes -->
  &install.unix.source;


### PR DESCRIPTION
Syncs the Unix installation index with EN commits f0f5d8646b (Arch Linux, php/doc-en#5259) and 5a5899391e (Alpine Linux, php/doc-en#5266), adding `&install.unix.alpine;` and `&install.unix.pacman;`.

The referenced pages `install/unix/alpine.xml` and `install/unix/pacman.xml` are not translated yet and are served from EN.

Fixes: #1157
Fixes: #1158
