### PR TITLE
[Sync-En] Update PCRE documentation to PCRE2

### DIFF
--- a/reference/pcre/book.xml
+++ b/reference/pcre/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: PhilDaiguille Status: ready -->
 
 <book xml:id="book.pcre" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <?phpdoc extension-membership="core" ?>
@@ -9,43 +8,36 @@
 
  <preface xml:id="intro.pcre">
   &reftitle.intro;
-  <para>
-   La sintaxis de los patrones utilizados en estas funciones se asemeja
-   mucho a la de Perl. Las expresiones estarán rodeadas
-   de delimitadores, como la barra (/), por ejemplo. Un delimitador puede
-   ser cualquier carácter, siempre que no sea alfanumérico, un carácter blanco,
-   la barra invertida (\) o el carácter nulo (\0).
-   Si un delimitador debe ser utilizado en
-   la expresión, deberá protegerse con una barra invertida.
-   Los delimitadores a la Perl (), {}, [], y &lt;&gt; también pueden ser utilizados.
-   Consulte la <link linkend="reference.pcre.pattern.syntax">sintaxis de los patrones</link>
-   para más explicaciones.
-  </para>
-  <para>
-   El delimitador final puede ser seguido de opciones que
-   afectarán la búsqueda. Consulte también
-   <link linkend="reference.pcre.pattern.modifiers">opciones de búsqueda</link>.
-  </para>
+  <simpara>
+   Esta extensión integra en PHP el soporte de coincidencia de patrones
+   de expresiones regulares. Está basada en la biblioteca libre y de código
+   abierto <link xlink:href="&url.pcre2.website;">PCRE2</link>.
+   Esta biblioteca implementa la coincidencia de patrones de expresiones regulares
+   utilizando la sintaxis y semántica compatibles con Perl,
+   con algunas
+   <link xlink:href="&url.pcre2.perlcompat;">diferencias documentadas</link>.
+   Consulte la <link linkend="reference.pcre.pattern.syntax">Sintaxis de patrones</link>
+   y las <link linkend="reference.pcre.pattern.modifiers">Opciones de búsqueda</link>
+   para una explicación detallada.
+  </simpara>
+  <simpara>
+   Para mejorar el rendimiento, la extensión almacena en caché las expresiones
+   regulares compiladas. Cada hilo tiene su propio caché dedicado, con capacidad
+   para albergar hasta 4096 expresiones.
+  </simpara>
   <note>
-   <para>
-    Esta extensión mantiene un caché global por hilo de las expresiones
-    regulares compiladas (hasta 4096).
-   </para>
+   <simpara>
+    Cuando la caché está llena, se descarta un lote de las entradas más antiguas
+    que no están en uso en ese momento para hacer sitio a las nuevas. El tamaño
+    de la caché no es configurable.
+   </simpara>
   </note>
   <warning>
-   <para>
-    Deben tenerse en cuenta las limitaciones de PCRE.
-    Consulte <link
-     xlink:href="&url.pcre.man;">&url.pcre.man;</link> para más detalles.
-   </para>
+   <simpara>
+    PCRE2 impone <link xlink:href="&url.pcre2.limits;">límites de tamaño y otros</link>
+    que pueden ser relevantes en algunos casos.
+   </simpara>
   </warning>
-  <!-- FIXME: Check what Perl version implementation corresponds -->
-  <para>
-   La biblioteca PCRE es un conjunto de funciones que implementan las
-   expresiones regulares utilizando la misma sintaxis y semántica
-   que Perl 5 con solo algunas diferencias (ver más abajo). La implementación
-   actual corresponde a Perl 5.005.
-  </para>
  </preface>
 
  &reference.pcre.setup;

--- a/reference/pcre/configure.xml
+++ b/reference/pcre/configure.xml
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 62a00eed7c748c2331eb5744c7a48af8582a2046 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: PhilDaiguille Status: ready -->
 
 <section xml:id="pcre.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
- <para>
-  La extensión PCRE es una extensión nativa de PHP, por lo que siempre está
-  activada. Por omisión, esta extensión se compila utilizando la
-  biblioteca PCRE empaquetada. Opcionalmente, puede utilizarse una
-  biblioteca PCRE externa pasando la opción de configuración
-  <option role="configure">--with-pcre-regex=DIR</option> donde
-  <literal>DIR</literal> es la ruta de acceso a los ficheros de la biblioteca PCRE.
-  Se recomienda utilizar PCRE 8.10 o más reciente;
-  a partir de PHP 7.3.0, PCRE2 es requerido.
- </para>
- <para>
-  La compilación Just In Time (JIT) de PCRE es soportada por omisión,
-  pudiendo ser desactivada con la opción de configuración
-  <option role="configure">--without-pcre-jit</option> a partir de PHP 7.0.12.
- </para>
+ <simpara>
+  La extensión PCRE es una extensión nativa de PHP y siempre está activada.
+ </simpara>
+ <simpara>
+  Por omisión, la extensión usa una versión empaquetada de la biblioteca PCRE2.
+  En sistemas no Windows, se puede usar en su lugar una biblioteca PCRE2 externa
+  mediante la opción de configuración
+  <option role="configure">--with-external-pcre</option>.
+  La versión mínima soportada es 10.30. Las compilaciones para Windows siempre
+  usan la biblioteca empaquetada.
+ </simpara>
+ <simpara>
+  La compilación Just In Time (JIT) de PCRE2 está activada por omisión.
+  Puede desactivarse con la opción de configuración
+  <option role="configure">--without-pcre-jit</option>.
+ </simpara>
  &windows.builtin;
- <para>
-  PCRE es un proyecto activo y a medida que cambia, las
-  funcionalidades de PHP también lo hacen. Es posible que algunas
-  partes del manual de PHP estén obsoletas y no cubran
-  las nuevas funcionalidades proporcionadas por PCRE. Para una lista de
-  modificaciones, consúltese el
-  <link xlink:href="&url.pcre.changelog;">registro de cambios de la biblioteca PCRE</link>
-  así como el historial siguiente de la versión PCRE incluida en PHP:
- </para>
+ <simpara>
+  PCRE2 es un proyecto activo y a medida que cambia, las funcionalidades de PHP
+  que dependen de él también lo hacen. Es posible que algunas partes del manual
+  de PHP estén obsoletas. Para una lista de cambios, consulte el
+  <link xlink:href="&url.pcre2.changelog;">registro de cambios de la biblioteca PCRE2</link>.
+  El historial de actualizaciones de la biblioteca incluida se indica a continuación:
+ </simpara>
  <para>
   <table>
    <title>Historial de actualizaciones de la biblioteca PCRE incluida en PHP</title>
@@ -43,13 +41,28 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>10.44</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>10.42</entry>
+      <entry></entry>
+     </row>
+     <row>
       <entry>8.2.0</entry>
       <entry>10.40</entry>
       <entry></entry>
      </row>
      <row>
-      <entry>8.1.0</entry>
+      <entry>8.1.1</entry>
       <entry>10.39</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>10.37</entry>
       <entry></entry>
      </row>
      <row>

--- a/reference/pcre/pattern.differences.xml
+++ b/reference/pcre/pattern.differences.xml
@@ -1,136 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: andresdzphp -->
+<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: seros Status: ready -->
 <!-- splitted from ./en/functions/pcre.xml, last change in rev 1.2 -->
-<article xml:id="reference.pcre.pattern.differences" xmlns="http://docbook.org/ns/docbook">
+<article xml:id="reference.pcre.pattern.differences" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Diferencias con Perl</title>
  <titleabbrev>Diferencias con Perl</titleabbrev>
- <para>
-  Las diferencias descritas aquí se refieren a las que hay con Perl 5.005.
-  <orderedlist>
-   <listitem>
-    <simpara>
-     Por defecto, un carácter espacio en blanco es cualquier carácter que
-     la función isspace() de la biblioteca C reconoce, aunque es
-     posible compilar PCRE con tablas de tipo de caracteres alternativas.
-     Normalmente isspace() coincide con un espacio, salto de página, nueva línea,
-     retorno de carro, tabulador horizontal y tabulador vertical. Perl 5 ya
-     no incluye el tabulador vertical en su juego caracteres de espacios en blanco.
-     De hecho, el carácter de escape \v, el cual estuvo en la documentación de Perl
-     durante mucho tiempo, nunca fue reconocido. Sin embargo, el carácter
-     mismo fue tratado como espacio en blanco al menos hasta 5.002.
-     En 5.004 y 5.005 no coincide con \s.
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     PCRE no permite los cuantificadores de repetición en declaraciones
-     de búsqueda hacia delante. Perl las permite, pero no significan lo que
-     se puede estar pensando. Por ejemplo, (?!a){3} no afirma que los
-     tres caracteres siguientes no son "a". Simplemente afirma que el
-     siguiente carácter no es "a" tres veces.
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     Los sub-patrones de captura que tienen lugar dentro de declaraciones
-     de búsqueda hacia delante negativas se cuentan, pero sus entradas en los
-     índices del vector nunca se establecen. Perl establece sus variables
-     numéricas desde cualquiera de los patrones que han coincidido antes de que
-     la declaración falle al coincidir con algo (de ese modo teniendo éxito), pero
-     sólo si la declaración de búsqueda hacia delante negativa contiene sólo una rama.
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     Aunque los caracteres cero binario están soportados en la cadena objetivo,
-     no están permitidos en un patrón de cadena porque es pasado como una
-     cadena C normal, finalizada por cero. La secuencia de escape "\x00" se puede
-     usar para representar un cero binario en un patrón.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     Las siguientes secuencias de escape de Perl no estás soportadas:
-     \l,  \u,  \L,  \U. De hecho, éstas están implementadas por
-     el manejo de cadenas general de Perl y no son parte de su motor de
-     comparación de patrones.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     La declaración \G de Perl no está soportada y no es
-     relevante para las comparaciones de patrones individuales.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     Obviamente, PCRE no soporta la construcción de (?{código}) y
-     (??{código}). Sin embargo, tiene soporte para patrones recursivos.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     Hay, a la hora de escribir, algunas singularidades en Perl
-     5.005_02 concernientes con la configuración de las cadenas capturadas
-     cuando una parte de un patrón se repite. Por ejemplo, al comparar
-     "aba" con el patrón /^(a(b)?)+$/ establece $2 con el valor
-     "b", pero al comparar "aabbaa" con /^(aa(bb)?)+$/ deja $2
-     sin establecer. Sin embargo, si el patrón se cambia a
-     /^(aa(b(b))?)+$/ entonces $2 (y $3) se establecen.
-     En Perl 5.004 $2 es establecido en ambos casos, y esto también es &true;
-     en PCRE. Si en el futuro Perl cambia a un estado de consistencia que es
-     diferente, PCRE puede cambiar para seguir su ejemplo.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     Una discrepancia todavía no resuelta es que en Perl
-     5.005_02 el patrón /^(a)?(?(1)a|b)+$/ coincide con la cadena
-     "a", mientras que en PCRE no lo hace. Sin embargo, en Perl y en
-     PCRE /^(a)?a/ coincide con "a" dejando $1 sin establecer.
-    </simpara>
-    </listitem>
-    <listitem>
-    <para>
-     PCRE proporciona algunas extensiones para las herramientas de expresiones
-     regulares de Perl:
-      <orderedlist>
-       <listitem>
-        <simpara>
-         Aunque las declaraciones de búsqueda hacia atrás deben coincidir con cadenas de
-         longitud fija, cada rama alternativa de una declaración de búsqueda hacia atrás
-         puede coincidir con una longitud de cadena diferente. Perl 5.005 requiere que
-         todas ellas tengan la misma longitud.
-       </simpara>
-      </listitem>
-      <listitem>
-       <simpara>
-        Si se aplica <link linkend="reference.pcre.pattern.modifiers">PCRE_DOLLAR_ENDONLY</link>
-        y no se aplica <link linkend="reference.pcre.pattern.modifiers">PCRE_MULTILINE</link>,
-        el meta-carácter $ coincide sólo con el final absoluto de la cadena.
-       </simpara>
-      </listitem>
-      <listitem>
-       <simpara>
-        Si se aplica <link linkend="reference.pcre.pattern.modifiers">PCRE_EXTRA</link>,
-        una barra invertida seguida de una letra sin ningún significado especial fallará.
-       </simpara>
-      </listitem>
-      <listitem>
-       <simpara>
-        Si se aplica <link linkend="reference.pcre.pattern.modifiers">PCRE_UNGREEDY</link>,
-        la codicia de los cuantificadores de repetición se invierte,
-        es decir, por defecto dejan de ser codiciosos, pero si son seguidos por un
-        signo de interrogación lo serán.
-       </simpara>
-      </listitem>
-     </orderedlist>
-    </para>
-   </listitem>
-  </orderedlist>
- </para>
+ <simpara>
+  Tanto Perl como PCRE2 cambian continuamente, por lo que el conjunto exacto
+  de diferencias depende de la versión de la biblioteca PCRE2 en uso. Consulte
+  la <link xlink:href="&url.pcre2.perlcompat;">documentación de PCRE2 sobre las
+  diferencias entre PCRE2 y Perl</link> para obtener una lista actualizada.
+ </simpara>
 </article>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Syncs the PCRE reference documentation with doc-en commit b55141fe2d4f601e32555c33fb00e1f9225c4638, replacing the outdated Perl-5.005-era content with PCRE2 content in `book.xml`, `configure.xml` and `pattern.differences.xml`.

Worth noting: `configure.xml` now documents `--with-external-pcre` instead of the removed `--with-pcre-regex`, and its bundled-version table gains the 8.4.0 (10.44) and 8.3.0 (10.42) rows and corrects the 8.1.0 row to 8.1.1 (10.39). `pattern.differences.xml` no longer lists the differences itself and points to the upstream PCRE2 documentation instead, as upstream does.

Fixes: #1154
