### PR TITLE
[Sync-En] Enhance Yac class documentation

### DIFF
--- a/reference/yac/yac.xml
+++ b/reference/yac/yac.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: andresdzphp Status: ready -->
 
 <reference xml:id="class.yac" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,9 +11,28 @@
 <!-- {{{ Yac intro -->
   <section xml:id="yac.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    La clase <classname>Yac</classname> es la interfaz para el caché.
+    Cada instancia en el mismo host es un identificador ligero hacia un
+    caché compartido: todas las instancias leen y escriben las mismas entradas,
+    y crear una no supone ninguna asignación más allá del propio identificador.
+   </simpara>
+   <simpara>
+    El prefijo opcional pasado a
+    <methodname>Yac::__construct</methodname> se antepone a cada
+    clave, de modo que varias instancias (o aplicaciones) pueden compartir un
+    mismo caché sin que sus claves colisionen. Además de las operaciones
+    clásicas de caché
+    (<methodname>Yac::add</methodname>,
+    <methodname>Yac::set</methodname>,
+    <methodname>Yac::get</methodname>,
+    <methodname>Yac::delete</methodname> y
+    <methodname>Yac::flush</methodname>), la clase proporciona
+    <methodname>Yac::info</methodname> y
+    <methodname>Yac::dump</methodname> para inspeccionar el caché, y
+    sobrecarga el acceso a propiedades para que leer o escribir una propiedad
+    de objeto lea o escriba una entrada del caché.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -56,7 +73,13 @@
     <varlistentry xml:id="yac.props.prefix">
      <term><varname>_prefix</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       El prefijo de clave definido mediante
+       <methodname>Yac::__construct</methodname>. Se antepone a
+       cada clave usada con la instancia; no se inserta ningún separador,
+       así que inclúyalo en el prefijo cuando sea necesario. El prefijo no
+       puede superar <constant>YAC_MAX_KEY_LEN</constant> (48) bytes.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Syncs `reference/yac/yac.xml` with doc-en commit d3a03f8f542cd083d793bbd8ef3d7756aae7711f: the empty `<para/>` placeholders for the class intro and the `_prefix` property are replaced with translated descriptions (prefix scoping, available methods, `YAC_MAX_KEY_LEN` 48-byte limit).

The other four files listed in the issue (`book.xml`, `setup.xml`, `yac/delete.xml`, `yac/dump.xml`) are already at the target EN-Revision hash and required no changes.

Fixes: #1153
