### PR TITLE
[Sync-En] snmp: factor out the SNMPv3 security parameter descriptions

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e5166dc6a5ff650b649298470d19eb7c3637a63 Maintainer: argosback Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: argosback Status: ready -->
 
 <!ENTITY installation.enabled.disable 'Esta extensión está activada por defecto. Puede ser desactivada utilizando la opción de configuración: '>
 
@@ -1209,6 +1209,22 @@ de la codificación de caracteres interna.</simpara>'>
  </entry>
 </row>'>
 
+<!ENTITY mbstring.errors.encoding-invalid '<para xmlns="http://docbook.org/ns/docbook">
+ A partir de PHP 8.0.0, se lanza un <exceptionname>ValueError</exceptionname> si
+ <parameter>encoding</parameter> es una codificación no válida.
+ Anteriormente a PHP 8.0.0, se emitía un <constant>E_WARNING</constant> en su lugar.
+</para>'>
+
+<!ENTITY mbstring.changelog.encoding-invalid '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.0.0</entry>
+ <entry>
+  Ahora se lanza un <exceptionname>ValueError</exceptionname> si
+  <parameter>encoding</parameter> es una codificación no válida.
+  Anteriormente, se emitía un <constant>E_WARNING</constant>
+  y se devolvía &false;.
+ </entry>
+</row>'>
+
 <!-- mcrypt notes -->
 
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">Una de las constantes <constant>MCRYPT_ciphername</constant>, o el nombre del algoritmo como cadena.</simpara>'>
@@ -2085,6 +2101,42 @@ que <constant>PGSQL_BOTH</constant> devolverá ambos índices numéricos y asoci
   se devolvía un &resource;.
  </entry>
 </row>'>
+
+<!-- SNMP entities -->
+
+<!ENTITY snmp.changelog.auth-protocol-sha2 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.1.0</entry>
+ <entry>
+  El protocolo de autenticación ahora acepta <literal>"SHA256"</literal>
+  y <literal>"SHA512"</literal> cuando la biblioteca Net-SNMP lo admite.
+ </entry>
+</row>'>
+
+<!ENTITY snmp.changelog.privacy-protocol-aes '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.6.0</entry>
+ <entry>
+  El protocolo de privacidad ahora acepta <literal>"AES192"</literal>,
+  <literal>"AES192C"</literal>, <literal>"AES256"</literal> y
+  <literal>"AES256C"</literal> cuando la biblioteca Net-SNMP lo admite.
+ </entry>
+</row>'>
+
+<!ENTITY snmp.parameter.security-name '<simpara xmlns="http://docbook.org/ns/docbook">El nombre de seguridad, generalmente algún tipo de nombre de usuario.</simpara>'>
+
+<!ENTITY snmp.parameter.security-level '<simpara xmlns="http://docbook.org/ns/docbook">El nivel de seguridad: <literal>"noAuthNoPriv"</literal>,
+<literal>"authNoPriv"</literal> o <literal>"authPriv"</literal>.</simpara>'>
+
+<!ENTITY snmp.parameter.auth-protocol '<simpara xmlns="http://docbook.org/ns/docbook">El protocolo de autenticación: <literal>"MD5"</literal>, <literal>"SHA"</literal>,
+<literal>"SHA256"</literal> o <literal>"SHA512"</literal>.</simpara>'>
+
+<!ENTITY snmp.parameter.auth-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">La frase secreta de autenticación.</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-protocol '<simpara xmlns="http://docbook.org/ns/docbook">El protocolo de privacidad: <literal>"DES"</literal> o <literal>"AES"</literal>,
+aceptado también como <literal>"AES128"</literal>. <literal>"AES192"</literal>, <literal>"AES192C"</literal>,
+<literal>"AES256"</literal> y <literal>"AES256C"</literal> se aceptan cuando los admite la
+biblioteca Net-SNMP.</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">La frase secreta de privacidad.</simpara>'>
 
 <!-- Common pieces for reference part END -->
 

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-get">
  <refnamediv>
@@ -43,50 +43,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de la seguridad, habitualmente, el nombre de usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (MD5 o SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta de autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> o <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -135,6 +122,7 @@
      </row>
     </thead>
     <tbody>
+     &snmp.changelog.privacy-protocol-aes;
      <row>
       <entry>8.5.0</entry>
       <entry>
@@ -144,14 +132,7 @@
        timeout o reintentos son menores a -1 o demasiado grandes.
       </entry>
      </row>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       El parámetro <parameter>auth_protocol</parameter> acepta ahora
-       <literal>"SHA256"</literal> y <literal>"SHA512"</literal>
-       cuando es soportado por libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-getnext.xml
+++ b/reference/snmp/functions/snmp3-getnext.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-getnext">
  <refnamediv>
   <refname>snmp3_getnext</refname>
-  <refpurpose>Recupera el objeto <acronym>SNMP</acronym> que sigue inmediatamente al objeto proporcionado</refpurpose>
+  <refpurpose>Recupera el objeto <acronym>SNMP</acronym> que sigue al identificador de objeto proporcionado</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -24,8 +24,8 @@
   </methodsynopsis>
   <simpara>
    La función <function>snmp3_getnext</function> se utiliza para leer
-   el valor de un objeto <acronym>SNMP</acronym> que sigue inmediatamente
-   al especificado por el identificador <parameter>object_id</parameter>.
+   el valor del objeto <acronym>SNMP</acronym> que sigue al
+   <parameter>object_id</parameter> especificado.
   </simpara>
  </refsect1>
 
@@ -44,50 +44,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de la seguridad, habitualmente, el nombre de usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El grado de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (MD5 o SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta de autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> o <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -110,7 +97,7 @@
     <term><parameter>retries</parameter></term>
     <listitem>
      <simpara>
-      El número de intentos en caso de que ocurra un tiempo límite.
+      El número de reintentos en caso de que ocurran tiempos límite.
      </simpara>
     </listitem>
    </varlistentry>
@@ -120,10 +107,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve el valor del objeto <acronym>SNMP</acronym> en caso
-   de éxito o &false; si ocurre un error.
-   En caso de error, se emitirá una alerta de tipo
-   E_WARNING.
+   Devuelve el valor del objeto <acronym>SNMP</acronym> en caso de éxito o &false; en caso de error.
+   En caso de error, se muestra un mensaje E_WARNING.
   </simpara>
  </refsect1>
 
@@ -138,14 +123,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       El parámetro <parameter>auth_protocol</parameter> acepta ahora
-       <literal>"SHA256"</literal> y <literal>"SHA512"</literal>
-       cuando es soportado por libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>
@@ -154,11 +133,11 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo con <function>snmp3_getnext</function></title>
+   <title>Uso de <function>snmp3_getnext</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$nameOfSecondInterface  = snmp3_getnext('localhost', 'james', 'authPriv', 'SHA', 'secret007',  'AES', 'secret007', 'IF-MIB::ifName.1');
+$nameOfSecondInterface = snmp3_getnext('localhost', 'james', 'authPriv', 'SHA', 'secret007', 'AES', 'secret007', 'IF-MIB::ifName.1');
 ?>
 ]]>
    </programlisting>

--- a/reference/snmp/functions/snmp3-real-walk.xml
+++ b/reference/snmp/functions/snmp3-real-walk.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-real-walk">
  <refnamediv>
   <refname>snmp3_real_walk</refname>
-  <refpurpose> Devuelve todos los objetos incluyendo los identificadores de sus respectivos objetos</refpurpose>
+  <refpurpose>Devuelve todos los objetos incluyendo los identificadores de sus respectivos objetos</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -23,7 +23,10 @@
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   La función <function>snmp3_real_walk</function> se utiliza para recorrer un número de objetos <acronym>SNMP</acronym> comenzando por el objeto cuyo identificador es <parameter>object_id</parameter> y devuelve no solo sus valores, sino también los identificadores de los objetos asociados.
+   La función <function>snmp3_real_walk</function> se utiliza para recorrer un
+   número de objetos <acronym>SNMP</acronym> comenzando por
+   <parameter>object_id</parameter> y devuelve no solo sus valores, sino también
+   los identificadores de los objetos asociados.
   </simpara>
  </refsect1>
 
@@ -31,7 +34,9 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>hostname</parameter></term>
+    <term>
+     <parameter>hostname</parameter>
+    </term>
     <listitem>
      <simpara>
       El nombre del host del agente <acronym>SNMP</acronym> (servidor).
@@ -39,55 +44,57 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>security_name</parameter></term>
+    <term>
+     <parameter>security_name</parameter>
+    </term>
     <listitem>
-     <simpara>
-      El nombre de seguridad, generalmente el nombre de usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>security_level</parameter></term>
+    <term>
+     <parameter>security_level</parameter>
+    </term>
     <listitem>
-     <simpara>
-      El nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>auth_protocol</parameter></term>
+    <term>
+     <parameter>auth_protocol</parameter>
+    </term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (MD5 o SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>auth_passphrase</parameter></term>
+    <term>
+     <parameter>auth_passphrase</parameter>
+    </term>
     <listitem>
-     <simpara>
-      La frase secreta de autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>privacy_protocol</parameter></term>
+    <term>
+     <parameter>privacy_protocol</parameter>
+    </term>
     <listitem>
-     <simpara>
-      El protocolo de privacidad (<literal>"MD5"</literal>, <literal>"SHA"</literal>, <literal>"SHA256"</literal> o <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>privacy_passphrase</parameter></term>
+    <term>
+     <parameter>privacy_passphrase</parameter>
+    </term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>object_id</parameter></term>
+    <term>
+     <parameter>object_id</parameter>
+    </term>
     <listitem>
      <simpara>
       El identificador del objeto <acronym>SNMP</acronym>.
@@ -95,7 +102,9 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>timeout</parameter></term>
+    <term>
+     <parameter>timeout</parameter>
+    </term>
     <listitem>
      <simpara>
       El número de microsegundos antes del primer tiempo límite.
@@ -103,7 +112,9 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>retries</parameter></term>
+    <term>
+     <parameter>retries</parameter>
+    </term>
     <listitem>
      <simpara>
       El número de intentos en caso de que ocurra un tiempo límite.
@@ -116,7 +127,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve un array asociativo de identificadores de objetos <acronym>SNMP</acronym> junto con sus valores en caso de éxito, o &false; si ocurre un error. En caso de error, se emite una alerta de nivel E_WARNING.
+   Devuelve un array asociativo de identificadores de objetos
+   <acronym>SNMP</acronym> junto con sus valores en caso de éxito, o &false; si
+   ocurre un error. En caso de error, se emite una alerta de nivel E_WARNING.
   </simpara>
  </refsect1>
 
@@ -131,12 +144,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       El parámetro <parameter>auth_protocol</parameter> acepta ahora <literal>"SHA256"</literal> y <literal>"SHA512"</literal> cuando es soportado por libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>
@@ -145,7 +154,9 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Ejemplo con <function>snmp3_real_walk</function></title>
+   <title>Ejemplo con
+    <function>snmp3_real_walk</function>
+   </title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-set">
  <refnamediv>
@@ -25,13 +25,13 @@
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>snmp3_set</function> se utiliza para definir el
-   valor de un objeto <acronym>SNMP</acronym> especificado por
-   el parámetro <parameter>object_id</parameter>.
+   <function>snmp3_set</function> se utiliza para definir el valor de un objeto
+   <acronym>SNMP</acronym> especificado por el parámetro <parameter>object_id</parameter>.
   </simpara>
   <simpara>
-   Aunque el nivel de seguridad no utilice autenticación
-   o protocolo privado por contraseña, se deben especificar valores válidos.
+   Los argumentos de autenticación y de privacidad siempre se deben pasar, pero
+   sus valores se ignoran cuando <parameter>security_level</parameter> no los
+   utiliza.
   </simpara>
 
  </refsect1>
@@ -50,49 +50,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de seguridad, generalmente, el nombre de usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (MD5 o SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta para la autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo privado (DES o AES).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -124,7 +112,7 @@
     <term><parameter>timeout</parameter></term>
     <listitem>
      <simpara>
-      El número de milisegundos antes del primer tiempo límite.
+      El número de microsegundos antes del primer tiempo límite.
      </simpara>
     </listitem>
    </varlistentry>
@@ -145,8 +133,8 @@
    &return.success;
   </simpara>
   <simpara>
-   Si el host SNMP rechaza el tipo de datos, se muestra una alerta de tipo
-   E_WARNING como "Warning: Error in packet. Reason: (badValue) The value given has the wrong type or length."
+   Si el host SNMP rechaza el tipo de datos, se muestra un mensaje E_WARNING como
+   "Warning: Error in packet. Reason: (badValue) The value given has the wrong type or length."
    Si se especifica un OID desconocido o inválido, la alerta será probablemente
    "Could not add variable".
   </simpara>
@@ -163,6 +151,7 @@
      </row>
     </thead>
     <tbody>
+     &snmp.changelog.privacy-protocol-aes;
      <row>
       <entry>8.5.0</entry>
       <entry>
@@ -172,6 +161,7 @@
        timeout o reintentos son menores a -1 o demasiado grandes.
       </entry>
      </row>
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>
@@ -179,29 +169,30 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example>
-   <title>Ejemplo con <function>snmp3_set</function></title>
-   <programlisting role="php">
+   <example>
+    <title>Ejemplo con <function>snmp3_set</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
   snmp3_set('localhost', 'james', 'authPriv', 'SHA', 'secret007', 'AES', 'secret007', 'IF-MIB::ifAlias.3', 's', "foo");
 ?>
  ]]>
-   </programlisting>
-  </example>
-  <example>
-   <title>Ejemplo con <function>snmp3_set</function> para configurar el identificador del objeto <acronym>SNMP</acronym> BITS</title>
-   <programlisting role="php">
+    </programlisting>
+   </example>
+   <example>
+    <title>Ejemplo con <function>snmp3_set</function> para definir un identificador de objeto <acronym>SNMP</acronym> BITS</title>
+    <programlisting role="php">
 <![CDATA[
 <?php
   snmp3_set('localhost', 'james', 'authPriv', 'SHA', 'secret007', 'AES', 'secret007', 'FOO-MIB::bar.42', 'b', '0 1 2 3 4');
-// or
+// o
   snmp3_set('localhost', 'james', 'authPriv', 'SHA', 'secret007', 'AES', 'secret007', 'FOO-MIB::bar.42', 'x', 'F0');
 ?>
  ]]>
-   </programlisting>
-  </example>
+    </programlisting>
+   </example>
  </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/snmp/functions/snmp3-walk.xml
+++ b/reference/snmp/functions/snmp3-walk.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-walk">
  <refnamediv>
@@ -23,13 +23,14 @@
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   La función <function>snmp3_walk</function> se utiliza para leer
-   todos los valores desde un agente <acronym>SNMP</acronym> especificado
-   por el parámetro <parameter>host</parameter>.
+   La función <function>snmp3_walk</function> se utiliza para leer todos los
+   valores de un agente <acronym>SNMP</acronym> especificado por el parámetro
+   <parameter>hostname</parameter>.
   </simpara>
   <simpara>
-   Aunque el nivel de seguridad no utilice un protocolo
-   de autenticación, se deben especificar valores válidos.
+   Los argumentos de autenticación y de privacidad siempre deben ser pasados,
+   pero sus valores son ignorados cuando <parameter>security_level</parameter>
+   no los utiliza.
   </simpara>
  </refsect1>
 
@@ -47,64 +48,52 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de la seguridad, habitualmente, el nombre del usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> o <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta de autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo privado (DES o AES).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>object_id</parameter></term>
     <listitem>
      <simpara>
-      Si vale &null;, <parameter>object_id</parameter> será la raíz
-      del árbol de objetos <acronym>SNMP</acronym> y todos los
-      objetos subyacentes se devuelven en forma de array.
+      Si es una cadena vacía, <parameter>object_id</parameter> se toma como
+      <literal>.1.3.6.1.2.1</literal>, la raíz del árbol de objetos
+      <acronym>SNMP</acronym>, y todos los objetos bajo ese árbol se devuelven
+      en forma de array.
      </simpara>
      <simpara>
-      Si <parameter>object_id</parameter> está especificado,
-      todos los objetos <acronym>SNMP</acronym> bajo el objeto
-      <parameter>object_id</parameter> serán devueltos.
+      Si <parameter>object_id</parameter> está especificado, se devuelven todos
+      los objetos <acronym>SNMP</acronym> situados bajo ese
+      <parameter>object_id</parameter>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -130,11 +119,12 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve un array de valores de objetos <acronym>SNMP</acronym>
-   comenzando desde el objeto <parameter>object_id</parameter>
-   como raíz, o &false; si ocurre un error.
+   Devuelve un array de valores de objetos <acronym>SNMP</acronym> comenzando
+   desde el objeto <parameter>object_id</parameter> como raíz, o &false; si
+   ocurre un error.
   </simpara>
  </refsect1>
+
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -147,14 +137,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       El parámetro <parameter>auth_protocol</parameter> acepta ahora
-       <literal>"SHA256"</literal> y <literal>"SHA512"</literal>
-       cuando es soportado por libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>
@@ -175,8 +159,8 @@ var_export($ret);
   </example>
   <simpara>
    La llamada a la función anterior devolverá todos los objetos
-   <acronym>SNMP</acronym> desde el agente
-   <acronym>SNMP</acronym> ejecutándose en localhost:
+   <acronym>SNMP</acronym> desde el agente <acronym>SNMP</acronym>
+   ejecutándose en localhost:
 <![CDATA[
 array (
   0 => 'STRING: lo',

--- a/reference/snmp/snmp/construct.xml
+++ b/reference/snmp/snmp/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.construct">
  <refnamediv>
@@ -42,12 +42,12 @@
     <listitem>
      <para>
       El agente <acronym>SNMP</acronym>. El parámetro <parameter>hostname</parameter>
-      puede ser prefijado con el puerto del agente opcional <acronym>SNMP</acronym>
-      después de una coma. Las direcciones IPV6 deben estar rodeadas de corchetes ([])
-      si se utilizan puertos adicionales. Si FQDN se utiliza para el parámetro
+      puede ir seguido del puerto opcional del agente <acronym>SNMP</acronym>
+      después de dos puntos. Las direcciones IPv6 deben ir entre corchetes
+      si se utilizan con un puerto. Si se utiliza un FQDN para
       <parameter>hostname</parameter>, será resuelto por la extensión PHP SNMP,
-      y no por el motor <productname>Net-SNMP</productname>. El uso de direcciones IPV6
-      al utilizar FQDN puede ser forzado rodeando FQDN con corchetes.
+      y no por el motor <productname>Net-SNMP</productname>. El uso de direcciones IPv6
+      al indicar un FQDN puede forzarse encerrando el FQDN entre corchetes.
       A continuación se muestran algunos ejemplos:
      <informaltable>
       <tgroup cols="2">
@@ -58,8 +58,8 @@
         <row><entry>IPv6 con puerto específico</entry><entry>[::1]:1161</entry></row>
         <row><entry>FQDN con puerto por defecto</entry><entry>host.domain</entry></row>
         <row><entry>FQDN con puerto específico</entry><entry>host.domain:1161</entry></row>
-        <row><entry>FQDN con puerto por defecto, forzando el uso de direcciones IPV6</entry><entry>[host.domain]</entry></row>
-        <row><entry>FQDN con puerto específico, forzando el uso de direcciones IPV6</entry><entry>[host.domain]:1161</entry></row>
+        <row><entry>FQDN con puerto por defecto, forzando el uso de direcciones IPv6</entry><entry>[host.domain]</entry></row>
+        <row><entry>FQDN con puerto específico, forzando el uso de direcciones IPv6</entry><entry>[host.domain]:1161</entry></row>
        </tbody>
       </tgroup>
      </informaltable>
@@ -70,9 +70,10 @@
     <term><parameter>community</parameter></term>
     <listitem>
      <simpara>
-      Especifica el nivel de seguridad para la <parameter>version</parameter> dada.
-      El objetivo de la cadena de acceso <parameter>community</parameter> es específico
-      a la versión de <acronym>SNMP</acronym>:
+      La cadena de comunidad o, para <constant>SNMP::VERSION_3</constant>, el
+      nombre de seguridad. El objetivo de la cadena de acceso
+      <parameter>community</parameter> es específico de la versión de
+      <acronym>SNMP</acronym>:
      </simpara>
      <informaltable>
       <tgroup cols="2">
@@ -100,10 +101,7 @@
           <constant>SNMP::VERSION_3</constant>
          </entry>
          <entry>
-          Nombre de seguridad <acronym>SNMP</acronym>v3, puede ser uno de los siguientes:
-          <literal>noAuthNoPriv</literal>,
-          <literal>authNoPriv</literal> (se requiere una contraseña de autenticación y un protocolo de autenticación), o
-          <literal>authPriv</literal> (se requiere una contraseña y un protocolo de autenticación, así como una contraseña y un protocolo de confidencialidad)
+          &snmp.parameter.security-name;
          </entry>
         </row>
        </tbody>
@@ -137,9 +135,9 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   <methodname>SNMP::__construct</methodname> lanza una excepción cuando
-   los parámetros son incorrectos o la versión del protocolo <acronym>SNMP</acronym>
-   es desconocida.
+   <methodname>SNMP::__construct</methodname> lanza una excepción cuando el
+   número o los tipos de los parámetros son incorrectos, o cuando se especifica
+   una versión desconocida del protocolo <acronym>SNMP</acronym>.
   </simpara>
  </refsect1>
 
@@ -151,7 +149,7 @@
 <![CDATA[
 <?php
 
-$session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+$session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
 $sysdescr = $session->get("sysDescr.0");
 echo "$sysdescr\n";
 

--- a/reference/snmp/snmp/setsecurity.xml
+++ b/reference/snmp/snmp/setsecurity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.setsecurity">
  <refnamediv>
@@ -21,7 +21,7 @@
    <methodparam choice="opt"><type>string</type><parameter>contextEngineId</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Configura los parámetros de seguridad de las sesiones del protocolo <acronym>SNMP</acronym>v3.
+   setSecurity configura los parámetros de sesión relacionados con la seguridad utilizados en la versión 3 del protocolo <acronym>SNMP</acronym>
   </simpara>
  </refsect1>
 
@@ -31,41 +31,31 @@
    <varlistentry>
     <term><parameter>securityLevel</parameter></term>
     <listitem>
-     <simpara>
-      el nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>authProtocol</parameter></term>
     <listitem>
-     <simpara>
-      el protocolo de autenticación (MD5 o SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>authPassphrase</parameter></term>
     <listitem>
-     <simpara>
-      la frase de paso para la autenticación
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacyProtocol</parameter></term>
     <listitem>
-     <simpara>
-      el protocolo privado (DES o AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacyPassphrase</parameter></term>
     <listitem>
-     <simpara>
-      la frase de paso para el protocolo privado
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -80,7 +70,7 @@
     <term><parameter>contextEngineId</parameter></term>
     <listitem>
      <simpara>
-      el contexto EngineID
+      el EngineID del contexto
      </simpara>
     </listitem>
    </varlistentry>
@@ -94,6 +84,24 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="snmp.setsecurity.example.basic">
@@ -103,7 +111,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_3, $hostname, $rwuser, $timeout, $retries);
+  $session = new SNMP(SNMP::VERSION_3, $hostname, $rwuser, $timeout, $retries);
   $session->setSecurity('authPriv', 'MD5', $auth_pass, 'AES', $priv_pass, '', 'aeeeff');
 ?>
 ]]>


### PR DESCRIPTION
Mirrors php/doc-en#5228 (commit 1ab1069) for `reference/snmp`. The SNMPv3 security parameter descriptions were duplicated by hand across six pages and had drifted apart; they are now defined once in `language-snippets.ent` as `snmp.parameter.*` entities, translated into Spanish, and referenced by the pages.

This fixes real errors the Spanish pages carried, notably `privacy_protocol` described with the authentication protocols on four pages, and `snmp3_set()` documenting `timeout` in milliseconds instead of microseconds. `language-snippets.ent` also gains the two `mbstring.*.encoding-invalid` entities added upstream by an intermediate commit, without which its EN-Revision would be inaccurate.

Fixes: #1164
