### PR TITLE
[Sync-En] yar: add the protocol chapter, PIE install and clarifications

### DIFF
--- a/reference/yar/book.xml
+++ b/reference/yar/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <book xml:id="book.yar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -24,11 +24,13 @@
    adicional ni proceso proxy.
   </simpara>
   <simpara>
-   El protocolo es independiente del lenguaje: existen implementaciones
-   compatibles para C, Java y Lua.
+   El protocolo es independiente del lenguaje, por lo que los servicios
+   pueden ser consumidos por cualquier lenguaje; véase
+   <link linkend="yar.protocol">El protocolo Yar</link> para más detalles.
   </simpara>
  </preface>
 
+ &reference.yar.protocol;
  &reference.yar.setup;
  &reference.yar.constants;
  &reference.yar.examples;

--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <appendix xml:id="yar.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -309,6 +309,20 @@
     <simpara>
      El servicio remoto lanzó una excepción durante el procesamiento de la
      petición.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-forbidden">
+   <term>
+    <constant>YAR_ERR_FORBIDDEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La petición fue rechazada por la autenticación del servidor
+     (véanse los campos <literal>provider</literal> y
+     <literal>token</literal> de la
+     <link linkend="yar.protocol">cabecera del protocolo Yar</link>).
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,15 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
+ <simpara>
+  Los ejemplos siguientes recorren un servicio completo: un servidor que
+  expone algunos métodos aritméticos, un cliente síncrono que los llama,
+  un cliente que lanza varias llamadas de forma concurrente y un cliente
+  que se comunica con un servidor por TCP.
+ </simpara>
+
  <example>
   <title>Ejemplo de servidor Yar</title>
+  <simpara>
+   Un servicio Yar no es más que una clase PHP normal envuelta por
+   <classname>Yar_Server</classname>. Cada método público del objeto se
+   convierte en un punto de acceso RPC; los métodos protegidos y privados,
+   así como los métodos cuyo nombre empieza por un guion bajo, permanecen
+   ocultos para los clientes. Los comentarios de documentación de los
+   métodos públicos se recopilan y se muestran en la página de información
+   del servicio.
+  </simpara>
+  <simpara>
+   Las peticiones RPC llegan como peticiones HTTP POST que transportan una
+   carga útil binaria del protocolo Yar, por lo que el script suele
+   asociarse a un URI de un servidor web normal.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
 
-/* se supone que esta página es accesible en http://example.com/operator.php */
+/* se supone que esta página es accesible en http://api.example.com/operator.php */
 
 class Operator {
 
@@ -56,11 +77,13 @@ $server->handle();
  <example>
   <title>Acceso al servidor desde el navegador (petición GET)</title>
   <simpara>
-   Cuando se emite una petición GET al URI del servicio, Yar muestra una
-   página de información que lista todos los métodos públicos del objeto
-   ejecutor junto con su comentario de documentación. Esto se controla con
-   la directiva
-   <link linkend="ini.yar.expose-info">yar.expose_info</link>.
+   Cuando se emite una petición GET al URI del servicio, por ejemplo al
+   abrirlo en un navegador, Yar no realiza una llamada RPC, sino que
+   muestra una página de información que lista todos los métodos públicos
+   del objeto ejecutor junto con su comentario de documentación. Esto se
+   controla con la directiva
+   <link linkend="ini.yar.expose-info">yar.expose_info</link>; cuando está
+   desactivada, la petición GET falla en su lugar.
   </simpara>
   &example.outputs.similar;
   <mediaobject>
@@ -73,10 +96,23 @@ $server->handle();
 
  <example>
   <title>Ejemplo de cliente Yar</title>
+  <simpara>
+   Un <classname>Yar_Client</classname> está asociado a una única dirección
+   de servicio. Llamar a cualquier método no definido sobre él se convierte
+   de forma transparente en una llamada RPC síncrona, de modo que los
+   métodos remotos se ven y se usan como si fueran locales;
+   <methodname>Yar_Client::call</methodname> hace lo mismo indicando el
+   nombre de forma explícita.
+  </simpara>
+  <simpara>
+   Los métodos protegidos no se exponen: llamar a uno de ellos falla con
+   una <exceptionname>Yar_Client_Exception</exceptionname> cuyo código es
+   <constant>YAR_ERR_REQUEST</constant>.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://example.com/operator.php");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* llamada directa */
 var_dump($client->add(1, 2));
@@ -94,17 +130,35 @@ var_dump($client->_add(1, 2));
 <![CDATA[
 int(3)
 int(5)
-PHP Fatal error:  Uncaught Yar_Server_Request_Exception: call to undefined api Operator::_add() in *
+PHP Fatal error:  Uncaught Yar_Client_Exception: call to undefined api Operator::_add() in *
 ]]>
   </screen>
  </example>
 
  <example>
   <title>Ejemplo de cliente concurrente Yar</title>
+  <simpara>
+   En lugar de llamar a los servicios uno tras otro,
+   <classname>Yar_Concurrent_Client</classname> registra primero varias
+   llamadas y luego las envía todas a la vez con
+   <methodname>Yar_Concurrent_Client::loop</methodname>. Las respuestas se
+   pasan al callback en el orden en que llegan, no en el orden en que se
+   registraron las llamadas.
+  </simpara>
+  <simpara>
+   Justo después de que se hayan enviado todas las peticiones, el callback
+   se invoca una vez con argumentos &null; para que quien lo llama sepa que
+   no queda ninguna petición pendiente; el ejemplo siguiente comprueba esta
+   notificación.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
 function callback($ret, $callinfo) {
+    if ($callinfo == NULL) {
+        /* todas las peticiones se han enviado, esperando las respuestas */
+        return;
+    }
     echo $callinfo['method'], " resultado: ", $ret, "\n";
 }
 
@@ -113,9 +167,9 @@ function error_callback($type, $error, $callinfo) {
 }
 
 /* registra llamadas asíncronas a servicios remotos */
-Yar_Concurrent_Client::call("http://example.com/operator.php", "add", array(1, 2), "callback");
-Yar_Concurrent_Client::call("http://example.com/operator.php", "sub", array(2, 1), "callback");
-Yar_Concurrent_Client::call("http://example.com/operator.php", "mul", array(2, 2), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "add", array(1, 2), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "sub", array(2, 1), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "mul", array(2, 2), "callback");
 
 /* envía todas las peticiones y espera las respuestas */
 Yar_Concurrent_Client::loop("callback", "error_callback");
@@ -137,8 +191,9 @@ add resultado: 3
   <simpara>
    Además de HTTP, <classname>Yar_Client</classname> puede comunicarse con
    servidores compatibles con Yar a través de TCP o de sockets Unix, por
-   ejemplo con un servicio implementado con el framework Yar en C. El
-   servidor remoto debe implementar el mismo protocolo binario de Yar.
+   ejemplo con un servicio implementado con el
+   <link xlink:href="&url.git.hub;laruence/yar-c">framework Yar en C</link>,
+   que sirve el mismo protocolo binario de Yar que usa el servidor PHP.
   </simpara>
   <programlisting role="php">
 <![CDATA[

--- a/reference/yar/protocol.xml
+++ b/reference/yar/protocol.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
+
+<chapter xml:id="yar.protocol" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>El protocolo Yar</title>
+ <simpara>
+  Yar no depende de un esquema ni de un fichero IDL: todo se intercambia
+  por la red como bytes sin formato. Cualquier lenguaje capaz de leer y
+  escribir bytes puede comunicarse con un servicio Yar, sin instalar
+  ningún framework —basta con construir una cabecera binaria de tamaño
+  fijo y un cuerpo de petición serializado, enviarlos al URI del servicio
+  y analizar la respuesta.
+ </simpara>
+ <simpara>
+  Un mensaje consta de una cabecera de tamaño fijo de 82 bytes seguida de
+  un cuerpo. La cabecera tiene exactamente la disposición de la siguiente
+  estructura C, empaquetada sin relleno, y se escribe en la red campo a
+  campo en el orden de declaración:
+ </simpara>
+ <programlisting role="c">
+<![CDATA[
+typedef struct _yar_header {
+    uint32_t       id;            /* identificador de la transacción */
+    uint16_t       version;       /* versión del protocolo, actualmente siempre 0 */
+    uint32_t       magic_num;     /* debe ser 0x80DFEC60 */
+    uint32_t       reserved;
+    unsigned char  provider[32];  /* de quién procede la petición (autenticación) */
+    unsigned char  token[32];     /* token de la petición (autenticación) */
+    uint32_t       body_len;      /* longitud del cuerpo completo, incluido
+                                     el identificador del empaquetador */
+} __attribute__ ((packed)) yar_header_t;
+]]>
+ </programlisting>
+ <simpara>
+  Los campos <literal>id</literal>, <literal>magic_num</literal>,
+  <literal>reserved</literal> y <literal>body_len</literal> se almacenan
+  en el orden de bytes de red (big-endian); los campos restantes son
+  bytes sin formato.
+ </simpara>
+ <simpara>
+  El cuerpo comienza con un identificador de empaquetador de 8 bytes
+  —<literal>PHP</literal>, <literal>JSON</literal> o
+  <literal>MSGPACK</literal>, rellenado con ceros— que indica al receptor
+  cómo se ha codificado el resto, seguido del propio contenido
+  serializado.
+ </simpara>
+ <itemizedlist>
+  <listitem>
+   <simpara>
+    El cuerpo de la petición se decodifica en un array con las claves
+    <literal>i</literal> (el identificador de la transacción),
+    <literal>m</literal> (el método invocado) y <literal>p</literal> (la
+    lista de parámetros).
+   </simpara>
+  </listitem>
+  <listitem>
+   <simpara>
+    El cuerpo de la respuesta se decodifica en un array con las claves
+    <literal>i</literal> (el identificador de la transacción),
+    <literal>s</literal> (el estado, uno de los códigos
+    <literal>YAR_ERR_*</literal>), <literal>r</literal> (el valor
+    devuelto), <literal>o</literal> (la salida producida por el método
+    del servicio) y <literal>e</literal> (el error o la excepción, cuando
+    la llamada ha fallado).
+   </simpara>
+  </listitem>
+ </itemizedlist>
+ <simpara>
+  Sobre HTTP, el mensaje se envía como cuerpo de una petición POST, y la
+  respuesta llega como cuerpo de la contestación; sobre TCP o sockets
+  Unix se escribe directamente en el flujo.
+ </simpara>
+ <example>
+  <title>Llamada a un servicio Yar sin la extensión</title>
+  <simpara>
+   El siguiente script autónomo construye una petición Yar válida para el
+   empaquetador <literal>php</literal> únicamente con sockets estándar, la
+   envía al URI de un servicio y muestra la respuesta decodificada. Al
+   ejecutarlo contra el servicio <classname>Operator</classname> de los
+   <link linkend="yar.examples">ejemplos</link>, muestra
+   <literal>int(3)</literal>.
+  </simpara>
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+$uri = "http://api.example.com/operator.php";
+
+/* 1. el cuerpo: identificador del empaquetador + petición serializada */
+$serialized = serialize(array("i" => 1, "m" => "add", "p" => array(1, 2)));
+$body = str_pad("PHP", 8, "\0") . $serialized;
+
+/* 2. la cabecera: 82 bytes, enteros multibyte en orden de bytes de red */
+$header = pack("N", 1)                    /* id */
+        . pack("v", 0)                    /* versión */
+        . pack("N", 0x80DFEC60)           /* número mágico */
+        . pack("N", 0)                    /* reservado */
+        . str_pad("", 32, "\0")           /* proveedor */
+        . str_pad("", 32, "\0")           /* token */
+        . pack("N", strlen($body));       /* longitud del cuerpo */
+
+/* 3. se envía como cuerpo de una petición POST */
+$stream = stream_context_create(array("http" => array(
+    "method"  => "POST",
+    "header"  => "Content-Type: application/octet-stream\r\n",
+    "content" => $header . $body,
+)));
+$reply = file_get_contents($uri, false, $stream);
+
+/* 4. se analiza la respuesta: cabecera de 82 bytes, luego el cuerpo */
+$response = unserialize(substr($reply, 82 + 8));
+var_dump($response["r"]);
+?>
+]]>
+  </programlisting>
+ </example>
+ <simpara>
+  En el directorio <literal>tools/</literal> del
+  <link xlink:href="&url.git.hub;laruence/yar">repositorio de código
+  fuente de Yar</link> se encuentra una implementación de cliente más
+  completa en PHP puro, que además decodifica la cabecera de la respuesta
+  y admite llamadas concurrentes.
+ </simpara>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yar/setup.xml
+++ b/reference/yar/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: PhilDaiguille Status: ready -->
 
 <chapter xml:id="yar.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -27,6 +27,10 @@
  <section xml:id="yar.installation">
   &reftitle.install;
   <simpara>
+   Yar se puede instalar de tres maneras: mediante PECL, mediante PIE o
+   compilándolo a partir del código fuente.
+  </simpara>
+  <simpara>
    &pecl.moved;
   </simpara>
   <simpara>
@@ -36,66 +40,100 @@
   <simpara>
    &pecl.windows.download.avail;
   </simpara>
-  <para>
-   El código fuente está alojado en
-   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. Para compilar
-   la extensión a partir del código fuente:
-   <screen>
+  <example>
+   <title>Instalación de Yar con PECL</title>
+   <programlisting role="shell">
 <![CDATA[
-$ git clone https://github.com/laruence/yar.git
-$ cd yar
-$ phpize
-$ ./configure
-$ make
-$ sudo make install
+pecl install yar
 ]]>
-   </screen>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
+   A partir de Yar 2.4.0, la extensión se puede instalar con
+   &link.pie;, el instalador de extensiones de PHP, ejecutando lo
+   siguiente en la línea de comandos.
+  </simpara>
+  <example>
+   <title>Instalación de Yar con PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yar
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   El empaquetador msgpack se puede activar en el momento de la instalación:
+  </simpara>
+  <example>
+   <title>Instalación de Yar con PIE y msgpack</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yar --enable-msgpack
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   El código fuente está alojado en
+   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. Para
+   compilar la extensión a partir del código fuente, se debe ejecutar lo
+   siguiente en la línea de comandos, sustituyendo las rutas por las de la
+   instalación local de PHP.
+  </simpara>
+  <example>
+   <title>Compilación de Yar a partir del código fuente</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
+  <simpara>
    Están disponibles las siguientes opciones de <literal>configure</literal>:
-   <variablelist>
-    <varlistentry>
-     <term>
-      <option role="configure">--with-curl</option>
-     </term>
-     <listitem>
-      <simpara>
-       Ubicación de la instalación de cURL, si no se encuentra en las rutas
-       de inclusión predeterminadas.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <option role="configure">--enable-msgpack</option>
-     </term>
-     <listitem>
-      <simpara>
-       Activa el empaquetador <literal>msgpack</literal> y convierte la
-       extensión <literal>msgpack</literal> en una dependencia opcional.
-       Cuando Yar se compila con esta opción, el valor predeterminado de
-       <link linkend="ini.yar.packager">yar.packager</link> pasa a ser
-       <literal>msgpack</literal>.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <option role="configure">--enable-epoll</option>
-     </term>
-     <listitem>
-      <simpara>
-       Utiliza <literal>epoll</literal> de Linux en lugar de
-       <literal>select()</literal> para la multiplexación de E/S, disponible
-       a partir de Yar 2.1.2. Esto puede mejorar el rendimiento de
-       <classname>Yar_Concurrent_Client</classname> con una concurrencia
-       elevada. Solo tiene efecto en Linux; en las demás plataformas se
-       ignora silenciosamente.
-      </simpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term>
+     <option role="configure">--with-curl</option>
+    </term>
+    <listitem>
+     <simpara>
+      Ubicación de la instalación de cURL, si no se encuentra en las rutas
+      de inclusión predeterminadas.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option role="configure">--enable-msgpack</option>
+    </term>
+    <listitem>
+     <simpara>
+      Activa el empaquetador <literal>msgpack</literal> y convierte la
+      extensión <literal>msgpack</literal> en una dependencia opcional.
+      Cuando Yar se compila con esta opción, el valor predeterminado de
+      <link linkend="ini.yar.packager">yar.packager</link> pasa a ser
+      <literal>msgpack</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option role="configure">--enable-epoll</option>
+    </term>
+    <listitem>
+     <simpara>
+      Utiliza <literal>epoll</literal> de Linux en lugar de
+      <literal>select()</literal> para la multiplexación de E/S, disponible
+      a partir de Yar 2.1.2. Esto puede mejorar el rendimiento de
+      <classname>Yar_Concurrent_Client</classname> con una concurrencia
+      elevada. Solo tiene efecto en Linux; en las demás plataformas se
+      ignora silenciosamente.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </section>
  <!-- }}} -->
 

--- a/reference/yar/yar-concurrent-client.xml
+++ b/reference/yar/yar-concurrent-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <reference xml:id="class.yar-concurrent-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -17,9 +17,22 @@
     se envían inmediatamente; todas se despachan a la vez, en paralelo,
     mediante <methodname>Yar_Concurrent_Client::loop</methodname>.
    </simpara>
+   <simpara>
+    La clase está pensada para aplicaciones que necesitan los resultados de
+    varias llamadas remotas. Solo las llamadas independientes — aquellas que
+    no necesitan los resultados de las demás — pueden agruparse de esta
+    manera; cuando una llamada depende del resultado de otra, ambas tienen
+    que ejecutarse secuencialmente. Mediante
+    <classname>Yar_Client</classname> las llamadas se envían una tras otra, y
+    cada una paga su tiempo completo de ida y vuelta; con el cliente
+    concurrente se envían al mismo tiempo, por lo que el tiempo de espera
+    total se reduce a la duración de la llamada más lenta.
+   </simpara>
    <note>
     <simpara>
-     Solo se admiten servicios HTTP(S) para las llamadas concurrentes.
+     Solo se admiten servicios HTTP(S) para las llamadas concurrentes. Se
+     envían de forma concurrente mediante la interfaz multi-handle de curl,
+     que el transporte por sockets TCP/Unix no implementa.
     </simpara>
    </note>
   </section>

--- a/reference/yar/yar-server.xml
+++ b/reference/yar/yar-server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <reference xml:id="class.yar-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -15,6 +15,11 @@
     Envuelve un objeto y expone todos sus métodos públicos como un servicio
     remoto, servido a través de HTTP por
     <methodname>Yar_Server::handle</methodname>.
+   </simpara>
+   <simpara>
+    La extensión de PHP solo proporciona un servidor HTTP. Un servidor TCP y
+    de sockets Unix que emplea el mismo protocolo Yar lo proporciona el
+    <link xlink:href="&url.git.hub;laruence/yar-c">framework Yar en C</link>.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/yar/yar_client/call.xml
+++ b/reference/yar/yar_client/call.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -17,8 +17,8 @@
   <simpara>
    Emite una llamada RPC al método remoto <literal>method</literal>. Esto
    es exactamente lo que ocurre cuando se invoca un método inexistente sobre
-   un objeto <classname>Yar_Client</classname> (véase
-   <methodname>Yar_Client::__call</methodname>);
+   un objeto <classname>Yar_Client</classname> (a través del método mágico
+   <literal>__call</literal> de PHP);
    <methodname>Yar_Client::call</methodname> solo existe para que los métodos
    remotos llamados literalmente <literal>call</literal> o
    <literal>__call</literal> sigan siendo accesibles.
@@ -57,18 +57,51 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   Cuando el método <literal>call</literal> no existe en el lado del
-   servidor, se lanza una
-   <exceptionname>Yar_Server_Request_Exception</exceptionname>. Véase
-   <methodname>Yar_Client::__call</methodname> para la lista completa de
-   fallos y sus clases de excepción.
+   Cuando el método remoto no existe en el servidor, o no es público, el
+   cliente lanza una
+   <exceptionname>Yar_Client_Exception</exceptionname> con el código
+   <constant>YAR_ERR_REQUEST</constant>. Véase
+   <link linkend="class.yar-client-exception">Yar_Client_Exception</link>
+   para los demás fallos del lado del cliente y sus clases de excepción.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Yar_Client::call</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("http://api.example.com/operator.php");
+
+/* La forma habitual: invocar el método remoto como si fuera local.
+ * Esto se traduce internamente en call("add", array(1, 2)). */
+var_dump($client->add(1, 2));
+
+/* Equivalente: llamar al método explícitamente por su nombre */
+var_dump($client->call("add", array(1, 2)));
+
+/* Solo es necesario cuando el servicio remoto expone literalmente un método
+ * llamado call (o __call), al que el __call mágico no puede acceder */
+var_dump($client->call("call", array($some_argument)));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(3)
+int(3)
+...
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yar_Client::__call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/construct.xml
+++ b/reference/yar/yar_client/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -70,10 +70,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* con opciones */
-$client = new Yar_Client("http://host/api/", [
+$client = new Yar_Client("http://api.example.com/operator.php", [
     YAR_OPT_TIMEOUT => 1000,
     YAR_OPT_PACKAGER => "json",
 ]);
@@ -86,7 +86,7 @@ $client = new Yar_Client("http://host/api/", [
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yar_Client::__call</methodname></member>
+   <member><methodname>Yar_Client::call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/getopt.xml
+++ b/reference/yar/yar_client/getopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client.getopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,7 +51,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 $client->setOpt(YAR_OPT_TIMEOUT, 1000);
 
 var_dump($client->getOpt(YAR_OPT_TIMEOUT));

--- a/reference/yar/yar_client/setopt.xml
+++ b/reference/yar/yar_client/setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client.setopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -104,7 +104,7 @@
 <![CDATA[
 <?php
 
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* Establece el tiempo de espera en 1s */
 $client->setOpt(YAR_OPT_TIMEOUT, 1000);
@@ -130,7 +130,7 @@ $result = $client->some_method("parameter");
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Yar_Client::getOpt</methodname></member>
-   <member><methodname>Yar_Client::__call</methodname></member>
+   <member><methodname>Yar_Client::call</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_client_exception/gettype.xml
+++ b/reference/yar/yar_client_exception/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-client-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -43,7 +43,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 try {
     $client->some_method("parameter");

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -26,8 +26,9 @@
   </simpara>
   <note>
    <simpara>
-    Solo se admiten URIs HTTP y HTTPS. Los transportes TCP y de sockets Unix
-    no están disponibles para las llamadas concurrentes.
+    Solo se admiten URIs HTTP y HTTPS. Las llamadas concurrentes se envían
+    simultáneamente utilizando la interfaz multi-handle de curl, y el
+    transporte por sockets TCP/Unix no proporciona esta facilidad.
    </simpara>
   </note>
  </refsect1>
@@ -66,11 +67,18 @@
      <simpara>
       Un <type>callable</type> invocado cuando llega la respuesta de esta
       llamada, con dos argumentos: el valor de la respuesta y un
-      &array; <literal>callinfo</literal> con las claves
-      <literal>sequence</literal>, <literal>uri</literal> y
-      <literal>method</literal>. Si se omite, se utiliza el
-      <literal>callback</literal> de
-      <methodname>Yar_Concurrent_Client::loop</methodname>.
+      &array; <literal>callinfo</literal> que describe la llamada:
+     </simpara>
+     <simplelist>
+      <member><literal>sequence</literal> — el número de secuencia devuelto
+       cuando se registró la llamada</member>
+      <member><literal>uri</literal> — la dirección del servicio</member>
+      <member><literal>method</literal> — el nombre del método remoto</member>
+     </simplelist>
+     <simpara>
+      Si se omite, se utiliza el <literal>callback</literal> de
+      <methodname>Yar_Concurrent_Client::loop</methodname>;
+      véase ese método para saber qué ocurre cuando no se indica ninguno.
      </simpara>
     </listitem>
    </varlistentry>
@@ -81,9 +89,10 @@
       Un <type>callable</type> invocado cuando esta llamada falla, con tres
       argumentos: el tipo de error (uno de los códigos
       <literal>YAR_ERR_*</literal>), el mensaje de error y el
-      &array; <literal>callinfo</literal>. Si se omite, se utiliza el
-      <literal>error_callback</literal> de
-      <methodname>Yar_Concurrent_Client::loop</methodname>.
+      &array; <literal>callinfo</literal> descrito anteriormente. Si se
+      omite, se utiliza el <literal>error_callback</literal> de
+      <methodname>Yar_Concurrent_Client::loop</methodname>;
+      véase ese método para saber qué ocurre cuando no se indica ninguno.
      </simpara>
     </listitem>
    </varlistentry>
@@ -132,16 +141,16 @@ function error_callback($type, $error, $callinfo)
     error_log($error);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* Si no se especifica el callback, se utilizará el callback de loop() */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"));
 
 /* Este servidor acepta el empaquetador JSON */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
 
 /* Tiempo de espera personalizado */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
 
 /* Las peticiones todavía no se han enviado */
 ]]>

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,6 +21,20 @@
    todas las respuestas hayan llegado y hayan sido tratadas. La lista de
    llamadas se vacía cuando este método retorna.
   </simpara>
+  <simpara>
+   Como las llamadas se ejecutan simultáneamente, el bucle solo dura lo que
+   dura la llamada más lenta, en lugar de la suma de todas las llamadas. Sin
+   embargo, los callbacks no se invocan en el orden en que se registraron las
+   llamadas: un callback se dispara en cuanto llega su respuesta. Para saber a
+   qué llamada corresponde una respuesta, se debe comparar la clave
+   <literal>sequence</literal> del argumento <literal>callinfo</literal> con
+   el número de secuencia devuelto por
+   <methodname>Yar_Concurrent_Client::call</methodname>. El
+   &array; <literal>callinfo</literal> contiene la
+   <literal>sequence</literal>, la <literal>uri</literal> y el
+   <literal>method</literal> de la llamada; véase
+   <methodname>Yar_Concurrent_Client::call</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -35,6 +49,10 @@
       que se hayan enviado todas las peticiones, se le llama además una vez
       con dos argumentos &null;, antes de que llegue ninguna respuesta.
      </simpara>
+     <simpara>
+      Si se omite este parámetro, el valor de retorno de una llamada
+      satisfactoria simplemente se imprime cuando llega su respuesta.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -46,6 +64,11 @@
       tres argumentos: el tipo de error (uno de los códigos
       <literal>YAR_ERR_*</literal>), el mensaje de error y el
       &array; <literal>callinfo</literal>.
+     </simpara>
+     <simpara>
+      Si se omite este parámetro, una llamada fallida emite en su lugar una
+      advertencia de PHP; a diferencia del <classname>Yar_Client</classname>
+      síncrono, no se lanza ninguna excepción.
      </simpara>
     </listitem>
    </varlistentry>
@@ -93,10 +116,10 @@ function error_callback($type, $error, $callinfo) {
     error_log($error);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* si no se especifica el callback, se utilizará el callback de loop() */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"));
 
 Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,7 +53,7 @@ function callback($retval, $callinfo) {
     var_dump($retval);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* nunca enviada: se descarta la llamada registrada */
 Yar_Concurrent_Client::reset();

--- a/reference/yar/yar_server/construct.xml
+++ b/reference/yar/yar_server/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -29,6 +29,43 @@
       Cualquier objeto cuyos métodos públicos deban exponerse como
       servicios RPC. Los métodos protegidos y privados, y los métodos cuyo
       nombre empieza por un guion bajo, no se exponen.
+     </simpara>
+     <simpara>
+      El ejecutor puede definir opcionalmente dos métodos mágicos
+      protegidos, que son reconocidos por
+      <methodname>Yar_Server::handle</methodname> y nunca se exponen
+      como puntos de acceso RPC:
+     </simpara>
+     <itemizedlist>
+      <listitem>
+       <simpara>
+        <literal>protected function __info(string $markup):
+        string</literal> — a partir de Yar 2.3.0. Se llama cuando se
+        solicita la página de información del servicio; recibe el
+        marcado de la página que Yar mostraría en otro caso, y si
+        devuelve una &string;, esa cadena se envía al cliente en su
+        lugar. Véase <methodname>Yar_Server::handle</methodname>.
+       </simpara>
+      </listitem>
+      <listitem>
+       <simpara>
+        <literal>protected function __auth(string $provider, string
+        $token): bool</literal> — a partir de Yar 2.3.0. Se llama al
+        principio de cada petición con los campos
+        <literal>provider</literal> y <literal>token</literal> de la
+        cabecera de la petición, establecidos por el cliente mediante
+        las opciones <constant>YAR_OPT_PROVIDER</constant> y
+        <constant>YAR_OPT_TOKEN</constant>. Devolver exactamente
+        &false; rechaza la petición; cualquier otro valor de retorno
+        permite que continúe. Véase
+        <methodname>Yar_Server::handle</methodname>.
+       </simpara>
+      </listitem>
+     </itemizedlist>
+     <simpara>
+      Ambos métodos solo surten efecto cuando son
+      <literal>protected</literal>; un método público o privado con el
+      mismo nombre se ignora.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 07275f5d03cf34c5a2218e0c103978f8024da153 Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-server.handle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -30,12 +30,11 @@
   </note>
   <note>
    <simpara>
-    A partir de Yar 2.3.0, la página de información del servicio se puede
-    personalizar definiendo un método <literal>protected</literal> llamado
-    <literal>__info</literal> en el objeto ejecutor. Cuando llega una
-    petición GET, Yar llama a este método pasándole el marcado de la página
-    que mostraría en otro caso; si el método devuelve una &string;, esa
-    cadena se envía al cliente en lugar de la página predeterminada.
+    A partir de Yar 2.3.0, el objeto ejecutor puede definir los métodos
+    mágicos protegidos <literal>__info</literal> y
+    <literal>__auth</literal> para personalizar la página de información
+    del servicio y para autenticar las peticiones; véase
+    <methodname>Yar_Server::__construct</methodname> para más detalles.
    </simpara>
   </note>
  </refsect1>

--- a/reference/yar/yar_server_exception/gettype.xml
+++ b/reference/yar/yar_server_exception/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: seros Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: seros Status: ready -->
 
 <refentry xml:id="yar-server-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -60,7 +60,7 @@ $service->handle();
 <![CDATA[
 <?php
 /* Client.php */
-$client = new Yar_Client("http://host/api.php");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 try {
     $client->throw_exception("client");


### PR DESCRIPTION
Mirrors php/doc-en#5815 (commit 60ce1c5) for `reference/yar`.

Adds the new protocol chapter, the PECL/PIE installation instructions and the `YAR_ERR_FORBIDDEN` constant, and completes the concurrent client and server pages.

Also fixes stale content the Spanish pages carried: the errors section of `Yar_Client::call()` named `Yar_Server_Request_Exception` instead of `Yar_Client_Exception`, and several seealso blocks pointed at `Yar_Client::__call`, which has no page.

Fixes: #1163
