### PR TITLE
[Sync-En] intl: add the grapheme_levenshtein documentation

### DIFF
--- a/reference/intl/grapheme/grapheme-levenshtein.xml
+++ b/reference/intl/grapheme/grapheme-levenshtein.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 469efd89e78e8d003d7222550f7cdcf4a8f417b1 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.grapheme-levenshtein" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>grapheme_levenshtein</refname>
+  <refpurpose>Calcula la distancia de Levenshtein entre dos cadenas en unidades de grafema</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>grapheme_levenshtein</methodname>
+   <methodparam><type>string</type><parameter>string1</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string2</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>insertion_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>replacement_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>deletion_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>""</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   La distancia de Levenshtein se define como el número mínimo de
+   clusters de grafemas que hay que reemplazar, insertar o eliminar para transformar
+   <parameter>string1</parameter> en <parameter>string2</parameter>.
+   La complejidad del algoritmo es <literal>O(m*n)</literal>,
+   donde <literal>n</literal> y <literal>m</literal> son la
+   longitud de <parameter>string1</parameter> y de
+   <parameter>string2</parameter> en unidades de grafema.
+  </simpara>
+  <simpara>
+   A diferencia de <function>levenshtein</function>, que opera sobre bytes, esta
+   función cuenta clusters de grafemas Unicode, de modo que las formas compuesta y
+   descompuesta de un mismo carácter (por ejemplo <literal>U+00E9</literal> y
+   <literal>U+0065 U+0301</literal>, que representan ambas <literal>é</literal>)
+   se consideran equivalentes y tienen una distancia de cero.
+  </simpara>
+  <simpara>
+   Si <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>
+   y/o <parameter>deletion_cost</parameter> son distintos de <literal>1</literal>,
+   el algoritmo se adapta para elegir las transformaciones más baratas.
+   Por ejemplo, si <literal>$insertion_cost + $deletion_cost &lt; $replacement_cost</literal>,
+   no se realizará ningún reemplazo, sino más bien inserciones y eliminaciones.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>string1</parameter></term>
+     <listitem>
+      <simpara>
+       Una de las cadenas evaluadas para la distancia de Levenshtein.
+       Debe ser UTF-8 válido.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>string2</parameter></term>
+     <listitem>
+      <simpara>
+       Una de las cadenas evaluadas para la distancia de Levenshtein.
+       Debe ser UTF-8 válido.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>insertion_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Define el coste de la inserción. Debe ser mayor que <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>replacement_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Define el coste del reemplazo. Debe ser mayor que <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>deletion_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Define el coste de la eliminación. Debe ser mayor que <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>locale</parameter></term>
+     <listitem>
+      &intl.param.grapheme.locale;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la distancia de Levenshtein entre las dos cadenas, medida en
+   unidades de grafema, o &false; en caso de fallo. Se debe utilizar
+   <function>intl_get_error_message</function> para obtener detalles sobre
+   el fallo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lanza una <exceptionname>ValueError</exceptionname> si
+   <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>
+   o <parameter>deletion_cost</parameter> es menor o igual que
+   <literal>0</literal>.
+  </simpara>
+  <simpara>
+   Devuelve &false; y establece un error intl si una de las cadenas de entrada no es
+   UTF-8 válido, si <parameter>locale</parameter> no es un identificador de
+   configuración regional válido, o si se produce un error interno de ICU.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Esta función ha sido añadida.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo con <function>grapheme_levenshtein</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+// Forma compuesta (NFC): U+00E9 LATIN SMALL LETTER E WITH ACUTE
+$e_composed = "\u{00E9}";
+
+// Forma descompuesta (NFD): U+0065 + U+0301 (e + acento agudo combinante)
+$e_decomposed = "\u{0065}\u{0301}";
+
+// grapheme_levenshtein los trata como el mismo cluster de grafemas
+var_dump(grapheme_levenshtein($e_composed, $e_decomposed));
+
+// levenshtein() opera sobre bytes y los ve como diferentes
+var_dump(levenshtein($e_composed, $e_decomposed));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(0)
+int(3)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>levenshtein</function></member>
+    <member><function>grapheme_strlen</function></member>
+    <member><function>grapheme_substr</function></member>
+    <member><function>similar_text</function></member>
+    <member>
+     <link xlink:href="&uri.unicode.graphemes;">
+      Segmentación de texto Unicode: Límites de Clusters de Grafemas
+     </link>
+    </member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Mirrors php/doc-en#5005 (commit 469efd8): translation of the new `grapheme_levenshtein()` page.

The page is picked up automatically by `&reference.intl.grapheme;`, so no other file needed a change.

Fixes: #1155
