### PR TITLE
[Sync-En] taint: revise the extension documentation

### DIFF
--- a/reference/taint/book.xml
+++ b/reference/taint/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cfe2c34143ab17e522b1594ae0902b7245f072d5 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: Marqitos -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: PhilDaiguille Status: ready -->
 
 <book xml:id="book.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -9,50 +8,59 @@
 
  <preface xml:id="intro.taint">
   &reftitle.intro;
-  <para>
-   Taint es una extensión que sirve para detectar código XSS (strings
-   corrompidos, «tainted»).
-   También se puede utilizar para localizar vulnerabilidades a inyecciones SQL, inyecciones
-   «shell», etc.
-  </para>
-  <para>
-   Si taint está habilitada, advertirá de si se ha proporcionado una cadena corrompida
-   (que venga de <varname>$_GET</varname>, <varname>$_POST</varname>
-   o <varname>$_COOKIE</varname>) a alguna función.
-  </para>
+  <simpara>
+   Taint es una extensión para detectar código XSS (strings corrompidos,
+   «tainted»). También puede utilizarse para localizar inyecciones SQL,
+   inyecciones de comandos, inyecciones de rutas de ficheros y
+   vulnerabilidades similares.
+  </simpara>
+  <simpara>
+   Cuando taint está habilitada, los strings recibidos de la entrada del
+   usuario — <varname>$_GET</varname>, <varname>$_POST</varname> y
+   <varname>$_COOKIE</varname> — se marcan como corrompidos al inicio de la
+   petición, y la marca se propaga a través de las operaciones con strings.
+   Cuando un string corrompido alcanza un punto peligroso (salida, consulta
+   SQL, comando del sistema, ruta de fichero, ...), taint emite una
+   advertencia que señala ese punto. Consulte
+   <link linkend="taint.detail">Propagación y puntos comprobados</link> para
+   ver las listas completas.
+  </simpara>
+  <simpara>
+   Taint es una herramienta de desarrollo y auditoría, no una defensa en
+   tiempo de ejecución: solo informa de posibles problemas, y nunca bloquea
+   ni altera los datos. Es deliberadamente conservadora y puede informar de
+   más de la cuenta, de modo que una ejecución limpia solo significa «nada
+   que taint pudiera ver», nunca «demostrablemente seguro». No la habilite
+   en entornos de producción.
+  </simpara>
   <example>
-   <title>Ejemplo de <function>taint</function></title>
+   <title>Ejemplo de taint</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 $a = trim($_GET['a']);
 
-$nombre_fichero = '/tmp' .  $a;
-$salida    = "¡¡¡Bienvenido, {$a} !!!";
-$var       = "salida";
-$sql       = "Select *  from " . $a;
-$sql      .= "ooxx";
+$file_name = '/tmp/' . $a;
+$output    = "Welcome, {$a} !!!";
+$sql       = "SELECT * FROM users WHERE name = " . $a;
 
-echo $salida;
-
-print $$var;
-
-include $nombre_fichero;
-
-mysql_query($sql);
+echo $output;
+print $output;
+include $file_name;
+mysqli_query($link, $sql);
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Warning: main() [function.echo]: Attempt to echo a string that might be tainted
+Warning: main() [echo]: Attempt to echo a string that might be tainted in /path/to/script.php on line 9
 
-Warning: main() [function.echo]: Attempt to print a string that might be tainted
+Warning: main() [print]: Attempt to print a string that might be tainted in /path/to/script.php on line 10
 
-Warning: include() [function.include]: File path contains data that might be tainted
+Warning: main() [include]: File path contains data that might be tainted in /path/to/script.php on line 11
 
-Warning: mysql_query() [function.mysql-query]: SQL statement contains data that might be tainted
+Warning: main() [mysqli_query]: SQL statement contains data that might be tainted in /path/to/script.php on line 12
 ]]>
    </screen>
   </example>

--- a/reference/taint/configure.xml
+++ b/reference/taint/configure.xml
@@ -1,19 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: seros Status: ready -->
 
 <section xml:id="taint.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
- <para>
+ <simpara>
   &pecl.info;
-  <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>
+  <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>.
+ </simpara>
+
+ <simpara>
+  Se instala con <acronym>PECL</acronym>:
+ </simpara>
+ <para>
+  <screen>
+<![CDATA[
+$ pecl install taint
+]]>
+  </screen>
  </para>
 
+ <para>
+  El código fuente está alojado en
+  <link xlink:href="&url.git.hub;laruence/taint">GitHub</link>. Para compilar
+  la extensión desde el código fuente:
+  <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/taint.git
+$ cd taint
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+  </screen>
+ </para>
 
+ <simpara>
+  A continuación se habilita la extensión añadiendo
+  <literal>extension=taint.so</literal> (o <literal>extension=php_taint.dll</literal>
+  en Windows) a &php.ini;, y estableciendo
+  <link linkend="ini.taint.enable">taint.enable</link> a
+  <literal>1</literal>.
+ </simpara>
+
+ <warning>
+  <simpara>
+   Taint es una herramienta de desarrollo y auditoría. No la habilite en
+   entornos de producción: la instrumentación ralentiza cada petición y
+   deshabilita el JIT de OPcache, y las advertencias pueden filtrar datos de
+   la petición a los registros.
+  </simpara>
+ </warning>
 </section>
-
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/taint/detail.xml
+++ b/reference/taint/detail.xml
@@ -1,321 +1,281 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6d12569dcee7ac2012400c439eee8a971b813 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: seros Status: ready -->
 
 <chapter xml:id="taint.detail" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Más detalles</title>
+ <title>Propagación y puntos comprobados</title>
 
  <section xml:id="taint.detail.basic">
-  <title>Funciones y sentencias que propagarán la marca de corrupción de una
-   cadena corrupta</title>
+  <title>Cómo se propaga la marca de corrupción</title>
+  <simpara>
+   La marca de corrupción es un único bit almacenado en el propio string, no
+   en la variable que lo contiene. Asignar, pasar o compartir de cualquier
+   otra forma un string corrompido conserva la marca. La concatenación y la
+   interpolación de strings también la propagan:
+  </simpara>
   <para>
    <table>
-    <title></title>
-    <tgroup cols="2">
-     <colspec colname="name"/>
-     <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Función/Sentencia</entry>
-       <entry>Desde</entry>
-      </row>
-     </thead>
+    <title>Operadores que propagan la marca de corrupción</title>
+    <tgroup cols="1">
      <tbody>
       <row>
-       <entry>= (asignación)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>=</literal> (asignación, incluyendo <literal>list()</literal> y la desestructuración de arrays)</entry>
       </row>
       <row>
-       <entry>. (concatenación)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>.</literal> (concatenación)</entry>
       </row>
       <row>
-       <entry>"{$var}" (sustitución de variables)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>.=</literal> (asignación con concatenación)</entry>
       </row>
       <row>
-       <entry>.= (concatenación de asignación)</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>strval</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>explode/split</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>implode/join</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>sprintf</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>vsprintf</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>trim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>rtrim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>ltrim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>strstr</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>str_pad</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>str_replace</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>substr</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>strtolower</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>strtoupper</entry>
-       <entry>0.5.0</entry>
+       <entry><literal>"{$var}"</literal> (interpolación de strings, incluyendo la vía rápida <literal>ROPE</literal>)</entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
- </section>
-
- <section xml:id="taint.detail.taint">
-  <title>Funciones y sentencias que comprobarán cadenas corrompidas</title>
+  <simpara>
+   Además, taint conoce un conjunto fijo de funciones de strings: cuando
+   alguno de los argumentos de tipo string relevantes está corrompido, el
+   string devuelto también se marca como corrompido. Se cubren tanto la
+   llamada habitual como, en PHP 8.4 y posteriores, la llamada por la vía
+   rápida sin marco de pila.
+  </simpara>
   <para>
    <table>
-    <title></title>
-    <tgroup cols="2">
-     <colspec colname="name"/>
-     <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Función/Sentencia</entry>
-       <entry>Desde</entry>
-      </row>
-     </thead>
+    <title>Funciones que propagan la marca de corrupción</title>
+    <tgroup cols="1">
      <tbody>
       <row>
-       <entry namest="name" nameend="version">Sentencias básicas</entry>
+       <entry><function>trim</function>, <function>rtrim</function>, <function>ltrim</function></entry>
       </row>
       <row>
-       <entry>eval</entry>
-       <entry>0.1.0</entry>
+       <entry><function>substr</function>, <function>strstr</function></entry>
       </row>
       <row>
-       <entry>include/include_once</entry>
-       <entry>0.1.0</entry>
+       <entry><function>str_replace</function>, <function>str_ireplace</function></entry>
       </row>
       <row>
-       <entry>require/require_once</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <!--end basic -->
-
-      <row>
-       <entry namest="name" nameend="version">Funciones de salida</entry>
+       <entry><function>str_pad</function>, <function>strtolower</function>, <function>strtoupper</function>, <function>strval</function></entry>
       </row>
       <row>
-       <entry>echo</entry>
-       <entry>0.1.0</entry>
+       <entry><function>explode</function> (cada elemento del array resultante)</entry>
       </row>
       <row>
-       <entry>print</entry>
-       <entry>0.1.0</entry>
+       <entry><function>implode</function>/<function>join</function> (un separador corrompido también corrompe el resultado)</entry>
       </row>
       <row>
-       <entry>printf</entry>
-       <entry>0.1.0</entry>
+       <entry><function>sprintf</function>, <function>vsprintf</function> (solo el especificador <literal>%s</literal> transporta la marca; <literal>sprintf("%d", $t)</literal> devuelve un string limpio)</entry>
       </row>
       <row>
-       <entry>file_put_contents</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <!-- end outputing -->
-      <row>
-       <entry namest="name" nameend="version">Funciones del sistema de ficheros</entry>
-      </row>
-      <row>
-       <entry>fopen</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>opendir</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>basename</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>dirname</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>file</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>pathinfo</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <!-- end file system -->
-      <row>
-       <entry namest="name" nameend="version">Funciones relacionadas con bases de datos</entry>
-      </row>
-      <row>
-       <entry>mysql_query</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_query/MySQLi::query</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_query/SqliteDataBase::query</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_single_query/SqliteDataBase::singleQuery</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>oci_parse</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::query</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::prepare</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>SQLite3::query</entry>
-       <entry>2.0.1</entry>
-      </row>
-      <row>
-       <entry>SQLite3::prepare</entry>
-       <entry>2.0.1</entry>
-      </row>
-      <!-- end database -->
-      <row>
-       <entry namest="name" nameend="version">Funciones relacionadas con la línea de comandos</entry>
-      </row>
-      <row>
-       <entry>system</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>exec</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>proc_open</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>passthru</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>shell_exec</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <!-- end command line -->
-
-     </tbody>
-    </tgroup>
-   </table>
-  </para>
- </section>
-
- <section xml:id="taint.detail.untaint">
-  <title>Funciones que sanean cadenas corruptas</title>
-  <para>
-   <table>
-    <title></title>
-    <tgroup cols="2">
-     <colspec colname="name"/>
-     <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Función</entry>
-       <entry>Desde</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>addslashes</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>addcslashes</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>htmlspecialchars</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>htmlentities</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>escapeshellcmd</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysql_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysql_real_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_escape_string/MySQLi::escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_real_escape_string/MySQLi::real_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_escape_string/SqliteDataBase::escapeString</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::quote</entry>
-       <entry>0.3.0</entry>
+       <entry><function>dirname</function>, <function>basename</function>, <function>pathinfo</function></entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
-
+  <simpara>
+   Cualquier función que taint no conozca explícitamente devuelve un string
+   nuevo y sin marcar, incluidas las funciones de escapado como
+   <function>htmlspecialchars</function>, <function>htmlentities</function> o
+   <function>mysqli_real_escape_string</function>. Esto es deliberado: taint
+   informa de más de la cuenta en lugar de intentar decidir si un valor es
+   <quote>seguro</quote> para un contexto de salida concreto. Se debe usar
+   <function>untaint</function> para eliminar la marca de los valores que se
+   hayan validado manualmente.
+  </simpara>
  </section>
+
+ <section xml:id="taint.detail.sinks">
+  <title>Dónde emite advertencias taint</title>
+  <simpara>
+   Cuando un string corrompido alcanza uno de los puntos indicados a
+   continuación, taint emite una advertencia (por defecto un
+   <constant>E_USER_WARNING</constant>; el nivel es configurable mediante
+   <link linkend="ini.taint.error-level">taint.error_level</link>).
+   Solo se inspeccionan los argumentos de tipo string de primer nivel;
+   volcar un array que simplemente contiene valores corrompidos no genera
+   ninguna advertencia.
+  </simpara>
+  <para>
+   <table>
+    <title>Puntos de salida</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Punto</entry><entry>Comprobado</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><literal>echo</literal>, <literal>print</literal></entry>
+       <entry>la expresión mostrada o impresa</entry>
+      </row>
+      <row>
+       <entry><function>printf</function>, <function>vprintf</function></entry>
+       <entry>el string de formato y los valores sustituidos</entry>
+      </row>
+      <row>
+       <entry><function>print_r</function>, <function>var_dump</function>, <function>var_export</function></entry>
+       <entry>el valor volcado, cuando es un string</entry>
+      </row>
+      <row>
+       <entry><literal>exit</literal>/<literal>die</literal> con un mensaje</entry>
+       <entry>el mensaje</entry>
+      </row>
+      <row>
+       <entry><function>file_put_contents</function>, <function>fwrite</function>, <function>fputs</function> hacia <literal>php://output</literal></entry>
+       <entry>los datos escritos</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Puntos del sistema de ficheros</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Punto</entry><entry>Comprobado</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>fopen</function>, <function>opendir</function>, <function>unlink</function></entry>
+       <entry>la ruta</entry>
+      </row>
+      <row>
+       <entry><function>file</function>, <function>readfile</function>, <function>file_get_contents</function>, <function>highlight_file</function>/<function>show_source</function></entry>
+       <entry>la ruta</entry>
+      </row>
+      <row>
+       <entry><function>copy</function>, <function>rename</function>, <function>move_uploaded_file</function></entry>
+       <entry>tanto la ruta de origen como la de destino</entry>
+      </row>
+      <row>
+       <entry><function>mkdir</function>, <function>rmdir</function>, <function>touch</function></entry>
+       <entry>la ruta</entry>
+      </row>
+      <row>
+       <entry><literal>include</literal>, <literal>include_once</literal>, <literal>require</literal>, <literal>require_once</literal></entry>
+       <entry>la ruta del fichero</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Puntos SQL</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Punto</entry><entry>Comprobado</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>mysqli_query</function>, <function>mysqli_prepare</function>, <function>mysqli_real_query</function>, <function>mysqli_multi_query</function></entry>
+       <entry>el string de la consulta</entry>
+      </row>
+      <row>
+       <entry><function>mysql_query</function>, <function>sqlite_query</function>, <function>sqlite_single_query</function>, <function>oci_parse</function>, <function>pg_query</function>, <function>pg_send_query</function></entry>
+       <entry>el string de la consulta</entry>
+      </row>
+      <row>
+       <entry><methodname>mysqli::query</methodname>, <methodname>mysqli::prepare</methodname>, <methodname>mysqli::real_query</methodname>, <methodname>mysqli::multi_query</methodname></entry>
+       <entry>el string de la consulta</entry>
+      </row>
+      <row>
+       <entry><methodname>PDO::query</methodname>, <methodname>PDO::prepare</methodname>, <methodname>PDO::exec</methodname></entry>
+       <entry>el string de la consulta</entry>
+      </row>
+      <row>
+       <entry><methodname>SQLite3::query</methodname>, <methodname>SQLite3::prepare</methodname>, <methodname>SQLite3::exec</methodname>, <methodname>SQLiteDatabase::query</methodname>, <methodname>SQLiteDatabase::singleQuery</methodname></entry>
+       <entry>el string de la consulta</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Puntos de ejecución de comandos</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Punto</entry><entry>Comprobado</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>exec</function>, <function>system</function>, <function>passthru</function>, <function>shell_exec</function> (incluyendo el operador de comillas invertidas)</entry>
+       <entry>el string del comando</entry>
+      </row>
+      <row>
+       <entry><function>proc_open</function>, <function>popen</function></entry>
+       <entry>el string del comando</entry>
+      </row>
+      <row>
+       <entry><literal>eval</literal></entry>
+       <entry>el código evaluado</entry>
+      </row>
+      <row>
+       <entry>las llamadas dinámicas como <literal>$func()</literal>, <literal>$obj-&gt;$method()</literal>, <function>call_user_func</function> o los callables en forma de array</entry>
+       <entry>el nombre de la función, del método o de la clase que se resuelve</entry>
+      </row>
+      <row>
+       <entry><function>preg_match</function>, <function>preg_match_all</function>, <function>preg_replace</function>, <function>preg_split</function>, <function>preg_grep</function>, <function>preg_replace_callback</function></entry>
+       <entry>el patrón (y el nombre de la retrollamada en el caso de <function>preg_replace_callback</function>)</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Puntos de cabeceras y cookies</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Punto</entry><entry>Comprobado</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>header</function></entry>
+       <entry>el string de la cabecera</entry>
+      </row>
+      <row>
+       <entry><function>setcookie</function>, <function>setrawcookie</function></entry>
+       <entry>el nombre y el valor de la cookie</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Otros puntos</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Punto</entry><entry>Comprobado</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>unserialize</function></entry>
+       <entry>el string serializado</entry>
+      </row>
+      <row>
+       <entry><function>mail</function></entry>
+       <entry>el destinatario, el asunto, los parámetros adicionales y las cabeceras adicionales (el cuerpo del mensaje es contenido y no se comprueba)</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <simpara>
+   Las advertencias siguen el formato
+   <literal>nombre_de_funcion() [punto]: mensaje</literal>, donde
+   <literal>punto</literal> identifica la operación comprobada (por ejemplo
+   <literal>echo</literal>, <literal>include</literal> o el nombre de la
+   función) y el mensaje describe lo que se ha encontrado como posiblemente
+   corrompido.
+  </simpara>
+ </section>
+
 </chapter>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: andresdzphp Status: ready -->
-<!-- Reviewed: yes Maintainer: seros -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: andresdzphp Status: ready -->
 
 <refentry xml:id="function.is-tainted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>is_tainted</refname>
-  <refpurpose>Comprobar si un string está corrompido</refpurpose>
+  <refpurpose>Comprueba si un string está corrompido</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,10 +13,10 @@
    <type>bool</type><methodname>is_tainted</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Comprueba si un string está corrompido
-  </para>
-
+  <simpara>
+   Comprueba si el valor indicado lleva la marca de corrupción. Solo los
+   strings pueden estar corrompidos; cualquier otro tipo devuelve &false;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +25,9 @@
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      El valor que se va a comprobar.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,11 +35,43 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve TRUE si el string está corrompido, FALSE en caso contrario.
-  </para>
+  <simpara>
+   Devuelve &true; si el valor es un string corrompido, y &false; en caso
+   contrario. Devuelve siempre &false; cuando
+   <link linkend="ini.taint.enable">taint.enable</link> está deshabilitado.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo con <function>is_tainted</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$name = $_GET['name'] ?? 'world';
+var_dump(is_tainted($name));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>taint</function></member>
+    <member><function>untaint</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: seros Status: ready -->
-<!-- Reviewed: yes Maintainer: seros -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: seros Status: ready -->
 
 <refentry xml:id="function.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>taint</refname>
-  <refpurpose>Corrompe un string</refpurpose>
+  <refpurpose>Marca strings como corrompidos</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,11 +12,23 @@
   <methodsynopsis>
    <type>bool</type><methodname>taint</methodname>
    <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
-   <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter role="reference">strings</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Crea un string corrompido. Solamente se usa para realizar pruebas.
-  </para>
+  <simpara>
+   Marca manualmente los strings indicados como corrompidos, como si
+   procedieran de la entrada del usuario. Las variables se pasan por
+   referencia, pero la marca se almacena en el string y no en la variable:
+   todas las variables que comparten el mismo string quedan corrompidas a la
+   vez.
+  </simpara>
+  <simpara>
+   Resulta útil sobre todo para pruebas, y para simular la entrada del
+   usuario en scripts <acronym>CLI</acronym>, donde las superglobales
+   <link linkend="reserved.variables.get">$_GET</link>,
+   <link linkend="reserved.variables.post">$_POST</link> y
+   <link linkend="reserved.variables.cookies">$_COOKIE</link> no están
+   pobladas.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,16 +37,17 @@
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Una variable que contiene el string que se va a marcar.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>strings</parameter></term>
     <listitem>
-     <para>
-     </para>
+     <simpara>
+      Variables adicionales que se van a marcar.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -43,12 +55,61 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve TRUE si la transformación se lleva a cabo. Siempre devuelve TRUE si la extensión
-   taint no esta activada.
-  </para>
+  <simpara>
+   Devuelve siempre &true;. Cuando
+   <link linkend="ini.taint.enable">taint.enable</link> está deshabilitado,
+   la función no hace nada y aun así devuelve &true;.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo con <function>taint</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$name = "world";
+taint($name);
+var_dump(is_tainted($name));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Solo se marcan los strings no vacíos; las variables que contienen otros
+    tipos, o strings vacíos, se ignoran silenciosamente.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Los strings internados, persistentes y permanentes (literales de string,
+    strings compartidos de opcache) no pueden llevar nunca la marca y se
+    omiten silenciosamente.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>untaint</function></member>
+    <member><function>is_tainted</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/taint/functions/untaint.xml
+++ b/reference/taint/functions/untaint.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: seros Status: ready -->
-<!-- Reviewed: no Maintainer: seros -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: seros Status: ready -->
 
 <refentry xml:id="function.untaint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>untaint</refname>
-  <refpurpose>Sanea un string</refpurpose>
+  <refpurpose>Elimina la marca de corrupción de los strings</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,11 +12,18 @@
   <methodsynopsis>
    <type>bool</type><methodname>untaint</methodname>
    <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
-   <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter role="reference">strings</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    Sanea un string
-  </para>
+  <simpara>
+   Elimina la marca de corrupción de los strings indicados.
+  </simpara>
+  <simpara>
+   La marca se almacena en el propio string y no en la variable, por lo que
+   se elimina a la vez para todas las variables que comparten ese string. Se
+   utiliza para dar por buenos los valores que se hayan validado
+   manualmente, por ejemplo tras una comprobación estricta contra una lista
+   de valores permitidos.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,17 +32,17 @@
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Una variable que contiene el string que se va a limpiar.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>strings</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Variables adicionales que se van a limpiar.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,11 +50,58 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Devuelve siempre &true;. Cuando
+   <link linkend="ini.taint.enable">taint.enable</link> está deshabilitado,
+   la función no hace nada y aun así devuelve &true;.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo con <function>untaint</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$id = "42";
+taint($id);
+if (preg_match('/^\d+$/', $id)) {
+    // validado estrictamente como dígitos: se puede confiar en él
+    untaint($id);
+}
+var_dump(is_tainted($id));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Solo los valores de tipo string pueden llevar la marca; pasar un valor
+    que no sea un string no tiene ningún efecto.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>taint</function></member>
+    <member><function>is_tainted</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/taint/ini.xml
+++ b/reference/taint/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: seros Status: ready -->
 
 <section xml:id="taint.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -26,7 +25,7 @@
      </row>
      <row>
       <entry><link linkend="ini.taint.error-level">taint.error_level</link></entry>
-      <entry>E_WARNING</entry>
+      <entry>512 (E_USER_WARNING)</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -42,12 +41,27 @@
    <varlistentry xml:id="ini.taint.enable">
      <term>
       <parameter>taint.enable</parameter>
-      <type>int</type>
+      <type>bool</type>
      </term>
      <listitem>
-      <para>
-       Si habilitar taint.
-      </para>
+      <simpara>
+       Interruptor principal. Cuando está habilitado, taint engancha el
+       ejecutor y marca como corrompidos los strings de
+       <varname>$_GET</varname>, <varname>$_POST</varname> y
+       <varname>$_COOKIE</varname> al inicio de la petición.
+      </simpara>
+      <simpara>
+       Esta directiva solo puede establecerse en &php.ini;: habilitarla
+       requiere reiniciar el proceso, por lo que no puede alternarse por
+       petición ni por directorio.
+      </simpara>
+      <note>
+       <simpara>
+        No habilite esta directiva en entornos de producción: la
+        instrumentación ralentiza cada petición y es incompatible con el JIT
+        de OPcache.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.taint.error-level">
@@ -56,13 +70,27 @@
       <type>int</type>
      </term>
      <listitem>
+      <simpara>
+       El nivel de error utilizado cuando taint informa de un string
+       posiblemente corrompido. Por defecto es
+       <constant>E_USER_WARNING</constant> (512).
+      </simpara>
+      <simpara>
+       Puesto que esta directiva es <constant>INI_ALL</constant>, puede
+       modificarse en tiempo de ejecución. Por ejemplo, para silenciar las
+       advertencias de taint en el script actual:
+      </simpara>
       <para>
-       El tipo del error del que taint informará cuando encuentre una cadena
-       corrupta.
+       <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('taint.error_level', 0);
+?>
+]]>
+       </programlisting>
       </para>
      </listitem>
     </varlistentry>
-
   </variablelist>
  </para>
 </section>

--- a/reference/taint/reference.xml
+++ b/reference/taint/reference.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: seros Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: seros Status: ready -->
 
 <reference xml:id="ref.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>&Functions; de taint</title>

--- a/reference/taint/setup.xml
+++ b/reference/taint/setup.xml
@@ -1,24 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 307e7d78baacfcd228eef8f384e96659b67d9adb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: PhilDaiguille Status: ready -->
 
 <chapter xml:id="taint.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
- <section xml:id="taint.installation">
-  &reftitle.install;
-  <para>
-   &pecl.moved;
-  </para>
-  <para>
-   &pecl.info;
-   <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>.
-  </para>
+ <section xml:id="taint.requirements">
+  &reftitle.required;
+  <simpara>
+   Taint 3.x requiere PHP 8.0 o posterior. Para PHP 7.x se deben utilizar las
+   versiones taint 2.1.x, y para PHP 5.x las versiones taint 1.x.
+  </simpara>
  </section>
 
- <!-- {{{ Configuration -->
-  &reference.taint.ini;
+ <!-- {{{ Installation -->
+ &reference.taint.configure;
  <!-- }}} -->
+
+ <!-- {{{ Configuration -->
+ &reference.taint.ini;
+ <!-- }}} -->
+
+ <section xml:id="taint.resources">
+  &reftitle.resources;
+  <simpara>
+   Taint no define ningún tipo de recurso. La propia marca de corrupción se
+   almacena en la estructura interna <literal>zend_string</literal>, no en un
+   recurso visible por el usuario.
+  </simpara>
+ </section>
 
 </chapter>
 


### PR DESCRIPTION
Translation of php/doc-en#5802 (commit befe2b9): rewritten introduction, requirements and installation sections, the propagation and checked sinks chapter, the INI directives and the three function pages. EN-Revision updated.

Fixes: #1128