### PR TITLE
[Sync-En] snmp: factor out the SNMPv3 security parameter descriptions

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8465ca6ec4bbcf79583ecd057860164dd9c7e385 Maintainer: argosback Status: ready -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: argosback Status: ready -->
 
 <!ENTITY installation.enabled.disable 'Esta extensión está activada por defecto. Puede ser desactivada utilizando la opción de configuración: '>
 
@@ -2101,6 +2101,42 @@ que <constant>PGSQL_BOTH</constant> devolverá ambos índices numéricos y asoci
   se devolvía un &resource;.
  </entry>
 </row>'>
+
+<!-- SNMP entities -->
+
+<!ENTITY snmp.changelog.auth-protocol-sha2 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.1.0</entry>
+ <entry>
+  El protocolo de autenticación ahora acepta <literal>"SHA256"</literal>
+  y <literal>"SHA512"</literal> cuando la biblioteca Net-SNMP lo soporta.
+ </entry>
+</row>'>
+
+<!ENTITY snmp.changelog.privacy-protocol-aes '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.6.0</entry>
+ <entry>
+  El protocolo de privacidad ahora acepta <literal>"AES192"</literal>,
+  <literal>"AES192C"</literal>, <literal>"AES256"</literal> y
+  <literal>"AES256C"</literal> cuando la biblioteca Net-SNMP lo soporta.
+ </entry>
+</row>'>
+
+<!ENTITY snmp.parameter.security-name '<simpara xmlns="http://docbook.org/ns/docbook">El nombre de seguridad, habitualmente algún tipo de nombre de usuario.</simpara>'>
+
+<!ENTITY snmp.parameter.security-level '<simpara xmlns="http://docbook.org/ns/docbook">El nivel de seguridad: <literal>"noAuthNoPriv"</literal>,
+<literal>"authNoPriv"</literal> o <literal>"authPriv"</literal>.</simpara>'>
+
+<!ENTITY snmp.parameter.auth-protocol '<simpara xmlns="http://docbook.org/ns/docbook">El protocolo de autenticación: <literal>"MD5"</literal>, <literal>"SHA"</literal>,
+<literal>"SHA256"</literal> o <literal>"SHA512"</literal>.</simpara>'>
+
+<!ENTITY snmp.parameter.auth-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">La frase de contraseña de autenticación.</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-protocol '<simpara xmlns="http://docbook.org/ns/docbook">El protocolo de privacidad: <literal>"DES"</literal> o <literal>"AES"</literal>,
+aceptado también como <literal>"AES128"</literal>. <literal>"AES192"</literal>, <literal>"AES192C"</literal>,
+<literal>"AES256"</literal> y <literal>"AES256C"</literal> se aceptan cuando la biblioteca
+Net-SNMP los soporta.</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">La frase de contraseña de privacidad.</simpara>'>
 
 <!-- Common pieces for reference part END -->
 

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-get">
  <refnamediv>
   <refname>snmp3_get</refname>
@@ -43,50 +42,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de la seguridad, habitualmente, el nombre de usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (MD5 o SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta de autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> o <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -135,6 +121,7 @@
      </row>
     </thead>
     <tbody>
+     &snmp.changelog.privacy-protocol-aes;
      <row>
       <entry>8.5.0</entry>
       <entry>
@@ -144,14 +131,7 @@
        timeout o reintentos son menores a -1 o demasiado grandes.
       </entry>
      </row>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       El parámetro <parameter>auth_protocol</parameter> acepta ahora
-       <literal>"SHA256"</literal> y <literal>"SHA512"</literal>
-       cuando es soportado por libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-getnext.xml
+++ b/reference/snmp/functions/snmp3-getnext.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-getnext">
  <refnamediv>
   <refname>snmp3_getnext</refname>
@@ -44,50 +43,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de la seguridad, habitualmente, el nombre de usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El grado de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (MD5 o SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta de autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> o <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -138,14 +124,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       El parámetro <parameter>auth_protocol</parameter> acepta ahora
-       <literal>"SHA256"</literal> y <literal>"SHA512"</literal>
-       cuando es soportado por libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-real-walk.xml
+++ b/reference/snmp/functions/snmp3-real-walk.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-real-walk">
  <refnamediv>
   <refname>snmp3_real_walk</refname>
@@ -41,49 +40,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de seguridad, generalmente el nombre de usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (MD5 o SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta de autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de privacidad (<literal>"MD5"</literal>, <literal>"SHA"</literal>, <literal>"SHA256"</literal> o <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -131,12 +118,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       El parámetro <parameter>auth_protocol</parameter> acepta ahora <literal>"SHA256"</literal> y <literal>"SHA512"</literal> cuando es soportado por libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-set">
  <refnamediv>
   <refname>snmp3_set</refname>
@@ -30,8 +29,9 @@
    el parámetro <parameter>object_id</parameter>.
   </simpara>
   <simpara>
-   Aunque el nivel de seguridad no utilice autenticación
-   o protocolo privado por contraseña, se deben especificar valores válidos.
+   Los argumentos de autenticación y de privacidad deben pasarse siempre, pero
+   sus valores se ignoran cuando <parameter>security_level</parameter> no los
+   utiliza.
   </simpara>
 
  </refsect1>
@@ -50,49 +50,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de seguridad, generalmente, el nombre de usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (MD5 o SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta para la autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo privado (DES o AES).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -163,6 +151,7 @@
      </row>
     </thead>
     <tbody>
+     &snmp.changelog.privacy-protocol-aes;
      <row>
       <entry>8.5.0</entry>
       <entry>
@@ -172,6 +161,7 @@
        timeout o reintentos son menores a -1 o demasiado grandes.
       </entry>
      </row>
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-walk.xml
+++ b/reference/snmp/functions/snmp3-walk.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-walk">
  <refnamediv>
   <refname>snmp3_walk</refname>
@@ -28,8 +27,9 @@
    por el parámetro <parameter>host</parameter>.
   </simpara>
   <simpara>
-   Aunque el nivel de seguridad no utilice un protocolo
-   de autenticación, se deben especificar valores válidos.
+   Los argumentos de autenticación y de privacidad deben pasarse siempre, pero
+   sus valores se ignoran cuando <parameter>security_level</parameter> no los
+   utiliza.
   </simpara>
  </refsect1>
 
@@ -47,59 +47,47 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      El nombre de la seguridad, habitualmente, el nombre del usuario.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      El nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo de autenticación (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> o <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta de autenticación.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      El protocolo privado (DES o AES).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La frase secreta privada.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>object_id</parameter></term>
     <listitem>
      <simpara>
-      Si vale &null;, <parameter>object_id</parameter> será la raíz
-      del árbol de objetos <acronym>SNMP</acronym> y todos los
-      objetos subyacentes se devuelven en forma de array.
+      Si es un string vacío, <parameter>object_id</parameter> se toma como
+      <literal>.1.3.6.1.2.1</literal>, la raíz del árbol de objetos
+      <acronym>SNMP</acronym>, y todos los objetos subyacentes se devuelven en
+      forma de array.
      </simpara>
      <simpara>
       Si <parameter>object_id</parameter> está especificado,
@@ -147,14 +135,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       El parámetro <parameter>auth_protocol</parameter> acepta ahora
-       <literal>"SHA256"</literal> y <literal>"SHA512"</literal>
-       cuando es soportado por libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/snmp/construct.xml
+++ b/reference/snmp/snmp/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.construct">
  <refnamediv>
   <refname>SNMP::__construct</refname>
@@ -70,9 +69,10 @@
     <term><parameter>community</parameter></term>
     <listitem>
      <simpara>
-      Especifica el nivel de seguridad para la <parameter>version</parameter> dada.
-      El objetivo de la cadena de acceso <parameter>community</parameter> es específico
-      a la versión de <acronym>SNMP</acronym>:
+      La cadena de comunidad o, para <constant>SNMP::VERSION_3</constant>, el
+      nombre de seguridad. El objetivo de la cadena de acceso
+      <parameter>community</parameter> es específico a la versión de
+      <acronym>SNMP</acronym>:
      </simpara>
      <informaltable>
       <tgroup cols="2">
@@ -100,10 +100,7 @@
           <constant>SNMP::VERSION_3</constant>
          </entry>
          <entry>
-          Nombre de seguridad <acronym>SNMP</acronym>v3, puede ser uno de los siguientes:
-          <literal>noAuthNoPriv</literal>,
-          <literal>authNoPriv</literal> (se requiere una contraseña de autenticación y un protocolo de autenticación), o
-          <literal>authPriv</literal> (se requiere una contraseña y un protocolo de autenticación, así como una contraseña y un protocolo de confidencialidad)
+          &snmp.parameter.security-name;
          </entry>
         </row>
        </tbody>

--- a/reference/snmp/snmp/setsecurity.xml
+++ b/reference/snmp/snmp/setsecurity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.setsecurity">
  <refnamediv>
   <refname>SNMP::setSecurity</refname>
@@ -31,41 +30,31 @@
    <varlistentry>
     <term><parameter>securityLevel</parameter></term>
     <listitem>
-     <simpara>
-      el nivel de seguridad (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>authProtocol</parameter></term>
     <listitem>
-     <simpara>
-      el protocolo de autenticación (MD5 o SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>authPassphrase</parameter></term>
     <listitem>
-     <simpara>
-      la frase de paso para la autenticación
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacyProtocol</parameter></term>
     <listitem>
-     <simpara>
-      el protocolo privado (DES o AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacyPassphrase</parameter></term>
     <listitem>
-     <simpara>
-      la frase de paso para el protocolo privado
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -92,6 +81,24 @@
   <simpara>
    &return.success;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Translation of php/doc-en#5228 (commit 1ab1069): the SNMPv3 security parameter descriptions are now defined once in language-snippets.ent and shared by the five snmp3_*() pages, SNMP::__construct() and SNMP::setSecurity(); privacy protocol list completed, and the auth/privacy arguments and the snmp3_walk() root walk described as implemented. EN-Revision updated.

Fixes: #1164