### PR TITLE
[Sync-En] crypt(): add the CVE warning about unsuitable algorithms

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4850727cb124abe071e9adaf851f86a872eb2adf Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.crypt">
  <refnamediv>
   <refname>crypt</refname>
@@ -34,6 +32,22 @@
   <para>
    <function>crypt</function>, cuando se utiliza con el cifrado estándar DES, devuelve el <parameter>salt</parameter> en los dos primeros caracteres de la cadena devuelta. Solo utiliza los primeros 8 caracteres de <parameter>string</parameter>, lo que hace que todas las cadenas más largas, que tienen los mismos primeros 8 octetos, devuelvan el mismo resultado (siempre que el <parameter>salt</parameter> sea siempre el mismo).
   </para>
+  <warning>
+   <simpara>
+    Ninguno de los algoritmos enumerados a continuación es adecuado para
+    calcular el hash de nuevas contraseñas.
+    <constant>CRYPT_STD_DES</constant>, <constant>CRYPT_EXT_DES</constant> y
+    <constant>CRYPT_MD5</constant> son demasiado rápidos para resistir un
+    ataque de fuerza bruta fuera de línea; md5crypt fue declarado obsoleto por
+    ese motivo (CVE-2012-3287).
+    El tiempo de ejecución de <constant>CRYPT_SHA256</constant> y
+    <constant>CRYPT_SHA512</constant> crece con el cuadrado de la longitud de
+    <parameter>string</parameter>, de modo que una entrada sin límite puede
+    utilizarse para agotar la CPU (CVE-2016-20013).
+    En su lugar se debe utilizar <function>password_hash</function>, que
+    selecciona automáticamente un algoritmo y un coste adecuados.
+   </simpara>
+  </warning>
   <simpara>
    Los siguientes tipos de hash son soportados:
   </simpara>


### PR DESCRIPTION
Translation of php/doc-en#3447 (commit 4850727): warning about CVE-2012-3287 and CVE-2016-20013 before the list of supported hash types. EN-Revision updated.

Fixes: #1180