### PR TITLE
[Sync-En] ext/ldap: document the PHP 8.5 deprecations and ValueError

### DIFF
--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: c048a5adc2726c0e5b68c5d7d8751e9854b6f637 Maintainer: PhilDaiguille Status: ready -->
 
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -424,10 +422,8 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara>
-     Modo de autenticación SSL - No se requiere autenticación. (solo
-     para Oracle LDAP)
-    </simpara>
+    <simpara>Modo de autenticación SSL - No se requiere autenticación. (solo para Oracle LDAP)</simpara>
+    <warning><simpara>Obsoleto a partir de PHP 8.5.0.</simpara></warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.gslc-ssl-oneway-auth">
@@ -436,10 +432,8 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara>
-     Modo de autenticación SSL - Solo se requiere autenticación del servidor. (solo
-     para Oracle LDAP)
-    </simpara>
+    <simpara>Modo de autenticación SSL - Solo se requiere autenticación del servidor. (solo para Oracle LDAP)</simpara>
+    <warning><simpara>Obsoleto a partir de PHP 8.5.0.</simpara></warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.gslc-ssl-twoway-auth">
@@ -448,10 +442,8 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara>
-     Modo de autenticación SSL - Se requiere autenticación del servidor y del cliente. (solo
-     para Oracle LDAP)
-    </simpara>
+    <simpara>Modo de autenticación SSL - Se requiere autenticación del servidor y del cliente. (solo para Oracle LDAP)</simpara>
+    <warning><simpara>Obsoleto a partir de PHP 8.5.0.</simpara></warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.ldap-exop-start-tls">

--- a/reference/ldap/functions/ldap-connect-wallet.xml
+++ b/reference/ldap/functions/ldap-connect-wallet.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: Marqitos -->
+<!-- EN-Revision: c048a5adc2726c0e5b68c5d7d8751e9854b6f637 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ldap-connect-wallet" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_connect_wallet</refname>
@@ -72,6 +71,29 @@
   <para>
 
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Esta función ha quedado obsoleta. El soporte de Oracle LDAP
+       (Oracle Instant Client) está obsoleto en PHP 8.5.0.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87d63aa1a3fc86d64dc994332042fdd2c13bf3d8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c048a5adc2726c0e5b68c5d7d8751e9854b6f637 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ldap-connect" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_connect</refname>
@@ -115,6 +115,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Llamar a <function>ldap_connect</function> con argumentos de wallet de
+       Oracle está obsoleto. El soporte de Oracle LDAP (Oracle Instant Client)
+       está obsoleto a partir de PHP 8.5.0.
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: c048a5adc2726c0e5b68c5d7d8751e9854b6f637 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ldap-get-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_get_option</refname>
@@ -254,6 +253,8 @@
       <entry>8.5.0</entry>
       <entry>
        <parameter>ldap</parameter> ahora acepta &null;.
+       Ahora se lanza un <exceptionname>ValueError</exceptionname> cuando se
+       proporciona una <parameter>option</parameter> inválida.
       </entry>
      </row>
      &ldap.changelog.ldap-object;

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87d63aa1a3fc86d64dc994332042fdd2c13bf3d8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c048a5adc2726c0e5b68c5d7d8751e9854b6f637 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ldap-set-option" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ldap_set_option</refname>
@@ -259,6 +259,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ahora se lanza un <exceptionname>ValueError</exceptionname> cuando se
+       proporciona una <parameter>option</parameter> inválida.
+      </entry>
+     </row>
      &ldap.changelog.ldap-object;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Translation of php/doc-en#5805 (commit c048a5a): Oracle Instant Client constants and ldap_connect_wallet() deprecated in 8.5.0, ldap_connect() with wallet arguments deprecated, ValueError thrown by ldap_get_option()/ldap_set_option() on an invalid option. EN-Revision updated.

Fixes: #1181