### PR TITLE
[Sync-En] document the partitioned cookie attribute (PHP 8.5)

### DIFF
--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6122a8317ca0068fc71f6a5167e0a2d99166ec7c Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.setcookie" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>setcookie</refname>
@@ -157,7 +156,7 @@
       <simpara>
        Un &array; asociativo que puede tener como claves
        <literal>expires</literal>, <literal>path</literal>, <literal>domain</literal>,
-       <literal>secure</literal>, <literal>httponly</literal> y <literal>samesite</literal>.
+       <literal>secure</literal>, <literal>httponly</literal>, <literal>partitioned</literal> y <literal>samesite</literal>.
       </simpara>
       <simpara>
        Los valores tienen el mismo significado que los descritos para los argumentos
@@ -179,6 +178,13 @@
         Si <literal>samesite</literal> es <literal>"None"</literal>, entonces
         <literal>secure</literal> también debe estar habilitado o el cliente
         bloqueará la cookie.
+       </simpara>
+      </note>
+      <note>
+       <simpara>
+        Si <literal>partitioned</literal> es &true;, entonces
+        <literal>secure</literal> también debe estar habilitado; en caso
+        contrario se lanza un <exceptionname>ValueError</exceptionname>.
        </simpara>
       </note>
      </listitem>
@@ -228,6 +234,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Se añadió la entrada "partitioned" al array <parameter>options</parameter>.
+       Si se establece a <literal>true</literal>, la cookie se marcará como
+       Partitioned (CHIPS).
+      </entry>
+     </row>
      <row>
       <entry>8.2.0</entry>
       <entry>

--- a/reference/network/functions/setrawcookie.xml
+++ b/reference/network/functions/setrawcookie.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d829c7d11f311e5b115865fe6920f63aa2d9bde7 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.setrawcookie" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>setrawcookie</refname>
@@ -50,28 +49,34 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.3.0</entry>
-       <entry>
-        Se ha añadido una firma alternativa que soporta un array
-        de <parameter>options</parameter>. Esta firma permite
-        definir el atributo SameSite del cookie.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Se añadió la entrada "partitioned" al array <parameter>options</parameter>.
+       Si se establece a <literal>true</literal>, la cookie se marcará como
+       Partitioned (CHIPS).
+      </entry>
+     </row>
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Se ha añadido una firma alternativa que soporta un array
+       de <parameter>options</parameter>. Esta firma permite
+       definir el atributo SameSite del cookie.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/session/functions/session-get-cookie-params.xml
+++ b/reference/session/functions/session-get-cookie-params.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 35b95a56ccc03b66af7117fc815ac7881e2e0ad3 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-get-cookie-params">
  <refnamediv>
@@ -56,6 +54,12 @@
     </listitem>
     <listitem>
      <simpara>
+      <link linkend="ini.session.cookie-partitioned">"<literal>partitioned</literal>"</link>:
+      la cookie se marca como Partitioned (CHIPS).
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
       <link linkend="ini.session.cookie-httponly">"<literal>httponly</literal>"</link>:
       el cookie será accesible solo vía el protocolo HTTP.
      </simpara>
@@ -82,6 +86,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        La entrada "<literal>partitioned</literal>" ha sido añadida en el array devuelto.
+       </entry>
+      </row>
       <row>
        <entry>7.3.0</entry>
        <entry>
@@ -112,6 +122,9 @@
     </member>
     <member>
      <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>
+    </member>
+    <member>
+     <link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link>
     </member>
     <member>
      <link linkend="ini.session.cookie-samesite">session.cookie_samesite</link>

--- a/reference/session/functions/session-set-cookie-params.xml
+++ b/reference/session/functions/session-set-cookie-params.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 37be0e0626e8b96e617e800392651eacc5f65bdc Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.session-set-cookie-params" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>session_set_cookie_params</refname>
@@ -47,11 +45,12 @@
        Al utilizar la primera firma, la duración de vida de la cookie, en segundos.
        Ver la directiva <link linkend="ini.session.cookie-lifetime">lifetime</link>.
       </para>
-      <para>
+      <simpara>
        Al utilizar la segunda firma,
        un &array; asociativo que puede tener como claves
        <literal>lifetime</literal>, <literal>path</literal>, <literal>domain</literal>,
-       <literal>secure</literal>, <literal>httponly</literal> y <literal>samesite</literal>.
+       <literal>secure</literal>, <literal>httponly</literal>, <literal>partitioned</literal>
+       y <literal>samesite</literal>.
        Los valores tienen la misma significación que los descritos para los parámetros
        con el mismo nombre. El valor del elemento <literal>samesite</literal> debe ser
        <literal>Lax</literal> o <literal>Strict</literal>.
@@ -59,7 +58,7 @@
        idéntico al valor por defecto de los parámetros explícitos. Si el elemento
        <literal>samesite</literal> es omitido, entonces el atributo SameSite de la cookie
        no será definido.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -126,6 +125,14 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Se añadió la entrada "partitioned" al array
+        <parameter>lifetime_or_options</parameter>. Si se establece a
+        <literal>true</literal>, la cookie se marcará como Partitioned (CHIPS).
+       </entry>
+      </row>
+      <row>
        <entry>8.0.0</entry>
        <entry>
         <parameter>path</parameter>, <parameter>domain</parameter>,
@@ -170,6 +177,9 @@
     </member>
     <member>
      <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>
+    </member>
+    <member>
+     <link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link>
     </member>
     <member>
      <link linkend="ini.session.cookie-samesite">session.cookie_samesite</link>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7fabff299de8a894888e8064797ed3278f50b356 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: PhilDaiguille Status: ready -->
 
 <section xml:id="session.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -95,6 +94,12 @@
       <entry>"0"</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Anterior a PHP 7.2.0, el valor por omisión era <literal>""</literal>.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link></entry>
+      <entry>"0"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>Disponible a partir de PHP 8.5.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.cookie-samesite">session.cookie_samesite</link></entry>
@@ -682,6 +687,27 @@
       que la cookie no será accesible por los lenguajes de script, como Javascript.
       Esta configuración permite limitar ataques como los ataques XSS (aunque
       no es soportado por todos los navegadores).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.session.cookie-partitioned">
+    <term>
+     <parameter>session.cookie_partitioned</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Marca la cookie como particionada (CHIPS), lo que significa que la cookie
+      quedará aislada en un contexto de origen (first-party). Esta
+      configuración ayuda a mitigar el rastreo entre sitios (aunque no está
+      soportada por todos los navegadores).
+     </simpara>
+     <simpara>
+      Si se habilita, también debe habilitarse
+      <link linkend="ini.session.cookie-secure">session.cookie_secure</link>;
+      en caso contrario la cookie de sesión no se enviará y se emitirá una
+      advertencia.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Translation of php/doc-en#5051 (commit 736b8b3): the "partitioned" option for setcookie()/setrawcookie()/session_set_cookie_params(), the entry returned by session_get_cookie_params(), and the new session.cookie_partitioned INI directive. EN-Revision updated.

Fixes: #1182