### PR TITLE
[Sync-En] ssl context: document the missing SSL context options

### DIFF
--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 8bc832a464e33122e8129f5a623bd845b69fa7e0 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6819d9e5807762161caace88a21930156a313195 Maintainer: PhilDaiguille Status: ready -->
 
 <refentry xml:id="context.ssl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
@@ -11,280 +9,386 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>
+  <simpara>
    Opciones de contexto para los protocolos <literal>ssl://</literal>
    y <literal>tls://</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
-  <para>
-   <variablelist>
-    <varlistentry xml:id="context.ssl.peer-name">
-     <term>
-      <parameter>peer_name</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Nombre de pares a utilizar. Si este valor no está definido, entonces el
-       nombre será adivinado basándose en el nombre de host utilizado al abrir el flujo.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-peer">
-     <term>
-      <parameter>verify_peer</parameter>
-      &boolean;
-     </term>
-     <listitem>
-      <para>
-       Requiere una verificación del certificado SSL utilizado.
-      </para>
-      <para>
-       Por omisión, vale &true;.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-peer-name">
-     <term>
-      <parameter>verify_peer_name</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Requiere la verificación del nombre de pares.
-      </para>
-      <para>
-       Por omisión, vale &true;.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.allow-self-signed">
-     <term>
-      <parameter>allow_self_signed</parameter>
-      &boolean;
-     </term>
-     <listitem>
-      <para>
-       Permite los certificados autofirmados. Requiere el
-       parámetro <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>.
-      </para>
-      <para>
-       Por omisión, vale &false;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.cafile">
-     <term>
-      <parameter>cafile</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Ubicación del fichero de la autoridad del certificado
-       en el sistema de ficheros local que deberá ser utilizado
-       con la opción de contexto <literal>verify_peer</literal>
-       para identificar el par distante.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capath">
-     <term>
-      <parameter>capath</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Si <literal>cafile</literal> no está especificado o si el certificado
-       no ha sido encontrado, se realizará una búsqueda en el directorio señalado por
-       <literal>capath</literal> para encontrar un certificado válido. <literal>capath</literal> debe ser un directorio de certificados válido.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.local-cert">
-     <term>
-      <parameter>local_cert</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Ruta al certificado local, en el sistema de ficheros.
-       Debe ser un fichero codificado <acronym>PEM</acronym> que contiene su certificado
-       y su clave privada. Puede, opcionalmente, contener la
-       cadena de certificación del emisor.
-       La clave privada también puede estar contenida en un fichero separado
-       especificado por <literal>local_pk</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.local-pk">
-     <term>
-      <parameter>local_pk</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Ruta de acceso al fichero de clave privada local en el sistema de
-       ficheros en el caso de ficheros separados para el certificado
-       (<literal>local_cert</literal>) y la clave privada.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.passphrase">
-     <term>
-      <parameter>passphrase</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       La frase de paso con la que su fichero
-       <literal>local_cert</literal> ha sido codificado.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-depth">
-     <term>
-      <parameter>verify_depth</parameter>
-      <type>int</type>
-     </term>
-     <listitem>
-      <para>
-       Fallará si la cadena de certificación es demasiado profunda.
-      </para>
-      <para>
-       Por omisión, no se realiza ninguna verificación.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.ciphers">
-     <term>
-      <parameter>ciphers</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Define la lista de cifrados. El formato de la cadena está descrito
-       en la página <link xlink:href="&url.openssl.ciphers;">ciphers(1)</link>.
-      </para>
-      <para>
-       Por omisión, vale <literal>DEFAULT</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capture-peer-cert">
-     <term>
-      <parameter>capture_peer_cert</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Si se define a &true;, se creará una opción de contexto <literal>peer_certificate</literal>
-       que contendrá el certificado del emisor.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capture-peer-cert-chain">
-     <term>
-      <parameter>capture_peer_cert_chain</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Si se define a &true;, se creará una opción de contexto <literal>peer_certificate_chain</literal>
-       que contendrá la cadena de certificación.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.sni-enabled">
-     <term>
-      <parameter>SNI_enabled</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Si vale &true;, la indicación sobre el nombre del servidor estará activada.
-       Activar SNI permite utilizar múltiples certificados
-       en la misma dirección IP.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.disable-compression">
-     <term>
-      <parameter>disable_compression</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Si se define, la compresión TLS estará desactivada.
-       Esto puede ayudar a mitigar el vector de ataque CRIME.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.peer-fingerprint">
-     <term>
-      <parameter>peer_fingerprint</parameter>
-      <type>string</type> | <type>array</type>
-     </term>
-     <listitem>
-      <para>
-       Se detiene cuando el digest del certificado distante no coincide con el hash especificado.
-      </para>
-      <para>
-       Cuando se utiliza una &string;, la longitud determinará el algoritmo
-       de hachaje utilizado, ya sea "md5" (32) o "sha1" (40).
-      </para>
-      <para>
-       Cuando se utiliza un &array;, la clave indica el nombre del algoritmo de
-       hachaje, y cada valor correspondiente representa el digest esperado.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.security-level">
-     <term>
-      <parameter>security_level</parameter>
-      <type>int</type>
-     </term>
-     <listitem>
-      <para>
-       Define el nivel de seguridad. Si no se especifica, se utiliza el nivel de seguridad por
-       omisión.
-       Los niveles de seguridad están descritos en
-       <link xlink:href="&url.openssl.security-level;">SSL_CTX_get_security_level(3)</link>.
-      </para>
-      <para>
-       Disponible a partir de PHP 7.2.0 y OpenSSL 1.1.0.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
- </refsect1><!-- }}} -->
+  <variablelist>
+   <varlistentry xml:id="context.ssl.peer-name">
+    <term>
+     <parameter>peer_name</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Nombre de pares a utilizar. Si este valor no está definido, entonces el
+      nombre será adivinado basándose en el nombre de host utilizado al abrir el flujo.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-peer">
+    <term>
+     <parameter>verify_peer</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Requiere una verificación del certificado SSL utilizado.
+     </simpara>
+     <simpara>
+      Por omisión, vale &true;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-peer-name">
+    <term>
+     <parameter>verify_peer_name</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Requiere la verificación del nombre de pares.
+     </simpara>
+     <simpara>
+      Por omisión, vale &true;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.allow-self-signed">
+    <term>
+     <parameter>allow_self_signed</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Permite los certificados autofirmados. Requiere el
+      parámetro <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>.
+     </simpara>
+     <simpara>
+      Por omisión, vale &false;
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.cafile">
+    <term>
+     <parameter>cafile</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Ubicación del fichero de la autoridad del certificado
+      en el sistema de ficheros local que deberá ser utilizado
+      con la opción de contexto <literal>verify_peer</literal>
+      para identificar el par distante.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capath">
+    <term>
+     <parameter>capath</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si <literal>cafile</literal> no está especificado o si el certificado
+      no ha sido encontrado, se realizará una búsqueda en el directorio señalado por
+      <literal>capath</literal> para encontrar un certificado válido. <literal>capath</literal> debe ser un directorio de certificados válido.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.local-cert">
+    <term>
+     <parameter>local_cert</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Ruta al certificado local, en el sistema de ficheros.
+      Debe ser un fichero codificado <acronym>PEM</acronym> que contiene el certificado
+      y la clave privada. Puede, opcionalmente, contener la
+      cadena de certificación del emisor.
+      La clave privada también puede estar contenida en un fichero separado
+      especificado por <literal>local_pk</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.local-pk">
+    <term>
+     <parameter>local_pk</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Ruta de acceso al fichero de clave privada local en el sistema de
+      ficheros en el caso de ficheros separados para el certificado
+      (<literal>local_cert</literal>) y la clave privada.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.passphrase">
+    <term>
+     <parameter>passphrase</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      La frase de paso con la que el fichero
+      <literal>local_cert</literal> ha sido codificado.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-depth">
+    <term>
+     <parameter>verify_depth</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Fallará si la cadena de certificación es demasiado profunda.
+     </simpara>
+     <simpara>
+      Por omisión, no se realiza ninguna verificación.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.ciphers">
+    <term>
+     <parameter>ciphers</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Define la lista de cifrados. El formato de la cadena está descrito
+      en la página <link xlink:href="&url.openssl.ciphers;">ciphers(1)</link>.
+     </simpara>
+     <simpara>
+      Por omisión, vale <literal>DEFAULT</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capture-peer-cert">
+    <term>
+     <parameter>capture_peer_cert</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si se define a &true;, se creará una opción de contexto <literal>peer_certificate</literal>
+      que contendrá el certificado del emisor.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capture-peer-cert-chain">
+    <term>
+     <parameter>capture_peer_cert_chain</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si se define a &true;, se creará una opción de contexto <literal>peer_certificate_chain</literal>
+      que contendrá la cadena de certificación.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.sni-enabled">
+    <term>
+     <parameter>SNI_enabled</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si vale &true;, la indicación sobre el nombre del servidor estará activada.
+      Activar SNI permite utilizar múltiples certificados
+      en la misma dirección IP.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.sni-server-certs">
+    <term>
+     <parameter>SNI_server_certs</parameter>
+     <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      Un array de nombres de servidores y sus certificados correspondientes, a
+      utilizar para SNI. Las claves son los nombres de los servidores y los
+      valores son las rutas a los ficheros de certificado en el sistema de
+      ficheros local. Los ficheros de certificado deben estar codificados en
+      <acronym>PEM</acronym> y contener tanto el certificado como la clave privada.
+     </simpara>
+     <simpara>
+      Disponible a partir de PHP 5.6.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.alpn-protocols">
+    <term>
+     <parameter>alpn_protocols</parameter>
+     <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      Un array de nombres de protocolos de la capa de aplicación a utilizar
+      para ALPN (Application-Layer Protocol Negotiation). Los valores son los
+      nombres de los protocolos en forma de strings (por ejemplo "http/1.1",
+      "h2").
+     </simpara>
+     <simpara>
+      Disponible a partir de PHP 7.0.0 y OpenSSL 1.0.2.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.no-ticket">
+    <term>
+     <parameter>no_ticket</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si se define, los tickets de sesión TLS quedan desactivados. Esto puede
+      ayudar a reforzar la seguridad aportando confidencialidad persistente
+      (Perfect Forward Secrecy, PFS).
+     </simpara>
+     <simpara>
+      Disponible a partir de PHP 5.3.6.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.disable-compression">
+    <term>
+     <parameter>disable_compression</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si se define, la compresión TLS estará desactivada.
+      Esto puede ayudar a mitigar el vector de ataque CRIME.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.peer-fingerprint">
+    <term>
+     <parameter>peer_fingerprint</parameter>
+     <type>string</type> | <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      Se detiene cuando el digest del certificado distante no coincide con el hash especificado.
+     </simpara>
+     <simpara>
+      Cuando se utiliza una &string;, la longitud determinará el algoritmo
+      de hachaje utilizado, ya sea "md5" (32) o "sha1" (40).
+     </simpara>
+     <simpara>
+      Cuando se utiliza un &array;, la clave indica el nombre del algoritmo de
+      hachaje, y cada valor correspondiente representa el digest esperado.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.security-level">
+    <term>
+     <parameter>security_level</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Define el nivel de seguridad. Si no se especifica, se utiliza el nivel de seguridad por
+      omisión de la biblioteca.
+      Los niveles de seguridad están descritos en
+      <link xlink:href="&url.openssl.security-level;">SSL_CTX_get_security_level(3)</link>.
+     </simpara>
+     <simpara>
+      Disponible a partir de PHP 7.2.0 y OpenSSL 1.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.min-proto-version">
+    <term>
+     <parameter>min_proto_version</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Define la versión mínima del protocolo permitida. Si no se especifica, se
+      utiliza la versión mínima del protocolo por omisión de la biblioteca.
+      Las versiones del protocolo están descritas en
+      <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_min_proto_version(3)</link>.
+     </simpara>
+     <simpara>
+      Disponible a partir de PHP 7.3.0 y OpenSSL 1.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.max-proto-version">
+    <term>
+     <parameter>max_proto_version</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Define la versión máxima del protocolo permitida. Si no se especifica, se
+      utiliza la versión máxima del protocolo por omisión de la biblioteca.
+      Las versiones del protocolo están descritas en
+      <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_max_proto_version(3)</link>.
+     </simpara>
+     <simpara>
+      Disponible a partir de PHP 7.3.0 y OpenSSL 1.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.2.0</entry>
-       <entry>
-        Adición de <parameter>security_level</parameter>. Requiere OpenSSL &gt;= 1.1.0.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1><!-- }}} -->
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Adición de <parameter>min_proto_version</parameter> y
+       <parameter>max_proto_version</parameter>. Requiere OpenSSL &gt;= 1.1.0.
+      </entry>
+     </row>
+     <row>
+      <entry>7.2.0</entry>
+      <entry>
+       Adición de <parameter>security_level</parameter>. Requiere OpenSSL &gt;= 1.1.0.
+      </entry>
+     </row>
+     <row>
+      <entry>7.0.0</entry>
+      <entry>
+       Adición de <parameter>alpn_protocols</parameter>. Requiere OpenSSL &gt;= 1.0.2.
+      </entry>
+     </row>
+     <row>
+      <entry>5.6.0</entry>
+      <entry>
+       Adición de <parameter>SNI_server_certs</parameter>.
+      </entry>
+     </row>
+     <row>
+      <entry>5.3.6</entry>
+      <entry>
+       Adición de <parameter>no_ticket</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
@@ -309,11 +413,9 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><xref linkend="context.socket" /></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><xref linkend="context.socket" /></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/openssl/functions/openssl-x509-verify.xml
+++ b/reference/openssl/functions/openssl-x509-verify.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6819d9e5807762161caace88a21930156a313195 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.openssl-x509-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_x509_verify</refname>
@@ -101,7 +99,7 @@ $ssloptions = array(
     "CN_match" => $hostname,
     "verify_peer" => true,
     "SNI_enabled" => true,
-    "SNI_server_name" => $hostname,
+    "peer_name" => $hostname,
 );
 
 $ctx = stream_context_create( array("ssl" => $ssloptions) );


### PR DESCRIPTION
Translation of php/doc-en#5413 (commit 6819d9e): adds SNI_server_certs, alpn_protocols, no_ticket, min_proto_version and max_proto_version, completes the changelog, unwraps the lists from their para and fixes the SNI_server_name option name in the openssl_x509_verify() example. EN-Revision updated.

Fixes: #1183