### PR TITLE
[Sync-En] in_array(): clarify the loose comparison behaviour as of PHP 8.0

### DIFF
--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 40514c7a2d1262c4126d2c8906835ecaf53d6354 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.in-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>in_array</refname>
@@ -55,14 +54,24 @@
        coincide con el tipo del valor encontrado en <parameter>haystack</parameter>.
       </para>
       <note>
-       <para>
-        Antes de PHP 8.0.0, un <literal>string</literal> <parameter>needle</parameter> coincidirá
-        con un valor de array de <literal>0</literal> en modo no estricto y viceversa.
-        Esto puede llevar a resultados no deseados.
-        Casos similares también existen para otros tipos.
-        Si no se está absolutamente seguro de los tipos de valores involucrados,
-        siempre se debe utilizar el flag <parameter>strict</parameter> para evitar cualquier comportamiento inesperado.
-       </para>
+       <simpara>
+        Anterior a PHP 8.0.0, un <parameter>needle</parameter> de tipo
+        <type>string</type> no numérico coincidía de forma laxa con un valor
+        <literal>0</literal> de <parameter>haystack</parameter>, y viceversa. A
+        partir de PHP 8.0.0, el número se convierte a <type>string</type> y
+        ambos se comparan como strings, de modo que solo sigue coincidiendo una
+        <type>string</type> numérica con el mismo valor.
+       </simpara>
+       <simpara>
+        No obstante, el modo no estricto utiliza una
+        <link linkend="types.comparisions-loose">comparación laxa</link>, por lo
+        que valores de tipos distintos pueden seguir considerándose iguales:
+        &true; coincide con cualquier <type>string</type> evaluada como
+        verdadera, y &false; coincide tanto con <literal>""</literal> como con
+        <literal>"0"</literal>. A menos que se conozcan con certeza los tipos de
+        todos los valores involucrados, se debe pasar siempre
+        <parameter>strict</parameter> para forzar una comparación de identidad.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Translation of php/doc-en#5519 (commit 40514c7): the note on non-strict mode now describes the PHP 8.0 string/number comparison and the remaining loose-comparison pitfalls. EN-Revision updated.

Fixes: #1185