### PR TITLE
[Sync-En] ssh2: translate five previously undocumented functions

### DIFF
--- a/reference/ssh2/functions/ssh2-auth-agent.xml
+++ b/reference/ssh2/functions/ssh2-auth-agent.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-auth-agent">
  <refnamediv>
   <refname>ssh2_auth_agent</refname>
@@ -21,7 +19,7 @@
   <note>
     <simpara>
      La función <function>ssh2_auth_agent</function> solo está disponible
-     cuando la extensión ssh2 ha sido compilada con libssh &gt;= 1.2.3.
+     cuando la extensión ssh2 ha sido compilada con libssh2 &gt;= 1.2.3.
     </simpara>
   </note>
  </refsect1>

--- a/reference/ssh2/functions/ssh2-auth-pubkey-file.xml
+++ b/reference/ssh2/functions/ssh2-auth-pubkey-file.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 74ef2355c59e814d14f75a0792d22727be72f137 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: PhilDaiguille Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-auth-pubkey-file">
  <refnamediv>
   <refname>ssh2_auth_pubkey_file</refname>
@@ -106,7 +104,7 @@ if (ssh2_auth_pubkey_file($connection, 'username',
   &reftitle.notes;
   <note>
    <simpara>
-    La biblioteca libssh subyacente no soporta muy limpiamente las
+    La biblioteca libssh2 subyacente no soporta muy limpiamente las
     autenticaciones parciales. Es decir, que si debe proporcionar a la
     vez una clave pública y una contraseña, entonces parecerá como si
     la función estuviera en error. En este caso particular, un error en esta

--- a/reference/ssh2/functions/ssh2-auth-pubkey.xml
+++ b/reference/ssh2/functions/ssh2-auth-pubkey.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 74ef2355c59e814d14f75a0792d22727be72f137 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-auth-pubkey">
  <refnamediv>
   <refname>ssh2_auth_pubkey</refname>
@@ -108,7 +106,7 @@ if (ssh2_auth_pubkey($connection, 'username',
   &reftitle.notes;
   <note>
    <simpara>
-    La biblioteca libssh subyacente no soporta muy limpiamente las
+    La biblioteca libssh2 subyacente no soporta muy limpiamente las
     autenticaciones parciales. Es decir, que si debe proporcionar a la
     vez una clave pública y una contraseña, entonces parecerá como si
     la función estuviera en error. En este caso particular, un error en esta

--- a/reference/ssh2/functions/ssh2-keepalive-config.xml
+++ b/reference/ssh2/functions/ssh2-keepalive-config.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-keepalive-config" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_keepalive_config</refname>
+  <refpurpose>Configura la frecuencia de envío de los mensajes de mantenimiento de conexión</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>ssh2_keepalive_config</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>want_reply</parameter></methodparam>
+   <methodparam><type>int</type><parameter>interval</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Configura con qué frecuencia se envían los mensajes de mantenimiento de
+   conexión en la <parameter>session</parameter> indicada, y si se solicita al
+   servidor que responda a ellos.
+  </simpara>
+  <simpara>
+   Los mensajes de mantenimiento de conexión no se envían automáticamente. Una
+   vez configurados, se debe llamar a <function>ssh2_keepalive_send</function>
+   para enviar realmente un mensaje de mantenimiento de conexión.
+  </simpara>
+  <note>
+   <simpara>
+    Esta función solo está disponible cuando la extensión se compila con una
+    versión de libssh2 que proporciona soporte de mantenimiento de conexión.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      Un identificador de enlace de conexión SSH, obtenido de una llamada a
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>want_reply</parameter></term>
+    <listitem>
+     <simpara>
+      Indica si se solicita al servidor que responda a los mensajes de
+      mantenimiento de conexión. Solicitar una respuesta permite detectar un
+      servidor que no responde, a costa de algo de tráfico adicional.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>interval</parameter></term>
+    <listitem>
+     <simpara>
+      El número de segundos que pueden transcurrir sin ningún tráfico antes de
+      que deba enviarse un mensaje de mantenimiento de conexión. El valor
+      <literal>0</literal> deshabilita los mensajes de mantenimiento de
+      conexión, y el valor <literal>1</literal> es tratado como
+      <literal>2</literal> por la biblioteca subyacente.
+     </simpara>
+     <simpara>
+      Los valores aceptados van de <literal>0</literal> a
+      <literal>4294967295</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Se emite un error de nivel <constant>E_WARNING</constant> cuando
+   <parameter>interval</parameter> queda fuera del rango aceptado; en ese caso
+   la configuración del mantenimiento de conexión permanece sin cambios.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Envío de mensajes de mantenimiento de conexión</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+// Solicita una respuesta del servidor, tras 30 segundos sin ningún tráfico
+ssh2_keepalive_config($connection, true, 30);
+
+// Los mensajes de mantenimiento de conexión solo se envían en esta llamada
+ssh2_keepalive_send($connection);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_keepalive_send</function></member>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-keepalive-send.xml
+++ b/reference/ssh2/functions/ssh2-keepalive-send.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-keepalive-send" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_keepalive_send</refname>
+  <refpurpose>Envía un mensaje de mantenimiento de conexión</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>ssh2_keepalive_send</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Envía un mensaje de mantenimiento de conexión en la
+   <parameter>session</parameter> indicada, de acuerdo con la configuración
+   establecida con <function>ssh2_keepalive_config</function>.
+  </simpara>
+  <note>
+   <simpara>
+    Esta función solo está disponible cuando la extensión se compila con una
+    versión de libssh2 que proporciona soporte de mantenimiento de conexión.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      Un identificador de enlace de conexión SSH, obtenido de una llamada a
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve el número de segundos que pueden transcurrir antes de que deba
+   enviarse otro mensaje de mantenimiento de conexión, o &false; en caso de
+   error. Devuelve <literal>0</literal> cuando los mensajes de mantenimiento de
+   conexión están deshabilitados.
+  </simpara>
+  <simpara>
+   Puesto que tanto <literal>0</literal> como &false; se evalúan como falso,
+   debe utilizarse el operador <literal>===</literal> para distinguirlos.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Envío de un mensaje de mantenimiento de conexión</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+ssh2_keepalive_config($connection, true, 30);
+
+$seconds = ssh2_keepalive_send($connection);
+
+if ($seconds === false) {
+    echo "No se ha podido enviar el mensaje de mantenimiento de conexión", PHP_EOL;
+} elseif ($seconds === 0) {
+    echo "Los mensajes de mantenimiento de conexión están deshabilitados", PHP_EOL;
+} else {
+    echo "Próximo mensaje de mantenimiento de conexión en $seconds segundos", PHP_EOL;
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_keepalive_config</function></member>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-send-signal.xml
+++ b/reference/ssh2/functions/ssh2-send-signal.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-send-signal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_send_signal</refname>
+  <refpurpose>Envía una señal a un proceso remoto</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>ssh2_send_signal</methodname>
+   <methodparam><type>resource</type><parameter>channel</parameter></methodparam>
+   <methodparam><type>string</type><parameter>signal</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Envía una señal al proceso que se ejecuta en el extremo remoto del
+   <parameter>channel</parameter> indicado.
+  </simpara>
+  <note>
+   <simpara>
+    Esta función solo está disponible cuando la extensión se compila con
+    libssh2 &gt;= 1.9.0.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>channel</parameter></term>
+    <listitem>
+     <simpara>
+      Un flujo de canal SSH, tal como el devuelto por
+      <function>ssh2_exec</function> o <function>ssh2_shell</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>signal</parameter></term>
+    <listitem>
+     <simpara>
+      El nombre de la señal a enviar, sin el prefijo <literal>SIG</literal>,
+      tal como lo define el protocolo de conexión SSH
+      (<link xlink:href="&url.rfc;4254">RFC 4254</link>); por ejemplo
+      <literal>TERM</literal>, <literal>KILL</literal> o
+      <literal>INT</literal>.
+     </simpara>
+     <simpara>
+      El valor se transmite al servidor tal cual; no se valida contra los
+      nombres enumerados por el protocolo.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Se emite un error de nivel <constant>E_WARNING</constant> cuando
+   <parameter>channel</parameter> no es un flujo de canal SSH, y cuando no se
+   ha podido enviar la señal.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Interrupción de un comando remoto</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+$stream = ssh2_exec($connection, 'trap "echo interrupted" INT; sleep 60');
+
+ssh2_send_signal($stream, 'INT');
+
+stream_set_blocking($stream, true);
+echo stream_get_contents($stream);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_exec</function></member>
+   <member><function>ssh2_shell</function></member>
+   <member><function>ssh2_send_eof</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-set-timeout.xml
+++ b/reference/ssh2/functions/ssh2-set-timeout.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-set-timeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_set_timeout</refname>
+  <refpurpose>Define el tiempo límite de las operaciones bloqueantes de una sesión</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>ssh2_set_timeout</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+   <methodparam><type>int</type><parameter>seconds</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>microseconds</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Define cuánto tiempo puede esperar una operación bloqueante en la
+   <parameter>session</parameter> indicada antes de considerarse expirada.
+  </simpara>
+  <simpara>
+   Cuando el tiempo límite resultante es <literal>0</literal>, que es el valor
+   por omisión, no se aplica ningún tiempo límite y las operaciones bloqueantes
+   pueden esperar indefinidamente.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      Un identificador de enlace de conexión SSH, obtenido de una llamada a
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>seconds</parameter></term>
+    <listitem>
+     <simpara>
+      El tiempo límite, en segundos.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>microseconds</parameter></term>
+    <listitem>
+     <simpara>
+      Un número adicional de microsegundos que se añade al tiempo límite. La
+      biblioteca subyacente solo soporta precisión de milisegundos, por lo que
+      este valor se redondea al milisegundo entero superior.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Limitación del tiempo de espera de las operaciones bloqueantes</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+
+// Abandona las operaciones bloqueantes tras 5,5 segundos
+ssh2_set_timeout($connection, 5, 500000);
+
+ssh2_auth_password($connection, 'username', 'password');
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_connect</function></member>
+   <member><function>ssh2_keepalive_config</function></member>
+   <member><function>stream_set_timeout</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-shell-resize.xml
+++ b/reference/ssh2/functions/ssh2-shell-resize.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-shell-resize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_shell_resize</refname>
+  <refpurpose>Cambia las dimensiones del pseudoterminal de un canal</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>ssh2_shell_resize</methodname>
+   <methodparam><type>resource</type><parameter>channel</parameter></methodparam>
+   <methodparam><type>int</type><parameter>width</parameter></methodparam>
+   <methodparam><type>int</type><parameter>height</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>width_px</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>height_px</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Solicita que el pseudoterminal (PTY) asociado al
+   <parameter>channel</parameter> indicado se redimensione a las dimensiones
+   dadas.
+  </simpara>
+  <note>
+   <simpara>
+    La extensión solo declara los tres primeros parámetros, con el nombre
+    <literal>session</literal> para <parameter>channel</parameter>. Por
+    consiguiente, <parameter>width_px</parameter> y
+    <parameter>height_px</parameter> solo pueden pasarse posicionalmente.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>channel</parameter></term>
+    <listitem>
+     <simpara>
+      Un flujo de canal SSH, tal como el devuelto por
+      <function>ssh2_exec</function> o <function>ssh2_shell</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width</parameter></term>
+    <listitem>
+     <simpara>
+      El ancho del terminal, en caracteres.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>height</parameter></term>
+    <listitem>
+     <simpara>
+      La altura del terminal, en caracteres.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width_px</parameter></term>
+    <listitem>
+     <simpara>
+      El ancho del terminal en píxeles, o <literal>0</literal> para dejar sin
+      especificar las dimensiones en píxeles.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>height_px</parameter></term>
+    <listitem>
+     <simpara>
+      La altura del terminal en píxeles, o <literal>0</literal> para dejar sin
+      especificar las dimensiones en píxeles.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve &true;, o &false; cuando <parameter>channel</parameter> no es un
+   flujo de canal SSH.
+  </simpara>
+  <simpara>
+   El resultado de la propia solicitud de redimensionado no se informa: se
+   devuelve &true; incluso cuando el extremo remoto no la atiende.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Se emite un error de nivel <constant>E_WARNING</constant> cuando
+   <parameter>channel</parameter> no es un flujo de canal SSH.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Redimensionado del pseudoterminal de un shell</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+$shell = ssh2_shell($connection, 'xterm', null, 80, 24);
+
+// Indica al extremo remoto que el terminal tiene ahora 132 columnas por 43 filas
+ssh2_shell_resize($shell, 132, 43);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_shell</function></member>
+   <member><function>ssh2_exec</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/setup.xml
+++ b/reference/ssh2/setup.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: PhilDaiguille Status: ready -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ssh2.setup">
  &reftitle.setup;
 
@@ -21,11 +20,11 @@
   </simpara>
   <simpara>
    La función <function>ssh2_auth_agent</function> estará disponible únicamente
-   con libssh &gt;= 1.2.3.
+   con libssh2 &gt;= 1.2.3.
   </simpara>
   <simpara>
    El soporte para <function>stream_set_timeout</function> para canalizar secuencias
-   sólo estará disponible con libssh &gt;= 1.2.9.
+   sólo estará disponible con libssh2 &gt;= 1.2.9.
   </simpara>
   <simpara>
    libssh2 viene en dos versiones: gcrypt y openssl. Algunas distribuciones


### PR DESCRIPTION
Translation of php/doc-en#5688 (commit 3c1b114): new pages for ssh2_keepalive_config(), ssh2_keepalive_send(), ssh2_send_signal(), ssh2_set_timeout() and ssh2_shell_resize(), plus the libssh -> libssh2 fixes in the existing pages. EN-Revision updated.

Fixes: #1186