### PR TITLE
[Sync-En] ext/session: document the 8.4.0 INI deprecations

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7fabff299de8a894888e8064797ed3278f50b356 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: PhilDaiguille Status: ready -->
 
 <section xml:id="session.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -166,13 +165,19 @@
       <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
       <entry>"32"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Disponible a partir de PHP 7.1.0. Obsoleto a partir de PHP 8.4.0.</entry>
+      <entry>
+       Disponible a partir de PHP 7.1.0.
+       Modificar esta directiva está obsoleto a partir de PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.sid-bits-per-character">session.sid_bits_per_character</link></entry>
       <entry>"4"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Disponible a partir de PHP 7.1.0. Obsoleto a partir de PHP 8.4.0.</entry>
+      <entry>
+       Disponible a partir de PHP 7.1.0.
+       Modificar esta directiva está obsoleto a partir de PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.upload-progress.enabled">session.upload_progress.enabled</link></entry>
@@ -844,26 +849,15 @@
       comprendida entre 22 y 256.
      </simpara>
      <simpara>
-      El valor por omisión es 32. Si necesita compatibilidad, puede especificar 32, 40, etc. El ID de sesión más largo es más difícil
-      de adivinar. Al menos 32 caracteres son recomendados.
+      El valor por omisión es 32. Un ID de sesión más largo es más difícil de
+      adivinar.
      </simpara>
-     <tip>
-      <para>
-       Nota de compatibilidad: utilizar 32 en lugar de
-       <literal>session.hash_function</literal>=0 (MD5) y
-       <literal>session.hash_bits_per_character</literal>=4,
-       <literal>session.hash_function</literal>=1 (SHA1) y
-       <literal>session.hash_bits_per_character</literal>=6. Utilizar 26 en lugar de
-       <literal>session.hash_function</literal>=0 (MD5) y
-       <literal>session.hash_bits_per_character</literal>=5. Utilizar 22 en lugar de
-       <literal>session.hash_function</literal>=0 (MD5) y
-       <literal>session.hash_bits_per_character</literal>=6.
-       Debe configurar los valores INI para que haya 128 bits en
-       el ID de sesión. No olvide definir el valor apropiado a
-       <literal>session.sid_bits_per_character</literal>, de lo contrario tendrá
-       ID de sesión más débiles.
-      </para>
-     </tip>
+     <warning>
+      <simpara>
+       Modificar <literal>session.sid_length</literal> respecto a su valor por
+       omisión está obsoleto a partir de PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        Disponible a partir de PHP 7.1.0.
@@ -885,11 +879,15 @@
       '4' (0-9, a-f), '5' (0-9, a-v), y '6' (0-9, a-z, A-Z, "-", ",").
      </simpara>
      <simpara>
-      El valor por omisión es 4. Más bits resultan en un ID de sesión más
-      fuerte. 5 es el valor recomendado para la mayoría de los entornos.
+      El valor por omisión es 4. Un número de bits mayor resulta en un ID de
+      sesión más fuerte.
      </simpara>
-     <para>
-     </para>
+     <warning>
+      <simpara>
+       Modificar <literal>session.sid_bits_per_character</literal> respecto a su
+       valor por omisión está obsoleto a partir de PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        Disponible a partir de PHP 7.1.0.

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 55e0481a24fd4d7db21b62f1885973edbca25e60 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 35cadcfe561fc27ee973457a64880f0b85db2ec5 Maintainer: PhilDaiguille Status: ready -->
 
 <chapter xml:id="session.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Sesiones y Seguridad</title>
@@ -722,14 +720,18 @@
     <para>
      <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>=Off
     </para>
-    <para>
-     El uso de un gestor de identificadores de sesiones transparente
-     no está prohibido. Los desarrolladores deben emplearlo cuando sea necesario.
-     Sin embargo, la desactivación de la gestión de identificadores de sesión de
-     forma transparente permite asegurar un poco más los identificadores de sesión
-     eliminando la posibilidad de una inyección de identificador de sesión o
-     fuga de este identificador.
-    </para>
+    <simpara>
+     La desactivación de la gestión transparente de identificadores de sesión
+     permite asegurar un poco más los identificadores de sesión, eliminando la
+     posibilidad de una inyección de identificador de sesión o la fuga de este
+     identificador.
+    </simpara>
+    <warning>
+     <simpara>
+      Habilitar <literal>session.use_trans_sid</literal> está obsoleto a partir
+      de PHP 8.4.0.
+     </simpara>
+    </warning>
     <note>
      <para>
       El identificador de sesión puede filtrarse desde URLs guardadas,
@@ -739,48 +741,62 @@
    </listitem>
 
    <listitem>
-    <para>
-     <link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link>=[banderas limitadas]
-    </para>
-    <para>
-     (PHP 7.1.0 &gt;=) Los desarrolladores no deben reescribir banderas HTML
-     innecesarias. El valor por defecto debe ser suficiente para
-     la mayoría de los usos. Para versiones de PHP más antiguas,
+    <simpara>
+     <link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link>="a=href,area=href,frame=src,form="
+    </simpara>
+    <simpara>
+     No deben reescribirse etiquetas HTML innecesarias. El valor por defecto es
+     suficiente para la mayoría de los usos. Para versiones de PHP más antiguas,
      utilice en su lugar
      <link linkend="ini.url-rewriter.tags">url_rewriter.tags</link>.
-    </para>
+    </simpara>
+    <warning>
+     <simpara>
+      Modificar <literal>session.trans_sid_tags</literal> respecto a su valor
+      por defecto está obsoleto a partir de PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
 
    <listitem>
-    <para>
-     <link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link>=[hosts limitados]
-    </para>
-    <para>
-     (PHP 7.1.0 &gt;=) Este parámetro define una lista blanca de hosts que están
-     autorizados a reescribir los identificadores de sesión transparentes. ¡Nunca
-     añada hosts que no sean de confianza!
-     El módulo de sesión solo autoriza <literal>$_SERVER['HTTP_HOST']</literal>
-     cuando este parámetro está vacío.
-    </para>
+    <simpara>
+     <link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link>=""
+    </simpara>
+    <simpara>
+     Este parámetro enumera los hosts para los que el identificador de sesión
+     puede añadirse a las URL. Nunca deben añadirse hosts que no sean de
+     confianza. Cuando está vacío, el módulo de sesión solo autoriza
+     <literal>$_SERVER['HTTP_HOST']</literal>.
+    </simpara>
+    <warning>
+     <simpara>
+      Establecer <literal>session.trans_sid_hosts</literal> a un valor no vacío
+      está obsoleto a partir de PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
 
    <listitem>
-    <para>
-     <link linkend="ini.session.referer-check">session.referer_check</link>=[URL de origen]
-    </para>
-    <para>
+    <simpara>
+     <link linkend="ini.session.referer-check">session.referer_check</link>=""
+    </simpara>
+    <simpara>
      Cuando el parámetro <link
      linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
-     está activo.
-     Este parámetro reduce los riesgos de inyección de identificador de sesión.
-     Si un sitio web es <literal>http://example.com/</literal>,
-     defina como valor para este parámetro <literal>http://example.com/</literal>.
-     Tenga en cuenta que los navegadores HTTPS no envían el encabezado referrer.
-     Los navegadores pueden no enviar el encabezado referrer debido
-     a su propia configuración. Por lo tanto, este parámetro no puede ser
-     considerado como una medida fiable de seguridad.
-     A pesar de todo, su uso es recomendado.
-    </para>
+     está activo, un valor no vacío reduce los riesgos de inyección de
+     identificador de sesión: el identificador de sesión enviado por el cliente
+     se descarta salvo que el encabezado <literal>Referer</literal> contenga ese
+     valor. Tenga en cuenta que con HTTPS los navegadores no envían el
+     encabezado <literal>Referer</literal>, y que los navegadores pueden
+     omitirlo debido a su propia configuración. Por lo tanto, este parámetro no
+     puede ser considerado como una medida fiable de seguridad.
+    </simpara>
+    <warning>
+     <simpara>
+      Establecer <literal>session.referer_check</literal> a un valor no vacío
+      está obsoleto a partir de PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
 
    <listitem>
@@ -796,21 +812,6 @@
      puede transmitir datos privados almacenados en caché para los clientes
      compartidos. <literal>"public"</literal> solo debe ser utilizado cuando el contenido HTML
      no contiene ningún dato privado.
-    </para>
-   </listitem>
-
-   <listitem>
-    <para>
-     <link linkend="ini.session.hash-function">session.hash_function</link>="sha256"
-    </para>
-    <para>
-     (PHP 7.1.0 &lt;) Una función de hash fuerte generará un identificador
-     de sesión fuerte. Aunque una colisión de hash es poco probable con algoritmos
-     de hash MD5, los desarrolladores deben utilizar SHA-2 o un
-     algoritmo de hash más fuerte como sha384 y sha512.
-     Los desarrolladores deben asegurarse de una longitud suficiente de
-     la <link linkend="ini.session.entropy-length">entropía</link> para la
-     función de hash utilizada.
     </para>
    </listitem>
 


### PR DESCRIPTION
Translation of php/doc-en#5800 (commit 35cadcf): conditional 8.4.0 deprecations for session.sid_length, session.sid_bits_per_character, session.use_trans_sid, session.trans_sid_tags, session.trans_sid_hosts and session.referer_check, and removal of the session.hash_function recommendation (removed in 7.1.0). EN-Revision updated.

Fixes: #1187