### PR TITLE
[Sync-En] strings: split the illegal string offsets output by PHP version

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0d964bcaac6618dd80b974eb6fcdf3c67ca07340 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: eb4bde8a489ee6523879baa482247ed49aea951d Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="language.types.string">
  <title>Cadenas</title>
 
@@ -1061,10 +1061,16 @@ var_dump($str);
     </programlisting>
    </example>
 
-   <para>
-    Los offsets de string deben ser enteros o strings que parezcan enteros,
-    de lo contrario se emitirá una advertencia.
-   </para>
+   <simpara>
+    Los offsets de string deben ser enteros o strings que parezcan enteros. A
+    partir de PHP 8.0.0, cualquier otra string lanza un
+    <exceptionname>TypeError</exceptionname>, salvo una string que comience por
+    un entero seguido de otros caracteres, que emite un
+    <constant>E_WARNING</constant> y se interpreta como ese entero inicial.
+    Anterior a PHP 8.0.0, no se lanzaba ningún
+    <exceptionname>TypeError</exceptionname>: un offset ilegal emitía un
+    <constant>E_WARNING</constant> en su lugar.
+   </simpara>
 
    <example>
     <title>Ejemplo de offsets de string ilegales</title>
@@ -1072,6 +1078,8 @@ var_dump($str);
 <![CDATA[
 <?php
 $str = 'abc';
+
+$keys = [ '1', '1.0', 'x', '1x' ];
 
 foreach ($keys as $keyToTry) {
     var_dump(isset($str[$keyToTry]));
@@ -1087,7 +1095,7 @@ foreach ($keys as $keyToTry) {
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.8;
     <screen>
 <![CDATA[
 bool(true)
@@ -1101,7 +1109,29 @@ Cannot access offset of type string on string
 
 bool(false)
 
-Warning: Illegal string offset "1x" in Standard input code on line 10
+Warning: Illegal string offset "1x" in example.php on line 10
+string(1) "b"
+]]>
+    </screen>
+    &example.outputs.7;
+    <screen>
+<![CDATA[
+bool(true)
+string(1) "b"
+
+bool(false)
+
+Warning: Illegal string offset '1.0' in example.php on line 10
+string(1) "b"
+
+bool(false)
+
+Warning: Illegal string offset 'x' in example.php on line 10
+string(1) "a"
+
+bool(false)
+
+Notice: A non well formed numeric value encountered in example.php on line 10
 string(1) "b"
 ]]>
     </screen>


### PR DESCRIPTION
Translation of php/doc-en#5232 (commit eb4bde8): the example now shows the PHP 8 and PHP 7 outputs separately, and the introductory paragraph states the PHP 8 rule. The $keys array missing from the example code is restored. EN-Revision updated.

Fixes: #1188