### PR TITLE
[Sync-En] ext/intl: correct the 8.4.0 Error normalization, it only concerns cloning

### DIFF
--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 66bf3dcc3870f91bda607fe90717a8291d195236 Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="migration84.other-changes">
  <title>Otros cambios</title>
 
@@ -548,9 +547,13 @@
    <title>Intl</title>
 
    <simpara>
-    El comportamiento de la clase Intl se ha normalizado para siempre lanzar
-    excepciones <exceptionname>Error</exceptionname> al intentar usar
-    un objeto no inicializado, o cuando la clonación falla.
+    La clonación de un objeto Intl lanza sistemáticamente un
+    <exceptionname>Error</exceptionname> cuando la clonación no puede
+    realizarse, ya sea porque el objeto no ha sido inicializado, o porque la
+    operación de clonación subyacente de ICU ha fallado. Anteriormente, la
+    mayoría de estas clases lanzaban una
+    <exceptionname>Exception</exceptionname> en su lugar, y
+    <classname>Spoofchecker</classname> emitía un error fatal.
    </simpara>
   </sect3>
 

--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a03f9eda2d45b725f75b4d6a1a22e8aec63e157a Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 66bf3dcc3870f91bda607fe90717a8291d195236 Maintainer: PhilDaiguille Status: ready -->
 <!-- CREDITS: DAnnebicque -->
 
 <book xml:id="book.intl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -99,6 +97,18 @@
     </simpara>
    </listitem>
   </itemizedlist>
+
+  <note>
+   <simpara>
+    A partir de PHP 8.4.0, la clonación de un objeto Intl lanza
+    sistemáticamente un <exceptionname>Error</exceptionname> cuando la clonación
+    no puede realizarse, ya sea porque el objeto no ha sido inicializado (creado
+    sin invocar su constructor), o porque la operación de clonación subyacente
+    de ICU ha fallado. Anteriormente, la mayoría de estas clases lanzaban una
+    <exceptionname>Exception</exceptionname> en su lugar, y
+    <classname>Spoofchecker</classname> emitía un error fatal.
+   </simpara>
+  </note>
 
   <!-- {{{ Enlaces -->
   <section xml:id="intl.links">


### PR DESCRIPTION
Translation of php/doc-en#5798 (commit 66bf3dc): the 8.4.0 change only concerns the clone handlers, so the migration entry is corrected and the same note is added to the intl book. EN-Revision updated.

Fixes: #1190