### PR TITLE
[Sync-En] ext/mbstring: fix the version of the character index change (8.3.2)

### DIFF
--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b2acdf5697fa3c189f24c3b0147bef57cb8a6c32 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="migration84.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Cambios incompatibles con versiones anteriores</title>
 
@@ -516,19 +515,20 @@
   <title>MBString</title>
 
   <simpara>
-   En caso de cadenas no válidas (aquellas con errores de codificación),
-   <function>mb_substr</function> ahora interpreta los índices de caracteres
-   de la misma manera que la mayoría de las otras funciones mbstring.
-   Esto significa que los índices de caracteres devueltos por <function>mb_strpos</function>
-   pueden pasarse a <function>mb_substr</function>.
+   A partir de PHP 8.3.2, en caso de cadenas no válidas (aquellas con errores de
+   codificación), <function>mb_substr</function> y <function>mb_strstr</function>
+   interpretan los índices de caracteres de la misma manera que la mayoría de las
+   otras funciones mbstring. Esto significa que los índices de caracteres
+   devueltos por <function>mb_strpos</function> pueden pasarse a
+   <function>mb_substr</function>.
   </simpara>
 
   <simpara>
-   Para las cadenas SJIS-Mac (MacJapanese), los índices de caracteres pasados a
-   <function>mb_substr</function> ahora se refieren a los índices de
-   los puntos de código Unicode que se producen cuando la cadena se convierte a Unicode.
-   Esto es significativo porque aproximadamente 40 caracteres SJIS-Mac se convierten en una
-   secuencia de múltiples puntos de código Unicode.
+   Para las cadenas <literal>SJIS-mac</literal> (MacJapanese), esos índices de
+   caracteres se refieren a los índices de los puntos de código Unicode que se
+   producen cuando la cadena se convierte a Unicode, los cuales difieren de los
+   índices de caracteres de los caracteres <literal>SJIS-mac</literal> que se
+   convierten en una secuencia de varios puntos de código.
   </simpara>
  </sect2>
 

--- a/reference/mbstring/book.xml
+++ b/reference/mbstring/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes Maintainer: Marqitos -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: PhilDaiguille Status: ready -->
 
 <book xml:id="book.mbstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <?phpdoc extension-membership="bundled" ?>
@@ -30,14 +28,19 @@
    carácter multibyte, y que se termine con una cadena de caracteres corrupta que
    probablemente pierda su significado original.
   </para>
-  <para>
+  <simpara>
    <literal>mbstring</literal> proporciona funciones específicas para cadenas de texto
    multibyte que ayudan a tratar codificaciones multibyte en PHP. Además,
    <literal>mbstring</literal> controla la conversión de la codificación de caracteres entre
    los posibles esquemas de codificación. <literal>mbstring</literal> está diseñada para
    manejar codificaciones basadas en Unicode, tales como UTF-8 y UCS-2, y, por conveniencia,
    varias codificaciones de un solo byte (enumeradas en <link linkend="mbstring.supported-encodings">Codificaciones de caracteres soportadas</link>).
-  </para>
+  </simpara>
+  <simpara>
+   Las tablas de datos Unicode utilizadas por <literal>mbstring</literal> se
+   actualizaron a Unicode 16.0 a partir de PHP 8.4.0, y a Unicode 17.0 a partir
+   de PHP 8.5.0.
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/mbstring/functions/mb-strstr.xml
+++ b/reference/mbstring/functions/mb-strstr.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.mb-strstr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_strstr</refname>
@@ -88,6 +86,17 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.2</entry>
+      <entry>
+       En cadenas inválidas (aquellas con errores de codificación) y en cadenas
+       <literal>SJIS-mac</literal> (MacJapanese), la porción de
+       <parameter>haystack</parameter> devuelta cuando
+       <parameter>before_needle</parameter> vale &true; se determina ahora a
+       partir de los mismos índices de caracteres que las demás funciones
+       mbstring.
+      </entry>
+     </row>
      &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
     </tbody>

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.mb-substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_substr</refname>
@@ -100,12 +98,17 @@
     </thead>
     <tbody>
      <row>
-      <entry>8.4.0</entry>
+      <entry>8.3.2</entry>
       <entry>
        En cadenas inválidas (aquellas con errores de codificación),
        los índices de caracteres ahora se interpretan de la misma manera que la mayoría
        de las otras funciones de mbstring. Esto significa que los índices de caracteres devueltos
        por <function>mb_strpos</function> pueden pasarse directamente.
+       Para las cadenas <literal>SJIS-mac</literal> (MacJapanese), los índices de
+       caracteres se refieren ahora a los índices de los puntos de código Unicode
+       producidos cuando la cadena se convierte a Unicode, los cuales difieren de
+       los índices de caracteres de los caracteres <literal>SJIS-mac</literal> que
+       se convierten en una secuencia de varios puntos de código.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;
@@ -116,12 +119,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>mb_strcut</function></member>
-    <member><function>mb_internal_encoding</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>mb_strcut</function></member>
+   <member><function>mb_internal_encoding</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Translation of php/doc-en#5797 (commit 5c52e84): the character index change shipped in 8.3.2 and also affects mb_strstr(); SJIS-mac wording aligned, and the Unicode table versions (16.0 in 8.4.0, 17.0 in 8.5.0) added to the book. EN-Revision updated.

Fixes: #1191