### PR TITLE
[Sync-En] Simplify docbookcs entity configuration

### DIFF
--- a/docbookcs.xml
+++ b/docbookcs.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- EN-Revision: f3aa7a8fff15164808bdabb0281d5e88f8a5e504 Maintainer: aeoris Status: ready -->
+<docbookcs xmlns="https://php.github.io/docbook-cs/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://php.github.io/docbook-cs/config
+                               https://php.github.io/docbook-cs/config.xsd">
+
+ <project>
+  <directory alias="doc-en">en</directory>
+  <directory>doc-base</directory>
+ </project>
+
+ <sniffs>
+  <sniff class="DocbookCS\Sniff\SimparaSniff" />
+  <sniff class="DocbookCS\Sniff\ExceptionNameSniff" />
+  <sniff class="DocbookCS\Sniff\AttributeOrderSniff" />
+  <sniff class="DocbookCS\Sniff\MixedIndentationSniff" />
+  <sniff class="DocbookCS\Sniff\TrailingWhitespaceSniff" />
+ </sniffs>
+
+ <paths>
+  <path>.</path>
+ </paths>
+
+ <entities>
+  <file>../doc-base/temp/doctype.dtd</file>
+ </entities>
+
+ <exclude>
+  <pattern>output/*</pattern>
+  <pattern>appendices/extensions.xml</pattern>
+ </exclude>
+
+</docbookcs>


### PR DESCRIPTION
Closes #1064

Adds `docbookcs.xml` with the simplified entity configuration introduced in EN commit f3aa7a8fff15164808bdabb0281d5e88f8a5e504: replaces individual entity file listings with a single reference to `../doc-base/temp/doctype.dtd`.