### PR TITLE
[Sync-En] pcntl_signal(): document the SIGALRM default for restart_syscalls (#5821)

### DIFF
--- a/reference/pcntl/functions/pcntl-signal.xml
+++ b/reference/pcntl/functions/pcntl-signal.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5fe0f8494374d594762e56b2d769c2828b1e0ddb Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3866fba43ed70c07afa89df7daf21529b09b4f3b Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.pcntl-signal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>pcntl_signal</refname>
@@ -38,13 +37,13 @@
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El gestor de señales. Puede ser un <type>callable</type>,
        que será llamado para gestionar la señal, o bien una de las dos
        constantes globales <constant>SIG_IGN</constant> o <constant>SIG_DFL</constant>,
        que, respectivamente, ignorarán la señal o restaurarán el gestor
        de señales por defecto.
-      </para>
+      </simpara>
       <para>
        Si se proporciona un <type>callable</type>, debe implementar la siguiente firma:
       </para>
@@ -56,7 +55,7 @@
        </methodsynopsis>
        <variablelist>
         <varlistentry>
-         <term><parameter>signal</parameter></term>
+         <term><parameter>signo</parameter></term>
          <listitem>
           <simpara>
            La señal a gestionar.
@@ -74,11 +73,11 @@
        </variablelist>
       </para>
       <note>
-       <para>
-        Téngase en cuenta que cuando se configura el gestor con un método de objeto,
-        el contador de referencia del objeto se incrementa, lo que lo hace persistente
-        hasta que se cambie el gestor de señales por otro, o hasta que el script termine.
-       </para>
+       <simpara>
+        Cuando el gestor se configura con un método de objeto, el contador de referencia
+        de ese objeto se incrementa, lo que lo hace persistente hasta que el gestor
+        se cambie por otro, o hasta que el script termine.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -89,6 +88,16 @@
        Especifica si la llamada al sistema de reinicio (restarting) debe ser utilizada
        cuando llega esta señal.
       </para>
+      <note>
+       <simpara>
+        Aunque este parámetro tiene como valor predeterminado &true;, dicho valor
+        predeterminado no se aplica a <constant>SIGALRM</constant>: cuando
+        <parameter>restart_syscalls</parameter> no se pasa y
+        <parameter>signal</parameter> es <constant>SIGALRM</constant>,
+        el reinicio de las llamadas al sistema queda desactivado. Pase &true;
+        explícitamente para habilitarlo en <constant>SIGALRM</constant>.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -100,6 +109,21 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Se lanza una <exceptionname>ValueError</exceptionname> si
+   <parameter>signal</parameter> es menor que <literal>1</literal> o mayor o igual
+   a <constant>NSIG</constant>, o si <parameter>handler</parameter> es un
+   <type>int</type> distinto de <constant>SIG_DFL</constant> o <constant>SIG_IGN</constant>.
+  </simpara>
+  <simpara>
+   Se lanza una <exceptionname>TypeError</exceptionname> si
+   <parameter>handler</parameter> no es ni un <type>callable</type> ni un
+   <type>int</type>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -114,6 +138,16 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        <parameter>restart_syscalls</parameter> ahora se tiene en cuenta para
+        <constant>SIGALRM</constant>; anteriormente el reinicio de llamadas al sistema
+        siempre estaba desactivado para esa señal. Cuando no se pasa el argumento,
+        el reinicio de llamadas al sistema permanece desactivado para
+        <constant>SIGALRM</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.1.0</entry>
        <entry>
@@ -187,10 +221,10 @@ echo "Hecho\n";
 
  <refsect1 role="notes"><!-- {{{ -->
   &reftitle.notes;
-  <para>
+  <simpara>
    La función <function>pcntl_signal</function> no apila
    los gestores de señales, sino que los reemplaza.
-  </para>
+  </simpara>
   <refsect2>
    <title>Método de dispatch</title>
    <para>
@@ -210,15 +244,13 @@ echo "Hecho\n";
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><link xlink:href="https://en.wikipedia.org/wiki/Signal_(IPC)">Signal (IPC)</link> en Wikipedia</member>
-    <member><function>pcntl_async_signals</function></member>
-    <member><function>pcntl_fork</function></member>
-    <member><function>pcntl_signal_dispatch</function></member>
-    <member><function>pcntl_waitpid</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><link xlink:href="https://en.wikipedia.org/wiki/Signal_(IPC)">Signal (IPC)</link> en Wikipedia</member>
+   <member><function>pcntl_async_signals</function></member>
+   <member><function>pcntl_fork</function></member>
+   <member><function>pcntl_signal_dispatch</function></member>
+   <member><function>pcntl_waitpid</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Closes #1207

Based on EN commit 3866fba43ed70c07afa89df7daf21529b09b4f3b:
- Add note on `restart_syscalls` explaining the SIGALRM exception to the default
- Add errors section (ValueError/TypeError)
- Add 7.4.0 changelog entry for SIGALRM behaviour
- Convert `<para>` to `<simpara>` in handler description and notes
- Fix parameter name `signal` → `signo` in handler signature
- Remove `<para>` wrapper from `seealso`