### PR TITLE
[Sync-En] ext/pdo_sqlite: document the PHP 8.5 additions and behaviour changes (#5818)

### DIFF
--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no Maintainer: Marqitos -->
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdo.quote" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::quote</refname>
@@ -81,6 +80,31 @@
    en una consulta SQL. Devuelve &false; si el controlador no soporta
    este tipo de protecciones.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Al usar el controlador SQLite, ahora se lanza una <exceptionname>PDOException</exceptionname>
+       o se emite una advertencia, según el modo de error, si el
+       <parameter>string</parameter> contiene un byte nulo; anteriormente el
+       string era truncado silenciosamente en el byte nulo.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo_sqlite/configure.xml
+++ b/reference/pdo_sqlite/configure.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 859713422861ee5d25d5e8504928a4af9ce198ad Maintainer: seros Status: ready -->
-<!-- Reviewed: yes Maintainer: julionc -->
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: seros Status: ready -->
 
 <section xml:id="ref.pdo-sqlite.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
- <para>
+ <simpara>
   El controlador PDO_SQLITE PDO está habilitado por omisión. Para deshabilitarlo,
   se puede usar <option role="configure">--without-pdo-sqlite[=DIR]</option>,
   donde el parámetro opcional <literal>[=DIR]</literal> es el directorio base de instalación de sqlite.
-  A partir de PHP 7.4.0 se requiere <link xlink:href="&url.sqlite;">libsqlite</link> ≥ 3.5.0.
+  A partir de PHP 7.4.0 se requiere <link xlink:href="&url.sqlite;">libsqlite</link> ≥ 3.5.0,
+  y a partir de PHP 8.5.0 se requiere libsqlite ≥ 3.7.17.
   Anteriormente, si libsqlite incluido podría haberse usado en su lugar, por omisión,
   si <literal>[=DIR]</literal> era omitido.
- </para>
+ </simpara>
  <note>
   <title>Configuración adicional en Windows a partir de PHP 7.4.0</title>
   <para>

--- a/reference/pdo_sqlite/configure.xml
+++ b/reference/pdo_sqlite/configure.xml
@@ -5,13 +5,13 @@
 <section xml:id="ref.pdo-sqlite.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
  <simpara>
-  El controlador PDO_SQLITE PDO está habilitado por omisión. Para deshabilitarlo,
+  El controlador PDO_SQLITE PDO está habilitado por defecto. Para deshabilitarlo,
   se puede usar <option role="configure">--without-pdo-sqlite[=DIR]</option>,
   donde el parámetro opcional <literal>[=DIR]</literal> es el directorio base de instalación de sqlite.
   A partir de PHP 7.4.0 se requiere <link xlink:href="&url.sqlite;">libsqlite</link> ≥ 3.5.0,
   y a partir de PHP 8.5.0 se requiere libsqlite ≥ 3.7.17.
-  Anteriormente, si libsqlite incluido podría haberse usado en su lugar, por omisión,
-  si <literal>[=DIR]</literal> era omitido.
+  Anteriormente, la libsqlite incluida podría haberse usado en su lugar, y era la
+  opción predeterminada, si se omitía <literal>[=DIR]</literal>.
  </simpara>
  <note>
   <title>Configuración adicional en Windows a partir de PHP 7.4.0</title>

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: PhilDaiguille Status: ready -->
 <reference xml:id="class.pdo-sqlite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Pdo\Sqlite</title>
  <titleabbrev>Pdo\Sqlite</titleabbrev>
@@ -100,6 +99,78 @@
      <type>int</type>
      <varname linkend="pdo-sqlite.constants.attr-extended-result-codes">Pdo\Sqlite::ATTR_EXTENDED_RESULT_CODES</varname>
     </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.attr-busy-statement">Pdo\Sqlite::ATTR_BUSY_STATEMENT</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.attr-explain-statement">Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.explain-mode-prepared">Pdo\Sqlite::EXPLAIN_MODE_PREPARED</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.explain-mode-explain">Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.explain-mode-explain-query-plan">Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.attr-transaction-mode">Pdo\Sqlite::ATTR_TRANSACTION_MODE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.transaction-mode-deferred">Pdo\Sqlite::TRANSACTION_MODE_DEFERRED</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.transaction-mode-immediate">Pdo\Sqlite::TRANSACTION_MODE_IMMEDIATE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.transaction-mode-exclusive">Pdo\Sqlite::TRANSACTION_MODE_EXCLUSIVE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.ok">Pdo\Sqlite::OK</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.deny">Pdo\Sqlite::DENY</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.ignore">Pdo\Sqlite::IGNORE</varname>
+    </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-sqlite')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Sqlite'])">
@@ -170,8 +241,175 @@
       </simpara>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.attr-busy-statement">
+     <term><constant>Pdo\Sqlite::ATTR_BUSY_STATEMENT</constant></term>
+     <listitem>
+      <simpara>
+       Atributo de sentencia de solo lectura, recuperado con
+       <methodname>PDOStatement::getAttribute</methodname>, que es &true; si
+       la sentencia ha sido ejecutada y todavía tiene una fila pendiente, y &false;
+       en caso contrario.
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.attr-explain-statement">
+     <term><constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant></term>
+     <listitem>
+      <simpara>
+       Atributo de sentencia que controla el modo de explicación, establecido con
+       <methodname>PDOStatement::setAttribute</methodname>. Los valores posibles son
+       <constant>Pdo\Sqlite::EXPLAIN_MODE_PREPARED</constant>,
+       <constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN</constant> y
+       <constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant>.
+       Se lanza un <exceptionname>ValueError</exceptionname> si PHP ha sido compilado
+       con una versión de libsqlite anterior a 3.43.0.
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.explain-mode-prepared">
+     <term><constant>Pdo\Sqlite::EXPLAIN_MODE_PREPARED</constant></term>
+     <listitem>
+      <simpara>
+       Valor para <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant>:
+       devuelve la sentencia tal como fue preparada (sin explicación).
+       Disponible a partir de PHP 8.5.0, compilado con libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.explain-mode-explain">
+     <term><constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN</constant></term>
+     <listitem>
+      <simpara>
+       Valor para <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant>:
+       devuelve los códigos de operación de la máquina virtual utilizada para ejecutar la sentencia
+       (equivalente al <literal>EXPLAIN</literal> de SQLite).
+       Disponible a partir de PHP 8.5.0, compilado con libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.explain-mode-explain-query-plan">
+     <term><constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant></term>
+     <listitem>
+      <simpara>
+       Valor para <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant>:
+       devuelve el plan de consulta (equivalente al
+       <literal>EXPLAIN QUERY PLAN</literal> de SQLite).
+       Disponible a partir de PHP 8.5.0, compilado con libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.attr-transaction-mode">
+     <term><constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant></term>
+     <listitem>
+      <simpara>
+       Atributo de conexión que configura el modo de transacción utilizado por
+       <methodname>PDO::beginTransaction</methodname>. Los valores posibles son
+       <constant>Pdo\Sqlite::TRANSACTION_MODE_DEFERRED</constant>,
+       <constant>Pdo\Sqlite::TRANSACTION_MODE_IMMEDIATE</constant> y
+       <constant>Pdo\Sqlite::TRANSACTION_MODE_EXCLUSIVE</constant>.
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.transaction-mode-deferred">
+     <term><constant>Pdo\Sqlite::TRANSACTION_MODE_DEFERRED</constant></term>
+     <listitem>
+      <simpara>
+       Valor para <constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant>:
+       utiliza el modo de transacción DEFERRED de SQLite (el predeterminado).
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.transaction-mode-immediate">
+     <term><constant>Pdo\Sqlite::TRANSACTION_MODE_IMMEDIATE</constant></term>
+     <listitem>
+      <simpara>
+       Valor para <constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant>:
+       utiliza el modo de transacción IMMEDIATE de SQLite.
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.transaction-mode-exclusive">
+     <term><constant>Pdo\Sqlite::TRANSACTION_MODE_EXCLUSIVE</constant></term>
+     <listitem>
+      <simpara>
+       Valor para <constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant>:
+       utiliza el modo de transacción EXCLUSIVE de SQLite.
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.ok">
+     <term><constant>Pdo\Sqlite::OK</constant></term>
+     <listitem>
+      <simpara>
+       Valor de retorno de una retrollamada de autorización establecida con
+       <methodname>Pdo\Sqlite::setAuthorizer</methodname>, que permite la acción.
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.deny">
+     <term><constant>Pdo\Sqlite::DENY</constant></term>
+     <listitem>
+      <simpara>
+       Valor de retorno de una retrollamada de autorización establecida con
+       <methodname>Pdo\Sqlite::setAuthorizer</methodname>, que deniega la acción.
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.ignore">
+     <term><constant>Pdo\Sqlite::IGNORE</constant></term>
+     <listitem>
+      <simpara>
+       Valor de retorno de una retrollamada de autorización establecida con
+       <methodname>Pdo\Sqlite::setAuthorizer</methodname>, que sustituye un valor &null;
+       por la columna que habría sido leída.
+       Disponible a partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Se añadieron las constantes <constant>Pdo\Sqlite::ATTR_BUSY_STATEMENT</constant>,
+        <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant>,
+        <constant>Pdo\Sqlite::EXPLAIN_MODE_PREPARED</constant>,
+        <constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN</constant>,
+        <constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant>,
+        <constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant>,
+        <constant>Pdo\Sqlite::TRANSACTION_MODE_DEFERRED</constant>,
+        <constant>Pdo\Sqlite::TRANSACTION_MODE_IMMEDIATE</constant>,
+        <constant>Pdo\Sqlite::TRANSACTION_MODE_EXCLUSIVE</constant>,
+        <constant>Pdo\Sqlite::OK</constant>,
+        <constant>Pdo\Sqlite::DENY</constant> y
+        <constant>Pdo\Sqlite::IGNORE</constant>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.pdo-sqlite.pdo.entities.sqlite;

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -266,7 +266,7 @@
       <simpara>
        Valor para <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant>:
        devuelve la sentencia tal como fue preparada (sin explicación).
-       Disponible a partir de PHP 8.5.0, compilado con libsqlite &gt;= 3.43.0.
+       Disponible a partir de PHP 8.5.0, cuando se compila con libsqlite &gt;= 3.43.0.
       </simpara>
      </listitem>
     </varlistentry>
@@ -277,7 +277,7 @@
        Valor para <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant>:
        devuelve los códigos de operación de la máquina virtual utilizada para ejecutar la sentencia
        (equivalente al <literal>EXPLAIN</literal> de SQLite).
-       Disponible a partir de PHP 8.5.0, compilado con libsqlite &gt;= 3.43.0.
+       Disponible a partir de PHP 8.5.0, cuando se compila con libsqlite &gt;= 3.43.0.
       </simpara>
      </listitem>
     </varlistentry>
@@ -288,7 +288,7 @@
        Valor para <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant>:
        devuelve el plan de consulta (equivalente al
        <literal>EXPLAIN QUERY PLAN</literal> de SQLite).
-       Disponible a partir de PHP 8.5.0, compilado con libsqlite &gt;= 3.43.0.
+       Disponible a partir de PHP 8.5.0, cuando se compila con libsqlite &gt;= 3.43.0.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -52,9 +52,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -173,17 +171,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-sqlite')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Sqlite'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-sqlite')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Sqlite'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/pdo_sqlite/pdo/sqlite/createcollation.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/createcollation.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 51610360d58ed09bc9d1312f419057c0d1d1a998 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdo-sqlite.createcollation" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Pdo\Sqlite::createCollation</refname>
@@ -62,6 +61,38 @@
   <simpara>
    &return.success;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Se lanza un <exceptionname>TypeError</exceptionname> si la
+   <parameter>callback</parameter> no devuelve un valor de tipo <type>int</type>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Ahora se lanza un <exceptionname>TypeError</exceptionname> si la
+       <parameter>callback</parameter> no devuelve un valor de tipo <type>int</type>;
+       anteriormente el valor devuelto era convertido a <type>int</type>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo_sqlite/pdo/sqlite/setauthorizer.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/setauthorizer.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: PhilDaiguille Status: ready -->
+<refentry xml:id="pdo-sqlite.setauthorizer" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Pdo\Sqlite::setAuthorizer</refname>
+  <refpurpose>Configura una retrollamada para usarla como autorizador y limitar lo que puede hacer una sentencia</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Pdo\\Sqlite">
+   <modifier>public</modifier> <type>void</type><methodname>Pdo\Sqlite::setAuthorizer</methodname>
+   <methodparam><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Establece una retrollamada que será invocada por SQLite cada vez que se realice
+   una acción (lectura, eliminación, actualización, etc.). Se utiliza cuando se prepara
+   una sentencia SQL de una fuente no confiable para garantizar que la sentencia no acceda
+   a datos que no tiene permitido ver ni ejecute sentencias maliciosas que dañen la base de datos.
+  </simpara>
+  <simpara>
+   El autorizador solo se utiliza durante la fase de preparación de la sentencia.
+   Puede ser llamado varias veces para una sola sentencia: una consulta
+   <literal>SELECT</literal> o <literal>UPDATE</literal> lo invoca por cada
+   columna que sería leída o actualizada. Se ejecuta de nuevo cada vez que SQLite
+   vuelve a preparar una sentencia, lo que puede ocurrir mientras la sentencia está siendo
+   ejecutada, por ejemplo, después de que el esquema haya cambiado.
+  </simpara>
+  <simpara>
+   El autorizador es llamado con hasta cinco argumentos. Los argumentos recibidos se
+   describen en <methodname>SQLite3::setAuthorizer</methodname>.
+  </simpara>
+  <simpara>
+   Solo puede haber un autorizador activo en una conexión de base de datos a la vez.
+   Cada llamada a este método reemplaza la anterior. El autorizador está deshabilitado
+   de forma predeterminada, y puede deshabilitarse de nuevo estableciendo una retrollamada &null;.
+  </simpara>
+  <simpara>
+   La retrollamada no debe modificar la conexión de base de datos que la invocó.
+  </simpara>
+  <simpara>
+   Más detalles pueden encontrarse en la
+   <link xlink:href="&url.sqlite;c3ref/set_authorizer.html">documentación de SQLite</link>.
+  </simpara>
+  <note>
+   <simpara>
+    Este método es el equivalente de <methodname>SQLite3::setAuthorizer</methodname>,
+    salvo que devuelve <type>void</type> en lugar de <type>bool</type>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <simpara>
+      El <type>callable</type> a invocar, o &null; para deshabilitar la
+      retrollamada de autorización actual.
+     </simpara>
+     <simpara>
+      Debe devolver uno de <constant>Pdo\Sqlite::OK</constant>,
+      <constant>Pdo\Sqlite::DENY</constant> o
+      <constant>Pdo\Sqlite::IGNORE</constant>.
+      Cuando se devuelve <constant>Pdo\Sqlite::DENY</constant>, la sentencia que
+      activó el autorizador falla con un error que indica que el acceso ha sido denegado.
+      Cuando se devuelve <constant>Pdo\Sqlite::IGNORE</constant> para una acción de lectura,
+      la sentencia se prepara de modo que se sustituye un valor &null; por la
+      columna que habría sido leída.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Este método en sí mismo no lanza excepciones, pero si la retrollamada del autorizador
+   no devuelve un valor de tipo <type>int</type>, o devuelve un <type>int</type> que no es uno de
+   <constant>Pdo\Sqlite::OK</constant>, <constant>Pdo\Sqlite::DENY</constant> o
+   <constant>Pdo\Sqlite::IGNORE</constant>, la preparación de la sentencia lanza un
+   <exceptionname>TypeError</exceptionname> o un <exceptionname>ValueError</exceptionname>
+   respectivamente.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <methodname>Pdo\Sqlite::setAuthorizer</methodname></title>
+   <simpara>
+    Solo se permiten acciones de lectura en la conexión. Los códigos de acción están expuestos
+    como constantes de clase <classname>SQLite3</classname>, lo que requiere que la
+    extensión <link linkend="book.sqlite3">SQLite3</link> esté disponible; sus
+    valores enteros pueden usarse directamente en caso contrario.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Sqlite('sqlite::memory:');
+$db->exec('CREATE TABLE users (id, name)');
+
+$db->setAuthorizer(function (int $action, ...$args) {
+    return match ($action) {
+        SQLite3::SELECT, SQLite3::READ => Pdo\Sqlite::OK,
+        default => Pdo\Sqlite::DENY,
+    };
+});
+
+var_dump($db->query('SELECT name FROM users') instanceof PDOStatement);
+
+try {
+    $db->exec('DROP TABLE users');
+} catch (PDOException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+SQLSTATE[HY000]: General error: 23 not authorized
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::setAuthorizer</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translation of php/doc-en#5818 (commit eff8e0d): the PHP 8.5 additions and behaviour changes of pdo_sqlite, the new 8.5.0 constants, the libsqlite 3.7.17 requirement, the SQLite null byte changelog on PDO::quote, and a first translation of Pdo\Sqlite::setAuthorizer.

The class synopsis of pdo-sqlite.xml also drops the xi:fallback wrappers, which check-structure rejects: doc-en writes those xi:include elements self-closing.

Fixes: #1209