### PR TITLE
[Sync-En] Add warning about cloning exceptions (#5276)

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 62562234f18ac091ecd1fb648ac0d56172c74a1a Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="language.exceptions" annotations="interactive">
  <!-- we use our own DTD instead of xmlns="http://docbook.org/ns/docbook" so that we can use
@@ -422,7 +421,7 @@ string(6) "Fourth"
 <?php
 class Exception implements Throwable
 {
-    protected $message = 'Unknown exception';   // Mensaje de excepción
+    protected $message = '';                    // Mensaje de excepción
     private   $string;                          // caché de __toString
     protected $code = 0;                        // código de excepción definido por el usuario
     protected $file;                            // nombre de archivo fuente de la excepción
@@ -432,7 +431,7 @@ class Exception implements Throwable
 
     public function __construct($message = '', $code = 0, ?Throwable $previous = null);
 
-    final private function __clone();           // Inhibe la duplicación de excepciones.
+    private function __clone();                 // Inhibe la duplicación de excepciones.
 
     final public  function getMessage();        // mensaje de la excepción
     final public  function getCode();           // código de la excepción
@@ -459,11 +458,12 @@ class Exception implements Throwable
    en forma de string.
   </para>
   <note>
-   <para>
+   <simpara>
     Las excepciones no pueden ser clonadas. Intentar <link
-    linkend="language.oop5.cloning">clonar</link> una Exception resultará en un
-    error fatal <constant>E_ERROR</constant>.
-   </para>
+    linkend="language.oop5.cloning">clonar</link> una excepción lanza un
+    <exceptionname>Error</exceptionname>, incluso si una subclase declara su propio
+    método <link linkend="object.clone">__clone()</link>.
+   </simpara>
   </note>
   <example>
    <title>Extender la clase Exception</title>

--- a/language/predefined/exception/clone.xml
+++ b/language/predefined/exception/clone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 35c16b1543e292fa6913f02598daa435e58d997c Maintainer: yago Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 62562234f18ac091ecd1fb648ac0d56172c74a1a Maintainer: yago Status: ready -->
 <refentry xml:id="exception.clone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Exception::__clone</refname>
@@ -13,10 +12,18 @@
    <modifier>private</modifier> <type>void</type><methodname>Exception::__clone</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   <classname>Exception</classname>s no se pueden clonar,
-   y el intento de hacerlo lanzará un <classname>Error</classname>.
-  </para>
+  <simpara>
+   Las excepciones no admiten clonación; este método existe únicamente para impedirla.
+  </simpara>
+  <warning>
+   <simpara>
+    Las excepciones no pueden ser clonadas, ya sean instancias de
+    <exceptionname>Exception</exceptionname> o de una subclase.
+    Intentar <link linkend="language.oop5.cloning">clonar</link> una
+    excepción lanza un <exceptionname>Error</exceptionname>, que puede
+    ser capturado.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -52,7 +59,12 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       <methodname>Error::__clone</methodname> ya no es final.
+       <methodname>Exception::__clone</methodname> ya no se declara
+       <modifier>final</modifier>, porque
+       <link linkend="language.oop5.final">declarar un método
+       <modifier>private</modifier> como
+       <modifier>final</modifier></link> emite una advertencia a partir de PHP 8.0.0.
+       Las excepciones siguen sin poder clonarse.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Syncs with EN commit 62562234f18ac091ecd1fb648ac0d56172c74a1a.

Changes:
- `language/exceptions.xml`: update default `$message` value, remove `final` from `__clone()`, update note text
- `language/predefined/exception/clone.xml`: replace description with simpara + warning block, expand 8.1.0 changelog entry