### PR TITLE
[Sync-En] ext/pdo: document the PHP 8.5 fetch mode changes and deprecations (#5817)

### DIFF
--- a/reference/pdo/pdo.xml
+++ b/reference/pdo/pdo.xml
@@ -476,12 +476,8 @@
      <varname linkend="pdo.constants.cursor-scroll">PDO::CURSOR_SCROLL</varname>
     </fieldsynopsis>
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/pdo/pdo.xml
+++ b/reference/pdo/pdo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a78c7290730ac918c4eb6b199004d24051d1e93f Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: PhilDaiguille Status: ready -->
 <reference xml:id="class.pdo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase PDO</title>
  <titleabbrev>PDO</titleabbrev>
@@ -497,6 +496,17 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Las constantes específicas del controlador de la clase <classname>PDO</classname>
+        han sido marcadas como obsoletas en favor de las constantes equivalentes de las
+        subclases específicas del controlador (<classname>Pdo\Dblib</classname>,
+        <classname>Pdo\Firebird</classname>, <classname>Pdo\Mysql</classname>,
+        <classname>Pdo\Odbc</classname>, <classname>Pdo\Pgsql</classname>,
+        <classname>Pdo\Sqlite</classname>).
+       </entry>
+      </row>
       <row>
        <entry>8.4.0</entry>
        <entry>

--- a/reference/pdo/pdo/construct.xml
+++ b/reference/pdo/pdo/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7dd805d34addc6e98afaa0b3851c8656afbec9b6 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdo.construct" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::__construct</refname>
@@ -58,6 +57,13 @@
            la cadena DSN. La URI puede especificar un fichero local o remoto.
           </para>
           <para><userinput>uri:file:///path/to/dsnfile</userinput></para>
+          <warning>
+           <simpara>
+            El esquema DSN <userinput>uri:</userinput> está obsoleto a partir de
+            PHP 8.5.0 debido a problemas de seguridad con los DSN provenientes de
+            URIs remotas.
+           </simpara>
+          </warning>
          </listitem>
         </varlistentry>
         <varlistentry><term>Alias</term>
@@ -112,11 +118,33 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Se lanza una excepción <classname>PDOException</classname> si el intento
+  <simpara>
+   Se lanza una excepción <exceptionname>PDOException</exceptionname> si el intento
    de conexión a la base de datos solicitada falla,
    independientemente del <constant>PDO::ATTR_ERRMODE</constant> actualmente definido.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       El esquema DSN <userinput>uri:</userinput> está ahora obsoleto.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdostatement.fetchall" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::fetchAll</refname>
@@ -153,6 +152,17 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       El uso de <constant>PDO::FETCH_INTO</constant> como modo de recuperación ahora lanza un
+       <exceptionname>ValueError</exceptionname>, de manera similar a
+       <constant>PDO::FETCH_LAZY</constant>.
+       El uso de <constant>PDO::FETCH_PROPS_LATE</constant> con un modo de recuperación
+       distinto de <constant>PDO::FETCH_CLASS</constant> ahora lanza un
+       <exceptionname>ValueError</exceptionname>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdostatement.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::setAttribute</refname>
@@ -64,6 +63,39 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   A partir de PHP 8.5.0, cuando se usa el controlador Firebird, se lanza un
+   <exceptionname>ValueError</exceptionname> si el nombre de cursor establecido mediante
+   <constant>PDO::ATTR_CURSOR_NAME</constant> es demasiado largo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Al usar el controlador Firebird, ahora se lanza un <exceptionname>ValueError</exceptionname>
+       si el nombre de cursor establecido mediante
+       <constant>PDO::ATTR_CURSOR_NAME</constant> es demasiado largo.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -42,26 +42,26 @@
     <varlistentry>
      <term><parameter>mode</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        El modo de recuperación debe ser una de las constantes
        <link linkend="pdo.constants"><constant>PDO::FETCH_<replaceable>*</replaceable></constant></link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>colno</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Número de la columna.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
     <term><parameter>class</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de la clase.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -78,9 +78,9 @@
     <varlistentry>
      <term><parameter>object</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Objeto.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="pdostatement.setfetchmode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::setFetchMode</refname>
@@ -68,9 +67,12 @@
     <varlistentry>
      <term><parameter>constructorArgs</parameter></term>
      <listitem>
-      <para>
-       Argumentos del constructor.
-      </para>
+      <simpara>
+       Argumentos del constructor. A partir de PHP 8.5.0, las claves de tipo string
+       actúan como argumentos con nombre. Para pasar una variable por referencia,
+       se utiliza un elemento de referencia:
+       <code>$constructorArgs = [&amp;$valByRef]</code>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -92,6 +94,16 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   A partir de PHP 8.5.0, se lanza un <exceptionname>Error</exceptionname> si este método
+   es llamado durante una llamada a <methodname>PDOStatement::fetch</methodname>,
+   <methodname>PDOStatement::fetchObject</methodname> o
+   <methodname>PDOStatement::fetchAll</methodname>.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -103,6 +115,26 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       El <parameter>constructorArgs</parameter> para
+       <constant>PDO::FETCH_CLASS</constant> ahora sigue la semántica CUFA
+       (<function>call_user_func_array</function>): las claves de tipo string actúan
+       como argumentos con nombre, y la envoltura automática de argumentos por valor
+       para parámetros por referencia ha sido eliminada.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Llamar a este método durante una llamada a
+       <methodname>PDOStatement::fetch</methodname>,
+       <methodname>PDOStatement::fetchObject</methodname> o
+       <methodname>PDOStatement::fetchAll</methodname> ahora lanza un
+       <exceptionname>Error</exceptionname>.
+      </entry>
+     </row>
      &return.type.true.84;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Translation of php/doc-en#5817 (commit e16d04c): the PHP 8.5 fetch mode changes and deprecations of ext/pdo, covering the deprecated driver-specific constants, the uri: DSN deprecation on the constructor, and the new errors and changelog sections of fetchAll(), setAttribute() and setFetchMode().

pdo.xml also drops the xi:fallback wrappers, which check-structure rejects: doc-en writes those xi:include elements self-closing.

Fixes: #1212