### PR TITLE
[Sync-En] localtime, parse, parseToCalendar: correct the offset semantics (#4820)

### DIFF
--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -28,7 +28,7 @@
   <simpara>
    Convierte <parameter>string</parameter> en una fecha descompuesta (un &array;
    de campos), comenzando en <parameter>offset</parameter> y consumiendo tantos
-   caracteres de la cadena de entrada como sea posible.
+   caracteres del string de entrada como sea posible.
   </simpara>
  </refsect1>
 
@@ -48,7 +48,7 @@
      <term><parameter>string</parameter></term>
      <listitem>
       <simpara>
-       La cadena a convertir en un tiempo.
+       El string a convertir en un tiempo.
       </simpara>
      </listitem>
     </varlistentry>
@@ -57,7 +57,7 @@
      <listitem>
       <simpara>
        La posición desde la cual comenzar el análisis en <parameter>string</parameter>
-       (base-0).
+       (basada en cero).
        Al regresar, <parameter>offset</parameter> contiene la posición en la que
        terminó el análisis, independientemente de si el análisis tuvo éxito o no.
        Si <parameter>offset</parameter> es negativo o mayor que
@@ -76,8 +76,8 @@
    Un array asociativo de enteros cuyas claves son las de
    <function>localtime</function>, con la hora en formato de 24 horas en
    <literal>tm_hour</literal>&return.falseforfailure;.
-   Nótese que <literal>tm_yday</literal> es base-1 aquí, mientras que
-   <function>localtime</function> lo devuelve base-0.
+   Nótese que <literal>tm_yday</literal> empieza en 1 aquí, mientras que
+   <function>localtime</function> lo devuelve empezando en 0.
   </simpara>
  </refsect1>
 

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8ddf539e5993e427cb1385c5a01b6d2ce971b418 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8871302d240f124f7e9dabac85862e31bf97b442 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="intldateformatter.localtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlDateFormatter::localtime</refname>
@@ -26,11 +25,11 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Convierte la cadena $value en una fecha descompuesta (un &array; de
-   campos), comenzando en la posición $parse_pos y consumiendo tantos
-   caracteres como sea posible.
-  </para>
+  <simpara>
+   Convierte <parameter>string</parameter> en una fecha descompuesta (un &array;
+   de campos), comenzando en <parameter>offset</parameter> y consumiendo tantos
+   caracteres de la cadena de entrada como sea posible.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,30 +39,31 @@
     <varlistentry>
      <term><parameter>formatter</parameter></term>
      <listitem>
-      <para>
-       El recurso de formateador <classname>IntlDateFormatter</classname>.
-      </para>
+      <simpara>
+       El objeto <classname>IntlDateFormatter</classname>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>string</parameter></term>
      <listitem>
-      <para>
-       La cadena a convertir.
-      </para>
+      <simpara>
+       La cadena a convertir en un tiempo.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>offset</parameter></term>
      <listitem>
-      <para>
-       La posición desde la cual comenzar el análisis en el valor $value.
-       Las posiciones comienzan en 0. Si no ocurre ningún error durante el análisis
-       de $value, $parse_pos contendrá -1, y de lo contrario, contendrá la posición en la cual
-       terminó el análisis (y ocurrió el error). Esta variable contendrá
-       la posición de fin si el análisis falla.
-       Si $parse_pos &gt; strlen($value), el análisis falla inmediatamente.
-      </para>
+      <simpara>
+       La posición desde la cual comenzar el análisis en <parameter>string</parameter>
+       (base-0).
+       Al regresar, <parameter>offset</parameter> contiene la posición en la que
+       terminó el análisis, independientemente de si el análisis tuvo éxito o no.
+       Si <parameter>offset</parameter> es negativo o mayor que
+       <literal>strlen($string)</literal>, el análisis falla inmediatamente y
+       <parameter>offset</parameter> queda sin cambios.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -72,10 +72,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Un array de enteros compatible con localtime: contiene la hora
-   en formato de 24 horas en el campo tm_hour, &return.falseforfailure;.
-  </para>
+  <simpara>
+   Un array asociativo de enteros cuyas claves son las de
+   <function>localtime</function>, con la hora en formato de 24 horas en
+   <literal>tm_hour</literal>&return.falseforfailure;.
+   Nótese que <literal>tm_yday</literal> es base-1 aquí, mientras que
+   <function>localtime</function> lo devuelve base-0.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/intl/dateformatter/parse.xml
+++ b/reference/intl/dateformatter/parse.xml
@@ -56,7 +56,7 @@
      <listitem>
       <simpara>
        La posición desde la cual comenzar el análisis en <parameter>string</parameter>
-       (base-0).
+       (basada en cero).
        Al regresar, <parameter>offset</parameter> contiene la posición en la que
        terminó el análisis, independientemente de si el análisis tuvo éxito o no.
        Si <parameter>offset</parameter> es negativo o mayor que

--- a/reference/intl/dateformatter/parse.xml
+++ b/reference/intl/dateformatter/parse.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8871302d240f124f7e9dabac85862e31bf97b442 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="intldateformatter.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlDateFormatter::parse</refname>
@@ -39,9 +38,9 @@
     <varlistentry>
      <term><parameter>formatter</parameter></term>
      <listitem>
-      <para>
-       El recurso de formateador <classname>IntlDateFormatter</classname>.
-      </para>
+      <simpara>
+       El objeto <classname>IntlDateFormatter</classname>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -55,14 +54,15 @@
     <varlistentry>
      <term><parameter>offset</parameter></term>
      <listitem>
-      <para>
-       La posición desde la cual comenzar el análisis en el valor <parameter>string</parameter>.
-       Las posiciones comienzan en 0. Si no ocurre ningún error durante el análisis
-       de <parameter>string</parameter>, <parameter>offset</parameter> contendrá -1, y de lo contrario, contendrá la posición en la cual
-       el análisis terminó (y el error ocurrió). Esta variable contendrá
-       la posición de fin si el análisis falla.
-       Si <parameter>offset</parameter> &gt; <code>strlen($string)</code>, el análisis falla inmediatamente.
-      </para>
+      <simpara>
+       La posición desde la cual comenzar el análisis en <parameter>string</parameter>
+       (base-0).
+       Al regresar, <parameter>offset</parameter> contiene la posición en la que
+       terminó el análisis, independientemente de si el análisis tuvo éxito o no.
+       Si <parameter>offset</parameter> es negativo o mayor que
+       <literal>strlen($string)</literal>, el análisis falla inmediatamente y
+       <parameter>offset</parameter> queda sin cambios.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8871302d240f124f7e9dabac85862e31bf97b442 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="intldateformatter.parsetocalendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlDateFormatter::parseToCalendar</refname>
@@ -38,12 +38,12 @@
     <term><parameter>offset</parameter></term>
     <listitem>
      <simpara>
-      Posición en la que comenzar el análisis en <parameter>string</parameter> (basada en cero).
-      Si no ocurre ningún error antes de que <parameter>string</parameter> sea consumida,
-      <parameter>offset</parameter> contendrá -1; de lo contrario contendrá la posición
-      en la que el análisis terminó (y se produjo el error).
-      Esta variable contendrá la posición final si el análisis falla.
-      Si <parameter>offset</parameter> &gt; <code>strlen($string)</code>, el análisis falla inmediatamente.
+      Posición en la que comenzar el análisis en <parameter>string</parameter> (base-0).
+      Al regresar, <parameter>offset</parameter> contiene la posición en la que
+      terminó el análisis, independientemente de si el análisis tuvo éxito o no.
+      Si <parameter>offset</parameter> es mayor que
+      <literal>strlen($string)</literal>, el análisis falla inmediatamente y
+      <parameter>offset</parameter> queda sin cambios.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -38,7 +38,7 @@
     <term><parameter>offset</parameter></term>
     <listitem>
      <simpara>
-      Posición en la que comenzar el análisis en <parameter>string</parameter> (base-0).
+      Posición en la que comenzar el análisis en <parameter>string</parameter> (basada en cero).
       Al regresar, <parameter>offset</parameter> contiene la posición en la que
       terminó el análisis, independientemente de si el análisis tuvo éxito o no.
       Si <parameter>offset</parameter> es mayor que


### PR DESCRIPTION
Fixes #1213

Sync with EN commit 8871302d240f124f7e9dabac85862e31bf97b442.

- Correct offset parameter documentation: it holds the position at which parsing ended (success or failure), not -1 on success
- localtime/parse: also fail immediately if offset is negative
- parseToCalendar: only fails immediately if offset > strlen (exempts -1)
- localtime: mark up parameter references ($value/$parse_pos → parameter tags)
- localtime: qualify tm_yday as 1-based (unlike localtime() which is 0-based)
- parse: describe formatter as object, not resource