### PR TITLE
[Sync-En] Add namespace caveats to define(), defined(), and constant() (#5256)

### DIFF
--- a/reference/misc/functions/constant.xml
+++ b/reference/misc/functions/constant.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6c3091b54b66181db5f81ef5afe1d2e8b6efdeac Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.constant" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>constant</refname>
@@ -34,6 +33,28 @@
       <para>
        El nombre de la constante.
       </para>
+      <note>
+       <simpara>
+        <function>constant</function> toma el nombre como un
+        <type>string</type> ordinario y no lo resuelve con respecto al
+        <link linkend="language.namespaces.dynamic">espacio de nombres</link>
+        actual: el nombre se busca en el espacio de nombres global, por lo que
+        un nombre sin calificar puede devolver silenciosamente una constante
+        diferente a la que el mismo identificador sin prefijo haría referencia.
+        Para recuperar el valor de una constante declarada en un espacio de
+        nombres, el espacio de nombres debe formar parte del nombre, como en
+        <literal>constant('Mi\Espacio\MICONSTANTE')</literal> o
+        <literal>constant(__NAMESPACE__ . '\MICONSTANTE')</literal>.
+        Como el nombre es una cadena simple, los alias introducidos por
+        sentencias <literal>use</literal> y el prefijo
+        <literal>namespace\</literal> no se aplican a él.
+        En una cadena entre comillas dobles, los separadores de espacio de
+        nombres deben escaparse, como en
+        <literal>"Mi\\Espacio\\MICONSTANTE"</literal>.
+        La parte del espacio de nombres del nombre no distingue entre
+        mayúsculas y minúsculas, el nombre de la constante sí lo hace.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a124543dd3f6b1e5567b07420d23899e582514dc Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.define" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>define</refname>
@@ -37,6 +36,31 @@
         ser recuperados con la función <function>constant</function>.
         Sin embargo, hacer esto no se recomienda.
        </para>
+       <simpara>
+        <function>define</function> toma el nombre como un
+        <type>string</type> ordinario y no lo resuelve con respecto al
+        <link linkend="language.namespaces.dynamic">espacio de nombres</link>
+        actual.
+        Dentro de <literal>namespace Mi\Espacio;</literal>,
+        <literal>define('MICONSTANTE', 1)</literal> define
+        <literal>MICONSTANTE</literal> en el espacio de nombres global,
+        silenciosamente y sin error.
+        Para situar la constante en un espacio de nombres, el espacio de nombres
+        debe formar parte del nombre, escrito sin un separador de espacio de
+        nombres inicial, como en
+        <literal>define('Mi\Espacio\MICONSTANTE', 1)</literal> o
+        <literal>define(__NAMESPACE__ . '\MICONSTANTE', 1)</literal>.
+        A diferencia de <function>defined</function> y
+        <function>constant</function>, <function>define</function> no elimina
+        un separador inicial:
+        <literal>define('\Mi\Espacio\MICONSTANTE', 1)</literal> devuelve &true;
+        pero crea una constante que nunca puede ser recuperada.
+        Como el nombre es una cadena simple, los alias introducidos por
+        sentencias <literal>use</literal> no se aplican a él.
+        En una cadena entre comillas dobles, los separadores de espacio de
+        nombres deben escaparse, como en
+        <literal>"Mi\\Espacio\\MICONSTANTE"</literal>.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/misc/functions/defined.xml
+++ b/reference/misc/functions/defined.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 36e1d917ef7be36e8b4ff5193b456390061f2e21 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.defined" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>defined</refname>
@@ -43,6 +41,28 @@
       <para>
        El nombre de la constante.
       </para>
+      <note>
+       <simpara>
+        <function>defined</function> toma el nombre como un
+        <type>string</type> ordinario y no lo resuelve con respecto al
+        <link linkend="language.namespaces.dynamic">espacio de nombres</link>
+        actual: el nombre se busca en el espacio de nombres global, por lo que
+        un nombre sin calificar puede comprobar silenciosamente una constante
+        diferente a la que el mismo identificador sin prefijo haría referencia.
+        Para verificar si una constante declarada en un espacio de nombres está
+        definida, el espacio de nombres debe formar parte del nombre, como en
+        <literal>defined('Mi\Espacio\MICONSTANTE')</literal> o
+        <literal>defined(__NAMESPACE__ . '\MICONSTANTE')</literal>.
+        Como el nombre es una cadena simple, los alias introducidos por
+        sentencias <literal>use</literal> y el prefijo
+        <literal>namespace\</literal> no se aplican a él.
+        En una cadena entre comillas dobles, los separadores de espacio de
+        nombres deben escaparse, como en
+        <literal>"Mi\\Espacio\\MICONSTANTE"</literal>.
+        La parte del espacio de nombres del nombre no distingue entre
+        mayúsculas y minúsculas, el nombre de la constante sí lo hace.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Fixes #1214

Sync with EN commit 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2.

Add notes to define(), defined(), and constant() explaining that these functions take the name as an ordinary string and never resolve it against the current namespace. Documents how to use them with namespaced constants and the differences between them (define() does not strip a leading namespace separator).