### PR TITLE
[Sync-En] fix: use strict comparisons of returns in openssl_verify examples (#4827)

### DIFF
--- a/reference/ldap/functions/ldap-compare.xml
+++ b/reference/ldap/functions/ldap-compare.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b7cbd468cb4c46d55d43a44cade0eb4590d25dea Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.ldap-compare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_compare</refname>
@@ -78,6 +77,15 @@
    Devuelve &true; si el valor <parameter>value</parameter> coincide, de lo contrario,
    devuelve &false;. Devuelve -1 si ocurre un error.
   </para>
+  <warning>
+   <simpara>
+    Tanto &true; como <literal>-1</literal> son
+    <link linkend="language.types.boolean.casting">truthy</link>, por lo que una
+    simple prueba de verdad como <code>if (ldap_compare(...))</code> trata un
+    error como una coincidencia. El resultado debe compararse estrictamente
+    contra &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-pkcs7-verify.xml
+++ b/reference/openssl/functions/openssl-pkcs7-verify.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.openssl-pkcs7-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_pkcs7_verify</refname>
@@ -110,6 +108,15 @@
    en caso contrario (el mensaje ha sido modificado, o bien el certificado de firma es
    inválido) o -1 si ocurre un error.
   </para>
+  <warning>
+   <simpara>
+    Tanto &true; como <literal>-1</literal> son
+    <link linkend="language.types.boolean.casting">truthy</link>, por lo que una
+    simple prueba de verdad como <code>if (openssl_pkcs7_verify(...))</code>
+    trata un error como una verificación exitosa. El resultado debe compararse
+    estrictamente contra &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ddcd63907372580151daf69458d6a8268232b703 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.openssl-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_verify</refname>
@@ -93,6 +91,15 @@ MIIBCgK...</literal>.
    Retorna 1 si la firma es correcta, 0 si es
    incorrecta y -1 o &false; si ocurre un error.
   </para>
+  <warning>
+   <simpara>
+    Tanto el valor de éxito como el valor de error son
+    <link linkend="language.types.boolean.casting">truthy</link>, por lo que una
+    simple prueba de verdad como <code>if (openssl_verify(...))</code> trata un
+    error como una verificación exitosa. El resultado debe compararse
+    estrictamente contra <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -141,9 +148,9 @@ $pubkeyid = openssl_pkey_get_public("file://src/openssl-0.9.6/demos/sign/cert.pe
 
 // indica si la firma es correcta
 $ok = openssl_verify($data, $signature, $pubkeyid);
-if ($ok == 1) {
+if ($ok === 1) {
     echo "Firma válida";
-} elseif ($ok == 0) {
+} elseif ($ok === 0) {
     echo "Firma errónea";
 } else {
     echo "Error de verificación de la firma";
@@ -175,9 +182,9 @@ openssl_sign($data, $signature, $private_key_res, "sha256WithRSAEncryption");
 
 //Verifica la firma
 $ok = openssl_verify($data, $signature, $public_key_res, OPENSSL_ALGO_SHA256);
-if ($ok == 1) {
+if ($ok === 1) {
     echo "válida";
-} elseif ($ok == 0) {
+} elseif ($ok === 0) {
     echo "inválida";
 } else {
     echo "error: ".openssl_error_string();

--- a/reference/openssl/functions/openssl-x509-checkpurpose.xml
+++ b/reference/openssl/functions/openssl-x509-checkpurpose.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.openssl-x509-checkpurpose" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_x509_checkpurpose</refname>
@@ -137,6 +135,15 @@
    Retorna &true; si el certificado puede ser utilizado para un propósito particular,
    &false; si no puede serlo, o -1 si ocurre un error.
   </para>
+  <warning>
+   <simpara>
+    Tanto &true; como <literal>-1</literal> son
+    <link linkend="language.types.boolean.casting">truthy</link>, por lo que una
+    simple prueba de verdad como <code>if (openssl_x509_checkpurpose(...))</code>
+    trata un error como una verificación exitosa. El resultado debe compararse
+    estrictamente contra &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-x509-verify.xml
+++ b/reference/openssl/functions/openssl-x509-verify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6819d9e5807762161caace88a21930156a313195 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: PhilDaiguille Status: ready -->
 <refentry xml:id="function.openssl-x509-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_x509_verify</refname>
@@ -48,6 +48,15 @@ MIIBCgK...</literal>.
    Devuelve 1 si la firma es correcta, 0 si es incorrecta y
    -1 si ocurre un error.
   </para>
+  <warning>
+   <simpara>
+    Tanto el valor de éxito como el valor de error son
+    <link linkend="language.types.boolean.casting">truthy</link>, por lo que una
+    simple prueba de verdad como <code>if (openssl_x509_verify(...))</code>
+    trata un error como una verificación exitosa. El resultado debe compararse
+    estrictamente contra <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -113,7 +122,7 @@ foreach($cont["options"]["ssl"]["peer_certificate_chain"] as $chaincert)
     $chainparsed = openssl_x509_parse($chaincert);
     $chain_public_key = openssl_get_publickey($chaincert);
     $r = openssl_x509_verify($x509, $chain_public_key);
-    if ($r==1)
+    if ($r === 1)
     {
         echo $certparsed['subject']['CN'];
         echo " fue firmado digitalmente por ";

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ziparchive.getarchiveflag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getArchiveFlag</refname>
@@ -70,6 +69,14 @@
   <simpara>
    Devuelve 1 si la bandera está definida para el archivo, 0 si no lo está, y -1 si ocurre un error.
   </simpara>
+  <warning>
+   <simpara>
+    Tanto <literal>1</literal> como <literal>-1</literal> son
+    <link linkend="language.types.boolean.casting">truthy</link>, por lo que una
+    simple prueba de verdad trata un error como que la bandera está definida.
+    El resultado debe compararse estrictamente contra <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Fixes #1215

Sync with EN commit 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69.

- Add warnings to openssl_verify(), openssl_x509_verify(), openssl_pkcs7_verify(), openssl_x509_checkpurpose(), ldap_compare(), and ZipArchive::getArchiveFlag() explaining that both the success value and -1 are truthy, so a plain truth test treats an error as a positive result
- Fix examples in openssl_verify() to use strict comparisons (=== instead of ==)
- Fix example in openssl_x509_verify() to use strict comparison