### PR TITLE
[Sync-En] Add a note about time zone changes in PHP 8.2

### DIFF
--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e4666d527453044f07c94da5ab51fd5cd4c1a615 Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="migration82.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Otros cambios</title>
 
@@ -125,6 +124,11 @@ compararse con <literal>0</literal>.
    <para>
     Las propiedades de <classname>DatePeriod</classname> ahora están correctamente declaradas.
    </para>
+
+   <simpara>
+    La zona horaria predeterminada usará UTC si la configuración ini
+    <link linkend="ini.date.timezone">date.timezone</link> no está definida.
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration82.other-changes.extensions.intl">


### PR DESCRIPTION
Fixes #1216

Sync with EN commit e4666d527453044f07c94da5ab51fd5cd4c1a615.

Add a note to the migration 8.2 documentation that the default timezone falls back to UTC if the date.timezone ini setting is not set.