### PR TITLE
[Sync-En] objects does not have to be Traversable to be ForEach'ed. (#4535)

### DIFF
--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: PhilDaiguille Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0d9947f2b1f0997cd8ddf80227b632dd5d3f2f92 Maintainer: PhilDaiguille Status: ready -->
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
  <?phpdoc print-version-for="foreach"?>
  <para>
   La estructura <literal>foreach</literal> proporciona una forma sencilla de
-  iterar sobre <type>array</type>s y objetos <interfacename>Traversable</interfacename>.
+  iterar sobre <type>array</type>s y objetos.
   <literal>foreach</literal> generará un error cuando se utilice con
   una variable que contenga un tipo de dato diferente o con una variable no inicializada.
   <informalexample>
@@ -27,7 +26,7 @@ foreach (iterable_expression as $key => $value) {
   </informalexample>
  </para>
  <simpara>
-  La primera forma recorre el iterable dado por
+  La primera forma recorre el valor dado por
   <literal>iterable_expression</literal>. En cada iteración, el valor del
   elemento actual se asigna a <literal>$value</literal>.
  </simpara>
@@ -41,6 +40,8 @@ foreach (iterable_expression as $key => $value) {
   y <function>key</function>.
  </simpara>
  <simpara>
+  Por defecto, un objeto se recorre sobre las propiedades que son
+  <link linkend="language.oop5.visibility">visibles</link> desde el ámbito actual.
   Es posible
   <link linkend="language.oop5.iterations">personalizar la iteración de objetos</link>.
  </simpara>


### PR DESCRIPTION
Fixes #1217

Sync with EN commit 0d9947f2b1f0997cd8ddf80227b632dd5d3f2f92.

- Remove the incorrect claim that foreach only works on Traversable objects
- Change "iterable" to "value" since the operand is not necessarily the iterable type
- Add a sentence explaining that objects are traversed over their visible properties by default