### PR TITLE
[Sync-En] ext/yaf: finish the Spanish translation of the loader and regex route pages

### DIFF
--- a/reference/yaf/yaf_loader/registerlocalnamespace.xml
+++ b/reference/yaf/yaf_loader/registerlocalnamespace.xml
@@ -56,11 +56,11 @@ class Bootstrap extends Yaf_Bootstrap_Abstract
         $loader = Yaf_Loader::getInstance();
 
         /* Models_User se busca ahora en
-                  * APPLICATION_PATH/library/Models/User.php */
+         * APPLICATION_PATH/library/Models/User.php */
         $loader->registerLocalNamespace("Models");
 
         /* se registran varios prefijos a la vez, cada uno con su
-                  * propio directorio de búsqueda */
+         * propio directorio de búsqueda */
         $loader->registerLocalNamespace(array(
             "Services" => APPLICATION_PATH . "/services",
             "Vendor"   => APPLICATION_PATH . "/vendor",

--- a/reference/yaf/yaf_loader/registernamespace.xml
+++ b/reference/yaf/yaf_loader/registernamespace.xml
@@ -60,7 +60,7 @@ class Bootstrap extends Yaf_Bootstrap_Abstract
 }
 
 /* new Vendor_Payment_Gateway() se busca ahora en
-  * APPLICATION_PATH/library/Vendor/Payment/Gateway.php */
+ * APPLICATION_PATH/library/Vendor/Payment/Gateway.php */
 ?>
 ]]>
    </programlisting>

--- a/reference/yaf/yaf_route_regex/construct.xml
+++ b/reference/yaf/yaf_route_regex/construct.xml
@@ -100,24 +100,24 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><classname>Yaf_Route_Regex</classname> via <methodname>Yaf_Router::addRoute</methodname></title>
+   <title><classname>Yaf_Route_Regex</classname> mediante <methodname>Yaf_Router::addRoute</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
 /**
-  * Añade una ruta regex a la pila de rutas de Yaf_Router
-  */
+ * Añade una ruta regex a la pila de rutas de Yaf_Router
+ */
 Yaf_Dispatcher::getInstance()->getRouter()->addRoute(
     "name",
     new Yaf_Route_Regex(
-        "#^/product/([^/]+)/([^/]+)#", // match a URI leading "/product"
+        "#^/product/([^/]+)/([^/]+)#", // coincide con una URI que empieza por "/product"
         array(
-            'controller' => "product", // route to the product controller
+            'controller' => "product", // enruta al controlador product
         ),
         array(
-            1 => "name", // $request->getParam("name") holds the first capture
-            2 => "id",   // and $request->getParam("id") the second
+            1 => "name", // $request->getParam("name") contiene la primera captura
+            2 => "id",   // y $request->getParam("id") la segunda
         )
     )
 );
@@ -132,18 +132,18 @@ Yaf_Dispatcher::getInstance()->getRouter()->addRoute(
 <?php
 
 /**
-  * Usa una captura como nombre del controlador
-  */
+ * Usa una captura como nombre del controlador
+ */
 Yaf_Dispatcher::getInstance()->getRouter()->addRoute(
     "name",
     new Yaf_Route_Regex(
-        "#^/product/([^/]+)/([^/]+)#i", // match a URI leading "/product"
+        "#^/product/([^/]+)/([^/]+)#i", // coincide con una URI que empieza por "/product"
         array(
-            'controller' => ":name", // the "name" capture (see map) becomes the controller
+            'controller' => ":name", // la captura "name" (véase map) se convierte en el controlador
         ),
         array(
-            1 => "name", // $request->getParam("name") holds the first capture
-            2 => "id",   // and $request->getParam("id") the second
+            1 => "name", // $request->getParam("name") contiene la primera captura
+            2 => "id",   // y $request->getParam("id") la segunda
         )
     )
 );
@@ -158,17 +158,17 @@ Yaf_Dispatcher::getInstance()->getRouter()->addRoute(
 <?php
 
 /**
-  * Usa un grupo de captura con nombre como nombre del controlador
-  */
+ * Usa un grupo de captura con nombre como nombre del controlador
+ */
 Yaf_Dispatcher::getInstance()->getRouter()->addRoute(
     "name",
     new Yaf_Route_Regex(
-        "#^/product/(?<name>[^/]+)/([^/]+)#i", // match a URI leading "/product"
+        "#^/product/(?<name>[^/]+)/([^/]+)#i", // coincide con una URI que empieza por "/product"
         array(
-            'controller' => ":name", // the "name" capture becomes the controller
+            'controller' => ":name", // la captura "name" se convierte en el controlador
         ),
         array(
-            2 => "id", // group 1 is named, only group 2 needs a map entry
+            2 => "id", // el grupo 1 tiene nombre, solo el grupo 2 necesita una entrada en map
         )
     )
 );
@@ -177,24 +177,24 @@ Yaf_Dispatcher::getInstance()->getRouter()->addRoute(
    </programlisting>
   </example>
   <example>
-   <title><classname>Yaf_Route_Regex</classname> via <methodname>Yaf_Router::addConfig</methodname></title>
+   <title><classname>Yaf_Route_Regex</classname> mediante <methodname>Yaf_Router::addConfig</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
 /**
-  * Añade una ruta regex a la pila de rutas de Yaf_Router mediante un array de configuración
-  */
+ * Añade una ruta regex a la pila de rutas de Yaf_Router mediante un array de configuración
+ */
 $config = array(
     "name" => array(
-        "type"  => "regex",          // a Yaf_Route_Regex route
-        "match" => "#(.*)#",         // match any request URI
+        "type"  => "regex",          // una ruta Yaf_Route_Regex
+        "match" => "#(.*)#",         // coincide con cualquier URI de petición
         "route" => array(
-            'controller' => "product", // route to the product controller
-            'action'     => "dummy",   // and to the dummy action
+            'controller' => "product", // enruta al controlador product
+            'action'     => "dummy",   // y a la acción dummy
         ),
         "map" => array(
-            1 => "uri", // $request->getParam("uri") holds the matched URI
+            1 => "uri", // $request->getParam("uri") contiene la URI coincidente
         ),
     ),
 );


### PR DESCRIPTION
Translation of php/doc-en#5490 (commit 052c737). The structural sync of these three pages already landed in php/doc-es#1179, which declared the right EN-Revision but left the example code untranslated: the inline comments of the four Yaf_Route_Regex examples were still in English, and two example titles were half translated. The continuation lines of the block comments were also misaligned in all three files.

Fixes: #1184