### PR TITLE
[Sync-En] array_unique: explain what the 7.2 rebuild actually changes

### DIFF
--- a/appendices/migration72/incompatible.xml
+++ b/appendices/migration72/incompatible.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8859c8b96cd9e80652813f7bcf561432a5e9f934 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5e26d11dc3f606b25c95467df22f9469636781f9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="migration72.incompatible">
@@ -273,12 +273,16 @@ int(2)
  <sect2 xml:id="migration72.incompatible.array-unique">
   <title><function>array_unique</function> con <constant>SORT_STRING</constant></title>
 
-  <para>
-   Mientras que <function>array_unique</function> con <constant>SORT_STRING</constant>
-   anteriormente copiaba el array y eliminaba elementos no únicos
-   (sin envolver el array después), ahora se construye un nuevo array añadiendo los elementos únicos.
-   Esto puede resultar en índices numéricos diferentes.
-  </para>
+  <simpara>
+   <function>array_unique</function> con <constant>SORT_STRING</constant>
+   construye el array devuelto añadiendo los elementos únicos a un array nuevo;
+   anteriormente, era una copia de la entrada de la que se eliminaban los
+   elementos no únicos.
+   Ambos contienen los mismos elementos bajo las mismas claves, pero si el
+   elemento con la clave entera mayor está entre los eliminados, el índice
+   generado para un elemento añadido al array devuelto difiere del que habría
+   generado la entrada.
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration72.incompatible.bcmod-and-floats">

--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 47cbf365f535be1517473eee446e94d096778ca8 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 5e26d11dc3f606b25c95467df22f9469636781f9 Maintainer: PhilDaiguille Status: ready -->
 <!-- CREDITS: DavidA. -->
 <refentry xml:id="function.array-unique" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -111,10 +111,13 @@
        <entry>7.2.0</entry>
        <entry>
         Si <parameter>flags</parameter> es <constant>SORT_STRING</constant>,
-        anteriormente <parameter>array</parameter> era copiado y los elementos
-        no únicos eran eliminados (sin comprimir el array después), pero
-        ahora se construye un nuevo array añadiendo los elementos únicos.
-        Como consecuencia, el resultado final puede tener índices numéricos diferentes.
+        el array devuelto se construye añadiendo los elementos únicos a un
+        array nuevo; anteriormente, era una copia de <parameter>array</parameter>
+        de la que se eliminaban los elementos no únicos.
+        Ambos contienen los mismos elementos bajo las mismas claves, pero si el
+        elemento con la clave entera mayor está entre los eliminados, el índice
+        generado para un elemento añadido al array devuelto difiere del que
+        habría generado <parameter>array</parameter>.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Translation of php/doc-en#5825 (commit 5e26d11): the 7.2 changelog entry and the migration appendix now say what the rebuild actually changes, namely the index generated for an element appended to the returned array. EN-Revision updated.

Fixes: #1232