### PR TITLE
[Sync-En] fpm: warn that an exposed FastCGI endpoint allows arbitrary code execution

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -265,7 +265,7 @@
          Cuando se utiliza un socket TCP, las direcciones autorizadas a
          conectarse deben enumerarse en
          <link linkend="listen-allowed-clients">listen.allowed_clients</link>,
-         que no está definida por omisión y acepta entonces cualquier dirección.
+         que no está definida por defecto y acepta entonces cualquier dirección.
          En entornos de contenedores, el servicio FPM no debe publicar su puerto
          en el host; los contenedores de la misma red se alcanzan directamente.
         </simpara>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7cd12cc82bc0a778241189596022acdda016d857 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7efe863bc4b65788f652e3d9eff27941b1a74540 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>Configuration</title>
@@ -252,6 +252,24 @@
         'ip.add.re.ss:port', 'port', '/path/to/unix/socket'. This option is
         mandatory for each pool.
        </para>
+       <warning>
+        <simpara>
+         Un punto de acceso FastCGI expuesto permite la ejecución de código
+         arbitrario.
+         Cuando el servidor web se ejecuta en el mismo host, es preferible un
+         socket Unix; en Linux su acceso se controla entonces mediante
+         <link linkend="listen-owner">listen.owner</link>,
+         <literal>listen.group</literal> y <literal>listen.mode</literal>,
+         aunque muchos sistemas derivados de BSD aceptan conexiones sin tener
+         en cuenta esos permisos.
+         Cuando se utiliza un socket TCP, las direcciones autorizadas a
+         conectarse deben enumerarse en
+         <link linkend="listen-allowed-clients">listen.allowed_clients</link>,
+         que no está definida por omisión y acepta entonces cualquier dirección.
+         En entornos de contenedores, el servicio FPM no debe publicar su puerto
+         en el host; los contenedores de la misma red se alcanzan directamente.
+        </simpara>
+       </warning>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="listen-backlog">

--- a/install/fpm/index.xml
+++ b/install/fpm/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 04210d535db52aed64b82572817f059059ddfebc Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 7efe863bc4b65788f652e3d9eff27941b1a74540 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: PhilDaiguille -->
 <chapter xml:id="install.fpm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>FastCGI Process Manager (FPM)</title>
@@ -41,10 +41,10 @@
     </para>
    </listitem>
    <listitem>
-    <para>
+    <simpara>
      <function>fastcgi_finish_request</function> - función especial para terminar la petición y volcar todas las datos
      mientras se continúa ejecutando una tarea consumidora (conversión de video por ejemplo) ;
-    </para>
+    </simpara>
    </listitem>
    <listitem>
     <para>
@@ -64,6 +64,19 @@
    </listitem>
   </itemizedlist>
  </para>
+
+ <warning>
+  <simpara>
+   php-fpm no debe ser accesible desde una red no confiable.
+   Un cliente capaz de abrir una conexión FastCGI controla la configuración
+   utilizada para la petición, incluida
+   <link linkend="ini.auto-prepend-file">auto_prepend_file</link>, y puede por
+   tanto ejecutar código arbitrario.
+   El acceso se restringe mediante las directivas
+   <link linkend="listen">listen</link> y
+   <link linkend="listen-allowed-clients">listen.allowed_clients</link>.
+  </simpara>
+ </warning>
 
  &install.fpm.install;
  &install.fpm.configuration;


### PR DESCRIPTION
Translation of php/doc-en#5263 (commit 7efe863): the FPM chapter and the listen directive now warn that a client able to open a FastCGI connection controls the configuration used for the request, and point at listen and listen.allowed_clients. EN-Revision updated.

install/fpm/configuration.xml is still an untranslated copy of the English page, so only the new warning is in Spanish there.

Fixes: #1233