### PR TITLE
[Sync-En] hash_algos: point at the algorithm categories in the extension introduction

### DIFF
--- a/reference/hash/functions/hash-algos.xml
+++ b/reference/hash/functions/hash-algos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 71e12e2df7b0bcf0dc2743681b73790ac0d45ccc Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 9d8fd9317e3167cee8da1c22031ece5f760e0fd9 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.hash-algos" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -26,9 +26,17 @@
    Devuelve un array indexado numéricamente que contiene la lista de algoritmos
    de hash disponibles.
   </para>
+  <note>
+   <simpara>
+    No todos los algoritmos son adecuados para todos los casos de uso.
+    Véase la <link linkend="intro.hash">introducción a la extensión Hash</link>
+    para una descripción de las distintas categorías (suma de comprobación,
+    no criptográfico y criptográfico).
+   </simpara>
+  </note>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -63,7 +71,7 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
@@ -153,13 +161,13 @@ Array
   </para>
  </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>hash</function></member>
    <member><function>hash_hmac_algos</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Translation of php/doc-en#5273 (commit 9d8fd93): a note on the return value warns that not every algorithm suits every use case, and links to the checksum / non-cryptographic / cryptographic categories described in the Hash introduction. EN-Revision updated.

Fixes: #1234