### PR TITLE
[Sync-En] swoole: document the Timer class and its remaining methods

### DIFF
--- a/reference/swoole/swoole.timer.xml
+++ b/reference/swoole/swoole.timer.xml
@@ -57,9 +57,10 @@ Swoole\Event::defer(function () {
     la retrollamada se dispara de nuevo en 0,032 s.
    </simpara>
    <simpara>
-    Por omisión, cuando un temporizador se dispara se crea automáticamente una
-    corrutina para ejecutar la función de retrollamada. Este comportamiento se
-    desactiva con <function>swoole_async_set</function>.
+    De forma predeterminada, cuando un temporizador se dispara se crea
+    automáticamente una corrutina para ejecutar la función de retrollamada.
+    Este comportamiento puede desactivarse con
+    <function>swoole_async_set</function>.
    </simpara>
    <warning>
     <simpara>

--- a/reference/swoole/swoole.timer.xml
+++ b/reference/swoole/swoole.timer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes Maintainer: Marqitos -->
 <reference xml:id="class.swoole-timer" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Swoole\Timer</title>
@@ -10,9 +10,74 @@
 <!-- {{{ Swoole\Timer intro -->
   <section xml:id="swoole-timer.intro">
    &reftitle.intro;
+   <simpara>
+    Temporizador con precisión de milisegundos. La implementación subyacente se
+    basa en epoll_wait y setitimer, con una estructura de datos de montículo
+    mínimo que permite añadir un gran número de temporizadores.
+   </simpara>
+   <simpara>
+    En los procesos con E/S síncrona, como los procesos Manager y TaskWorker, se
+    implementa mediante setitimer y señales.
+   </simpara>
+   <simpara>
+    En los procesos con E/S asíncrona, se implementa mediante el tiempo de
+    espera de epoll_wait/kevent/poll/select.
+   </simpara>
    <para>
-
+    El sistema subyacente no admite temporizadores con un retardo de
+    <literal>0</literal>; los valores inferiores a <literal>1</literal>
+    milisegundo emiten un <constant>E_WARNING</constant> y la llamada falla.
+    Esto difiere de lenguajes como Node.js.
+    <methodname linkend="swoole-event.defer">Swoole\Event::defer</methodname>
+    puede utilizarse para obtener una funcionalidad similar.
+    <programlisting role="php">
+<![CDATA[
+<?php
+Swoole\Event::defer(function () {
+  echo "hola\n";
+});
+?>
+]]>
+    </programlisting>
    </para>
+   <simpara>
+    Corrección del temporizador: el tiempo de ejecución de la función de
+    retrollamada no afecta al instante de la siguiente ejecución. Por ejemplo,
+    para un temporizador tick de 10 ms creado en 0,002 s, la primera
+    retrollamada se ejecuta en 0,012 s; si la función de retrollamada tarda
+    5 ms, el siguiente disparo se produce igualmente en 0,022 s, y no en
+    0,027 s.
+   </simpara>
+   <simpara>
+    En cambio, si la función de retrollamada tarda demasiado, hasta cubrir el
+    instante de la siguiente ejecución, el sistema subyacente corrige el tiempo:
+    descarta los disparos vencidos y vuelve a llamar a la función en el
+    siguiente instante disponible. Por ejemplo, si la retrollamada ejecutada en
+    0,012 s tarda 15 ms, lo que retrasa el temporizador previsto para 0,022 s,
+    la retrollamada se dispara de nuevo en 0,032 s.
+   </simpara>
+   <simpara>
+    Por omisión, cuando un temporizador se dispara se crea automáticamente una
+    corrutina para ejecutar la función de retrollamada. Este comportamiento se
+    desactiva con <function>swoole_async_set</function>.
+   </simpara>
+   <warning>
+    <simpara>
+     Un temporizador solo funciona en el espacio del proceso actual.
+    </simpara>
+   </warning>
+   <warning>
+    <simpara>
+     Los temporizadores son puramente asíncronos e incompatibles con las
+     funciones de E/S síncrona.
+    </simpara>
+   </warning>
+   <warning>
+    <simpara>
+     La ejecución de un temporizador puede presentar ligeras desviaciones de
+     tiempo.
+    </simpara>
+   </warning>
   </section>
 <!-- }}} -->
 

--- a/reference/swoole/swoole/timer/after.xml
+++ b/reference/swoole/swoole/timer/after.xml
@@ -1,42 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-timer.after" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Timer::after</refname>
-  <refpurpose>Dispara una retrollamada después de un período de tiempo.</refpurpose>
+  <refpurpose>Ejecuta una función después de un tiempo determinado</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Swoole\Timer::after</methodname>
-   <methodparam><type>int</type><parameter>after_time_ms</parameter></methodparam>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>Swoole\Timer::after</methodname>
+   <methodparam><type>int</type><parameter>ms</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    Dispara una retrollamada después de un período de tiempo.
-  </para>
-
+  <simpara>
+   Crea un temporizador de un solo disparo, que se destruye una vez ejecutada
+   su retrollamada. A diferencia de <function>sleep</function>, no bloquea el
+   proceso actual.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>after_time_ms</parameter></term>
+    <term><parameter>ms</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      El retardo en milisegundos. Debe ser mayor o igual que
+      <literal>1</literal>; un valor inferior emite un
+      <constant>E_WARNING</constant> y la llamada falla.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      La función a ejecutar una vez transcurrido el retardo. Se llama como
+      <literal>callback(mixed ...$params)</literal>. A diferencia de
+      <methodname>Swoole\Timer::tick</methodname>, el identificador del
+      temporizador no se pasa a la retrollamada.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>params</parameter></term>
+    <listitem>
+     <simpara>
+      Valores adicionales que se pasan a <parameter>callback</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,11 +59,36 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Devuelve el identificador del temporizador, que puede pasarse a
+   <methodname>Swoole\Timer::clear</methodname> para cancelarlo antes de que se
+   dispare. Devuelve &false; si el temporizador no ha podido crearse, en
+   particular cuando <parameter>ms</parameter> es menor que
+   <literal>1</literal>.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <function>Swoole\Timer::after</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+Swoole\Timer::after(1000, function (string $name) {
+    echo "Hola, $name\n";
+}, "Swoole");
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Hola, Swoole
+]]>
+   </screen>
+  </example>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/swoole/swoole/timer/clear.xml
+++ b/reference/swoole/swoole/timer/clear.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-timer.clear" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Timer::clear</refname>
-  <refpurpose>Elimina un temporizador por ID de temporizador.</refpurpose>
+  <refpurpose>Elimina un temporizador por su identificador</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Swoole\Timer::clear</methodname>
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Swoole\Timer::clear</methodname>
    <methodparam><type>int</type><parameter>timer_id</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    Elimina un temporizador por ID de temporizador.
-  </para>
-
+  <simpara>
+   Elimina el temporizador con el identificador indicado. Solo pueden
+   eliminarse los temporizadores creados por el proceso actual; los
+   temporizadores que pertenecen a otros procesos no son visibles aquí.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +26,11 @@
    <varlistentry>
     <term><parameter>timer_id</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      El identificador del temporizador devuelto por
+      <methodname>Swoole\Timer::tick</methodname> o
+      <methodname>Swoole\Timer::after</methodname>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,11 +38,36 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   &return.success;
+   Se devuelve &false; cuando no existe ningún temporizador con este
+   identificador en el proceso actual, o cuando el identificador corresponde a
+   un temporizador interno.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <function>Swoole\Timer::clear</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$timer_id = Swoole\Timer::after(1000, function () {
+    echo "nunca se imprime\n";
+});
+var_dump(Swoole\Timer::clear($timer_id));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/swoole/swoole/timer/clearAll.xml
+++ b/reference/swoole/swoole/timer/clearAll.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="swoole-timer.clearall" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::clearAll</refname>
+  <refpurpose>Elimina todos los temporizadores del proceso actual.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Swoole\Timer::clearAll</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Elimina todos los temporizadores del proceso actual. A partir de Swoole 4.4.0.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+   Se devuelve &false; cuando todavía no se ha creado ningún temporizador en
+   este proceso. Solo se eliminan los temporizadores creados desde PHP; los
+   temporizadores internos se mantienen.
+  </simpara>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/info.xml
+++ b/reference/swoole/swoole/timer/info.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="swoole-timer.info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::info</refname>
+  <refpurpose>Obtiene información sobre un temporizador.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>Swoole\Timer::info</methodname>
+   <methodparam><type>int</type><parameter>timer_id</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Obtiene información sobre un temporizador. A partir de Swoole 4.4.0.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timer_id</parameter></term>
+    <listitem>
+     <simpara>
+      El identificador del temporizador devuelto por
+      <methodname>Swoole\Timer::tick</methodname> o
+      <methodname>Swoole\Timer::after</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve un array que describe el temporizador, o &null; si no existe
+   ningún temporizador con este identificador en el proceso actual. El array
+   contiene las siguientes claves:
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>exec_msec</literal></term>
+    <listitem>
+     <simpara>
+      El instante de la siguiente ejecución, en milisegundos, contado desde el
+      momento en que se inició el subsistema de temporizadores. No es una
+      duración.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>exec_count</literal></term>
+    <listitem>
+     <simpara>
+      El número de veces que se ha ejecutado la retrollamada.
+      Disponible a partir de Swoole 4.8.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>interval</literal></term>
+    <listitem>
+     <simpara>
+      El intervalo del temporizador, en milisegundos.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>round</literal></term>
+    <listitem>
+     <simpara>
+      El número de la vuelta del bucle de temporizadores en la que se creó el
+      temporizador.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>removed</literal></term>
+    <listitem>
+     <simpara>
+      Indica si el temporizador ha sido eliminado.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <function>Swoole\Timer::info</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$timer_id = Swoole\Timer::tick(1000, function () {});
+var_dump(Swoole\Timer::info($timer_id));
+Swoole\Timer::clear($timer_id);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(5) {
+  ["exec_msec"]=>
+  int(1000)
+  ["exec_count"]=>
+  int(0)
+  ["interval"]=>
+  int(1000)
+  ["round"]=>
+  int(0)
+  ["removed"]=>
+  bool(false)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/list.xml
+++ b/reference/swoole/swoole/timer/list.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="swoole-timer.list" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::list</refname>
+  <refpurpose>Obtiene un iterador sobre los temporizadores del proceso actual</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>Swoole\Timer\Iterator</type><methodname>Swoole\Timer::list</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Devuelve un iterador sobre los identificadores de los temporizadores creados
+   desde PHP en el proceso actual. Los temporizadores creados internamente por
+   Swoole no se enumeran. A partir de Swoole 4.4.0.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve un objeto <classname>Swoole\Timer\Iterator</classname>, que extiende
+   <classname>ArrayIterator</classname> y proporciona los identificadores de
+   los temporizadores como valores <type>int</type>. El iterador es una
+   instantánea tomada en el momento de la llamada; está vacío cuando no existe
+   ningún temporizador.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <function>Swoole\Timer::list</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+Swoole\Timer::tick(1000, function () {});
+Swoole\Timer::after(5000, function () {});
+
+foreach (Swoole\Timer::list() as $timer_id) {
+    echo $timer_id, "\n";
+    Swoole\Timer::clear($timer_id);
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+1
+2
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/set.xml
+++ b/reference/swoole/swoole/timer/set.xml
@@ -1,35 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
-<refentry xml:id="swoole-timer.exists" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="swoole-timer.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>Swoole\Timer::exists</refname>
-  <refpurpose>Comprueba si un temporizador existe</refpurpose>
+  <refname>Swoole\Timer::set</refname>
+  <refpurpose>Define los parámetros relacionados con los temporizadores</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Swoole\Timer::exists</methodname>
-   <methodparam><type>int</type><parameter>timer_id</parameter></methodparam>
+   <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Swoole\Timer::set</methodname>
+   <methodparam><type>array</type><parameter>settings</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Comprueba si existe en el proceso actual un temporizador con el
-   identificador indicado.
+   Define las opciones utilizadas por los temporizadores del proceso actual.
   </simpara>
 
+  <warning>
+   <simpara>
+    Este método quedó obsoleto en Swoole 4.6.0 y se eliminó en Swoole 6.0.0.
+    Utilice <function>swoole_async_set</function> en su lugar.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>timer_id</parameter></term>
+    <term><parameter>settings</parameter></term>
     <listitem>
      <simpara>
-      El identificador del temporizador devuelto por
-      <methodname>Swoole\Timer::tick</methodname> o
-      <methodname>Swoole\Timer::after</methodname>.
+      Un array asociativo de opciones. Solo se reconoce
+      <literal>enable_coroutine</literal>: cuando vale &false;, las
+      retrollamadas de los temporizadores se ejecutan directamente y no dentro
+      de una corrutina creada al efecto.
      </simpara>
     </listitem>
    </varlistentry>
@@ -39,12 +45,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve &true; si existe un temporizador con este identificador en el
-   proceso actual, y &false; en caso contrario.
+   &return.void;
   </simpara>
  </refsect1>
-
-
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/swoole/swoole/timer/stats.xml
+++ b/reference/swoole/swoole/timer/stats.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="swoole-timer.stats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::stats</refname>
+  <refpurpose>Obtiene estadísticas de los temporizadores.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>array</type><methodname>Swoole\Timer::stats</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Obtiene estadísticas de los temporizadores. A partir de Swoole 4.4.0.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve un array con las siguientes claves:
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>initialized</literal></term>
+    <listitem>
+     <simpara>
+      Indica si el subsistema de temporizadores ha sido iniciado. Vale &false;
+      hasta que se crea el primer temporizador.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>num</literal></term>
+    <listitem>
+     <simpara>
+      El número de temporizadores registrados actualmente en el proceso.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>round</literal></term>
+    <listitem>
+     <simpara>
+      La vuelta actual del bucle de temporizadores.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <function>Swoole\Timer::stats</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$timer_id = Swoole\Timer::tick(1000, function () {});
+var_dump(Swoole\Timer::stats());
+Swoole\Timer::clear($timer_id);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(3) {
+  ["initialized"]=>
+  bool(true)
+  ["num"]=>
+  int(1)
+  ["round"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/tick.xml
+++ b/reference/swoole/swoole/timer/tick.xml
@@ -1,51 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="swoole-timer.tick" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Timer::tick</refname>
-  <refpurpose>Repite una función dada en cada intervalo de tiempo dado.</refpurpose>
+  <refpurpose>Define un temporizador de intervalo repetitivo</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Swoole\Timer::tick</methodname>
-   <methodparam><type>int</type><parameter>interval_ms</parameter></methodparam>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>Swoole\Timer::tick</methodname>
+   <methodparam><type>int</type><parameter>ms</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>param</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
+  <simpara>
+   Define un temporizador que se dispara cada <parameter>ms</parameter>
+   milisegundos. A diferencia de un temporizador creado con
+   <methodname>Swoole\Timer::after</methodname>, sigue disparándose hasta que
+   se elimina con <methodname>Swoole\Timer::clear</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>interval_ms</parameter></term>
+    <term><parameter>ms</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      El intervalo en milisegundos. Debe ser mayor o igual que
+      <literal>1</literal>; un valor inferior emite un
+      <constant>E_WARNING</constant> y la llamada falla.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      La función a ejecutar en cada disparo. Se llama como
+      <literal>callback(int $timer_id, mixed ...$params)</literal>: el
+      identificador del temporizador se pasa como primer argumento, seguido de
+      los valores indicados en <parameter>params</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>param</parameter></term>
+    <term><parameter>params</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Valores adicionales que se pasan a <parameter>callback</parameter>
+      después del identificador del temporizador.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -53,11 +61,41 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Devuelve el identificador del temporizador, que puede pasarse a
+   <methodname>Swoole\Timer::clear</methodname>. Devuelve &false; si el
+   temporizador no ha podido crearse, en particular cuando
+   <parameter>ms</parameter> es menor que <literal>1</literal>.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ejemplo de <function>Swoole\Timer::tick</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$ticks = 0;
+Swoole\Timer::tick(1000, function (int $timer_id, string $label) use (&$ticks) {
+    echo "tick #", ++$ticks, " ($label)\n";
+    if ($ticks === 3) {
+        Swoole\Timer::clear($timer_id);
+    }
+}, "job");
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+tick #1 (job)
+tick #2 (job)
+tick #3 (job)
+]]>
+   </screen>
+  </example>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Translation of php/doc-en#4773 (commit 6e77169): the Timer intro, tick(), after(), clear() and exists() were empty stubs and are now written out, and clearAll(), info(), list(), set() and stats() are translated for the first time. EN-Revision updated.

Fixes: #1235