### PR TITLE
[Sync-En] closures: make the variable inheritance example explain itself

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: c19f29d4fcf92c1a2d2c46d68adab31e98fcbe78 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Functions</title>
@@ -1158,15 +1158,18 @@ $greet('PHP');
     <programlisting role="php">
 <![CDATA[
 <?php
+// Una variable definida en el ámbito padre
 $message = 'hello';
 
-// No "use"
+// $message no se hereda y no está definida por la ausencia
+// de una cláusula "use"
 $example = function () {
     var_dump($message);
 };
 $example();
 
-// Inherit $message
+// $message se hereda del ámbito padre gracias a la
+// cláusula "use"
 $example = function () use ($message) {
     var_dump($message);
 };
@@ -1177,17 +1180,16 @@ $example();
 $message = 'world';
 $example();
 
-// Reset message
+// Reinicializa $message
 $message = 'hello';
 
-// Inherit by-reference
+// Herencia por referencia: un cambio hecho en el ámbito padre
+// después de definir la clausura es visible dentro de ella
 $example = function () use (&$message) {
     var_dump($message);
 };
 $example();
 
-// The changed value in the parent scope
-// is reflected inside the function call
 $message = 'world';
 $example();
 
@@ -1197,24 +1199,31 @@ $example = function ($arg) use ($message) {
 };
 $example("hello");
 
-// Return type declaration comes after the use clause
-$example = function () use ($message): string {
-    return "hello $message";
+// Las clausuras pueden devolver valores como cualquier otra
+// función; la declaración de tipo de retorno va después de la
+// cláusula use
+$example = function () use ($message): array {
+    return ["hello", $message];
 };
 var_dump($example());
 ]]>
     </programlisting>
-    &example.outputs.similar;
+    &example.outputs;
     <screen>
 <![CDATA[
-Notice: Undefined variable: message in /example.php on line 6
+Warning: Undefined variable $message in script on line 8
 NULL
 string(5) "hello"
 string(5) "hello"
 string(5) "hello"
 string(5) "world"
 string(11) "hello world"
-string(11) "hello world"
+array(2) {
+  [0]=>
+  string(5) "hello"
+  [1]=>
+  string(5) "world"
+}
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Translation of php/doc-en#4826 (commit c19f29d): the comments of the "inheriting variables from the parent scope" example now say what each closure demonstrates, the return type example returns an array, and the output block matches current PHP. EN-Revision updated.

language/functions.xml is still an untranslated copy of the English page, so only the comments of that example are in Spanish.

Fixes: #1236