### PR TITLE
[Sync-En] SolrQuery: clarify the highlight query accessors

### DIFF
--- a/reference/solr/solrquery/gethighlightquery.xml
+++ b/reference/solr/solrquery/gethighlightquery.xml
@@ -1,22 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45819f24afaf2ce388bdbb9b2dcbbbe62414a4f7 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e549ce16fdd9c1f73653700729d29ed7d3272fab Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="solrquery.gethighlightquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getHighlightQuery</refname>
-  <refpurpose>Devuelve la consulta de resaltado (hl.q)</refpurpose>
+  <refpurpose>Devuelve la consulta de resaltado</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>SolrQuery::getHighlightQuery</methodname>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>SolrQuery::getHighlightQuery</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Devuelve la consulta de resaltado previamente definida.
+  <simpara>
+   Devuelve la consulta de resaltado definida previamente mediante el parámetro
+   <literal>hl.q</literal>.
    Este parámetro permite resaltar términos o campos diferentes de los utilizados para recuperar los documentos.
-  </para>
+   Véase la sección <link xlink:href="https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html">Highlighting</link>
+   para más detalles.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +29,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve la cadena de consulta de resaltado actual, o null si no está definida.
-  </para>
+  <simpara>
+   Devuelve una cadena que contiene la consulta de resaltado del
+   <classname>SolrQuery</classname> actual, o &null; si la consulta de
+   resaltado no está definida.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SolrQuery::setHighlightQuery</methodname></member>
+   <member><methodname>SolrQuery::getHighlightFields</methodname></member>
+   <member><methodname>SolrQuery::setHighlightFields</methodname></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/solr/solrquery/sethighlightquery.xml
+++ b/reference/solr/solrquery/sethighlightquery.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="solrquery.sethighlightquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::setHighlightQuery</refname>
-  <refpurpose>Una consulta designada para la resaltación</refpurpose>
+  <refpurpose>Una consulta designada para el resaltado</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,14 +14,14 @@
    <methodparam><type>string</type><parameter>q</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Una consulta a utilizar para la resaltación, que se asignará como valor del
+   Una consulta a utilizar para el resaltado, que se asignará como valor del
    parámetro Solr <literal>hl.q</literal>.
    Este parámetro permite resaltar términos o campos diferentes de los utilizados para recuperar los documentos.
   </simpara>
 
   <simpara>
-   El valor por omisión si no está definido: el valor del parámetro
-   <literal>q</literal> de la consulta.
+   El valor predeterminado si no está definido: el valor del parámetro
+   <literal>q</literal> de la petición.
   </simpara>
 
   <simpara>
@@ -38,7 +38,7 @@
      <term><parameter>q</parameter></term>
      <listitem>
       <simpara>
-       La consulta de resaltación.
+       La consulta de resaltado.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/solr/solrquery/sethighlightquery.xml
+++ b/reference/solr/solrquery/sethighlightquery.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1d92acb7add86f36f352334a52679c078e328704 Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: e549ce16fdd9c1f73653700729d29ed7d3272fab Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="solrquery.sethighlightquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::setHighlightQuery</refname>
-  <refpurpose>Una consulta designada para la resaltación (hl.q)</refpurpose>
+  <refpurpose>Una consulta designada para la resaltación</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,13 +13,21 @@
    <modifier>public</modifier> <type>SolrQuery</type><methodname>SolrQuery::setHighlightQuery</methodname>
    <methodparam><type>string</type><parameter>q</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Una consulta a utilizar para la resaltación.
+  <simpara>
+   Una consulta a utilizar para la resaltación, que se asignará como valor del
+   parámetro Solr <literal>hl.q</literal>.
    Este parámetro permite resaltar términos o campos diferentes de los utilizados para recuperar los documentos.
-  </para>
+  </simpara>
 
-  <para>El valor por omisión si no está definido: el valor del parámetro q de la consulta</para>
-  <para>Referencia del parámetro Solr: hl.q</para>
+  <simpara>
+   El valor por omisión si no está definido: el valor del parámetro
+   <literal>q</literal> de la consulta.
+  </simpara>
+
+  <simpara>
+   Véase la sección <link xlink:href="https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html">Highlighting</link>
+   para más detalles sobre el parámetro Solr <literal>hl.q</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +37,9 @@
     <varlistentry>
      <term><parameter>q</parameter></term>
      <listitem>
-      <para>
-       La consulta de resaltación
-      </para>
+      <simpara>
+       La consulta de resaltación.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,9 +48,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Devuelve el objeto <classname>SolrQuery</classname> actual, si el valor devuelto es utilizado.
-  </para>
+  <simpara>
+   Devuelve el objeto <classname>SolrQuery</classname> actual.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SolrQuery::getHighlightQuery</methodname></member>
+   <member><methodname>SolrQuery::setHighlightFields</methodname></member>
+   <member><methodname>SolrQuery::getHighlightFields</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Translation of php/doc-en#3742 (commit e549ce1): getHighlightQuery() and setHighlightQuery() now name the Solr hl.q parameter explicitly, return the current SolrQuery rather than a SolrHighlightQuery string, link to the Solr highlighting guide and gain seealso sections. EN-Revision updated.

Fixes: #1238