### PR TITLE
[Sync-En] ext/intl: document the PHP 8.5 Locale changes

### DIFF
--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -37,7 +37,7 @@
     Las locales no pueden ser instanciadas. Todas son funciones estáticas.
     Utilice <methodname>Locale::getDefault</methodname> y
     <methodname>Locale::setDefault</methodname> para leer y escribir la locale
-    por omisión utilizada por ICU.
+    predeterminada utilizada por ICU.
    </simpara>
    <simpara>
     La cadena &null; o vacía permite obtener la locale raíz. La raíz es el equivalente

--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: PhilDaiguille Status: ready -->
+<!-- EN-Revision: 255b4f159662a2915dd5ac7e415148d064ff1c62 Maintainer: PhilDaiguille Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.locale" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La clase Locale</title>
@@ -35,6 +35,9 @@
    </simpara>
    <simpara>
     Las locales no pueden ser instanciadas. Todas son funciones estáticas.
+    Utilice <methodname>Locale::getDefault</methodname> y
+    <methodname>Locale::setDefault</methodname> para leer y escribir la locale
+    por omisión utilizada por ICU.
    </simpara>
    <simpara>
     La cadena &null; o vacía permite obtener la locale raíz. La raíz es el equivalente
@@ -118,9 +121,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.locale')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Locale'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.locale')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Locale'])"/>
    </classsynopsis>
    <!-- }}} -->
 
@@ -164,6 +165,14 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Los métodos de <classname>Locale</classname> ahora lanzan una
+        <exceptionname>ValueError</exceptionname> cuando un argumento de locale
+        contiene bytes nulos.
+       </entry>
+      </row>
       <row>
        <entry>8.4.0</entry>
        <entry>

--- a/reference/intl/locale/add-likely-subtags.xml
+++ b/reference/intl/locale/add-likely-subtags.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>Locale::addLikelySubtags</refname>
   <refname>locale_add_likely_subtags</refname>
-  <refpurpose>Añade las sub-etiquetas probables a una locale</refpurpose>
+  <refpurpose>Añade las subetiquetas probables a una locale</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -25,7 +25,7 @@
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Expande una etiqueta de locale añadiendo las sub-etiquetas probables a partir
+   Expande una etiqueta de locale añadiendo las subetiquetas probables a partir
    de los datos de locale de ICU. Por ejemplo, <literal>en</literal> se
    convierte en <literal>en_Latn_US</literal>.
   </simpara>
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve la locale con las sub-etiquetas probables añadidas, o &false; en
+   Devuelve la locale con las subetiquetas probables añadidas, o &false; en
    caso de fallo.
   </simpara>
  </refsect1>

--- a/reference/intl/locale/add-likely-subtags.xml
+++ b/reference/intl/locale/add-likely-subtags.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 255b4f159662a2915dd5ac7e415148d064ff1c62 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="locale.addlikelysubtags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Locale::addLikelySubtags</refname>
+  <refname>locale_add_likely_subtags</refname>
+  <refpurpose>Añade las sub-etiquetas probables a una locale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &style.oop;
+  </simpara>
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>Locale::addLikelySubtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   &style.procedural;
+  </simpara>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>locale_add_likely_subtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Expande una etiqueta de locale añadiendo las sub-etiquetas probables a partir
+   de los datos de locale de ICU. Por ejemplo, <literal>en</literal> se
+   convierte en <literal>en_Latn_US</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      La locale a expandir.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la locale con las sub-etiquetas probables añadidas, o &false; en
+   caso de fallo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lanza una <exceptionname>ValueError</exceptionname> cuando el argumento
+   <parameter>locale</parameter> contiene bytes nulos.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Locale::minimizeSubtags</methodname></member>
+   <member><methodname>Locale::canonicalize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/locale/minimize-subtags.xml
+++ b/reference/intl/locale/minimize-subtags.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 255b4f159662a2915dd5ac7e415148d064ff1c62 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="locale.minimizesubtags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Locale::minimizeSubtags</refname>
+  <refname>locale_minimize_subtags</refname>
+  <refpurpose>Elimina las sub-etiquetas probables de una locale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &style.oop;
+  </simpara>
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>Locale::minimizeSubtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   &style.procedural;
+  </simpara>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>locale_minimize_subtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Reduce una etiqueta de locale eliminando las sub-etiquetas que pueden
+   deducirse a partir de los datos de sub-etiquetas probables de ICU. Por
+   ejemplo, <literal>en_Latn_US</literal> se convierte en
+   <literal>en</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      La locale a reducir.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Devuelve la locale con las sub-etiquetas probables eliminadas, o &false; en
+   caso de fallo.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lanza una <exceptionname>ValueError</exceptionname> cuando el argumento
+   <parameter>locale</parameter> contiene bytes nulos.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Locale::addLikelySubtags</methodname></member>
+   <member><methodname>Locale::canonicalize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/locale/minimize-subtags.xml
+++ b/reference/intl/locale/minimize-subtags.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>Locale::minimizeSubtags</refname>
   <refname>locale_minimize_subtags</refname>
-  <refpurpose>Elimina las sub-etiquetas probables de una locale</refpurpose>
+  <refpurpose>Elimina las subetiquetas probables de una locale</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -25,8 +25,8 @@
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Reduce una etiqueta de locale eliminando las sub-etiquetas que pueden
-   deducirse a partir de los datos de sub-etiquetas probables de ICU. Por
+   Reduce una etiqueta de locale eliminando las subetiquetas que pueden
+   deducirse a partir de los datos de subetiquetas probables de ICU. Por
    ejemplo, <literal>en_Latn_US</literal> se convierte en
    <literal>en</literal>.
   </simpara>
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Devuelve la locale con las sub-etiquetas probables eliminadas, o &false; en
+   Devuelve la locale con las subetiquetas probables eliminadas, o &false; en
    caso de fallo.
   </simpara>
  </refsect1>


### PR DESCRIPTION
Translation of php/doc-en#5806 (commit 255b4f1): Locale::addLikelySubtags() and Locale::minimizeSubtags() are translated for the first time, and the class page gains the 8.5 changelog entry about ValueError on null bytes plus the pointer to getDefault()/setDefault(). EN-Revision updated.

The class synopsis also drops the xi:fallback wrapper, which check-structure rejects: doc-en writes that xi:include self-closing.

Fixes: #1239